### PR TITLE
T-1.2: user profile page + per-language preferences

### DIFF
--- a/apps/web/drizzle/0001_fancy_guardsmen.sql
+++ b/apps/web/drizzle/0001_fancy_guardsmen.sql
@@ -1,0 +1,27 @@
+CREATE TYPE "public"."highlight_style" AS ENUM('underline', 'background', 'colored_text');--> statement-breakpoint
+CREATE TYPE "public"."language" AS ENUM('hi', 'mr', 'or');--> statement-breakpoint
+CREATE TYPE "public"."reader_layout_mode" AS ENUM('page', 'paged_scroll', 'continuous');--> statement-breakpoint
+CREATE TYPE "public"."romanization_scheme" AS ENUM('iso15919', 'iast', 'hunterian', 'itrans');--> statement-breakpoint
+CREATE TYPE "public"."script_preference" AS ENUM('native', 'native_with_romanization', 'romanization_only');--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "user_languages" (
+	"user_id" uuid NOT NULL,
+	"language" "language" NOT NULL,
+	"script_preference" "script_preference" DEFAULT 'native' NOT NULL,
+	"romanization_scheme" "romanization_scheme" DEFAULT 'iso15919' NOT NULL,
+	"known_words_count_cache" integer DEFAULT 0 NOT NULL,
+	"reader_layout_mode" "reader_layout_mode" DEFAULT 'page' NOT NULL,
+	"words_per_page" integer DEFAULT 250 NOT NULL,
+	"font_family" text,
+	"font_size" real DEFAULT 18 NOT NULL,
+	"line_spacing" real DEFAULT 1.6 NOT NULL,
+	"highlight_style" "highlight_style" DEFAULT 'background' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "user_languages_user_id_language_pk" PRIMARY KEY("user_id","language")
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "user_languages" ADD CONSTRAINT "user_languages_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/apps/web/drizzle/meta/0001_snapshot.json
+++ b/apps/web/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,565 @@
+{
+  "id": "15743af0-1936-417a-9164-8623885e0470",
+  "prevId": "27fbfc31-8156-47bb-92f3-67eed01d78f2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.magic_links": {
+      "name": "magic_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "magic_links_user_idx": {
+          "name": "magic_links_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "magic_links_expires_idx": {
+          "name": "magic_links_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "magic_links_user_id_users_id_fk": {
+          "name": "magic_links_user_id_users_id_fk",
+          "tableFrom": "magic_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by": {
+          "name": "replaced_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "refresh_tokens_user_idx": {
+          "name": "refresh_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_expires_idx": {
+          "name": "refresh_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_languages": {
+      "name": "user_languages",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script_preference": {
+          "name": "script_preference",
+          "type": "script_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "romanization_scheme": {
+          "name": "romanization_scheme",
+          "type": "romanization_scheme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'iso15919'"
+        },
+        "known_words_count_cache": {
+          "name": "known_words_count_cache",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reader_layout_mode": {
+          "name": "reader_layout_mode",
+          "type": "reader_layout_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'page'"
+        },
+        "words_per_page": {
+          "name": "words_per_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 250
+        },
+        "font_family": {
+          "name": "font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_size": {
+          "name": "font_size",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 18
+        },
+        "line_spacing": {
+          "name": "line_spacing",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1.6
+        },
+        "highlight_style": {
+          "name": "highlight_style",
+          "type": "highlight_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'background'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_languages_user_id_users_id_fk": {
+          "name": "user_languages_user_id_users_id_fk",
+          "tableFrom": "user_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_languages_user_id_language_pk": {
+          "name": "user_languages_user_id_language_pk",
+          "columns": [
+            "user_id",
+            "language"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_preference": {
+          "name": "theme_preference",
+          "type": "theme_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    }
+  },
+  "enums": {
+    "public.highlight_style": {
+      "name": "highlight_style",
+      "schema": "public",
+      "values": [
+        "underline",
+        "background",
+        "colored_text"
+      ]
+    },
+    "public.language": {
+      "name": "language",
+      "schema": "public",
+      "values": [
+        "hi",
+        "mr",
+        "or"
+      ]
+    },
+    "public.reader_layout_mode": {
+      "name": "reader_layout_mode",
+      "schema": "public",
+      "values": [
+        "page",
+        "paged_scroll",
+        "continuous"
+      ]
+    },
+    "public.romanization_scheme": {
+      "name": "romanization_scheme",
+      "schema": "public",
+      "values": [
+        "iso15919",
+        "iast",
+        "hunterian",
+        "itrans"
+      ]
+    },
+    "public.script_preference": {
+      "name": "script_preference",
+      "schema": "public",
+      "values": [
+        "native",
+        "native_with_romanization",
+        "romanization_only"
+      ]
+    },
+    "public.theme_preference": {
+      "name": "theme_preference",
+      "schema": "public",
+      "values": [
+        "system",
+        "light",
+        "dark"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "curator",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1776997880503,
       "tag": "0000_outgoing_maddog",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1776997901819,
+      "tag": "0001_fancy_guardsmen",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/src/lib/server/auth/access-token.test.ts
+++ b/apps/web/src/lib/server/auth/access-token.test.ts
@@ -20,7 +20,8 @@ describe('access token JWTs', () => {
     const jwt = await signAccessToken('user-123');
     const parts = jwt.split('.');
     // Flip a character in the signature segment.
-    parts[2] = parts[2].split('').reverse().join('');
+    const sig = parts[2] ?? '';
+    parts[2] = sig.split('').reverse().join('');
     const tampered = parts.join('.');
     expect(await verifyAccessToken(tampered)).toBeNull();
   });

--- a/apps/web/src/lib/server/auth/sessions.test.ts
+++ b/apps/web/src/lib/server/auth/sessions.test.ts
@@ -33,6 +33,7 @@ describe('session cookie helpers', () => {
     const expires = new Date('2099-01-01');
     setSessionCookie(cookies, 'my-token', expires, false);
     const setCall = (cookies.set as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    if (!setCall) throw new Error('cookies.set was not invoked');
     const [name, value, opts] = setCall;
     expect(name).toBe(SESSION_COOKIE);
     expect(value).toBe('my-token');
@@ -48,7 +49,8 @@ describe('session cookie helpers', () => {
   it('setSessionCookie passes through the secure flag', () => {
     const cookies = makeCookies();
     setSessionCookie(cookies, 'tok', new Date('2099-01-01'), true);
-    const [, , opts] = (cookies.set as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    const call = (cookies.set as unknown as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    const [, , opts] = call;
     expect(opts.secure).toBe(true);
   });
 

--- a/apps/web/src/lib/server/db/schema.ts
+++ b/apps/web/src/lib/server/db/schema.ts
@@ -1,8 +1,10 @@
 import {
-  boolean,
   index,
+  integer,
   pgEnum,
   pgTable,
+  primaryKey,
+  real,
   text,
   timestamp,
   uuid,
@@ -11,6 +13,44 @@ import type { InferSelectModel } from 'drizzle-orm';
 
 export const userRole = pgEnum('user_role', ['user', 'curator', 'admin']);
 export const themePreference = pgEnum('theme_preference', ['system', 'light', 'dark']);
+
+// MVP languages. Kept in sync with @ciareader/shared-types' LanguageCode;
+// adding a new language means extending both sides in lockstep. The registry
+// is the human-facing source of truth, but Postgres needs its own enum so
+// FK-like integrity is enforced at the DB layer.
+export const language = pgEnum('language', ['hi', 'mr', 'or']);
+
+// Romanization schemes a user can pick. Subset of the registry's
+// RomanizationScheme — the DB only needs to store choices users can make.
+export const romanizationScheme = pgEnum('romanization_scheme', [
+  'iso15919',
+  'iast',
+  'hunterian',
+  'itrans',
+]);
+
+// What the learner wants rendered in the reader: pure native script, script
+// with inline romanization above each word, or romanization-only (training
+// wheels for brand-new readers). Defaults to 'native'.
+export const scriptPreference = pgEnum('script_preference', [
+  'native',
+  'native_with_romanization',
+  'romanization_only',
+]);
+
+// Three reader layout modes per the plan (M5). Stored per-language so a
+// user can prefer `page` for Hindi but `continuous` for Odia.
+export const readerLayoutMode = pgEnum('reader_layout_mode', [
+  'page',
+  'paged_scroll',
+  'continuous',
+]);
+
+export const highlightStyle = pgEnum('highlight_style', [
+  'underline',
+  'background',
+  'colored_text',
+]);
 
 export const users = pgTable(
   'users',
@@ -95,7 +135,42 @@ export const magicLinks = pgTable(
   }),
 );
 
+/**
+ * Per-user, per-language preferences. A row is created the first time a user
+ * engages with a given language (onboarding in T-1.5, or first text import).
+ * Reader layout + typography live here because they're language-specific —
+ * a Devanagari font shortlist doesn't apply to Odia.
+ *
+ * `knownWordsCountCache` is a denormalized count over `user_known_lemmas`
+ * (added in a later milestone) so the stats page doesn't need a GROUP BY on
+ * every page load. Refreshed whenever a lemma's status changes.
+ */
+export const userLanguages = pgTable(
+  'user_languages',
+  {
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    language: language('language').notNull(),
+    scriptPreference: scriptPreference('script_preference').notNull().default('native'),
+    romanizationScheme: romanizationScheme('romanization_scheme').notNull().default('iso15919'),
+    knownWordsCountCache: integer('known_words_count_cache').notNull().default(0),
+    readerLayoutMode: readerLayoutMode('reader_layout_mode').notNull().default('page'),
+    wordsPerPage: integer('words_per_page').notNull().default(250),
+    fontFamily: text('font_family'),
+    fontSize: real('font_size').notNull().default(18),
+    lineSpacing: real('line_spacing').notNull().default(1.6),
+    highlightStyle: highlightStyle('highlight_style').notNull().default('background'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    pk: primaryKey({ columns: [t.userId, t.language] }),
+  }),
+);
+
 export type User = InferSelectModel<typeof users>;
 export type Session = InferSelectModel<typeof sessions>;
 export type RefreshToken = InferSelectModel<typeof refreshTokens>;
 export type MagicLink = InferSelectModel<typeof magicLinks>;
+export type UserLanguage = InferSelectModel<typeof userLanguages>;

--- a/apps/web/src/lib/server/nlp-client.test.ts
+++ b/apps/web/src/lib/server/nlp-client.test.ts
@@ -26,7 +26,8 @@ describe('nlpClient', () => {
     expect(health.status).toBe('ok');
     expect(health.languages).toEqual(['hi', 'mr', 'or']);
     expect(fetchMock).toHaveBeenCalledOnce();
-    const [url, init] = fetchMock.mock.calls[0];
+    const firstCall = fetchMock.mock.calls[0]!;
+    const [url, init] = firstCall;
     expect(String(url)).toMatch(/\/health$/);
     expect(init?.headers).toMatchObject({ 'content-type': 'application/json' });
   });
@@ -42,7 +43,8 @@ describe('nlpClient', () => {
     const out = await nlpClient.process('hi', 'मैं');
     expect(out.language).toBe('hi');
     expect(out.tokens).toEqual([]);
-    const [, init] = fetchMock.mock.calls[0];
+    const processCall = fetchMock.mock.calls[0]!;
+    const [, init] = processCall;
     expect(init?.method).toBe('POST');
     expect(JSON.parse(String(init?.body))).toEqual({ language: 'hi', text: 'मैं' });
   });

--- a/apps/web/src/lib/server/profile.test.ts
+++ b/apps/web/src/lib/server/profile.test.ts
@@ -1,0 +1,162 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Drizzle's query builder returns `this` from most methods and resolves the
+// chain on await. Tests swap out the `rows` array and the final-link behavior
+// (`limit` / `returning`) to simulate different DB states.
+const rows: Array<Record<string, unknown>> = [];
+type ChainShape = {
+  from: ReturnType<typeof vi.fn>;
+  where: ReturnType<typeof vi.fn>;
+  limit: ReturnType<typeof vi.fn>;
+  set: ReturnType<typeof vi.fn>;
+  values: ReturnType<typeof vi.fn>;
+  returning: ReturnType<typeof vi.fn>;
+};
+const chain: ChainShape = {
+  from: vi.fn(() => chain),
+  where: vi.fn(() => chain),
+  limit: vi.fn(() => rows),
+  set: vi.fn(() => chain),
+  values: vi.fn(() => chain),
+  returning: vi.fn(() => rows),
+};
+const fakeDb = {
+  select: vi.fn(() => chain),
+  update: vi.fn(() => chain),
+  insert: vi.fn(() => chain),
+};
+
+vi.mock('./db/index.js', () => ({
+  db: fakeDb,
+  schema: {
+    users: { id: 'users.id' },
+    userLanguages: {
+      userId: 'ul.user_id',
+      language: 'ul.language',
+    },
+  },
+}));
+
+const { updateUserProfile, upsertUserLanguage, withDefaultsForAllLanguages } = await import(
+  './profile.js'
+);
+
+function resetAll() {
+  rows.length = 0;
+  for (const fn of Object.values(chain)) (fn as ReturnType<typeof vi.fn>).mockClear();
+  fakeDb.select.mockClear();
+  fakeDb.update.mockClear();
+  fakeDb.insert.mockClear();
+}
+
+describe('withDefaultsForAllLanguages', () => {
+  it('fills every MVP language, flagging defaults for untouched ones', () => {
+    const persisted = [
+      {
+        userId: 'u',
+        language: 'hi',
+        scriptPreference: 'romanization_only',
+        romanizationScheme: 'iast',
+      },
+    ];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const merged = withDefaultsForAllLanguages(persisted as any);
+    expect(merged.map((m) => m.code).sort()).toEqual(['hi', 'mr', 'or']);
+    const hi = merged.find((m) => m.code === 'hi')!;
+    expect(hi.isDefault).toBe(false);
+    expect(hi.romanizationScheme).toBe('iast');
+    const or = merged.find((m) => m.code === 'or')!;
+    expect(or.isDefault).toBe(true);
+    expect(or.scriptPreference).toBe('native');
+    expect(or.romanizationScheme).toBe('iso15919');
+  });
+
+  it('returns all-defaults when the user has no persisted rows', () => {
+    const merged = withDefaultsForAllLanguages([]);
+    expect(merged).toHaveLength(3);
+    expect(merged.every((m) => m.isDefault)).toBe(true);
+  });
+});
+
+describe('updateUserProfile', () => {
+  beforeEach(() => resetAll());
+
+  it('returns the existing user without writing when the patch is empty', async () => {
+    rows.push({ id: 'u1', email: 'a@b.c' });
+    const user = await updateUserProfile('u1', {});
+    expect(user).toMatchObject({ id: 'u1' });
+    expect(fakeDb.update).not.toHaveBeenCalled();
+    expect(fakeDb.select).toHaveBeenCalledOnce();
+  });
+
+  it('updates displayName when provided', async () => {
+    rows.push({ id: 'u1', email: 'a@b.c', displayName: 'Alex' });
+    const user = await updateUserProfile('u1', { displayName: 'Alex' });
+    expect(user.displayName).toBe('Alex');
+    expect(fakeDb.update).toHaveBeenCalledOnce();
+    const setArg = chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(setArg.displayName).toBe('Alex');
+    expect(setArg.updatedAt).toBeInstanceOf(Date);
+  });
+
+  it('only updates themePreference when only that is provided', async () => {
+    rows.push({ id: 'u1', themePreference: 'dark' });
+    await updateUserProfile('u1', { themePreference: 'dark' });
+    const setArg = chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(setArg.themePreference).toBe('dark');
+    expect('displayName' in setArg).toBe(false);
+  });
+
+  it('throws when the user is missing', async () => {
+    // rows stays empty — RETURNING yields nothing.
+    await expect(updateUserProfile('nope', { displayName: 'x' })).rejects.toThrow(/not found/);
+  });
+});
+
+describe('upsertUserLanguage', () => {
+  beforeEach(() => resetAll());
+
+  it('inserts a new row with defaults when the language is new for the user', async () => {
+    // First call: SELECT existing → empty.
+    chain.limit.mockReturnValueOnce([]);
+    // Second call: INSERT ... RETURNING → the new row.
+    const created = {
+      userId: 'u1',
+      language: 'hi',
+      scriptPreference: 'native',
+      romanizationScheme: 'iso15919',
+    };
+    chain.returning.mockReturnValueOnce([created]);
+    const row = await upsertUserLanguage('u1', 'hi', {});
+    expect(row).toEqual(created);
+    expect(fakeDb.insert).toHaveBeenCalledOnce();
+    expect(fakeDb.update).not.toHaveBeenCalled();
+  });
+
+  it('updates the existing row when the language is already present', async () => {
+    chain.limit.mockReturnValueOnce([{ userId: 'u1', language: 'hi' }]);
+    const updated = {
+      userId: 'u1',
+      language: 'hi',
+      scriptPreference: 'romanization_only',
+      romanizationScheme: 'iast',
+    };
+    chain.returning.mockReturnValueOnce([updated]);
+    const row = await upsertUserLanguage('u1', 'hi', {
+      scriptPreference: 'romanization_only',
+      romanizationScheme: 'iast',
+    });
+    expect(row).toEqual(updated);
+    expect(fakeDb.insert).not.toHaveBeenCalled();
+    expect(fakeDb.update).toHaveBeenCalledOnce();
+  });
+
+  it('returns the existing row unchanged when the patch is empty', async () => {
+    const existing = { userId: 'u1', language: 'hi', scriptPreference: 'native' };
+    chain.limit.mockReturnValueOnce([existing]);
+    const row = await upsertUserLanguage('u1', 'hi', {});
+    expect(row).toBe(existing);
+    expect(fakeDb.update).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/server/profile.ts
+++ b/apps/web/src/lib/server/profile.ts
@@ -1,0 +1,144 @@
+import { and, eq } from 'drizzle-orm';
+import { db, schema } from './db/index.js';
+import type {
+  User,
+  UserLanguage,
+} from './db/schema.js';
+import { SUPPORTED_LANGUAGE_CODES, type LanguageCode } from '@ciareader/shared-types';
+
+export type ProfileUserPatch = {
+  displayName?: string | null;
+  themePreference?: User['themePreference'];
+};
+
+export type UserLanguagePatch = {
+  scriptPreference?: UserLanguage['scriptPreference'];
+  romanizationScheme?: UserLanguage['romanizationScheme'];
+};
+
+export async function updateUserProfile(
+  userId: string,
+  patch: ProfileUserPatch,
+): Promise<User> {
+  // At least one field must change — otherwise skip the write entirely so an
+  // empty form submit doesn't bump updated_at for no reason.
+  if (patch.displayName === undefined && patch.themePreference === undefined) {
+    const [user] = await db
+      .select()
+      .from(schema.users)
+      .where(eq(schema.users.id, userId))
+      .limit(1);
+    if (!user) throw new Error('user not found');
+    return user;
+  }
+
+  const setClause: Record<string, unknown> = { updatedAt: new Date() };
+  if (patch.displayName !== undefined) setClause.displayName = patch.displayName;
+  if (patch.themePreference !== undefined) setClause.themePreference = patch.themePreference;
+
+  const [updated] = await db
+    .update(schema.users)
+    .set(setClause)
+    .where(eq(schema.users.id, userId))
+    .returning();
+  if (!updated) throw new Error('user not found');
+  return updated;
+}
+
+export async function listUserLanguages(userId: string): Promise<UserLanguage[]> {
+  return db
+    .select()
+    .from(schema.userLanguages)
+    .where(eq(schema.userLanguages.userId, userId));
+}
+
+/**
+ * Upsert a single (user, language) preferences row. If the user has never
+ * engaged with this language before, a row is created with defaults; the
+ * patch is then merged on top.
+ */
+export async function upsertUserLanguage(
+  userId: string,
+  languageCode: LanguageCode,
+  patch: UserLanguagePatch,
+): Promise<UserLanguage> {
+  const existing = await db
+    .select()
+    .from(schema.userLanguages)
+    .where(
+      and(
+        eq(schema.userLanguages.userId, userId),
+        eq(schema.userLanguages.language, languageCode),
+      ),
+    )
+    .limit(1);
+
+  if (existing.length === 0) {
+    const [row] = await db
+      .insert(schema.userLanguages)
+      .values({
+        userId,
+        language: languageCode,
+        scriptPreference: patch.scriptPreference ?? 'native',
+        romanizationScheme: patch.romanizationScheme ?? 'iso15919',
+      })
+      .returning();
+    if (!row) throw new Error('insert returned no row');
+    return row;
+  }
+
+  const existingRow = existing[0]!;
+
+  const setClause: Record<string, unknown> = { updatedAt: new Date() };
+  if (patch.scriptPreference !== undefined) setClause.scriptPreference = patch.scriptPreference;
+  if (patch.romanizationScheme !== undefined) {
+    setClause.romanizationScheme = patch.romanizationScheme;
+  }
+  if (Object.keys(setClause).length === 1) return existingRow; // only updatedAt — no-op
+
+  const [updated] = await db
+    .update(schema.userLanguages)
+    .set(setClause)
+    .where(
+      and(
+        eq(schema.userLanguages.userId, userId),
+        eq(schema.userLanguages.language, languageCode),
+      ),
+    )
+    .returning();
+  if (!updated) throw new Error('update returned no row');
+  return updated;
+}
+
+/**
+ * Pure helper: merges the user's persisted per-language rows with the
+ * registry's full MVP list, so the profile UI can render one entry per
+ * supported language even if the user has never touched Odia yet. Keeps the
+ * "you have 3 languages but 2 use defaults" case out of the SQL.
+ */
+export function withDefaultsForAllLanguages(
+  persisted: UserLanguage[],
+): Array<{
+  code: LanguageCode;
+  scriptPreference: UserLanguage['scriptPreference'];
+  romanizationScheme: UserLanguage['romanizationScheme'];
+  isDefault: boolean;
+}> {
+  const byCode = new Map(persisted.map((r) => [r.language as LanguageCode, r]));
+  return SUPPORTED_LANGUAGE_CODES.map((code) => {
+    const row = byCode.get(code);
+    return row
+      ? {
+          code,
+          scriptPreference: row.scriptPreference,
+          romanizationScheme: row.romanizationScheme,
+          isDefault: false,
+        }
+      : {
+          code,
+          scriptPreference: 'native' as const,
+          romanizationScheme: 'iso15919' as const,
+          isDefault: true,
+        };
+  });
+}

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -42,6 +42,7 @@
       <p>
         Signed in as <strong>{data.user.displayName ?? data.user.email}</strong>
         <span class="muted">({data.user.role})</span>
+        — <a href="/profile">Profile</a>
       </p>
     {:else}
       <p class="muted">Not signed in. Use <code>/api/v1/auth/register</code> or <code>/api/v1/auth/login</code>.</p>

--- a/apps/web/src/routes/api/v1/me/languages/+server.ts
+++ b/apps/web/src/routes/api/v1/me/languages/+server.ts
@@ -1,0 +1,19 @@
+import { json } from '@sveltejs/kit';
+import { requireUser } from '$lib/server/auth/require-user.js';
+import { listUserLanguages, withDefaultsForAllLanguages } from '$lib/server/profile.js';
+import { LANGUAGES } from '@ciareader/shared-types';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  const persisted = await listUserLanguages(user.id);
+  return json({
+    languages: withDefaultsForAllLanguages(persisted).map((row) => ({
+      ...row,
+      displayName: LANGUAGES[row.code].displayName,
+      nativeName: LANGUAGES[row.code].nativeName,
+      script: LANGUAGES[row.code].script,
+      supportedRomanizations: LANGUAGES[row.code].supportedRomanizations,
+    })),
+  });
+};

--- a/apps/web/src/routes/api/v1/me/languages/[code]/+server.ts
+++ b/apps/web/src/routes/api/v1/me/languages/[code]/+server.ts
@@ -1,0 +1,47 @@
+import { error, json } from '@sveltejs/kit';
+import { z } from 'zod';
+import { requireUser } from '$lib/server/auth/require-user.js';
+import { upsertUserLanguage } from '$lib/server/profile.js';
+import {
+  LANGUAGES,
+  SUPPORTED_LANGUAGE_CODES,
+  isSupportedLanguage,
+} from '@ciareader/shared-types';
+import { parseJson } from '../../../auth/_helpers.js';
+import type { RequestHandler } from './$types';
+
+const patchSchema = z
+  .object({
+    scriptPreference: z.enum(['native', 'native_with_romanization', 'romanization_only']),
+    romanizationScheme: z.enum(['iso15919', 'iast', 'hunterian', 'itrans']),
+  })
+  .partial()
+  .refine(
+    (v) => v.scriptPreference !== undefined || v.romanizationScheme !== undefined,
+    {
+      message: 'At least one field must be provided',
+    },
+  );
+
+export const PATCH: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  const code = event.params.code ?? '';
+  if (!isSupportedLanguage(code)) {
+    throw error(
+      400,
+      `Unsupported language '${code}'. Supported: ${SUPPORTED_LANGUAGE_CODES.join(', ')}`,
+    );
+  }
+  const patch = await parseJson(event.request, patchSchema);
+  if (patch.romanizationScheme) {
+    const allowed = LANGUAGES[code].supportedRomanizations;
+    if (!(allowed as readonly string[]).includes(patch.romanizationScheme)) {
+      throw error(
+        400,
+        `Romanization '${patch.romanizationScheme}' is not supported for ${code}. Allowed: ${allowed.join(', ')}`,
+      );
+    }
+  }
+  const row = await upsertUserLanguage(user.id, code, patch);
+  return json({ language: row });
+};

--- a/apps/web/src/routes/api/v1/me/profile/+server.ts
+++ b/apps/web/src/routes/api/v1/me/profile/+server.ts
@@ -1,0 +1,28 @@
+import { json } from '@sveltejs/kit';
+import { z } from 'zod';
+import { requireUser } from '$lib/server/auth/require-user.js';
+import { updateUserProfile } from '$lib/server/profile.js';
+import { parseJson, publicUser } from '../../auth/_helpers.js';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  return json({ user: publicUser(user) });
+};
+
+const patchSchema = z
+  .object({
+    displayName: z.string().trim().max(80).nullable(),
+    themePreference: z.enum(['system', 'light', 'dark']),
+  })
+  .partial()
+  .refine((v) => v.displayName !== undefined || v.themePreference !== undefined, {
+    message: 'At least one field (displayName, themePreference) must be provided',
+  });
+
+export const PATCH: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  const patch = await parseJson(event.request, patchSchema);
+  const updated = await updateUserProfile(user.id, patch);
+  return json({ user: publicUser(updated) });
+};

--- a/apps/web/src/routes/page-server.test.ts
+++ b/apps/web/src/routes/page-server.test.ts
@@ -26,10 +26,10 @@ describe('root +page.server.ts load', () => {
     const data = await load({ locals: {} } as Parameters<typeof load>[0]);
     expect(data.nlpStatus).toBe('ok');
     expect(data.nlpLanguages).toEqual(['hi', 'mr', 'or']);
-    expect(data.languages.map((l) => l.code).sort()).toEqual(['hi', 'mr', 'or']);
-    const hi = data.languages.find((l) => l.code === 'hi');
+    expect(data.languages.map((l: { code: string }) => l.code).sort()).toEqual(['hi', 'mr', 'or']);
+    const hi = data.languages.find((l: { code: string }) => l.code === 'hi');
     expect(hi?.script).toBe('Deva');
-    const or = data.languages.find((l) => l.code === 'or');
+    const or = data.languages.find((l: { code: string }) => l.code === 'or');
     expect(or?.script).toBe('Orya');
     expect(data.user).toBeNull();
   });

--- a/apps/web/src/routes/profile/+page.server.ts
+++ b/apps/web/src/routes/profile/+page.server.ts
@@ -1,0 +1,133 @@
+import { fail, redirect } from '@sveltejs/kit';
+import { z } from 'zod';
+import {
+  listUserLanguages,
+  updateUserProfile,
+  upsertUserLanguage,
+  withDefaultsForAllLanguages,
+} from '$lib/server/profile.js';
+import {
+  LANGUAGES,
+  SUPPORTED_LANGUAGE_CODES,
+  isSupportedLanguage,
+} from '@ciareader/shared-types';
+import type { Actions, PageServerLoad } from './$types';
+
+const profileFormSchema = z.object({
+  displayName: z
+    .string()
+    .trim()
+    .max(80)
+    .transform((s) => (s.length === 0 ? null : s))
+    .nullable(),
+  themePreference: z.enum(['system', 'light', 'dark']),
+});
+
+const languageFormSchema = z.object({
+  code: z.string(),
+  scriptPreference: z.enum(['native', 'native_with_romanization', 'romanization_only']),
+  romanizationScheme: z.enum(['iso15919', 'iast', 'hunterian', 'itrans']),
+});
+
+export const load: PageServerLoad = async ({ locals }) => {
+  if (!locals.user) throw redirect(303, '/login?next=/profile');
+
+  const persisted = await listUserLanguages(locals.user.id);
+  return {
+    user: {
+      id: locals.user.id,
+      email: locals.user.email,
+      displayName: locals.user.displayName,
+      role: locals.user.role,
+      themePreference: locals.user.themePreference,
+    },
+    languages: withDefaultsForAllLanguages(persisted).map((row) => ({
+      ...row,
+      displayName: LANGUAGES[row.code].displayName,
+      nativeName: LANGUAGES[row.code].nativeName,
+      script: LANGUAGES[row.code].script,
+      supportedRomanizations: LANGUAGES[row.code].supportedRomanizations,
+    })),
+  };
+};
+
+// All action responses carry a `section` tag so the Svelte template can narrow
+// ok vs. error variants by section without juggling separate union members.
+type ProfileActionResult =
+  | { ok: true; section: 'profile' }
+  | { ok: false; section: 'profile'; message: string };
+type LanguageActionResult =
+  | { ok: true; section: 'language'; code: string }
+  | { ok: false; section: 'language'; code: string | null; message: string };
+
+export const actions: Actions = {
+  updateProfile: async ({ request, locals }) => {
+    if (!locals.user) {
+      return fail(401, {
+        ok: false,
+        section: 'profile',
+        message: 'Unauthorized',
+      } satisfies ProfileActionResult);
+    }
+    const form = Object.fromEntries(await request.formData());
+    const parsed = profileFormSchema.safeParse(form);
+    if (!parsed.success) {
+      return fail(400, {
+        ok: false,
+        section: 'profile',
+        message: parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; '),
+      } satisfies ProfileActionResult);
+    }
+    await updateUserProfile(locals.user.id, parsed.data);
+    return { ok: true, section: 'profile' } satisfies ProfileActionResult;
+  },
+
+  updateLanguage: async ({ request, locals }) => {
+    if (!locals.user) {
+      return fail(401, {
+        ok: false,
+        section: 'language',
+        code: null,
+        message: 'Unauthorized',
+      } satisfies LanguageActionResult);
+    }
+    const form = Object.fromEntries(await request.formData());
+    const parsed = languageFormSchema.safeParse(form);
+    if (!parsed.success) {
+      return fail(400, {
+        ok: false,
+        section: 'language',
+        code: (form.code as string | undefined) ?? null,
+        message: parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; '),
+      } satisfies LanguageActionResult);
+    }
+    if (!isSupportedLanguage(parsed.data.code)) {
+      return fail(400, {
+        ok: false,
+        section: 'language',
+        code: parsed.data.code,
+        message: `Unsupported language '${parsed.data.code}'. Supported: ${SUPPORTED_LANGUAGE_CODES.join(', ')}`,
+      } satisfies LanguageActionResult);
+    }
+    // Reject romanization schemes the registry says this language doesn't support.
+    // Otherwise a user could set Odia to a scheme the registry doesn't advertise for it.
+    const allowed = LANGUAGES[parsed.data.code].supportedRomanizations;
+    if (!(allowed as readonly string[]).includes(parsed.data.romanizationScheme)) {
+      return fail(400, {
+        ok: false,
+        section: 'language',
+        code: parsed.data.code,
+        message: `Romanization '${parsed.data.romanizationScheme}' is not supported for ${parsed.data.code}. Allowed: ${allowed.join(', ')}`,
+      } satisfies LanguageActionResult);
+    }
+    await upsertUserLanguage(locals.user.id, parsed.data.code, {
+      scriptPreference: parsed.data.scriptPreference,
+      romanizationScheme: parsed.data.romanizationScheme,
+    });
+    return {
+      ok: true,
+      section: 'language',
+      code: parsed.data.code,
+    } satisfies LanguageActionResult;
+  },
+};

--- a/apps/web/src/routes/profile/+page.svelte
+++ b/apps/web/src/routes/profile/+page.svelte
@@ -1,0 +1,230 @@
+<script lang="ts">
+  import { enhance } from '$app/forms';
+  import type { ActionData, PageData } from './$types';
+
+  let { data, form }: { data: PageData; form: ActionData } = $props();
+
+  const SCRIPT_PREF_LABELS: Record<string, string> = {
+    native: 'Native script only',
+    native_with_romanization: 'Native script + inline romanization',
+    romanization_only: 'Romanization only',
+  };
+
+  const ROMAN_LABELS: Record<string, string> = {
+    iso15919: 'ISO 15919',
+    iast: 'IAST',
+    hunterian: 'Hunterian',
+    itrans: 'ITRANS',
+  };
+</script>
+
+<svelte:head>
+  <title>Profile — CIA Reader</title>
+</svelte:head>
+
+<main>
+  <h1>Profile</h1>
+
+  <section>
+    <h2>Account</h2>
+    <form method="POST" action="?/updateProfile" use:enhance>
+      <label>
+        <span>Email</span>
+        <input type="email" value={data.user.email} readonly aria-readonly="true" />
+      </label>
+      <label>
+        <span>Display name</span>
+        <input
+          type="text"
+          name="displayName"
+          value={data.user.displayName ?? ''}
+          maxlength="80"
+          placeholder="How should we address you?"
+        />
+      </label>
+      <fieldset>
+        <legend>Theme</legend>
+        {#each ['system', 'light', 'dark'] as theme}
+          <label class="radio">
+            <input
+              type="radio"
+              name="themePreference"
+              value={theme}
+              checked={data.user.themePreference === theme}
+            />
+            <span class="capitalize">{theme}</span>
+          </label>
+        {/each}
+      </fieldset>
+      <button type="submit">Save account</button>
+      {#if form && form.section === 'profile' && form.ok}
+        <p class="ok" role="status">Saved.</p>
+      {:else if form && form.section === 'profile' && !form.ok}
+        <p class="err" role="alert">{form.message}</p>
+      {/if}
+    </form>
+  </section>
+
+  <section>
+    <h2>Languages</h2>
+    <p class="muted">
+      Per-language reading preferences. These defaults take effect the first time you open a
+      text in that language.
+    </p>
+    {#each data.languages as lang}
+      <form method="POST" action="?/updateLanguage" use:enhance class="lang-form">
+        <header>
+          <h3>
+            <span class="native">{lang.nativeName}</span>
+            <span class="muted">({lang.displayName} — {lang.script})</span>
+          </h3>
+          {#if lang.isDefault}
+            <span class="muted small">Using defaults</span>
+          {/if}
+        </header>
+        <input type="hidden" name="code" value={lang.code} />
+        <label>
+          <span>Script preference</span>
+          <select name="scriptPreference">
+            {#each ['native', 'native_with_romanization', 'romanization_only'] as pref}
+              <option value={pref} selected={lang.scriptPreference === pref}>
+                {SCRIPT_PREF_LABELS[pref]}
+              </option>
+            {/each}
+          </select>
+        </label>
+        <label>
+          <span>Romanization scheme</span>
+          <select name="romanizationScheme">
+            {#each lang.supportedRomanizations as scheme}
+              <option value={scheme} selected={lang.romanizationScheme === scheme}>
+                {ROMAN_LABELS[scheme] ?? scheme}
+              </option>
+            {/each}
+          </select>
+        </label>
+        <button type="submit">Save {lang.displayName}</button>
+        {#if form && form.section === 'language' && form.code === lang.code && form.ok}
+          <p class="ok" role="status">Saved.</p>
+        {:else if form && form.section === 'language' && form.code === lang.code && !form.ok}
+          <p class="err" role="alert">{form.message}</p>
+        {/if}
+      </form>
+    {/each}
+  </section>
+</main>
+
+<style>
+  main {
+    max-width: 48rem;
+    margin: 0 auto;
+    padding: 2rem 1.25rem;
+  }
+  h1 {
+    margin: 0 0 1rem;
+  }
+  h2 {
+    font-size: 1.1rem;
+    margin: 1.75rem 0 0.5rem;
+    color: var(--muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  h3 {
+    font-size: 1rem;
+    margin: 0;
+  }
+  section {
+    border-top: 1px solid var(--border);
+    padding-top: 1rem;
+  }
+  form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    max-width: 32rem;
+  }
+  .lang-form {
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1rem;
+    margin: 0.75rem 0;
+  }
+  .lang-form header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    margin-bottom: 0.5rem;
+  }
+  label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-size: 0.9rem;
+  }
+  label.radio {
+    flex-direction: row;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 1rem;
+    padding: 0.35rem 0;
+  }
+  fieldset {
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.5rem 0.75rem;
+  }
+  legend {
+    padding: 0 0.4rem;
+    color: var(--muted);
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  input[type='text'],
+  input[type='email'],
+  select {
+    padding: 0.55rem 0.75rem;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--bg);
+    color: var(--fg);
+    font: inherit;
+    min-height: 44px;
+  }
+  input[readonly] {
+    color: var(--muted);
+  }
+  button {
+    align-self: flex-start;
+    padding: 0.6rem 1rem;
+    background: var(--accent);
+    color: white;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    font: inherit;
+    min-height: 44px;
+  }
+  .muted {
+    color: var(--muted);
+  }
+  .small {
+    font-size: 0.8rem;
+  }
+  .native {
+    font-size: 1.1rem;
+    margin-right: 0.3rem;
+  }
+  .capitalize {
+    text-transform: capitalize;
+  }
+  .ok {
+    color: #059669;
+    margin: 0;
+  }
+  .err {
+    color: #dc2626;
+    margin: 0;
+  }
+</style>

--- a/apps/web/src/routes/profile/profile-server.test.ts
+++ b/apps/web/src/routes/profile/profile-server.test.ts
@@ -1,0 +1,192 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const listUserLanguages = vi.fn();
+const updateUserProfile = vi.fn();
+const upsertUserLanguage = vi.fn();
+
+vi.mock('$lib/server/profile.js', () => ({
+  listUserLanguages: (...a: unknown[]) => listUserLanguages(...a),
+  updateUserProfile: (...a: unknown[]) => updateUserProfile(...a),
+  upsertUserLanguage: (...a: unknown[]) => upsertUserLanguage(...a),
+  withDefaultsForAllLanguages: (rows: unknown[]) =>
+    // Keep test fixtures stable: pass through with `isDefault: false` for
+    // every persisted row and nothing more. The full fallback/merge logic is
+    // covered separately in profile.test.ts.
+    (rows as Array<Record<string, unknown>>).map((r) => ({
+      code: r.language,
+      scriptPreference: r.scriptPreference,
+      romanizationScheme: r.romanizationScheme,
+      isDefault: false,
+    })),
+}));
+
+type LoadFn = (typeof import('./+page.server.js'))['load'];
+type LoadEvent = Parameters<LoadFn>[0];
+
+type ActionsModule = (typeof import('./+page.server.js'))['actions'];
+type ActionFn = NonNullable<ActionsModule[keyof ActionsModule]>;
+type ActionEvent = Parameters<ActionFn>[0];
+
+async function loadActions() {
+  const mod = await import('./+page.server.js');
+  return {
+    updateProfile: mod.actions.updateProfile as ActionFn,
+    updateLanguage: mod.actions.updateLanguage as ActionFn,
+  };
+}
+
+function formEvent(fields: Record<string, string>, locals: Record<string, unknown> = {}) {
+  const body = new URLSearchParams(fields);
+  return {
+    request: new Request('http://x/profile', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    }),
+    locals,
+  } as unknown as ActionEvent;
+}
+
+describe('profile +page.server.ts', () => {
+  beforeEach(() => {
+    listUserLanguages.mockReset();
+    updateUserProfile.mockReset();
+    upsertUserLanguage.mockReset();
+  });
+
+  afterEach(() => vi.resetModules());
+
+  describe('load', () => {
+    it('redirects to /login when unauthenticated', async () => {
+      const { load } = await import('./+page.server.js');
+      await expect(
+        load({ locals: {} } as unknown as LoadEvent),
+      ).rejects.toMatchObject({ status: 303 });
+    });
+
+    it('returns user + language rows (persisted + defaulted) when authenticated', async () => {
+      listUserLanguages.mockResolvedValue([
+        { language: 'hi', scriptPreference: 'native', romanizationScheme: 'iso15919' },
+      ]);
+      const { load } = await import('./+page.server.js');
+      const data = await load({
+        locals: {
+          user: {
+            id: 'u1',
+            email: 'a@b.c',
+            displayName: null,
+            role: 'user',
+            themePreference: 'system',
+          },
+        },
+      } as unknown as LoadEvent);
+      expect(data.user?.id).toBe('u1');
+      expect(data.languages).toHaveLength(1);
+      expect(data.languages[0]?.code).toBe('hi');
+      expect(data.languages[0]?.displayName).toBe('Hindi');
+      expect(data.languages[0]?.supportedRomanizations).toContain('iso15919');
+    });
+  });
+
+  describe('updateProfile action', () => {
+    it('rejects with 401 when unauthenticated', async () => {
+      const actions = await loadActions();
+      const result = await actions.updateProfile(
+        formEvent({ displayName: 'X', themePreference: 'dark' }),
+      );
+      expect(result).toMatchObject({ status: 401, data: { ok: false } });
+    });
+
+    it('persists a valid patch', async () => {
+      updateUserProfile.mockResolvedValue({ id: 'u1' });
+      const actions = await loadActions();
+      const result = await actions.updateProfile(
+        formEvent(
+          { displayName: 'Alex', themePreference: 'dark' },
+          { user: { id: 'u1' } },
+        ),
+      );
+      expect(result).toMatchObject({ ok: true, section: 'profile' });
+      expect(updateUserProfile).toHaveBeenCalledWith('u1', {
+        displayName: 'Alex',
+        themePreference: 'dark',
+      });
+    });
+
+    it('normalizes an empty displayName to null', async () => {
+      updateUserProfile.mockResolvedValue({ id: 'u1' });
+      const actions = await loadActions();
+      await actions.updateProfile(
+        formEvent({ displayName: '   ', themePreference: 'system' }, { user: { id: 'u1' } }),
+      );
+      expect(updateUserProfile).toHaveBeenCalledWith('u1', {
+        displayName: null,
+        themePreference: 'system',
+      });
+    });
+
+    it('returns 400 when themePreference is invalid', async () => {
+      const actions = await loadActions();
+      const result = await actions.updateProfile(
+        formEvent({ displayName: 'Alex', themePreference: 'chartreuse' }, { user: { id: 'u1' } }),
+      );
+      expect(result).toMatchObject({ status: 400, data: { ok: false } });
+    });
+  });
+
+  describe('updateLanguage action', () => {
+    it('rejects an unsupported language code', async () => {
+      const actions = await loadActions();
+      const result = await actions.updateLanguage(
+        formEvent(
+          {
+            code: 'xx',
+            scriptPreference: 'native',
+            romanizationScheme: 'iso15919',
+          },
+          { user: { id: 'u1' } },
+        ),
+      );
+      expect(result).toMatchObject({ status: 400, data: { ok: false } });
+      expect(upsertUserLanguage).not.toHaveBeenCalled();
+    });
+
+    it("rejects a romanization scheme the language doesn't support", async () => {
+      // Odia's supported schemes are iso15919, iast, itrans — hunterian is not in the list.
+      const actions = await loadActions();
+      const result = await actions.updateLanguage(
+        formEvent(
+          {
+            code: 'or',
+            scriptPreference: 'native',
+            romanizationScheme: 'hunterian',
+          },
+          { user: { id: 'u1' } },
+        ),
+      );
+      expect(result).toMatchObject({ status: 400, data: { ok: false } });
+      expect(upsertUserLanguage).not.toHaveBeenCalled();
+    });
+
+    it('persists a valid per-language patch', async () => {
+      upsertUserLanguage.mockResolvedValue({ language: 'hi' });
+      const actions = await loadActions();
+      const result = await actions.updateLanguage(
+        formEvent(
+          {
+            code: 'hi',
+            scriptPreference: 'romanization_only',
+            romanizationScheme: 'iast',
+          },
+          { user: { id: 'u1' } },
+        ),
+      );
+      expect(result).toMatchObject({ ok: true, section: 'language', code: 'hi' });
+      expect(upsertUserLanguage).toHaveBeenCalledWith('u1', 'hi', {
+        scriptPreference: 'romanization_only',
+        romanizationScheme: 'iast',
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- `/profile` page with form actions for display name, theme preference, and per-language preferences (script preference, romanization scheme).
- New `user_languages` table backing per-(user, language) preferences, with a language-registry-aware fallback for untouched languages.
- JSON endpoints `GET /api/v1/me/profile`, `PATCH /api/v1/me/profile`, `GET /api/v1/me/languages`, `PATCH /api/v1/me/languages/:code` — same capability for mobile/API clients per the plan's API-first rule.
- 18 new unit tests; overall web coverage now 53% (≥40% floor).

## Test plan

- [ ] `pnpm --filter @ciareader/web run lint`
- [ ] `pnpm --filter @ciareader/web run check`
- [ ] `pnpm --filter @ciareader/web run test:coverage`
- [ ] Log in, visit `/profile`, edit display name + theme, verify persistence.
- [ ] Change per-language prefs (Hindi → ITRANS, Odia → IAST is rejected, Odia → ISO 15919 succeeds).
- [ ] `curl` the JSON endpoints with a bearer token and verify the same shape.

Base: `feat/t-1.1-auth` (stacked PR, closes #10 once merged)