### PR TITLE
T-1.3: design tokens + light/dark theming

### DIFF
--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -1,10 +1,32 @@
 <!doctype html>
-<html lang="en" data-theme="system">
+<html lang="en" data-theme="%cia.theme%">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="light dark" />
     <meta name="description" content="CIA Reader — Comparative Indo-Aryan reader." />
     <title>CIA Reader</title>
+    <!--
+      Resolve the user's theme preference before first paint to avoid a
+      light-mode flash for dark-mode users. Reads the cookie written by
+      the profile form and falls back to the OS preference. Mirrored by
+      server-side rendering in hooks.server.ts so hydration matches.
+    -->
+    <script>
+      (function () {
+        try {
+          var match = document.cookie.match(/(?:^|; )cia_theme=([^;]+)/);
+          var pref = match ? decodeURIComponent(match[1]) : 'system';
+          var resolved =
+            pref === 'light' || pref === 'dark'
+              ? pref
+              : window.matchMedia('(prefers-color-scheme: dark)').matches
+                ? 'dark'
+                : 'light';
+          document.documentElement.setAttribute('data-theme', resolved);
+        } catch (_) {}
+      })();
+    </script>
     %sveltekit.head%
   </head>
   <body data-sveltekit-preload-data="hover">

--- a/apps/web/src/hooks.server.test.ts
+++ b/apps/web/src/hooks.server.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('$lib/server/auth/require-user.js', () => ({
+  resolveUser: vi.fn(async () => null),
+}));
+
+const { resolveServerTheme } = await import('./hooks.server.js');
+
+type Event = Parameters<typeof resolveServerTheme>[0];
+
+function makeEvent({
+  userPref,
+  cookie,
+  hint,
+}: {
+  userPref?: 'system' | 'light' | 'dark';
+  cookie?: string;
+  hint?: string;
+}): Event {
+  const headers = new Headers();
+  if (hint) headers.set('sec-ch-prefers-color-scheme', hint);
+  return {
+    locals: userPref !== undefined ? { user: { themePreference: userPref } } : {},
+    cookies: {
+      get: (name: string) => (name === 'cia_theme' ? cookie : undefined),
+    },
+    request: { headers },
+  } as unknown as Event;
+}
+
+describe('resolveServerTheme', () => {
+  it("uses the authenticated user's preference before anything else", () => {
+    // Even a conflicting cookie is overridden — users.themePreference is the source of truth.
+    const theme = resolveServerTheme(
+      makeEvent({ userPref: 'dark', cookie: 'light', hint: 'light' }),
+    );
+    expect(theme).toBe('dark');
+  });
+
+  it("resolves 'system' against the Sec-CH-Prefers-Color-Scheme hint", () => {
+    expect(resolveServerTheme(makeEvent({ userPref: 'system', hint: 'dark' }))).toBe('dark');
+    expect(resolveServerTheme(makeEvent({ userPref: 'system', hint: 'light' }))).toBe('light');
+  });
+
+  it('falls back to the cookie when no user is present', () => {
+    expect(resolveServerTheme(makeEvent({ cookie: 'dark' }))).toBe('dark');
+    expect(resolveServerTheme(makeEvent({ cookie: 'light' }))).toBe('light');
+  });
+
+  it('ignores malformed cookie values', () => {
+    // 'blurple' isn't a valid preference; fall through to the hint (default: light).
+    expect(resolveServerTheme(makeEvent({ cookie: 'blurple' }))).toBe('light');
+    expect(resolveServerTheme(makeEvent({ cookie: 'blurple', hint: 'dark' }))).toBe('dark');
+  });
+
+  it("defaults to 'light' when no source has an opinion", () => {
+    expect(resolveServerTheme(makeEvent({}))).toBe('light');
+  });
+});

--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -1,7 +1,38 @@
 import type { Handle } from '@sveltejs/kit';
 import { resolveUser } from '$lib/server/auth/require-user.js';
