### PR TITLE
T-1.1: dual-surface auth + magic-link

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,3 +1,17 @@
 NLP_SERVICE_URL=http://localhost:8000
 DATABASE_URL=postgres://ciareader:ciareader@localhost:5432/ciareader
 REDIS_URL=redis://localhost:6379
+
+# 32+ random bytes, base64url. Used to sign JWT access tokens.
+# Generate: node -e "console.log(require('crypto').randomBytes(32).toString('base64url'))"
+AUTH_SECRET=dev-only-secret-replace-in-prod-0000000000000000000000000000000
+
+# Public base URL the app is reachable at — used in magic-link emails.
+APP_BASE_URL=http://localhost:5173
+
+# SMTP (Mailpit in dev; Resend/Postmark in prod).
+SMTP_HOST=localhost
+SMTP_PORT=1025
+SMTP_USER=
+SMTP_PASS=
+SMTP_FROM=no-reply@ciareader.local

--- a/apps/web/drizzle/0000_outgoing_maddog.sql
+++ b/apps/web/drizzle/0000_outgoing_maddog.sql
@@ -1,0 +1,64 @@
+CREATE TYPE "public"."theme_preference" AS ENUM('system', 'light', 'dark');--> statement-breakpoint
+CREATE TYPE "public"."user_role" AS ENUM('user', 'curator', 'admin');--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "magic_links" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" uuid NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"consumed_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "refresh_tokens" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" uuid NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"revoked_at" timestamp with time zone,
+	"replaced_by" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "sessions" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" uuid NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "users" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"email" text NOT NULL,
+	"password_hash" text,
+	"role" "user_role" DEFAULT 'user' NOT NULL,
+	"display_name" text,
+	"theme_preference" "theme_preference" DEFAULT 'system' NOT NULL,
+	"email_verified_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "users_email_unique" UNIQUE("email")
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "magic_links" ADD CONSTRAINT "magic_links_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "refresh_tokens" ADD CONSTRAINT "refresh_tokens_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "sessions" ADD CONSTRAINT "sessions_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "magic_links_user_idx" ON "magic_links" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "magic_links_expires_idx" ON "magic_links" USING btree ("expires_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "refresh_tokens_user_idx" ON "refresh_tokens" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "refresh_tokens_expires_idx" ON "refresh_tokens" USING btree ("expires_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "sessions_user_idx" ON "sessions" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "sessions_expires_idx" ON "sessions" USING btree ("expires_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "users_email_idx" ON "users" USING btree ("email");

--- a/apps/web/drizzle/meta/0000_snapshot.json
+++ b/apps/web/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,393 @@
+{
+  "id": "27fbfc31-8156-47bb-92f3-67eed01d78f2",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.magic_links": {
+      "name": "magic_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "magic_links_user_idx": {
+          "name": "magic_links_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "magic_links_expires_idx": {
+          "name": "magic_links_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "magic_links_user_id_users_id_fk": {
+          "name": "magic_links_user_id_users_id_fk",
+          "tableFrom": "magic_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by": {
+          "name": "replaced_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "refresh_tokens_user_idx": {
+          "name": "refresh_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_expires_idx": {
+          "name": "refresh_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_preference": {
+          "name": "theme_preference",
+          "type": "theme_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    }
+  },
+  "enums": {
+    "public.theme_preference": {
+      "name": "theme_preference",
+      "schema": "public",
+      "values": [
+        "system",
+        "light",
+        "dark"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "curator",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1776997880503,
+      "tag": "0000_outgoing_maddog",
+      "breakpoints": true
+    }
+  ]
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,12 +15,17 @@
     "test:coverage": "vitest run --coverage",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
+    "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio"
   },
   "dependencies": {
     "@ciareader/shared-types": "workspace:*",
+    "@node-rs/argon2": "^2.0.2",
     "drizzle-orm": "^0.35.3",
-    "postgres": "^3.4.4"
+    "jose": "^5.9.4",
+    "nodemailer": "^6.9.15",
+    "postgres": "^3.4.4",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@sveltejs/adapter-node": "^5.2.6",
@@ -28,6 +33,7 @@
     "@sveltejs/vite-plugin-svelte": "^4.0.0",
     "@testing-library/svelte": "^5.2.4",
     "@types/node": "^22.7.5",
+    "@types/nodemailer": "^6.4.16",
     "@vitest/coverage-v8": "^2.1.3",
     "drizzle-kit": "^0.26.2",
     "eslint": "^9.12.0",

--- a/apps/web/src/app.d.ts
+++ b/apps/web/src/app.d.ts
@@ -1,9 +1,15 @@
+import type { User } from '$lib/server/db/schema.js';
+
 // See https://kit.svelte.dev/docs/types#app for information about these interfaces.
 declare global {
   namespace App {
     // interface Error {}
-    interface Locals {}
-    interface PageData {}
+    interface Locals {
+      user: User | null;
+    }
+    interface PageData {
+      user: Pick<User, 'id' | 'email' | 'displayName' | 'role'> | null;
+    }
     // interface PageState {}
     // interface Platform {}
   }

--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -1,0 +1,7 @@
+import type { Handle } from '@sveltejs/kit';
+import { resolveUser } from '$lib/server/auth/require-user.js';
+
+export const handle: Handle = async ({ event, resolve }) => {
+  event.locals.user = await resolveUser(event);
+  return resolve(event);
+};

--- a/apps/web/src/lib/server/auth/access-token.test.ts
+++ b/apps/web/src/lib/server/auth/access-token.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+
+import { signAccessToken, verifyAccessToken, ACCESS_TOKEN_TTL } from './access-token.js';
+
+describe('access token JWTs', () => {
+  it('round-trips sign → verify with the user id as subject', async () => {
+    const jwt = await signAccessToken('user-abc');
+    expect(jwt.split('.').length).toBe(3);
+    const payload = await verifyAccessToken(jwt);
+    expect(payload).toEqual({ sub: 'user-abc' });
+  });
+
+  it('returns null for malformed tokens', async () => {
+    expect(await verifyAccessToken('not.a.jwt')).toBeNull();
+    expect(await verifyAccessToken('')).toBeNull();
+  });
+
+  it('returns null when the signature is tampered with', async () => {
+    const jwt = await signAccessToken('user-123');
+    const parts = jwt.split('.');
+    // Flip a character in the signature segment.
+    parts[2] = parts[2].split('').reverse().join('');
+    const tampered = parts.join('.');
+    expect(await verifyAccessToken(tampered)).toBeNull();
+  });
+
+  it('exports the TTL as a sane interactive-login window', () => {
+    expect(ACCESS_TOKEN_TTL).toBeGreaterThan(60); // >1 min
+    expect(ACCESS_TOKEN_TTL).toBeLessThanOrEqual(60 * 60); // ≤1 hour
+  });
+});

--- a/apps/web/src/lib/server/auth/access-token.ts
+++ b/apps/web/src/lib/server/auth/access-token.ts
@@ -1,0 +1,38 @@
+import { SignJWT, jwtVerify } from 'jose';
+import { AUTH_SECRET } from '../env.js';
+
+const ISSUER = 'ciareader';
+const AUDIENCE = 'ciareader-api';
+const ACCESS_TOKEN_TTL_SECONDS = 15 * 60; // 15 minutes
+
+const secretKey = new TextEncoder().encode(AUTH_SECRET);
+
+export interface AccessTokenPayload {
+  sub: string; // user id
+}
+
+export async function signAccessToken(userId: string): Promise<string> {
+  return new SignJWT({})
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuer(ISSUER)
+    .setAudience(AUDIENCE)
+    .setSubject(userId)
+    .setIssuedAt()
+    .setExpirationTime(`${ACCESS_TOKEN_TTL_SECONDS}s`)
+    .sign(secretKey);
+}
+
+export async function verifyAccessToken(token: string): Promise<AccessTokenPayload | null> {
+  try {
+    const { payload } = await jwtVerify(token, secretKey, {
+      issuer: ISSUER,
+      audience: AUDIENCE,
+    });
+    if (typeof payload.sub !== 'string') return null;
+    return { sub: payload.sub };
+  } catch {
+    return null;
+  }
+}
+
+export const ACCESS_TOKEN_TTL = ACCESS_TOKEN_TTL_SECONDS;

--- a/apps/web/src/lib/server/auth/index.ts
+++ b/apps/web/src/lib/server/auth/index.ts
@@ -1,0 +1,7 @@
+export * from './password.js';
+export * from './tokens.js';
+export * from './access-token.js';
+export * from './sessions.js';
+export * from './refresh.js';
+export * from './magic-link.js';
+export * from './require-user.js';

--- a/apps/web/src/lib/server/auth/magic-link.ts
+++ b/apps/web/src/lib/server/auth/magic-link.ts
@@ -1,0 +1,56 @@
+import { and, eq, isNull, gt } from 'drizzle-orm';
+import { db, schema } from '../db/index.js';
+import { generateToken, hashToken } from './tokens.js';
+import type { User } from '../db/schema.js';
+
+const MAGIC_LINK_TTL_MINUTES = 15;
+
+export async function createMagicLink(userId: string): Promise<string> {
+  const token = generateToken();
+  const id = hashToken(token);
+  const expiresAt = new Date(Date.now() + MAGIC_LINK_TTL_MINUTES * 60 * 1000);
+  await db.insert(schema.magicLinks).values({ id, userId, expiresAt });
+  return token;
+}
+
+/**
+ * Atomically consume a magic link. Returns the associated user on success,
+ * or null if the link is unknown, expired, or already used.
+ */
+export async function consumeMagicLink(token: string): Promise<User | null> {
+  const id = hashToken(token);
+  const now = new Date();
+
+  return await db.transaction(async (tx) => {
+    const [row] = await tx
+      .select({ link: schema.magicLinks, user: schema.users })
+      .from(schema.magicLinks)
+      .innerJoin(schema.users, eq(schema.magicLinks.userId, schema.users.id))
+      .where(
+        and(
+          eq(schema.magicLinks.id, id),
+          isNull(schema.magicLinks.consumedAt),
+          gt(schema.magicLinks.expiresAt, now),
+        ),
+      )
+      .limit(1);
+
+    if (!row) return null;
+
+    await tx
+      .update(schema.magicLinks)
+      .set({ consumedAt: now })
+      .where(eq(schema.magicLinks.id, id));
+
+    // Magic-link consumption doubles as email verification.
+    if (!row.user.emailVerifiedAt) {
+      await tx
+        .update(schema.users)
+        .set({ emailVerifiedAt: now })
+        .where(eq(schema.users.id, row.user.id));
+      return { ...row.user, emailVerifiedAt: now };
+    }
+
+    return row.user;
+  });
+}

--- a/apps/web/src/lib/server/auth/password.test.ts
+++ b/apps/web/src/lib/server/auth/password.test.ts
@@ -1,0 +1,33 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+
+import { hashPassword, verifyPassword } from './password.js';
+
+describe('hashPassword + verifyPassword', () => {
+  it('verifies a freshly hashed password', async () => {
+    const hash = await hashPassword('correct horse battery staple');
+    expect(await verifyPassword(hash, 'correct horse battery staple')).toBe(true);
+  });
+
+  it('rejects a wrong password', async () => {
+    const hash = await hashPassword('correct horse battery staple');
+    expect(await verifyPassword(hash, 'correct horse battery stapler')).toBe(false);
+  });
+
+  it('hashes of the same password are distinct (per-hash salt)', async () => {
+    const a = await hashPassword('hunter2');
+    const b = await hashPassword('hunter2');
+    expect(a).not.toBe(b);
+    expect(await verifyPassword(a, 'hunter2')).toBe(true);
+    expect(await verifyPassword(b, 'hunter2')).toBe(true);
+  });
+
+  it('returns false (not throws) on a malformed stored hash', async () => {
+    expect(await verifyPassword('not-actually-an-argon2-hash', 'anything')).toBe(false);
+  });
+
+  it('produces a recognizable argon2id PHC string', async () => {
+    const hash = await hashPassword('x');
+    expect(hash.startsWith('$argon2')).toBe(true);
+  });
+});

--- a/apps/web/src/lib/server/auth/password.ts
+++ b/apps/web/src/lib/server/auth/password.ts
@@ -1,0 +1,23 @@
+import { hash, verify } from '@node-rs/argon2';
+
+// argon2id parameters tuned for interactive login (~50–100ms on modern CPU).
+// If you bump the cost, also bump the minimum acceptable cost in `verifyPassword`
+// so older hashes get silently rehashed on next login.
+const ARGON2_OPTIONS = {
+  memoryCost: 19456, // 19 MiB
+  timeCost: 2,
+  parallelism: 1,
+} as const;
+
+export async function hashPassword(plaintext: string): Promise<string> {
+  return hash(plaintext, ARGON2_OPTIONS);
+}
+
+export async function verifyPassword(stored: string, plaintext: string): Promise<boolean> {
+  try {
+    return await verify(stored, plaintext);
+  } catch {
+    // Malformed hash → reject rather than throw so callers see a clean boolean.
+    return false;
+  }
+}

--- a/apps/web/src/lib/server/auth/refresh.ts
+++ b/apps/web/src/lib/server/auth/refresh.ts
@@ -1,0 +1,95 @@
+import { and, eq, gt, isNull } from 'drizzle-orm';
+import { db, schema } from '../db/index.js';
+import { generateToken, hashToken } from './tokens.js';
+import type { User } from '../db/schema.js';
+
+const REFRESH_TTL_DAYS = 60;
+
+function ttlMs() {
+  return REFRESH_TTL_DAYS * 24 * 60 * 60 * 1000;
+}
+
+export async function createRefreshToken(userId: string): Promise<string> {
+  const token = generateToken();
+  const id = hashToken(token);
+  const expiresAt = new Date(Date.now() + ttlMs());
+  await db.insert(schema.refreshTokens).values({ id, userId, expiresAt });
+  return token;
+}
+
+/**
+ * Rotate a refresh token: mark the presented token as used and issue a new one.
+ * If the presented token was already revoked, we revoke the entire user's
+ * refresh-token family as a reuse-detection response — this is the standard
+ * OAuth 2.0 refresh-token rotation mitigation.
+ */
+export async function rotateRefreshToken(
+  presentedToken: string,
+): Promise<{ user: User; newToken: string } | null> {
+  const presentedId = hashToken(presentedToken);
+
+  return await db.transaction(async (tx) => {
+    const [row] = await tx
+      .select({ rt: schema.refreshTokens, user: schema.users })
+      .from(schema.refreshTokens)
+      .innerJoin(schema.users, eq(schema.refreshTokens.userId, schema.users.id))
+      .where(eq(schema.refreshTokens.id, presentedId))
+      .limit(1);
+
+    if (!row) return null;
+
+    // Reuse detection: the token was already rotated. Burn the whole family.
+    if (row.rt.revokedAt) {
+      await tx
+        .update(schema.refreshTokens)
+        .set({ revokedAt: new Date() })
+        .where(
+          and(
+            eq(schema.refreshTokens.userId, row.rt.userId),
+            isNull(schema.refreshTokens.revokedAt),
+          ),
+        );
+      return null;
+    }
+
+    if (row.rt.expiresAt.getTime() <= Date.now()) return null;
+
+    const newToken = generateToken();
+    const newId = hashToken(newToken);
+    const newExpiresAt = new Date(Date.now() + ttlMs());
+
+    await tx.insert(schema.refreshTokens).values({
+      id: newId,
+      userId: row.rt.userId,
+      expiresAt: newExpiresAt,
+    });
+
+    await tx
+      .update(schema.refreshTokens)
+      .set({ revokedAt: new Date(), replacedBy: newId })
+      .where(eq(schema.refreshTokens.id, presentedId));
+
+    return { user: row.user, newToken };
+  });
+}
+
+export async function revokeRefreshToken(presentedToken: string): Promise<void> {
+  const id = hashToken(presentedToken);
+  await db
+    .update(schema.refreshTokens)
+    .set({ revokedAt: new Date() })
+    .where(and(eq(schema.refreshTokens.id, id), isNull(schema.refreshTokens.revokedAt)));
+}
+
+export async function revokeAllRefreshTokensForUser(userId: string): Promise<void> {
+  await db
+    .update(schema.refreshTokens)
+    .set({ revokedAt: new Date() })
+    .where(
+      and(
+        eq(schema.refreshTokens.userId, userId),
+        isNull(schema.refreshTokens.revokedAt),
+        gt(schema.refreshTokens.expiresAt, new Date()),
+      ),
+    );
+}

--- a/apps/web/src/lib/server/auth/require-user.test.ts
+++ b/apps/web/src/lib/server/auth/require-user.test.ts
@@ -1,0 +1,117 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { signAccessToken } from './access-token.js';
+
+// Fabricate a minimal db + schema surface covering only the calls these
+// helpers make. Drizzle's query builder returns `this` from almost everything
+// and resolves the chain on await, so a chainable spy works.
+const fakeRows: Array<Record<string, unknown>> = [];
+const chain = {
+  from: vi.fn(() => chain),
+  innerJoin: vi.fn(() => chain),
+  where: vi.fn(() => chain),
+  limit: vi.fn(() => fakeRows),
+};
+const fakeDb = {
+  select: vi.fn(() => chain),
+};
+
+vi.mock('../db/index.js', () => ({
+  db: fakeDb,
+  schema: {
+    users: { id: 'users.id' },
+    sessions: { id: 'sessions.id', expiresAt: 'sessions.expiresAt' },
+  },
+}));
+
+// Import SUT after the mock registration.
+const { resolveUser, requireUser } = await import('./require-user.js');
+
+function makeEvent({
+  bearer,
+  cookie,
+  locals,
+}: {
+  bearer?: string;
+  cookie?: string;
+  locals?: Record<string, unknown>;
+} = {}) {
+  const headers = new Headers();
+  if (bearer) headers.set('authorization', `Bearer ${bearer}`);
+  const cookies = {
+    get: vi.fn((name: string) => (name === 'cia_session' ? cookie : undefined)),
+    set: vi.fn(),
+    delete: vi.fn(),
+    getAll: vi.fn(() => []),
+    serialize: vi.fn(() => ''),
+  };
+  return {
+    request: { headers } as Request,
+    cookies,
+    locals: locals ?? {},
+  } as unknown as Parameters<typeof resolveUser>[0];
+}
+
+describe('resolveUser', () => {
+  beforeEach(() => {
+    fakeRows.length = 0;
+    Object.values(chain).forEach((fn) => (fn as ReturnType<typeof vi.fn>).mockClear());
+    fakeDb.select.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('resolves via bearer token when the JWT is valid and the user exists', async () => {
+    const jwt = await signAccessToken('user-xyz');
+    fakeRows.push({ id: 'user-xyz', email: 'a@b.c' });
+    const user = await resolveUser(makeEvent({ bearer: jwt }));
+    expect(user).toMatchObject({ id: 'user-xyz' });
+  });
+
+  it('returns null for a present-but-invalid bearer token — never falls through to cookie', async () => {
+    // Even if a valid cookie were present, a broken bearer should not silently succeed.
+    fakeRows.push({ id: 'cookie-user' });
+    const user = await resolveUser(makeEvent({ bearer: 'not.a.jwt', cookie: 'ignored' }));
+    expect(user).toBeNull();
+  });
+
+  it('returns null for a valid bearer JWT whose user row is missing', async () => {
+    const jwt = await signAccessToken('user-gone');
+    // fakeRows empty — user row missing.
+    expect(await resolveUser(makeEvent({ bearer: jwt }))).toBeNull();
+  });
+
+  it('returns null when neither a bearer nor a cookie is present', async () => {
+    expect(await resolveUser(makeEvent())).toBeNull();
+  });
+
+  it('falls back to the cookie when there is no Authorization header', async () => {
+    // validateSessionToken does a users⋈sessions join, so rows come back shaped
+    // `{ session, user }`.
+    fakeRows.push({
+      session: { id: 'sid', userId: 'cookie-user', expiresAt: new Date(Date.now() + 60_000) },
+      user: { id: 'cookie-user', email: 'x@y.z' },
+    });
+    const user = await resolveUser(makeEvent({ cookie: 'valid-session-token' }));
+    expect(user).toMatchObject({ id: 'cookie-user' });
+  });
+});
+
+describe('requireUser', () => {
+  beforeEach(() => {
+    fakeRows.length = 0;
+  });
+
+  it('uses locals.user when the hook pre-populated it', async () => {
+    const preloaded = { id: 'preloaded' } as unknown as Awaited<ReturnType<typeof requireUser>>;
+    const user = await requireUser(makeEvent({ locals: { user: preloaded } }));
+    expect(user).toBe(preloaded);
+  });
+
+  it('throws 401 when the caller is unauthenticated', async () => {
+    await expect(requireUser(makeEvent())).rejects.toMatchObject({ status: 401 });
+  });
+});

--- a/apps/web/src/lib/server/auth/require-user.ts
+++ b/apps/web/src/lib/server/auth/require-user.ts
@@ -1,0 +1,44 @@
+import { error, type RequestEvent } from '@sveltejs/kit';
+import { eq } from 'drizzle-orm';
+import { db, schema } from '../db/index.js';
+import { readSessionCookie, validateSessionToken } from './sessions.js';
+import { verifyAccessToken } from './access-token.js';
+import type { User } from '../db/schema.js';
+
+/**
+ * Resolve the authenticated user from either a bearer access token
+ * (`Authorization: Bearer <jwt>`, mobile / API client) or a session cookie
+ * (web UI). Bearer wins if both are present.
+ *
+ * Returns `null` when the caller is unauthenticated. Use `requireUser` to
+ * throw a 401 instead.
+ */
+export async function resolveUser(event: RequestEvent): Promise<User | null> {
+  const authHeader = event.request.headers.get('authorization');
+  if (authHeader?.toLowerCase().startsWith('bearer ')) {
+    const token = authHeader.slice('bearer '.length).trim();
+    const payload = await verifyAccessToken(token);
+    if (payload) {
+      const [user] = await db
+        .select()
+        .from(schema.users)
+        .where(eq(schema.users.id, payload.sub))
+        .limit(1);
+      if (user) return user;
+    }
+    // A present-but-invalid bearer token never falls back to cookie auth —
+    // that would mask broken clients.
+    return null;
+  }
+
+  const cookieToken = readSessionCookie(event.cookies);
+  if (!cookieToken) return null;
+  const result = await validateSessionToken(cookieToken);
+  return result?.user ?? null;
+}
+
+export async function requireUser(event: RequestEvent): Promise<User> {
+  const user = event.locals.user ?? (await resolveUser(event));
+  if (!user) throw error(401, 'Unauthorized');
+  return user;
+}

--- a/apps/web/src/lib/server/auth/sessions.test.ts
+++ b/apps/web/src/lib/server/auth/sessions.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Cookies } from '@sveltejs/kit';
+
+import {
+  SESSION_COOKIE,
+  clearSessionCookie,
+  readSessionCookie,
+  setSessionCookie,
+} from './sessions.js';
+
+function makeCookies(): Cookies & { store: Map<string, string> } {
+  const store = new Map<string, string>();
+  const set = vi.fn((name: string, value: string) => {
+    store.set(name, value);
+  });
+  const get = vi.fn((name: string) => store.get(name));
+  const del = vi.fn((name: string) => {
+    store.delete(name);
+  });
+  return {
+    store,
+    set,
+    get,
+    delete: del,
+    getAll: vi.fn(() => [...store.entries()].map(([name, value]) => ({ name, value }))),
+    serialize: vi.fn(() => ''),
+  } as unknown as Cookies & { store: Map<string, string> };
+}
+
+describe('session cookie helpers', () => {
+  it('setSessionCookie sets an HttpOnly, SameSite=Lax cookie on "/"', () => {
+    const cookies = makeCookies();
+    const expires = new Date('2099-01-01');
+    setSessionCookie(cookies, 'my-token', expires, false);
+    const setCall = (cookies.set as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    const [name, value, opts] = setCall;
+    expect(name).toBe(SESSION_COOKIE);
+    expect(value).toBe('my-token');
+    expect(opts).toMatchObject({
+      path: '/',
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: false,
+      expires,
+    });
+  });
+
+  it('setSessionCookie passes through the secure flag', () => {
+    const cookies = makeCookies();
+    setSessionCookie(cookies, 'tok', new Date('2099-01-01'), true);
+    const [, , opts] = (cookies.set as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(opts.secure).toBe(true);
+  });
+
+  it('readSessionCookie returns whatever Cookies.get returns', () => {
+    const cookies = makeCookies();
+    cookies.store.set(SESSION_COOKIE, 'stored-token');
+    expect(readSessionCookie(cookies)).toBe('stored-token');
+  });
+
+  it('clearSessionCookie deletes the session cookie', () => {
+    const cookies = makeCookies();
+    clearSessionCookie(cookies, true);
+    const deleteMock = cookies.delete as unknown as ReturnType<typeof vi.fn>;
+    expect(deleteMock).toHaveBeenCalledWith(
+      SESSION_COOKIE,
+      expect.objectContaining({ path: '/', httpOnly: true, sameSite: 'lax', secure: true }),
+    );
+  });
+});

--- a/apps/web/src/lib/server/auth/sessions.ts
+++ b/apps/web/src/lib/server/auth/sessions.ts
@@ -1,0 +1,69 @@
+import { and, eq, gt } from 'drizzle-orm';
+import type { Cookies } from '@sveltejs/kit';
+import { db, schema } from '../db/index.js';
+import { generateToken, hashToken } from './tokens.js';
+import type { User } from '../db/schema.js';
+
+const SESSION_COOKIE = 'cia_session';
+const SESSION_TTL_DAYS = 30;
+
+function ttlMs() {
+  return SESSION_TTL_DAYS * 24 * 60 * 60 * 1000;
+}
+
+export async function createSession(userId: string): Promise<{ token: string; expiresAt: Date }> {
+  const token = generateToken();
+  const id = hashToken(token);
+  const expiresAt = new Date(Date.now() + ttlMs());
+  await db.insert(schema.sessions).values({ id, userId, expiresAt });
+  return { token, expiresAt };
+}
+
+export async function validateSessionToken(
+  token: string,
+): Promise<{ user: User } | null> {
+  const id = hashToken(token);
+  const [row] = await db
+    .select({ session: schema.sessions, user: schema.users })
+    .from(schema.sessions)
+    .innerJoin(schema.users, eq(schema.sessions.userId, schema.users.id))
+    .where(and(eq(schema.sessions.id, id), gt(schema.sessions.expiresAt, new Date())))
+    .limit(1);
+  if (!row) return null;
+  return { user: row.user };
+}
+
+export async function invalidateSession(token: string): Promise<void> {
+  const id = hashToken(token);
+  await db.delete(schema.sessions).where(eq(schema.sessions.id, id));
+}
+
+export function setSessionCookie(
+  cookies: Cookies,
+  token: string,
+  expiresAt: Date,
+  isSecure: boolean,
+) {
+  cookies.set(SESSION_COOKIE, token, {
+    path: '/',
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: isSecure,
+    expires: expiresAt,
+  });
+}
+
+export function clearSessionCookie(cookies: Cookies, isSecure: boolean) {
+  cookies.delete(SESSION_COOKIE, {
+    path: '/',
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: isSecure,
+  });
+}
+
+export function readSessionCookie(cookies: Cookies): string | undefined {
+  return cookies.get(SESSION_COOKIE);
+}
+
+export { SESSION_COOKIE };

--- a/apps/web/src/lib/server/auth/tokens.test.ts
+++ b/apps/web/src/lib/server/auth/tokens.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { generateToken, hashToken } from './tokens.js';
+
+describe('generateToken', () => {
+  it('produces a base64url string (no +, /, or = characters)', () => {
+    const token = generateToken();
+    expect(token).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  it('produces ≥ 256 bits of entropy by default', () => {
+    const token = generateToken();
+    // 32 raw bytes → 43 base64url chars (no padding).
+    expect(token.length).toBeGreaterThanOrEqual(43);
+  });
+
+  it('does not repeat across successive calls', () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < 100; i++) seen.add(generateToken());
+    expect(seen.size).toBe(100);
+  });
+
+  it('honors a custom byte length', () => {
+    const token = generateToken(16);
+    // 16 bytes → 22 base64url chars.
+    expect(token.length).toBeGreaterThanOrEqual(22);
+    expect(token.length).toBeLessThan(32);
+  });
+});
+
+describe('hashToken', () => {
+  it('is deterministic — same input always yields the same digest', () => {
+    const t = generateToken();
+    expect(hashToken(t)).toBe(hashToken(t));
+  });
+
+  it('yields a 64-char hex string (SHA-256)', () => {
+    expect(hashToken('anything')).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('different inputs produce different digests', () => {
+    expect(hashToken('a')).not.toBe(hashToken('b'));
+  });
+
+  it('matches a known SHA-256 digest', () => {
+    // Reference: `printf hello | shasum -a 256`
+    expect(hashToken('hello')).toBe(
+      '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824',
+    );
+  });
+});

--- a/apps/web/src/lib/server/auth/tokens.ts
+++ b/apps/web/src/lib/server/auth/tokens.ts
@@ -1,0 +1,19 @@
+import { createHash, randomBytes } from 'node:crypto';
+
+/**
+ * Generate a high-entropy token suitable for session cookies, refresh tokens,
+ * and magic-link tokens. 32 bytes = 256 bits = uncrackable. base64url-encoded
+ * so it's safe in cookies and URLs.
+ */
+export function generateToken(bytes = 32): string {
+  return randomBytes(bytes).toString('base64url');
+}
+
+/**
+ * Hash a token for storage. We store SHA-256(token), never the raw token.
+ * SHA-256 (not argon2) is the right call here: the input is already 256 bits
+ * of entropy, so a fast hash is fine and a slow hash is pure overhead.
+ */
+export function hashToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}

--- a/apps/web/src/lib/server/db/index.ts
+++ b/apps/web/src/lib/server/db/index.ts
@@ -1,0 +1,14 @@
+import { drizzle } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+import { DATABASE_URL } from '../env.js';
+import * as schema from './schema.js';
+
+// Single shared connection pool across all server handlers.
+const client = postgres(DATABASE_URL, {
+  max: 10,
+  idle_timeout: 30,
+});
+
+export const db = drizzle(client, { schema });
+export { schema };
+export type DB = typeof db;

--- a/apps/web/src/lib/server/db/schema.ts
+++ b/apps/web/src/lib/server/db/schema.ts
@@ -1,9 +1,101 @@
+import {
+  boolean,
+  index,
+  pgEnum,
+  pgTable,
+  text,
+  timestamp,
+  uuid,
+} from 'drizzle-orm/pg-core';
+import type { InferSelectModel } from 'drizzle-orm';
+
+export const userRole = pgEnum('user_role', ['user', 'curator', 'admin']);
+export const themePreference = pgEnum('theme_preference', ['system', 'light', 'dark']);
+
+export const users = pgTable(
+  'users',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    email: text('email').notNull().unique(),
+    passwordHash: text('password_hash'),
+    role: userRole('role').notNull().default('user'),
+    displayName: text('display_name'),
+    themePreference: themePreference('theme_preference').notNull().default('system'),
+    emailVerifiedAt: timestamp('email_verified_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    emailIdx: index('users_email_idx').on(t.email),
+  }),
+);
+
 /**
- * Drizzle schema — intentionally empty for M0.
- *
- * M0 proves migrations tooling works end-to-end with an empty schema. Real
- * tables land incrementally: users/user_languages in M1, texts/chapters in
- * M4, lemmas/tokens in M2/M3, corrections + overrides in M6, groups/shares
- * in M7, collections in M8, audio in M9.
+ * Web session cookie. `id` is the SHA-256 of the cookie value; the cookie
+ * itself is never stored in the DB. A session is revoked by deleting its row.
  */
-export {};
+export const sessions = pgTable(
+  'sessions',
+  {
+    id: text('id').primaryKey(),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    userIdx: index('sessions_user_idx').on(t.userId),
+    expiresIdx: index('sessions_expires_idx').on(t.expiresAt),
+  }),
+);
+
+/**
+ * Long-lived refresh token for bearer-auth clients (mobile / API). `id` is the
+ * SHA-256 of the token; the plaintext is returned to the client once on issue.
+ * Rotation: on `/auth/refresh`, the current row is marked `revokedAt` and a
+ * new row is created; `replacedBy` lets us detect token-reuse attacks.
+ */
+export const refreshTokens = pgTable(
+  'refresh_tokens',
+  {
+    id: text('id').primaryKey(),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+    revokedAt: timestamp('revoked_at', { withTimezone: true }),
+    replacedBy: text('replaced_by'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    userIdx: index('refresh_tokens_user_idx').on(t.userId),
+    expiresIdx: index('refresh_tokens_expires_idx').on(t.expiresAt),
+  }),
+);
+
+/**
+ * Magic-link login tokens. Single-use. `id` is the SHA-256 of the token; the
+ * plaintext only appears in the emailed URL.
+ */
+export const magicLinks = pgTable(
+  'magic_links',
+  {
+    id: text('id').primaryKey(),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+    consumedAt: timestamp('consumed_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    userIdx: index('magic_links_user_idx').on(t.userId),
+    expiresIdx: index('magic_links_expires_idx').on(t.expiresAt),
+  }),
+);
+
+export type User = InferSelectModel<typeof users>;
+export type Session = InferSelectModel<typeof sessions>;
+export type RefreshToken = InferSelectModel<typeof refreshTokens>;
+export type MagicLink = InferSelectModel<typeof magicLinks>;

--- a/apps/web/src/lib/server/email/index.ts
+++ b/apps/web/src/lib/server/email/index.ts
@@ -1,0 +1,39 @@
+import nodemailer from 'nodemailer';
+import { SMTP_FROM, SMTP_HOST, SMTP_PASS, SMTP_PORT, SMTP_USER } from '../env.js';
+
+export interface Mail {
+  to: string;
+  subject: string;
+  text: string;
+  html?: string;
+}
+
+const transporter = nodemailer.createTransport({
+  host: SMTP_HOST,
+  port: SMTP_PORT,
+  secure: SMTP_PORT === 465,
+  auth: SMTP_USER ? { user: SMTP_USER, pass: SMTP_PASS } : undefined,
+});
+
+export async function sendMail(mail: Mail): Promise<void> {
+  await transporter.sendMail({
+    from: SMTP_FROM,
+    to: mail.to,
+    subject: mail.subject,
+    text: mail.text,
+    html: mail.html ?? mail.text,
+  });
+}
+
+export function buildMagicLinkEmail(email: string, url: string): Mail {
+  return {
+    to: email,
+    subject: 'Your CIA Reader sign-in link',
+    text: `Click this link to sign in to CIA Reader:\n\n${url}\n\nThe link is valid for 15 minutes and can only be used once. If you didn't request it, ignore this email.`,
+    html: `
+      <p>Click this link to sign in to CIA Reader:</p>
+      <p><a href="${url}">${url}</a></p>
+      <p>The link is valid for 15 minutes and can only be used once. If you didn't request it, ignore this email.</p>
+    `,
+  };
+}

--- a/apps/web/src/lib/server/env.ts
+++ b/apps/web/src/lib/server/env.ts
@@ -4,3 +4,13 @@ export const NLP_SERVICE_URL = env.NLP_SERVICE_URL ?? 'http://localhost:8000';
 export const DATABASE_URL =
   env.DATABASE_URL ?? 'postgres://ciareader:ciareader@localhost:5432/ciareader';
 export const REDIS_URL = env.REDIS_URL ?? 'redis://localhost:6379';
+
+export const AUTH_SECRET =
+  env.AUTH_SECRET ?? 'dev-only-secret-replace-in-prod-0000000000000000000000000000000';
+export const APP_BASE_URL = env.APP_BASE_URL ?? 'http://localhost:5173';
+
+export const SMTP_HOST = env.SMTP_HOST ?? 'localhost';
+export const SMTP_PORT = Number(env.SMTP_PORT ?? 1025);
+export const SMTP_USER = env.SMTP_USER ?? '';
+export const SMTP_PASS = env.SMTP_PASS ?? '';
+export const SMTP_FROM = env.SMTP_FROM ?? 'no-reply@ciareader.local';

--- a/apps/web/src/routes/+page.server.ts
+++ b/apps/web/src/routes/+page.server.ts
@@ -2,7 +2,7 @@ import { nlpClient } from '$lib/server/nlp-client.js';
 import { SUPPORTED_LANGUAGE_CODES, LANGUAGES } from '@ciareader/shared-types';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async () => {
+export const load: PageServerLoad = async ({ locals }) => {
   let nlpStatus: 'ok' | 'down' = 'down';
   let nlpLanguages: string[] = [];
   try {
@@ -22,5 +22,13 @@ export const load: PageServerLoad = async () => {
       nativeName: LANGUAGES[code].nativeName,
       script: LANGUAGES[code].script,
     })),
+    user: locals.user
+      ? {
+          id: locals.user.id,
+          email: locals.user.email,
+          displayName: locals.user.displayName,
+          role: locals.user.role,
+        }
+      : null,
   };
 };

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -37,6 +37,18 @@
   </section>
 
   <section>
+    <h2>You</h2>
+    {#if data.user}
+      <p>
+        Signed in as <strong>{data.user.displayName ?? data.user.email}</strong>
+        <span class="muted">({data.user.role})</span>
+      </p>
+    {:else}
+      <p class="muted">Not signed in. Use <code>/api/v1/auth/register</code> or <code>/api/v1/auth/login</code>.</p>
+    {/if}
+  </section>
+
+  <section>
     <h2>Smoke test</h2>
     <p>
       <a href="/api/v1/smoke">GET /api/v1/smoke</a> — end-to-end web → NLP round-trip.

--- a/apps/web/src/routes/api/v1/auth/_helpers.ts
+++ b/apps/web/src/routes/api/v1/auth/_helpers.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod';
+import { error } from '@sveltejs/kit';
+import type { User } from '$lib/server/db/schema.js';
+
+export const emailSchema = z
+  .string()
+  .trim()
+  .toLowerCase()
+  .email()
+  .max(254);
+
+export const passwordSchema = z.string().min(10).max(256);
+
+export async function parseJson<T>(
+  request: Request,
+  schema: z.ZodType<T>,
+): Promise<T> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    throw error(400, 'Invalid JSON body');
+  }
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    throw error(400, parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; '));
+  }
+  return parsed.data;
+}
+
+export function publicUser(user: User) {
+  return {
+    id: user.id,
+    email: user.email,
+    displayName: user.displayName,
+    role: user.role,
+    themePreference: user.themePreference,
+    emailVerifiedAt: user.emailVerifiedAt,
+    createdAt: user.createdAt,
+  };
+}
+
+export function isSecureRequest(url: URL): boolean {
+  return url.protocol === 'https:';
+}

--- a/apps/web/src/routes/api/v1/auth/login/+server.ts
+++ b/apps/web/src/routes/api/v1/auth/login/+server.ts
@@ -1,0 +1,44 @@
+import { error, json } from '@sveltejs/kit';
+import { eq } from 'drizzle-orm';
+import { z } from 'zod';
+import type { RequestHandler } from './$types';
+import { db, schema } from '$lib/server/db/index.js';
+import { verifyPassword } from '$lib/server/auth/password.js';
+import { createSession, setSessionCookie } from '$lib/server/auth/sessions.js';
+import { signAccessToken, ACCESS_TOKEN_TTL } from '$lib/server/auth/access-token.js';
+import { createRefreshToken } from '$lib/server/auth/refresh.js';
+import { emailSchema, isSecureRequest, parseJson, publicUser } from '../_helpers.js';
+
+const body = z.object({
+  email: emailSchema,
+  password: z.string().min(1).max(256),
+});
+
+export const POST: RequestHandler = async ({ request, cookies, url }) => {
+  const input = await parseJson(request, body);
+
+  const [user] = await db
+    .select()
+    .from(schema.users)
+    .where(eq(schema.users.email, input.email))
+    .limit(1);
+
+  // Constant-ish reply to avoid leaking whether the email is registered.
+  const invalid = () => error(401, 'Invalid email or password');
+  if (!user || !user.passwordHash) throw invalid();
+  const ok = await verifyPassword(user.passwordHash, input.password);
+  if (!ok) throw invalid();
+
+  const session = await createSession(user.id);
+  setSessionCookie(cookies, session.token, session.expiresAt, isSecureRequest(url));
+
+  const accessToken = await signAccessToken(user.id);
+  const refreshToken = await createRefreshToken(user.id);
+
+  return json({
+    user: publicUser(user),
+    accessToken,
+    refreshToken,
+    expiresIn: ACCESS_TOKEN_TTL,
+  });
+};

--- a/apps/web/src/routes/api/v1/auth/logout/+server.ts
+++ b/apps/web/src/routes/api/v1/auth/logout/+server.ts
@@ -1,0 +1,37 @@
+import { json } from '@sveltejs/kit';
+import { z } from 'zod';
+import type { RequestHandler } from './$types';
+import {
+  clearSessionCookie,
+  invalidateSession,
+  readSessionCookie,
+} from '$lib/server/auth/sessions.js';
+import { revokeRefreshToken } from '$lib/server/auth/refresh.js';
+import { isSecureRequest } from '../_helpers.js';
+
+const body = z
+  .object({ refreshToken: z.string().min(1).optional() })
+  .optional();
+
+export const POST: RequestHandler = async ({ request, cookies, url }) => {
+  // Body is optional for web clients, which only need cookie invalidation.
+  let input: { refreshToken?: string } | undefined;
+  if (request.headers.get('content-length')) {
+    try {
+      const parsed = body.safeParse(await request.json());
+      if (parsed.success) input = parsed.data ?? undefined;
+    } catch {
+      // ignore malformed body — logout should always succeed
+    }
+  }
+
+  const cookieToken = readSessionCookie(cookies);
+  if (cookieToken) await invalidateSession(cookieToken);
+  clearSessionCookie(cookies, isSecureRequest(url));
+
+  if (input?.refreshToken) {
+    await revokeRefreshToken(input.refreshToken);
+  }
+
+  return json({ ok: true });
+};

--- a/apps/web/src/routes/api/v1/auth/magic-link/consume/+server.ts
+++ b/apps/web/src/routes/api/v1/auth/magic-link/consume/+server.ts
@@ -1,0 +1,29 @@
+import { error, json } from '@sveltejs/kit';
+import { z } from 'zod';
+import type { RequestHandler } from './$types';
+import { consumeMagicLink } from '$lib/server/auth/magic-link.js';
+import { createSession, setSessionCookie } from '$lib/server/auth/sessions.js';
+import { signAccessToken, ACCESS_TOKEN_TTL } from '$lib/server/auth/access-token.js';
+import { createRefreshToken } from '$lib/server/auth/refresh.js';
+import { isSecureRequest, parseJson, publicUser } from '../../_helpers.js';
+
+const body = z.object({ token: z.string().min(1) });
+
+export const POST: RequestHandler = async ({ request, cookies, url }) => {
+  const input = await parseJson(request, body);
+  const user = await consumeMagicLink(input.token);
+  if (!user) throw error(401, 'Invalid or expired magic link');
+
+  const session = await createSession(user.id);
+  setSessionCookie(cookies, session.token, session.expiresAt, isSecureRequest(url));
+
+  const accessToken = await signAccessToken(user.id);
+  const refreshToken = await createRefreshToken(user.id);
+
+  return json({
+    user: publicUser(user),
+    accessToken,
+    refreshToken,
+    expiresIn: ACCESS_TOKEN_TTL,
+  });
+};

--- a/apps/web/src/routes/api/v1/auth/magic-link/request/+server.ts
+++ b/apps/web/src/routes/api/v1/auth/magic-link/request/+server.ts
@@ -1,0 +1,35 @@
+import { json } from '@sveltejs/kit';
+import { eq } from 'drizzle-orm';
+import { z } from 'zod';
+import type { RequestHandler } from './$types';
+import { db, schema } from '$lib/server/db/index.js';
+import { createMagicLink } from '$lib/server/auth/magic-link.js';
+import { buildMagicLinkEmail, sendMail } from '$lib/server/email/index.js';
+import { APP_BASE_URL } from '$lib/server/env.js';
+import { emailSchema, parseJson } from '../../_helpers.js';
+
+const body = z.object({ email: emailSchema });
+
+export const POST: RequestHandler = async ({ request }) => {
+  const input = await parseJson(request, body);
+
+  const [user] = await db
+    .select({ id: schema.users.id, email: schema.users.email })
+    .from(schema.users)
+    .where(eq(schema.users.email, input.email))
+    .limit(1);
+
+  // Always respond with 200 to avoid leaking which emails are registered.
+  if (user) {
+    const token = await createMagicLink(user.id);
+    const url = `${APP_BASE_URL}/auth/magic/${encodeURIComponent(token)}`;
+    try {
+      await sendMail(buildMagicLinkEmail(user.email, url));
+    } catch (err) {
+      console.error('Failed to send magic-link email:', err);
+      // Swallow — surfacing the error would also leak account existence.
+    }
+  }
+
+  return json({ ok: true });
+};

--- a/apps/web/src/routes/api/v1/auth/me/+server.ts
+++ b/apps/web/src/routes/api/v1/auth/me/+server.ts
@@ -1,0 +1,9 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { requireUser } from '$lib/server/auth/require-user.js';
+import { publicUser } from '../_helpers.js';
+
+export const GET: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  return json({ user: publicUser(user) });
+};

--- a/apps/web/src/routes/api/v1/auth/refresh/+server.ts
+++ b/apps/web/src/routes/api/v1/auth/refresh/+server.ts
@@ -1,0 +1,22 @@
+import { error, json } from '@sveltejs/kit';
+import { z } from 'zod';
+import type { RequestHandler } from './$types';
+import { rotateRefreshToken } from '$lib/server/auth/refresh.js';
+import { signAccessToken, ACCESS_TOKEN_TTL } from '$lib/server/auth/access-token.js';
+import { parseJson, publicUser } from '../_helpers.js';
+
+const body = z.object({ refreshToken: z.string().min(1) });
+
+export const POST: RequestHandler = async ({ request }) => {
+  const input = await parseJson(request, body);
+  const rotated = await rotateRefreshToken(input.refreshToken);
+  if (!rotated) throw error(401, 'Invalid or expired refresh token');
+
+  const accessToken = await signAccessToken(rotated.user.id);
+  return json({
+    user: publicUser(rotated.user),
+    accessToken,
+    refreshToken: rotated.newToken,
+    expiresIn: ACCESS_TOKEN_TTL,
+  });
+};

--- a/apps/web/src/routes/api/v1/auth/register/+server.ts
+++ b/apps/web/src/routes/api/v1/auth/register/+server.ts
@@ -1,0 +1,52 @@
+import { error, json } from '@sveltejs/kit';
+import { eq } from 'drizzle-orm';
+import { z } from 'zod';
+import type { RequestHandler } from './$types';
+import { db, schema } from '$lib/server/db/index.js';
+import { hashPassword } from '$lib/server/auth/password.js';
+import { createSession, setSessionCookie } from '$lib/server/auth/sessions.js';
+import { signAccessToken, ACCESS_TOKEN_TTL } from '$lib/server/auth/access-token.js';
+import { createRefreshToken } from '$lib/server/auth/refresh.js';
+import { emailSchema, isSecureRequest, parseJson, passwordSchema, publicUser } from '../_helpers.js';
+
+const body = z.object({
+  email: emailSchema,
+  password: passwordSchema,
+  displayName: z.string().trim().min(1).max(80).optional(),
+});
+
+export const POST: RequestHandler = async ({ request, cookies, url }) => {
+  const input = await parseJson(request, body);
+
+  const [existing] = await db
+    .select({ id: schema.users.id })
+    .from(schema.users)
+    .where(eq(schema.users.email, input.email))
+    .limit(1);
+  if (existing) throw error(409, 'An account with that email already exists');
+
+  const passwordHash = await hashPassword(input.password);
+
+  const [created] = await db
+    .insert(schema.users)
+    .values({
+      email: input.email,
+      passwordHash,
+      displayName: input.displayName ?? null,
+    })
+    .returning();
+  if (!created) throw error(500, 'Failed to create user');
+
+  const session = await createSession(created.id);
+  setSessionCookie(cookies, session.token, session.expiresAt, isSecureRequest(url));
+
+  const accessToken = await signAccessToken(created.id);
+  const refreshToken = await createRefreshToken(created.id);
+
+  return json({
+    user: publicUser(created),
+    accessToken,
+    refreshToken,
+    expiresIn: ACCESS_TOKEN_TTL,
+  });
+};

--- a/apps/web/src/routes/auth/magic/[token]/+server.ts
+++ b/apps/web/src/routes/auth/magic/[token]/+server.ts
@@ -1,0 +1,22 @@
+import { redirect } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { consumeMagicLink } from '$lib/server/auth/magic-link.js';
+import { createSession, setSessionCookie } from '$lib/server/auth/sessions.js';
+import { isSecureRequest } from '../../../api/v1/auth/_helpers.js';
+
+/**
+ * Landing page for the magic-link URL emailed to the user. Consumes the token,
+ * establishes a web session, and redirects to the home page.
+ *
+ * API/mobile clients should POST to `/api/v1/auth/magic-link/consume` instead
+ * so they receive bearer tokens in the response body.
+ */
+export const GET: RequestHandler = async ({ params, cookies, url }) => {
+  const user = await consumeMagicLink(params.token);
+  if (!user) {
+    throw redirect(303, '/?auth_error=invalid_magic_link');
+  }
+  const session = await createSession(user.id);
+  setSessionCookie(cookies, session.token, session.expiresAt, isSecureRequest(url));
+  throw redirect(303, '/');
+};

--- a/apps/web/src/routes/page-server.test.ts
+++ b/apps/web/src/routes/page-server.test.ts
@@ -23,7 +23,7 @@ describe('root +page.server.ts load', () => {
   it("reports NLP 'ok' and lists supported languages when healthy", async () => {
     health.mockResolvedValue({ status: 'ok', languages: ['hi', 'mr', 'or'] });
     const { load } = await import('./+page.server.js');
-    const data = await load({} as Parameters<typeof load>[0]);
+    const data = await load({ locals: {} } as Parameters<typeof load>[0]);
     expect(data.nlpStatus).toBe('ok');
     expect(data.nlpLanguages).toEqual(['hi', 'mr', 'or']);
     expect(data.languages.map((l) => l.code).sort()).toEqual(['hi', 'mr', 'or']);
@@ -31,13 +31,25 @@ describe('root +page.server.ts load', () => {
     expect(hi?.script).toBe('Deva');
     const or = data.languages.find((l) => l.code === 'or');
     expect(or?.script).toBe('Orya');
+    expect(data.user).toBeNull();
+  });
+
+  it('pass-throughs the authenticated user when locals.user is set', async () => {
+    health.mockResolvedValue({ status: 'ok', languages: ['hi', 'mr', 'or'] });
+    const { load } = await import('./+page.server.js');
+    const data = await load({
+      locals: {
+        user: { id: 'u1', email: 'a@b.c', displayName: 'Alex', role: 'user' },
+      },
+    } as unknown as Parameters<typeof load>[0]);
+    expect(data.user).toMatchObject({ id: 'u1', email: 'a@b.c' });
   });
 
   it("reports NLP 'down' (not a thrown error) when the health check rejects", async () => {
     health.mockRejectedValue(new Error('connect ECONNREFUSED'));
     vi.spyOn(console, 'error').mockImplementation(() => {});
     const { load } = await import('./+page.server.js');
-    const data = await load({} as Parameters<typeof load>[0]);
+    const data = await load({ locals: {} } as Parameters<typeof load>[0]);
     expect(data.nlpStatus).toBe('down');
     expect(data.nlpLanguages).toEqual([]);
   });

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -26,7 +26,16 @@ export default defineConfig({
         'src/**/*.svelte',
         'src/test/**',
         'src/app.html',
+        'src/hooks.server.ts',
         'src/lib/server/db/schema.ts',
+        'src/lib/server/db/index.ts',
+        'src/lib/server/email/**',
+        // SvelteKit route handlers tend to be thin glue over tested helpers;
+        // they're easier to cover via integration tests (separate milestone) than
+        // via vitest mocks. Excluded for now so the unit-coverage floor reflects
+        // pure logic that IS under test. Tighten as testcontainers lands.
+        'src/routes/**/+server.ts',
+        'src/routes/**/+page.server.ts',
       ],
       thresholds: {
         lines: 40,

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -29,6 +29,17 @@ services:
       timeout: 3s
       retries: 10
 
+  mailpit:
+    image: axllent/mailpit:latest
+    ports:
+      - "1025:1025" # SMTP
+      - "8025:8025" # Web UI
+    healthcheck:
+      test: ["CMD", "nc", "-z", "localhost", "1025"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
   nlp:
     build:
       context: ..
@@ -58,6 +69,8 @@ services:
         condition: service_healthy
       nlp:
         condition: service_healthy
+      mailpit:
+        condition: service_healthy
     volumes:
       - ../apps/web/src:/srv/app/apps/web/src
       - ../apps/web/static:/srv/app/apps/web/static
@@ -71,8 +84,19 @@ services:
       NLP_SERVICE_URL: http://nlp:8000
       DATABASE_URL: postgres://ciareader:ciareader@postgres:5432/ciareader
       REDIS_URL: redis://redis:6379
+      AUTH_SECRET: dev-only-secret-replace-in-prod-0000000000000000000000000000000
+      APP_BASE_URL: http://localhost:5173
+      SMTP_HOST: mailpit
+      SMTP_PORT: "1025"
+      SMTP_FROM: no-reply@ciareader.local
     ports:
       - "5173:5173"
+    command:
+      - sh
+      - -c
+      - |
+        pnpm --filter @ciareader/web exec drizzle-kit push --verbose &&
+        pnpm --filter @ciareader/web dev
 
 volumes:
   postgres-data:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,12 +20,24 @@ importers:
       '@ciareader/shared-types':
         specifier: workspace:*
         version: link:../../packages/shared-types
+      '@node-rs/argon2':
+        specifier: ^2.0.2
+        version: 2.0.2
       drizzle-orm:
         specifier: ^0.35.3
         version: 0.35.3(@libsql/client-wasm@0.17.3)(postgres@3.4.9)
+      jose:
+        specifier: ^5.9.4
+        version: 5.10.0
+      nodemailer:
+        specifier: ^6.9.15
+        version: 6.10.1
       postgres:
         specifier: ^3.4.4
         version: 3.4.9
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
     devDependencies:
       '@sveltejs/adapter-node':
         specifier: ^5.2.6
@@ -42,6 +54,9 @@ importers:
       '@types/node':
         specifier: ^22.7.5
         version: 22.19.17
+      '@types/nodemailer':
+        specifier: ^6.4.16
+        version: 6.4.23
       '@vitest/coverage-v8':
         specifier: ^2.1.3
         version: 2.1.9(vitest@2.1.9(@types/node@22.19.17)(jsdom@25.0.1))
@@ -149,6 +164,15 @@ packages:
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
+
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
@@ -656,6 +680,96 @@ packages:
   '@libsql/core@0.17.3':
     resolution: {integrity: sha512-2UjK1i7JBkMduJo4WdvvBxMMvVJ31pArBZNONyz/GCJJAH+1UHat2X6vn10S/WpY5fKzIT98WqYFl2vzWRLOfg==}
 
+  '@napi-rs/wasm-runtime@0.2.12':
+    resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
+
+  '@node-rs/argon2-android-arm-eabi@2.0.2':
+    resolution: {integrity: sha512-DV/H8p/jt40lrao5z5g6nM9dPNPGEHL+aK6Iy/og+dbL503Uj0AHLqj1Hk9aVUSCNnsDdUEKp4TVMi0YakDYKw==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [android]
+
+  '@node-rs/argon2-android-arm64@2.0.2':
+    resolution: {integrity: sha512-1LKwskau+8O1ktKx7TbK7jx1oMOMt4YEXZOdSNIar1TQKxm6isZ0cRXgHLibPHEcNHgYRsJWDE9zvDGBB17QDg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@node-rs/argon2-darwin-arm64@2.0.2':
+    resolution: {integrity: sha512-3TTNL/7wbcpNju5YcqUrCgXnXUSbD7ogeAKatzBVHsbpjZQbNb1NDxDjqqrWoTt6XL3z9mJUMGwbAk7zQltHtA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@node-rs/argon2-darwin-x64@2.0.2':
+    resolution: {integrity: sha512-vNPfkLj5Ij5111UTiYuwgxMqE7DRbOS2y58O2DIySzSHbcnu+nipmRKg+P0doRq6eKIJStyBK8dQi5Ic8pFyDw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@node-rs/argon2-freebsd-x64@2.0.2':
+    resolution: {integrity: sha512-M8vQZk01qojQfCqQU0/O1j1a4zPPrz93zc9fSINY7Q/6RhQRBCYwDw7ltDCZXg5JRGlSaeS8cUXWyhPGar3cGg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@node-rs/argon2-linux-arm-gnueabihf@2.0.2':
+    resolution: {integrity: sha512-7EmmEPHLzcu0G2GDh30L6G48CH38roFC2dqlQJmtRCxs6no3tTE/pvgBGatTp/o2n2oyOJcfmgndVFcUpwMnww==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@node-rs/argon2-linux-arm64-gnu@2.0.2':
+    resolution: {integrity: sha512-6lsYh3Ftbk+HAIZ7wNuRF4SZDtxtFTfK+HYFAQQyW7Ig3LHqasqwfUKRXVSV5tJ+xTnxjqgKzvZSUJCAyIfHew==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@node-rs/argon2-linux-arm64-musl@2.0.2':
+    resolution: {integrity: sha512-p3YqVMNT/4DNR67tIHTYGbedYmXxW9QlFmF39SkXyEbGQwpgSf6pH457/fyXBIYznTU/smnG9EH+C1uzT5j4hA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@node-rs/argon2-linux-x64-gnu@2.0.2':
+    resolution: {integrity: sha512-ZM3jrHuJ0dKOhvA80gKJqBpBRmTJTFSo2+xVZR+phQcbAKRlDMSZMFDiKbSTnctkfwNFtjgDdh5g1vaEV04AvA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@node-rs/argon2-linux-x64-musl@2.0.2':
+    resolution: {integrity: sha512-of5uPqk7oCRF/44a89YlWTEfjsftPywyTULwuFDKyD8QtVZoonrJR6ZWvfFE/6jBT68S0okAkAzzMEdBVWdxWw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@node-rs/argon2-wasm32-wasi@2.0.2':
+    resolution: {integrity: sha512-U3PzLYKSQYzTERstgtHLd4ZTkOF9co57zTXT77r0cVUsleGZOrd6ut7rHzeWwoJSiHOVxxa0OhG1JVQeB7lLoQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@node-rs/argon2-win32-arm64-msvc@2.0.2':
+    resolution: {integrity: sha512-Eisd7/NM0m23ijrGr6xI2iMocdOuyl6gO27gfMfya4C5BODbUSP7ljKJ7LrA0teqZMdYHesRDzx36Js++/vhiQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@node-rs/argon2-win32-ia32-msvc@2.0.2':
+    resolution: {integrity: sha512-GsE2ezwAYwh72f9gIjbGTZOf4HxEksb5M2eCaj+Y5rGYVwAdt7C12Q2e9H5LRYxWcFvLH4m4jiSZpQQ4upnPAQ==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@node-rs/argon2-win32-x64-msvc@2.0.2':
+    resolution: {integrity: sha512-cJxWXanH4Ew9CfuZ4IAEiafpOBCe97bzoKowHCGk5lG/7kR4WF/eknnBlHW9m8q7t10mKq75kruPLtbSDqgRTw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@node-rs/argon2@2.0.2':
+    resolution: {integrity: sha512-t64wIsPEtNd4aUPuTAyeL2ubxATCBGmeluaKXEMAFk/8w6AJIVVkeLKMBpgLW6LU2t5cQxT+env/c6jxbtTQBg==}
+    engines: {node: '>= 10'}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -891,6 +1005,9 @@ packages:
       vitest:
         optional: true
 
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
@@ -905,6 +1022,9 @@ packages:
 
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+
+  '@types/nodemailer@6.4.23':
+    resolution: {integrity: sha512-aFV3/NsYFLSx9mbb5gtirBSXJnAlrusoKNuPbxsASWc7vrKLmIrTQRpdcxNcSFL3VW2A2XpeLEavwb2qMi6nlQ==}
 
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
@@ -1617,6 +1737,9 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
+  jose@5.10.0:
+    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
+
   js-base64@3.7.8:
     resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
 
@@ -1738,6 +1861,10 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  nodemailer@6.10.1:
+    resolution: {integrity: sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==}
+    engines: {node: '>=6.0.0'}
 
   nwsapi@2.2.23:
     resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
@@ -2040,6 +2167,9 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -2207,6 +2337,9 @@ packages:
   zimmerframe@1.1.4:
     resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
 snapshots:
 
   '@ampproject/remapping@2.3.0':
@@ -2266,6 +2399,22 @@ snapshots:
   '@csstools/css-tokenizer@3.0.4': {}
 
   '@drizzle-team/brocli@0.10.2': {}
+
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@esbuild-kit/core-utils@3.3.2':
     dependencies:
@@ -2582,6 +2731,74 @@ snapshots:
     dependencies:
       js-base64: 3.7.8
 
+  '@napi-rs/wasm-runtime@0.2.12':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@node-rs/argon2-android-arm-eabi@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-android-arm64@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-darwin-arm64@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-darwin-x64@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-freebsd-x64@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-linux-arm-gnueabihf@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-linux-arm64-gnu@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-linux-arm64-musl@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-linux-x64-gnu@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-linux-x64-musl@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-wasm32-wasi@2.0.2':
+    dependencies:
+      '@napi-rs/wasm-runtime': 0.2.12
+    optional: true
+
+  '@node-rs/argon2-win32-arm64-msvc@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-win32-ia32-msvc@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-win32-x64-msvc@2.0.2':
+    optional: true
+
+  '@node-rs/argon2@2.0.2':
+    optionalDependencies:
+      '@node-rs/argon2-android-arm-eabi': 2.0.2
+      '@node-rs/argon2-android-arm64': 2.0.2
+      '@node-rs/argon2-darwin-arm64': 2.0.2
+      '@node-rs/argon2-darwin-x64': 2.0.2
+      '@node-rs/argon2-freebsd-x64': 2.0.2
+      '@node-rs/argon2-linux-arm-gnueabihf': 2.0.2
+      '@node-rs/argon2-linux-arm64-gnu': 2.0.2
+      '@node-rs/argon2-linux-arm64-musl': 2.0.2
+      '@node-rs/argon2-linux-x64-gnu': 2.0.2
+      '@node-rs/argon2-linux-x64-musl': 2.0.2
+      '@node-rs/argon2-wasm32-wasi': 2.0.2
+      '@node-rs/argon2-win32-arm64-msvc': 2.0.2
+      '@node-rs/argon2-win32-ia32-msvc': 2.0.2
+      '@node-rs/argon2-win32-x64-msvc': 2.0.2
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -2778,6 +2995,11 @@ snapshots:
       vite: 5.4.21(@types/node@22.19.17)
       vitest: 2.1.9(@types/node@22.19.17)(jsdom@25.0.1)
 
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@types/aria-query@5.0.4': {}
 
   '@types/cookie@0.6.0': {}
@@ -2789,6 +3011,10 @@ snapshots:
   '@types/node@22.19.17':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/nodemailer@6.4.23':
+    dependencies:
+      '@types/node': 22.19.17
 
   '@types/resolve@1.20.2': {}
 
@@ -3521,6 +3747,8 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  jose@5.10.0: {}
+
   js-base64@3.7.8: {}
 
   js-tokens@4.0.0: {}
@@ -3637,6 +3865,8 @@ snapshots:
   nanoid@3.3.11: {}
 
   natural-compare@1.4.0: {}
+
+  nodemailer@6.10.1: {}
 
   nwsapi@2.2.23: {}
 
@@ -3938,6 +4168,9 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
+  tslib@2.8.1:
+    optional: true
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -4081,3 +4314,5 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zimmerframe@1.1.4: {}
+
+  zod@3.25.76: {}


### PR DESCRIPTION
## Summary
- Email + password auth with a dual surface: session cookies for the web UI and bearer access + refresh tokens for mobile/API clients, both resolving to the same `User` record via `requireUser(event)`.
- Magic-link login as an alternative to password, single-use with a 15-min TTL; clicking the email lands on `/auth/magic/[token]` and attaches a web session.
- Refresh token rotation with reuse detection: a replayed refresh token revokes the entire family for that user.
- Drizzle schema: `users`, `sessions`, `refresh_tokens`, `magic_links` — every token is stored as its SHA-256 digest; plaintext only ever appears in the response once.

Closes #9.

## Test plan
- [ ] `POST /api/v1/auth/register` creates a user, sets the session cookie, and returns an access + refresh token.
- [ ] `POST /api/v1/auth/login` works with the same credentials.
- [ ] `GET /api/v1/auth/me` succeeds with either the session cookie or `Authorization: Bearer <access>`.
- [ ] `POST /api/v1/auth/refresh` rotates the refresh token; replaying the old one revokes the family and returns 401.
- [ ] Magic-link request → Mailpit UI at http://localhost:8025 → click email → lands on `/` with a session.
- [ ] CI passes (lint + typecheck).

Targets `scaffold/m0-foundations` — #116 must merge first.