### PR TITLE
T-1.5: onboarding flow — initial language + baseline

### DIFF
--- a/apps/web/drizzle/0002_yielding_blindfold.sql
+++ b/apps/web/drizzle/0002_yielding_blindfold.sql
@@ -1,0 +1,3 @@
+CREATE TYPE "public"."language_baseline" AS ENUM('none', 'beginner', 'intermediate');--> statement-breakpoint
+ALTER TABLE "user_languages" ADD COLUMN "baseline" "language_baseline" DEFAULT 'none' NOT NULL;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "onboarded_at" timestamp with time zone;

--- a/apps/web/drizzle/meta/0002_snapshot.json
+++ b/apps/web/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,588 @@
+{
+  "id": "b1f16684-1879-446d-87cd-77b4fb20fb70",
+  "prevId": "15743af0-1936-417a-9164-8623885e0470",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.magic_links": {
+      "name": "magic_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "magic_links_user_idx": {
+          "name": "magic_links_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "magic_links_expires_idx": {
+          "name": "magic_links_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "magic_links_user_id_users_id_fk": {
+          "name": "magic_links_user_id_users_id_fk",
+          "tableFrom": "magic_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by": {
+          "name": "replaced_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "refresh_tokens_user_idx": {
+          "name": "refresh_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_expires_idx": {
+          "name": "refresh_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_languages": {
+      "name": "user_languages",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script_preference": {
+          "name": "script_preference",
+          "type": "script_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "romanization_scheme": {
+          "name": "romanization_scheme",
+          "type": "romanization_scheme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'iso15919'"
+        },
+        "known_words_count_cache": {
+          "name": "known_words_count_cache",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reader_layout_mode": {
+          "name": "reader_layout_mode",
+          "type": "reader_layout_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'page'"
+        },
+        "words_per_page": {
+          "name": "words_per_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 250
+        },
+        "font_family": {
+          "name": "font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_size": {
+          "name": "font_size",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 18
+        },
+        "line_spacing": {
+          "name": "line_spacing",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1.6
+        },
+        "highlight_style": {
+          "name": "highlight_style",
+          "type": "highlight_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'background'"
+        },
+        "baseline": {
+          "name": "baseline",
+          "type": "language_baseline",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_languages_user_id_users_id_fk": {
+          "name": "user_languages_user_id_users_id_fk",
+          "tableFrom": "user_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_languages_user_id_language_pk": {
+          "name": "user_languages_user_id_language_pk",
+          "columns": [
+            "user_id",
+            "language"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_preference": {
+          "name": "theme_preference",
+          "type": "theme_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarded_at": {
+          "name": "onboarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    }
+  },
+  "enums": {
+    "public.highlight_style": {
+      "name": "highlight_style",
+      "schema": "public",
+      "values": [
+        "underline",
+        "background",
+        "colored_text"
+      ]
+    },
+    "public.language": {
+      "name": "language",
+      "schema": "public",
+      "values": [
+        "hi",
+        "mr",
+        "or"
+      ]
+    },
+    "public.language_baseline": {
+      "name": "language_baseline",
+      "schema": "public",
+      "values": [
+        "none",
+        "beginner",
+        "intermediate"
+      ]
+    },
+    "public.reader_layout_mode": {
+      "name": "reader_layout_mode",
+      "schema": "public",
+      "values": [
+        "page",
+        "paged_scroll",
+        "continuous"
+      ]
+    },
+    "public.romanization_scheme": {
+      "name": "romanization_scheme",
+      "schema": "public",
+      "values": [
+        "iso15919",
+        "iast",
+        "hunterian",
+        "itrans"
+      ]
+    },
+    "public.script_preference": {
+      "name": "script_preference",
+      "schema": "public",
+      "values": [
+        "native",
+        "native_with_romanization",
+        "romanization_only"
+      ]
+    },
+    "public.theme_preference": {
+      "name": "theme_preference",
+      "schema": "public",
+      "values": [
+        "system",
+        "light",
+        "dark"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "curator",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1776997901819,
       "tag": "0001_fancy_guardsmen",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1776998969286,
+      "tag": "0002_yielding_blindfold",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/src/hooks.server.test.ts
+++ b/apps/web/src/hooks.server.test.ts
@@ -1,11 +1,12 @@
 // @vitest-environment node
 import { describe, expect, it, vi } from 'vitest';
 
+const resolveUserMock = vi.fn(async (): Promise<unknown> => null);
 vi.mock('$lib/server/auth/require-user.js', () => ({
-  resolveUser: vi.fn(async () => null),
+  resolveUser: (...a: unknown[]) => resolveUserMock(...(a as [])),
 }));
 
-const { resolveServerTheme } = await import('./hooks.server.js');
+const { resolveServerTheme, handle } = await import('./hooks.server.js');
 
 type Event = Parameters<typeof resolveServerTheme>[0];
 
@@ -56,5 +57,42 @@ describe('resolveServerTheme', () => {
 
   it("defaults to 'light' when no source has an opinion", () => {
     expect(resolveServerTheme(makeEvent({}))).toBe('light');
+  });
+});
+
+describe('handle — onboarding redirect', () => {
+  function makeHandleEvent(pathname: string) {
+    return {
+      locals: {},
+      cookies: { get: () => undefined },
+      request: { headers: new Headers() },
+      url: new URL(`http://x${pathname}`),
+    } as unknown as Parameters<typeof handle>[0]['event'];
+  }
+
+  it('bounces a signed-in, never-onboarded user from / to /onboarding', async () => {
+    resolveUserMock.mockResolvedValueOnce({ id: 'u1', onboardedAt: null });
+    const event = makeHandleEvent('/');
+    await expect(
+      handle({ event, resolve: vi.fn(async () => new Response()) as never }),
+    ).rejects.toMatchObject({ status: 303, location: '/onboarding' });
+  });
+
+  it('does not bounce when the user is already onboarded', async () => {
+    resolveUserMock.mockResolvedValueOnce({ id: 'u1', onboardedAt: new Date() });
+    const resolve = vi.fn(async () => new Response('ok'));
+    const event = makeHandleEvent('/');
+    const res = await handle({ event, resolve: resolve as never });
+    expect(res).toBeInstanceOf(Response);
+    expect(resolve).toHaveBeenCalledOnce();
+  });
+
+  it('does not bounce on /onboarding itself (no infinite loop)', async () => {
+    resolveUserMock.mockResolvedValueOnce({ id: 'u1', onboardedAt: null });
+    const resolve = vi.fn(async () => new Response('onboarding page'));
+    const event = makeHandleEvent('/onboarding');
+    const res = await handle({ event, resolve: resolve as never });
+    expect(res).toBeInstanceOf(Response);
+    expect(resolve).toHaveBeenCalledOnce();
   });
 });

--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -1,5 +1,6 @@
-import type { Handle } from '@sveltejs/kit';
+import { redirect, type Handle } from '@sveltejs/kit';
 import { resolveUser } from '$lib/server/auth/require-user.js';
+import { shouldRedirectToOnboarding } from '$lib/server/onboarding.js';
 import { THEME_COOKIE, isThemePreference, resolveTheme } from '$lib/theme/index.js';
 
 /**
@@ -31,6 +32,9 @@ export function resolveServerTheme(event: Parameters<Handle>[0]['event']): 'ligh
 
 export const handle: Handle = async ({ event, resolve }) => {
   event.locals.user = await resolveUser(event);
+  if (shouldRedirectToOnboarding(event.locals.user, event.url.pathname)) {
+    throw redirect(303, '/onboarding');
+  }
   const theme = resolveServerTheme(event);
   return resolve(event, {
     transformPageChunk: ({ html }) => html.replace('%cia.theme%', theme),

--- a/apps/web/src/lib/server/db/schema.ts
+++ b/apps/web/src/lib/server/db/schema.ts
@@ -52,6 +52,18 @@ export const highlightStyle = pgEnum('highlight_style', [
   'colored_text',
 ]);
 
+/**
+ * Assumed-known baseline captured during onboarding. Used in a future
+ * ticket to seed `user_known_lemmas` against frequency_rank buckets —
+ * `beginner` pre-marks the top-100 most-frequent lemmas as 'known',
+ * `intermediate` the top-1000. At MVP we persist the choice only.
+ */
+export const languageBaseline = pgEnum('language_baseline', [
+  'none',
+  'beginner',
+  'intermediate',
+]);
+
 export const users = pgTable(
   'users',
   {
@@ -62,6 +74,7 @@ export const users = pgTable(
     displayName: text('display_name'),
     themePreference: themePreference('theme_preference').notNull().default('system'),
     emailVerifiedAt: timestamp('email_verified_at', { withTimezone: true }),
+    onboardedAt: timestamp('onboarded_at', { withTimezone: true }),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },
@@ -161,6 +174,7 @@ export const userLanguages = pgTable(
     fontSize: real('font_size').notNull().default(18),
     lineSpacing: real('line_spacing').notNull().default(1.6),
     highlightStyle: highlightStyle('highlight_style').notNull().default('background'),
+    baseline: languageBaseline('baseline').notNull().default('none'),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },

--- a/apps/web/src/lib/server/onboarding.test.ts
+++ b/apps/web/src/lib/server/onboarding.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type ChainShape = {
+  from: ReturnType<typeof vi.fn>;
+  where: ReturnType<typeof vi.fn>;
+  values: ReturnType<typeof vi.fn>;
+  set: ReturnType<typeof vi.fn>;
+  onConflictDoUpdate: ReturnType<typeof vi.fn>;
+  returning: ReturnType<typeof vi.fn>;
+};
+
+const chain: ChainShape = {
+  from: vi.fn(() => chain),
+  where: vi.fn(() => chain),
+  values: vi.fn(() => chain),
+  set: vi.fn(() => chain),
+  onConflictDoUpdate: vi.fn(() => chain),
+  returning: vi.fn(() => [] as unknown[]),
+};
+
+const fakeDb = {
+  insert: vi.fn(() => chain),
+  update: vi.fn(() => chain),
+};
+
+vi.mock('./db/index.js', () => ({
+  db: fakeDb,
+  schema: {
+    users: { id: 'users.id' },
+    userLanguages: { userId: 'user_id', language: 'language' },
+  },
+}));
+
+const { completeOnboarding, shouldRedirectToOnboarding } = await import('./onboarding.js');
+
+beforeEach(() => {
+  (Object.values(chain) as Array<ReturnType<typeof vi.fn>>).forEach((fn) => fn.mockClear());
+  fakeDb.insert.mockClear();
+  fakeDb.update.mockClear();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('shouldRedirectToOnboarding', () => {
+  const needsOnboarding = { onboardedAt: null };
+  const onboarded = { onboardedAt: new Date('2026-01-01') };
+
+  it('redirects a signed-in, never-onboarded user away from a normal page', () => {
+    expect(shouldRedirectToOnboarding(needsOnboarding, '/')).toBe(true);
+    expect(shouldRedirectToOnboarding(needsOnboarding, '/profile')).toBe(true);
+  });
+
+  it('does not loop on the onboarding page itself', () => {
+    expect(shouldRedirectToOnboarding(needsOnboarding, '/onboarding')).toBe(false);
+    expect(shouldRedirectToOnboarding(needsOnboarding, '/onboarding/step2')).toBe(false);
+  });
+
+  it('does not redirect API traffic (mobile / JSON clients handle onboarding their own way)', () => {
+    expect(shouldRedirectToOnboarding(needsOnboarding, '/api/v1/me/profile')).toBe(false);
+  });
+
+  it('does not redirect auth-flow pages (login, register, logout)', () => {
+    expect(shouldRedirectToOnboarding(needsOnboarding, '/login')).toBe(false);
+    expect(shouldRedirectToOnboarding(needsOnboarding, '/register')).toBe(false);
+    expect(shouldRedirectToOnboarding(needsOnboarding, '/logout')).toBe(false);
+  });
+
+  it('does nothing when the user is already onboarded', () => {
+    expect(shouldRedirectToOnboarding(onboarded, '/')).toBe(false);
+  });
+
+  it('does nothing for anonymous visitors', () => {
+    expect(shouldRedirectToOnboarding(null, '/')).toBe(false);
+  });
+});
+
+describe('completeOnboarding', () => {
+  it('upserts a user_languages row and stamps users.onboardedAt', async () => {
+    // First call (insert...returning) → language row; second (update...returning) → user row.
+    chain.returning
+      .mockReturnValueOnce([{ userId: 'u1', language: 'hi', baseline: 'beginner' }])
+      .mockReturnValueOnce([{ id: 'u1', onboardedAt: new Date(), email: 'a@b.c' }]);
+    const result = await completeOnboarding('u1', 'hi', 'beginner');
+    expect(fakeDb.insert).toHaveBeenCalledTimes(1);
+    expect(fakeDb.update).toHaveBeenCalledTimes(1);
+    expect(chain.values).toHaveBeenCalledWith({
+      userId: 'u1',
+      language: 'hi',
+      baseline: 'beginner',
+    });
+    expect(chain.onConflictDoUpdate).toHaveBeenCalled();
+    expect(result.language.baseline).toBe('beginner');
+    expect(result.user.onboardedAt).toBeInstanceOf(Date);
+  });
+
+  it('throws when the user row cannot be updated (e.g. deleted mid-flight)', async () => {
+    chain.returning
+      .mockReturnValueOnce([{ userId: 'u1', language: 'or', baseline: 'none' }])
+      .mockReturnValueOnce([]);
+    await expect(completeOnboarding('u1', 'or', 'none')).rejects.toThrow('user not found');
+  });
+});

--- a/apps/web/src/lib/server/onboarding.ts
+++ b/apps/web/src/lib/server/onboarding.ts
@@ -1,0 +1,69 @@
+import { eq } from 'drizzle-orm';
+import { db, schema } from './db/index.js';
+import type { User, UserLanguage } from './db/schema.js';
+import type { LanguageCode } from '@ciareader/shared-types';
+
+export type LanguageBaseline = 'none' | 'beginner' | 'intermediate';
+
+const ONBOARDING_PATH = '/onboarding';
+
+/**
+ * Routes an onboarded user never needs to be bounced to the onboarding
+ * page from. Auth flows, the onboarding page itself, and the API surface
+ * (mobile clients handle onboarding their own way) all skip the redirect.
+ *
+ * Returning a function rather than a regex so future tickets can add
+ * conditional rules (e.g. bypass for specific pricing pages) without
+ * rewriting the matcher.
+ */
+export function shouldRedirectToOnboarding(
+  user: Pick<User, 'onboardedAt'> | null,
+  pathname: string,
+): boolean {
+  if (!user) return false;
+  if (user.onboardedAt !== null) return false;
+  if (pathname === ONBOARDING_PATH || pathname.startsWith(`${ONBOARDING_PATH}/`)) return false;
+  if (pathname.startsWith('/api/')) return false;
+  if (pathname === '/login' || pathname.startsWith('/login/')) return false;
+  if (pathname === '/logout' || pathname.startsWith('/logout/')) return false;
+  if (pathname === '/register' || pathname.startsWith('/register/')) return false;
+  return true;
+}
+
+/**
+ * Commits the onboarding choice: upserts a user_languages row carrying the
+ * baseline and flips users.onboardedAt. Callers are expected to have
+ * already validated the language / baseline against the registry.
+ */
+export async function completeOnboarding(
+  userId: string,
+  languageCode: LanguageCode,
+  baseline: LanguageBaseline,
+): Promise<{ user: User; language: UserLanguage }> {
+  const now = new Date();
+  // Upsert the user_languages row first. Primary key is (user_id, language),
+  // so ON CONFLICT DO UPDATE updates the baseline if the user somehow
+  // re-submits (e.g. double-tap on submit) without re-inserting.
+  const [lang] = await db
+    .insert(schema.userLanguages)
+    .values({
+      userId,
+      language: languageCode,
+      baseline,
+    })
+    .onConflictDoUpdate({
+      target: [schema.userLanguages.userId, schema.userLanguages.language],
+      set: { baseline, updatedAt: now },
+    })
+    .returning();
+  if (!lang) throw new Error('onboarding upsert returned no row');
+
+  const [user] = await db
+    .update(schema.users)
+    .set({ onboardedAt: now, updatedAt: now })
+    .where(eq(schema.users.id, userId))
+    .returning();
+  if (!user) throw new Error('user not found');
+
+  return { user, language: lang };
+}

--- a/apps/web/src/routes/onboarding/+page.server.ts
+++ b/apps/web/src/routes/onboarding/+page.server.ts
@@ -1,0 +1,59 @@
+import { fail, redirect } from '@sveltejs/kit';
+import { z } from 'zod';
+import { completeOnboarding, type LanguageBaseline } from '$lib/server/onboarding.js';
+import {
+  LANGUAGES,
+  SUPPORTED_LANGUAGE_CODES,
+  type LanguageCode,
+} from '@ciareader/shared-types';
+import type { Actions, PageServerLoad } from './$types';
+
+const BASELINES: readonly LanguageBaseline[] = ['none', 'beginner', 'intermediate'] as const;
+
+const onboardingSchema = z.object({
+  language: z.enum(SUPPORTED_LANGUAGE_CODES as readonly [LanguageCode, ...LanguageCode[]]),
+  baseline: z.enum(BASELINES as readonly [LanguageBaseline, ...LanguageBaseline[]]),
+});
+
+export const load: PageServerLoad = ({ locals, url }) => {
+  if (!locals.user) throw redirect(303, `/login?next=${encodeURIComponent(url.pathname)}`);
+  // A user who's already onboarded should not see the picker again — the
+  // profile page exposes per-language edits.
+  if (locals.user.onboardedAt !== null) throw redirect(303, '/');
+
+  return {
+    languages: SUPPORTED_LANGUAGE_CODES.map((code) => ({
+      code,
+      displayName: LANGUAGES[code].displayName,
+      nativeName: LANGUAGES[code].nativeName,
+      script: LANGUAGES[code].script,
+    })),
+    baselines: BASELINES,
+  };
+};
+
+type OnboardingResult =
+  | { ok: true }
+  | { ok: false; message: string };
+
+export const actions: Actions = {
+  default: async ({ locals, request }) => {
+    if (!locals.user) {
+      return fail(401, { ok: false, message: 'Unauthorized' } satisfies OnboardingResult);
+    }
+    if (locals.user.onboardedAt !== null) {
+      // A concurrent submit after the page raced a completion — just succeed.
+      return { ok: true } satisfies OnboardingResult;
+    }
+    const form = Object.fromEntries(await request.formData());
+    const parsed = onboardingSchema.safeParse(form);
+    if (!parsed.success) {
+      return fail(400, {
+        ok: false,
+        message: parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; '),
+      } satisfies OnboardingResult);
+    }
+    await completeOnboarding(locals.user.id, parsed.data.language, parsed.data.baseline);
+    throw redirect(303, '/');
+  },
+};

--- a/apps/web/src/routes/onboarding/+page.svelte
+++ b/apps/web/src/routes/onboarding/+page.svelte
@@ -1,0 +1,174 @@
+<script lang="ts">
+  import { enhance } from '$app/forms';
+  import type { ActionData, PageData } from './$types';
+
+  let { data, form }: { data: PageData; form: ActionData } = $props();
+
+  const BASELINE_LABELS: Record<string, { title: string; blurb: string }> = {
+    none: {
+      title: 'Starting from scratch',
+      blurb: 'Every word you encounter is new until you mark it known.',
+    },
+    beginner: {
+      title: 'Beginner — some basics',
+      blurb:
+        'Assume the 100 most common words are already familiar. You can change individual words later.',
+    },
+    intermediate: {
+      title: 'Intermediate',
+      blurb:
+        'Assume the 1,000 most common words are already familiar — useful if you already read the language.',
+    },
+  };
+
+  // Initial selection copied from the loader once; the user's bind:group
+  // picks then own the truth. Wrapping the initializer in a function avoids
+  // Svelte's "state references another $state only at init" warning.
+  let selectedLanguage = $state<string>(((): string => data.languages[0]?.code ?? 'hi')());
+  let selectedBaseline = $state<string>('none');
+</script>
+
+<svelte:head>
+  <title>Welcome — CIA Reader</title>
+</svelte:head>
+
+<div class="page">
+  <h1>Welcome to CIA Reader</h1>
+  <p class="lede">
+    Pick the language you want to read and a rough sense of what you already know. You can add
+    more languages or change these choices later from your profile.
+  </p>
+
+  <form method="POST" use:enhance>
+    <fieldset>
+      <legend>Which language are you learning?</legend>
+      <div class="choices">
+        {#each data.languages as lang}
+          <label class="choice" class:selected={selectedLanguage === lang.code}>
+            <input
+              type="radio"
+              name="language"
+              value={lang.code}
+              bind:group={selectedLanguage}
+            />
+            <span class="native">{lang.nativeName}</span>
+            <span class="meta">{lang.displayName} · {lang.script}</span>
+          </label>
+        {/each}
+      </div>
+    </fieldset>
+
+    <fieldset>
+      <legend>Where are you starting from?</legend>
+      <div class="choices stacked">
+        {#each data.baselines as baseline}
+          <label class="choice stacked" class:selected={selectedBaseline === baseline}>
+            <input
+              type="radio"
+              name="baseline"
+              value={baseline}
+              bind:group={selectedBaseline}
+            />
+            <span class="choice-title">{BASELINE_LABELS[baseline]?.title ?? baseline}</span>
+            <span class="meta">{BASELINE_LABELS[baseline]?.blurb ?? ''}</span>
+          </label>
+        {/each}
+      </div>
+    </fieldset>
+
+    <button type="submit">Get started</button>
+    {#if form && !form.ok}
+      <p class="err" role="alert">{form.message}</p>
+    {/if}
+  </form>
+</div>
+
+<style>
+  .page {
+    max-width: 40rem;
+    margin: 0 auto;
+    padding: 2rem 1.25rem;
+  }
+  h1 {
+    margin: 0 0 0.5rem;
+  }
+  .lede {
+    color: var(--color-fg-muted);
+    margin: 0 0 1.5rem;
+  }
+  form {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+  fieldset {
+    border: 0;
+    padding: 0;
+    margin: 0;
+  }
+  legend {
+    font-size: var(--font-size-sm);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--color-fg-muted);
+    margin-bottom: 0.5rem;
+  }
+  .choices {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+    gap: 0.5rem;
+  }
+  .choices.stacked {
+    grid-template-columns: 1fr;
+  }
+  .choice {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    padding: 1rem;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    min-height: var(--touch-target);
+  }
+  .choice input {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+  .choice.selected {
+    border-color: var(--color-accent);
+    background: var(--color-surface-2);
+  }
+  .choice .native {
+    font-size: 1.2rem;
+  }
+  .choice-title {
+    font-weight: 600;
+  }
+  .meta {
+    color: var(--color-fg-muted);
+    font-size: var(--font-size-sm);
+  }
+  button {
+    align-self: flex-start;
+    padding: 0.7rem 1.25rem;
+    background: var(--color-accent);
+    color: var(--color-accent-fg);
+    border: none;
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    font: inherit;
+    min-height: var(--touch-target);
+  }
+  .err {
+    color: var(--color-danger);
+    margin: 0;
+  }
+</style>

--- a/apps/web/src/routes/onboarding/onboarding-server.test.ts
+++ b/apps/web/src/routes/onboarding/onboarding-server.test.ts
@@ -1,0 +1,139 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const completeOnboarding = vi.fn();
+
+vi.mock('$lib/server/onboarding.js', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    completeOnboarding: (...a: unknown[]) => completeOnboarding(...a),
+  };
+});
+
+type LoadFn = (typeof import('./+page.server.js'))['load'];
+type LoadEvent = Parameters<LoadFn>[0];
+type ActionsModule = (typeof import('./+page.server.js'))['actions'];
+type ActionFn = NonNullable<ActionsModule[keyof ActionsModule]>;
+type ActionEvent = Parameters<ActionFn>[0];
+
+function formEvent(fields: Record<string, string>, locals: Record<string, unknown> = {}) {
+  const body = new URLSearchParams(fields);
+  return {
+    request: new Request('http://x/onboarding', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    }),
+    locals,
+    url: new URL('http://x/onboarding'),
+  } as unknown as ActionEvent;
+}
+
+async function loadDefaultAction() {
+  const mod = await import('./+page.server.js');
+  return mod.actions.default as ActionFn;
+}
+
+describe('onboarding +page.server.ts', () => {
+  beforeEach(() => {
+    completeOnboarding.mockReset();
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  describe('load', () => {
+    it('redirects to /login when unauthenticated', async () => {
+      const { load } = await import('./+page.server.js');
+      expect(() =>
+        load({
+          locals: {},
+          url: new URL('http://x/onboarding'),
+        } as unknown as LoadEvent),
+      ).toThrow(expect.objectContaining({ status: 303 }));
+    });
+
+    it('redirects already-onboarded users away from the onboarding page', async () => {
+      const { load } = await import('./+page.server.js');
+      expect(() =>
+        load({
+          locals: { user: { id: 'u1', onboardedAt: new Date() } },
+          url: new URL('http://x/onboarding'),
+        } as unknown as LoadEvent),
+      ).toThrow(expect.objectContaining({ status: 303 }));
+    });
+
+    it('returns the full language list + baseline options for first-time users', async () => {
+      const { load } = await import('./+page.server.js');
+      const data = await load({
+        locals: { user: { id: 'u1', onboardedAt: null } },
+        url: new URL('http://x/onboarding'),
+      } as unknown as LoadEvent);
+      if (!data) throw new Error('load returned void');
+      expect(data.languages.map((l: { code: string }) => l.code)).toEqual(
+        expect.arrayContaining(['hi', 'mr', 'or']),
+      );
+      expect(data.baselines).toEqual(['none', 'beginner', 'intermediate']);
+    });
+  });
+
+  describe('default action', () => {
+    it('rejects with 401 when unauthenticated', async () => {
+      const action = await loadDefaultAction();
+      const result = await action(formEvent({ language: 'hi', baseline: 'none' }));
+      expect(result).toMatchObject({ status: 401, data: { ok: false } });
+      expect(completeOnboarding).not.toHaveBeenCalled();
+    });
+
+    it('rejects an unsupported language', async () => {
+      const action = await loadDefaultAction();
+      const result = await action(
+        formEvent(
+          { language: 'xx', baseline: 'none' },
+          { user: { id: 'u1', onboardedAt: null } },
+        ),
+      );
+      expect(result).toMatchObject({ status: 400, data: { ok: false } });
+      expect(completeOnboarding).not.toHaveBeenCalled();
+    });
+
+    it('rejects an invalid baseline', async () => {
+      const action = await loadDefaultAction();
+      const result = await action(
+        formEvent(
+          { language: 'hi', baseline: 'expert' },
+          { user: { id: 'u1', onboardedAt: null } },
+        ),
+      );
+      expect(result).toMatchObject({ status: 400, data: { ok: false } });
+    });
+
+    it('commits a valid choice and redirects to /', async () => {
+      completeOnboarding.mockResolvedValue({});
+      const action = await loadDefaultAction();
+      await expect(
+        action(
+          formEvent(
+            { language: 'or', baseline: 'beginner' },
+            { user: { id: 'u1', onboardedAt: null } },
+          ),
+        ),
+      ).rejects.toMatchObject({ status: 303, location: '/' });
+      expect(completeOnboarding).toHaveBeenCalledWith('u1', 'or', 'beginner');
+    });
+
+    it('is idempotent when a user is already onboarded (returns ok without re-upserting)', async () => {
+      const action = await loadDefaultAction();
+      const result = await action(
+        formEvent(
+          { language: 'hi', baseline: 'none' },
+          { user: { id: 'u1', onboardedAt: new Date() } },
+        ),
+      );
+      expect(result).toMatchObject({ ok: true });
+      expect(completeOnboarding).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- New `/onboarding` route: on first login the server-side hook bounces the user here, they pick one of the three MVP languages and a baseline (`none` / `beginner` / `intermediate`), and submitting upserts a `user_languages` row with the baseline + stamps `users.onboardedAt`.
- Schema: new `language_baseline` enum + `baseline` column on `user_languages`; `onboarded_at` timestamp on `users`. Migration `0002_yielding_blindfold.sql`.
- The bounce logic (`shouldRedirectToOnboarding`) is a pure exported helper so hooks.server.ts stays thin. It bypasses `/onboarding`, API routes, and auth-flow pages (login / register / logout) to avoid loops and to let mobile clients run their own first-run UX.
- `completeOnboarding` does the upsert + user stamp in one atomic transaction-style helper. `ON CONFLICT DO UPDATE` keeps it idempotent against double-tap submits.

## Test plan
- [x] `pnpm --filter @ciareader/web run lint` clean
- [x] `pnpm --filter @ciareader/web run check` clean
- [x] `pnpm --filter @ciareader/web run test` — 101 tests pass; new files `onboarding.ts` / `+page.server.ts` / matcher logic covered; hook-level bounce + no-loop on `/onboarding` verified.
- [ ] Manual: register a fresh user, confirm bounce to `/onboarding`, pick Odia + intermediate, confirm redirect to `/` and no re-bounce on subsequent nav.