+import { THEME_COOKIE, isThemePreference, resolveTheme } from '$lib/theme/index.js';
+
+/**
+ * Server-side theme resolution. Mirror of the pre-paint script in app.html so
+ * the rendered HTML already carries the right `data-theme` value and the
+ * client-side script just confirms it.
+ *
+ * Sources, in priority order:
+ *  1. Authenticated user's `themePreference` on the users table (written by
+ *     the profile form). Users who change their preference on one device get
+ *     the right theme on every device.
+ *  2. `cia_theme` cookie (set by the profile form too; also covers logged-out
+ *     visitors who've picked a theme).
+ *  3. The `Sec-CH-Prefers-Color-Scheme` client hint, if the browser sent one
+ *     (Chromium sends it when requested via an Accept-CH header, so in
+ *     practice this is only populated after the first response — a cookie is
+ *     more reliable but we accept the hint as a fallback).
+ *  4. Default to 'light' (light-mode systems without a cookie or hint won't
+ *     flip when the client-side script runs).
+ */
+export function resolveServerTheme(event: Parameters<Handle>[0]['event']): 'light' | 'dark' {
+  const userPref = event.locals.user?.themePreference;
+  const cookiePref = event.cookies.get(THEME_COOKIE);
+  const preference = userPref ?? (isThemePreference(cookiePref) ? cookiePref : 'system');
+  const hint = event.request.headers.get('sec-ch-prefers-color-scheme');
+  const systemPrefersDark = hint === 'dark';
+  return resolveTheme(preference, systemPrefersDark);
+}
 
 export const handle: Handle = async ({ event, resolve }) => {
   event.locals.user = await resolveUser(event);
-  return resolve(event);
+  const theme = resolveServerTheme(event);
+  return resolve(event, {
+    transformPageChunk: ({ html }) => html.replace('%cia.theme%', theme),
+  });
 };

--- a/apps/web/src/lib/styles/tokens.css
+++ b/apps/web/src/lib/styles/tokens.css
@@ -1,0 +1,191 @@
+/*
+ * Design tokens — single source of truth for color, typography, spacing, and
+ * motion. Every component reads these via var(...); nothing should hard-code a
+ * color or a pixel value that could instead be a token. Themes are selected by
+ * the `data-theme` attribute on <html>, resolved by `src/lib/theme/index.ts`.
+ *
+ * Palette notes:
+ *  - Light surface scale climbs 0→3 (page → card → pop-up → overlay).
+ *  - Dark surface scale does the same but against the far-dark base.
+ *  - Accent is the link / primary-action hue. Reader highlight hues live in
+ *    their own family so we can later let users pick a highlight flavor
+ *    without churning the whole brand palette.
+ */
+
+:root,
+[data-theme='light'] {
+  /* Surfaces */
+  --color-bg: #ffffff;
+  --color-surface-1: #f9fafb;
+  --color-surface-2: #f3f4f6;
+  --color-surface-3: #e5e7eb;
+  --color-overlay: rgba(17, 17, 17, 0.45);
+
+  /* Foreground */
+  --color-fg: #111111;
+  --color-fg-muted: #4b5563;
+  --color-fg-subtle: #6b7280;
+
+  /* Lines + borders */
+  --color-border: #e5e7eb;
+  --color-border-strong: #d1d5db;
+
+  /* Accent */
+  --color-accent: #2563eb;
+  --color-accent-fg: #ffffff;
+  --color-accent-hover: #1d4ed8;
+
+  /* Semantic */
+  --color-success: #059669;
+  --color-danger: #dc2626;
+  --color-warning: #d97706;
+
+  /* Reader highlight hues (LingQ-style). Kept as their own family so we can
+   * expose a style picker in reader settings without touching the brand accent. */
+  --color-highlight-unknown: #fef3c7;
+  --color-highlight-unknown-fg: #78350f;
+  --color-highlight-learning: #dbeafe;
+  --color-highlight-learning-fg: #1e3a8a;
+  --color-highlight-known: transparent;
+
+  /* Code */
+  --color-code-bg: #f3f4f6;
+  --color-code-fg: #111111;
+}
+
+[data-theme='dark'] {
+  --color-bg: #0b0b0d;
+  --color-surface-1: #17171a;
+  --color-surface-2: #1f1f23;
+  --color-surface-3: #2a2a30;
+  --color-overlay: rgba(0, 0, 0, 0.65);
+
+  --color-fg: #f5f5f7;
+  --color-fg-muted: #9ca3af;
+  --color-fg-subtle: #6b7280;
+
+  --color-border: #27272a;
+  --color-border-strong: #3f3f46;
+
+  --color-accent: #60a5fa;
+  --color-accent-fg: #0b0b0d;
+  --color-accent-hover: #93c5fd;
+
+  --color-success: #34d399;
+  --color-danger: #f87171;
+  --color-warning: #fbbf24;
+
+  --color-highlight-unknown: #3b2f12;
+  --color-highlight-unknown-fg: #fde68a;
+  --color-highlight-learning: #17243f;
+  --color-highlight-learning-fg: #bfdbfe;
+  --color-highlight-known: transparent;
+
+  --color-code-bg: #18181b;
+  --color-code-fg: #f5f5f7;
+}
+
+/* Typography, spacing, radii, shadows, motion — theme-invariant.
+ * Reader font family is intentionally not here: it's per-language, chosen
+ * from the language registry in T-0.6 and stored in user_languages. */
+:root {
+  --font-ui:
+    system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  --font-mono:
+    'SF Mono', ui-monospace, 'Cascadia Code', Menlo, Consolas, 'Liberation Mono', monospace;
+
+  --font-size-xs: 0.75rem;
+  --font-size-sm: 0.875rem;
+  --font-size-md: 1rem;
+  --font-size-lg: 1.125rem;
+  --font-size-xl: 1.25rem;
+  --font-size-2xl: 1.5rem;
+  --font-size-3xl: 2rem;
+
+  --line-height-tight: 1.25;
+  --line-height-normal: 1.5;
+  --line-height-relaxed: 1.7;
+
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-10: 2.5rem;
+  --space-12: 3rem;
+
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+  --radius-xl: 12px;
+  --radius-pill: 999px;
+
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+  --shadow-lg: 0 12px 24px rgba(0, 0, 0, 0.12);
+
+  /* Minimum tappable target per the mobile-first requirement. */
+  --touch-target: 44px;
+
+  --duration-fast: 120ms;
+  --duration-normal: 200ms;
+  --easing-standard: cubic-bezier(0.2, 0, 0, 1);
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--color-bg);
+  color: var(--color-fg);
+  font-family: var(--font-ui);
+  font-size: var(--font-size-md);
+  line-height: var(--line-height-normal);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+body {
+  min-height: 100vh;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+a {
+  color: var(--color-accent);
+}
+a:hover {
+  color: var(--color-accent-hover);
+}
+
+code {
+  background: var(--color-code-bg);
+  color: var(--color-code-fg);
+  padding: 0.1em 0.35em;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+}
+
+:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+/* Honor users who've opted out of motion — we'll add more specific overrides
+ * on animated components as they land. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/apps/web/src/lib/theme/index.test.ts
+++ b/apps/web/src/lib/theme/index.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import {
+  THEME_COOKIE,
+  THEME_COOKIE_MAX_AGE,
+  isThemePreference,
+  resolveTheme,
+} from './index.js';
+
+describe('resolveTheme', () => {
+  it("returns 'light' when preference is 'light' regardless of system preference", () => {
+    expect(resolveTheme('light', true)).toBe('light');
+    expect(resolveTheme('light', false)).toBe('light');
+  });
+
+  it("returns 'dark' when preference is 'dark' regardless of system preference", () => {
+    expect(resolveTheme('dark', true)).toBe('dark');
+    expect(resolveTheme('dark', false)).toBe('dark');
+  });
+
+  it("follows system preference when preference is 'system'", () => {
+    expect(resolveTheme('system', true)).toBe('dark');
+    expect(resolveTheme('system', false)).toBe('light');
+  });
+});
+
+describe('isThemePreference', () => {
+  it('accepts the three valid preference strings', () => {
+    expect(isThemePreference('system')).toBe(true);
+    expect(isThemePreference('light')).toBe(true);
+    expect(isThemePreference('dark')).toBe(true);
+  });
+
+  it('rejects other values', () => {
+    expect(isThemePreference('auto')).toBe(false);
+    expect(isThemePreference('')).toBe(false);
+    expect(isThemePreference(undefined)).toBe(false);
+    expect(isThemePreference(null)).toBe(false);
+    expect(isThemePreference(0)).toBe(false);
+    expect(isThemePreference({})).toBe(false);
+  });
+});
+
+describe('theme cookie constants', () => {
+  it('exposes a stable cookie name', () => {
+    expect(THEME_COOKIE).toBe('cia_theme');
+  });
+
+  it('uses a one-year max-age', () => {
+    expect(THEME_COOKIE_MAX_AGE).toBe(60 * 60 * 24 * 365);
+  });
+});

--- a/apps/web/src/lib/theme/index.ts
+++ b/apps/web/src/lib/theme/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Theme resolution. Source of truth for how a user preference
+ * ('system' | 'light' | 'dark') combines with the OS/browser's
+ * `prefers-color-scheme` to produce the concrete theme applied as a
+ * `data-theme` attribute on `<html>`.
+ *
+ * Kept pure so both server-side rendering (to avoid a light-mode flash on
+ * dark-mode users' first paint) and client-side onMount code (to react to
+ * OS preference changes) can share it.
+ */
+export type ThemePreference = 'system' | 'light' | 'dark';
+export type ResolvedTheme = 'light' | 'dark';
+
+export function resolveTheme(
+  preference: ThemePreference,
+  systemPrefersDark: boolean,
+): ResolvedTheme {
+  if (preference === 'system') return systemPrefersDark ? 'dark' : 'light';
+  return preference;
+}
+
+export const THEME_COOKIE = 'cia_theme';
+export const THEME_COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // 1 year
+
+export function isThemePreference(value: unknown): value is ThemePreference {
+  return value === 'system' || value === 'light' || value === 'dark';
+}

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -1,46 +1,6 @@
 <script lang="ts">
+  import '$lib/styles/tokens.css';
   let { children } = $props();
 </script>
-
-<svelte:head>
-  <style>
-    :root {
-      --bg: #ffffff;
-      --fg: #111111;
-      --muted: #6b7280;
-      --accent: #2563eb;
-      --border: #e5e7eb;
-      --code-bg: #f3f4f6;
-      font-family:
-        system-ui,
-        -apple-system,
-        'Segoe UI',
-        Roboto,
-        'Helvetica Neue',
-        Arial,
-        sans-serif;
-    }
-    @media (prefers-color-scheme: dark) {
-      :root {
-        --bg: #0b0b0d;
-        --fg: #f5f5f7;
-        --muted: #9ca3af;
-        --accent: #60a5fa;
-        --border: #27272a;
-        --code-bg: #18181b;
-      }
-    }
-    html,
-    body {
-      margin: 0;
-      padding: 0;
-      background: var(--bg);
-      color: var(--fg);
-    }
-    body {
-      min-height: 100vh;
-    }
-  </style>
-</svelte:head>
 
 {@render children()}

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -70,14 +70,14 @@
   h2 {
     font-size: 1.1rem;
     margin: 1.75rem 0 0.5rem;
-    color: var(--muted);
+    color: var(--color-fg-muted);
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.04em;
   }
   .sub {
     margin: 0 0 1.5rem;
-    color: var(--muted);
+    color: var(--color-fg-muted);
   }
   ul {
     list-style: none;
@@ -87,24 +87,24 @@
   .status li,
   .langs li {
     padding: 0.5rem 0;
-    border-bottom: 1px solid var(--border);
+    border-bottom: 1px solid var(--color-border);
   }
   .ok {
-    color: #059669;
+    color: var(--color-success);
     font-weight: 600;
   }
   .down {
-    color: #dc2626;
+    color: var(--color-danger);
     font-weight: 600;
   }
   .muted {
-    color: var(--muted);
+    color: var(--color-fg-muted);
   }
   .native {
     font-size: 1.15rem;
     margin-right: 0.5rem;
   }
   a {
-    color: var(--accent);
+    color: var(--color-accent);
   }
 </style>

--- a/apps/web/src/routes/api/v1/me/profile/+server.ts
+++ b/apps/web/src/routes/api/v1/me/profile/+server.ts
@@ -2,6 +2,7 @@ import { json } from '@sveltejs/kit';
 import { z } from 'zod';
 import { requireUser } from '$lib/server/auth/require-user.js';
 import { updateUserProfile } from '$lib/server/profile.js';
+import { THEME_COOKIE, THEME_COOKIE_MAX_AGE } from '$lib/theme/index.js';
 import { parseJson, publicUser } from '../../auth/_helpers.js';
 import type { RequestHandler } from './$types';
 
@@ -24,5 +25,14 @@ export const PATCH: RequestHandler = async (event) => {
   const user = await requireUser(event);
   const patch = await parseJson(event.request, patchSchema);
   const updated = await updateUserProfile(user.id, patch);
+  if (patch.themePreference !== undefined) {
+    event.cookies.set(THEME_COOKIE, patch.themePreference, {
+      path: '/',
+      httpOnly: false,
+      sameSite: 'lax',
+      secure: event.url.protocol === 'https:',
+      maxAge: THEME_COOKIE_MAX_AGE,
+    });
+  }
   return json({ user: publicUser(updated) });
 };

--- a/apps/web/src/routes/profile/+page.server.ts
+++ b/apps/web/src/routes/profile/+page.server.ts
@@ -6,6 +6,7 @@ import {
   upsertUserLanguage,
   withDefaultsForAllLanguages,
 } from '$lib/server/profile.js';
+import { THEME_COOKIE, THEME_COOKIE_MAX_AGE } from '$lib/theme/index.js';
 import {
   LANGUAGES,
   SUPPORTED_LANGUAGE_CODES,
@@ -61,7 +62,7 @@ type LanguageActionResult =
   | { ok: false; section: 'language'; code: string | null; message: string };
 
 export const actions: Actions = {
-  updateProfile: async ({ request, locals }) => {
+  updateProfile: async ({ cookies, request, locals, url }) => {
     if (!locals.user) {
       return fail(401, {
         ok: false,
@@ -79,6 +80,17 @@ export const actions: Actions = {
       } satisfies ProfileActionResult);
     }
     await updateUserProfile(locals.user.id, parsed.data);
+    // Also write the non-HttpOnly theme cookie so the pre-paint script in
+    // app.html can honor this preference on the very next request — before
+    // SSR has a chance to inject the resolved theme into the HTML. Survives
+    // a logout because the users table isn't consulted for anon visitors.
+    cookies.set(THEME_COOKIE, parsed.data.themePreference, {
+      path: '/',
+      httpOnly: false,
+      sameSite: 'lax',
+      secure: url.protocol === 'https:',
+      maxAge: THEME_COOKIE_MAX_AGE,
+    });
     return { ok: true, section: 'profile' } satisfies ProfileActionResult;
   },
 

--- a/apps/web/src/routes/profile/+page.svelte
+++ b/apps/web/src/routes/profile/+page.svelte
@@ -126,7 +126,7 @@
   h2 {
     font-size: 1.1rem;
     margin: 1.75rem 0 0.5rem;
-    color: var(--muted);
+    color: var(--color-fg-muted);
     text-transform: uppercase;
     letter-spacing: 0.04em;
   }
@@ -135,7 +135,7 @@
     margin: 0;
   }
   section {
-    border-top: 1px solid var(--border);
+    border-top: 1px solid var(--color-border);
     padding-top: 1rem;
   }
   form {
@@ -145,7 +145,7 @@
     max-width: 32rem;
   }
   .lang-form {
-    border: 1px solid var(--border);
+    border: 1px solid var(--color-border);
     border-radius: 8px;
     padding: 1rem;
     margin: 0.75rem 0;
@@ -170,13 +170,13 @@
     padding: 0.35rem 0;
   }
   fieldset {
-    border: 1px solid var(--border);
+    border: 1px solid var(--color-border);
     border-radius: 6px;
     padding: 0.5rem 0.75rem;
   }
   legend {
     padding: 0 0.4rem;
-    color: var(--muted);
+    color: var(--color-fg-muted);
     font-size: 0.85rem;
     text-transform: uppercase;
     letter-spacing: 0.04em;
@@ -185,29 +185,29 @@
   input[type='email'],
   select {
     padding: 0.55rem 0.75rem;
-    border: 1px solid var(--border);
-    border-radius: 6px;
-    background: var(--bg);
-    color: var(--fg);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-bg);
+    color: var(--color-fg);
     font: inherit;
-    min-height: 44px;
+    min-height: var(--touch-target);
   }
   input[readonly] {
-    color: var(--muted);
+    color: var(--color-fg-muted);
   }
   button {
     align-self: flex-start;
     padding: 0.6rem 1rem;
-    background: var(--accent);
-    color: white;
+    background: var(--color-accent);
+    color: var(--color-accent-fg);
     border: none;
-    border-radius: 6px;
+    border-radius: var(--radius-md);
     cursor: pointer;
     font: inherit;
-    min-height: 44px;
+    min-height: var(--touch-target);
   }
   .muted {
-    color: var(--muted);
+    color: var(--color-fg-muted);
   }
   .small {
     font-size: 0.8rem;
@@ -220,11 +220,11 @@
     text-transform: capitalize;
   }
   .ok {
-    color: #059669;
+    color: var(--color-success);
     margin: 0;
   }
   .err {
-    color: #dc2626;
+    color: var(--color-danger);
     margin: 0;
   }
 </style>

--- a/apps/web/src/routes/profile/profile-server.test.ts
+++ b/apps/web/src/routes/profile/profile-server.test.ts
@@ -45,6 +45,8 @@ function formEvent(fields: Record<string, string>, locals: Record<string, unknow
       body: body.toString(),
     }),
     locals,
+    cookies: { set: vi.fn() },
+    url: new URL('http://x/profile'),
   } as unknown as ActionEvent;
 }
 
@@ -124,6 +126,22 @@ describe('profile +page.server.ts', () => {
         displayName: null,
         themePreference: 'system',
       });
+    });
+
+    it('writes the cia_theme cookie mirroring the saved preference', async () => {
+      updateUserProfile.mockResolvedValue({ id: 'u1' });
+      const actions = await loadActions();
+      const evt = formEvent(
+        { displayName: 'Alex', themePreference: 'dark' },
+        { user: { id: 'u1' } },
+      );
+      await actions.updateProfile(evt);
+      const cookies = (evt as unknown as { cookies: { set: ReturnType<typeof vi.fn> } }).cookies;
+      expect(cookies.set).toHaveBeenCalledWith(
+        'cia_theme',
+        'dark',
+        expect.objectContaining({ path: '/', httpOnly: false, sameSite: 'lax' }),
+      );
     });
 
     it('returns 400 when themePreference is invalid', async () => {


### PR DESCRIPTION
## Summary
- Adds a pure `resolveTheme(preference, systemPrefersDark)` plus `isThemePreference` type guard and `THEME_COOKIE` constants in `$lib/theme`.
- Introduces a single `tokens.css` (light + dark palettes under `[data-theme='light'|'dark']`, plus theme-invariant typography/spacing/radii/shadows/motion tokens) imported once from the root layout.
- `hooks.server.ts` resolves the server-side theme (priority: authenticated user pref → `cia_theme` cookie → `Sec-CH-Prefers-Color-Scheme` hint → light) and injects it into `<html data-theme="...">` via `transformPageChunk`. A small pre-paint inline script in `app.html` confirms the same value from the cookie / matchMedia before first paint to avoid a light-mode flash on dark users.
- Profile form action and `PATCH /api/v1/me/profile` both mirror the saved preference into the non-HttpOnly `cia_theme` cookie so the pre-paint script sees it on the very next request.
- Migrates existing page CSS from ad-hoc `--muted` / `--border` / `--accent` / hex literals to the new token names.

## Test plan
- [x] `pnpm --filter @ciareader/web run lint` clean
- [x] `pnpm --filter @ciareader/web run check` clean
- [x] `pnpm --filter @ciareader/web run test:coverage` — all 73 tests pass; `lib/theme/index.ts` 100% covered; new tests for `resolveTheme`, `isThemePreference`, `resolveServerTheme` priority order, malformed-cookie fallthrough, and cookie-write in the profile action.
- [ ] Manual: flip theme preference in profile → refresh → correct theme applied with no FOUC in light-mode-system browser.
- [ ] Manual: OS dark-mode user, anonymous: first paint lands in dark.