### PR TITLE
T-2.1: pipeline dispatch layer + NFC normalization in /process

### DIFF
--- a/services/nlp/app/main.py
+++ b/services/nlp/app/main.py
@@ -1,22 +1,21 @@
 """NLP service entry.
 
-M0 scope: health check + a canned /process response that proves the web
-service can reach this service through Docker networking and that types
-round-trip. Real pipelines land in M2 (T-2.2 / T-2.3 / T-2.3a).
+Routes the /process HTTP request to the per-language pipeline registered
+in :mod:`app.pipelines`. The HTTP layer's job is narrow: validate the
+language, NFC-normalize input, dispatch, and echo the pipeline_id back to
+the client. Real tokenization / lemmatization lives in the pipeline
+modules so each language can evolve independently.
 """
 
 from __future__ import annotations
 
+import unicodedata
+
 from fastapi import FastAPI, HTTPException
 
 from app.languages import LANGUAGES, SUPPORTED_LANGUAGE_CODES, is_supported_language
-from app.schemas import (
-    HealthResponse,
-    LemmaCandidate,
-    ProcessRequest,
-    ProcessResponse,
-    Token,
-)
+from app.pipelines import get_pipeline
+from app.schemas import HealthResponse, ProcessRequest, ProcessResponse
 
 app = FastAPI(title="CIA Reader NLP", version="0.0.0")
 
@@ -38,30 +37,20 @@ async def process(req: ProcessRequest) -> ProcessResponse:
             detail=f"Unsupported language '{req.language}'. Supported: {supported}",
         )
 
-    descriptor = LANGUAGES[req.language]  # type: ignore[index]
+    # NFC is the canonical form for every Indic script we support; many
+    # Devanagari / Odia inputs arrive in other normalizations from the
+    # wild web. Doing it once here means pipelines can assume NFC.
+    text = unicodedata.normalize("NFC", req.text)
+    pipeline = get_pipeline(req.language)
+    result = pipeline.process(text)
 
-    # Canned tokenization: split on whitespace, each word becomes a token with
-    # a single low-confidence candidate = the surface form. Real tokenization
-    # + lemmatization comes in M2.
-    raw_tokens = req.text.split()
-    tokens: list[Token] = []
-    for idx, surface in enumerate(raw_tokens):
-        tokens.append(
-            Token(
-                idx=idx,
-                surface=surface,
-                is_word=True,
-                candidates=[
-                    LemmaCandidate(lemma=surface, pos="X", score=1.0, features={}),
-                ],
-                is_ambiguous=False,
-                is_oov=True,
-                romanization=None,
-            )
-        )
-
+    # The client always sees the language's canonical pipeline_id (from
+    # the shared registry), not the pipeline instance's internal id — so
+    # swapping in a stub during local dev still looks like the real
+    # pipeline to the caller.
+    canonical_pipeline_id = LANGUAGES[req.language].pipeline_id
     return ProcessResponse(
         language=req.language,
-        pipeline_id=descriptor.pipeline_id,
-        tokens=tokens,
+        pipeline_id=canonical_pipeline_id,
+        tokens=result.tokens,
     )

--- a/services/nlp/app/pipelines/__init__.py
+++ b/services/nlp/app/pipelines/__init__.py
@@ -1,0 +1,73 @@
+"""Per-language NLP pipeline dispatch.
+
+Each supported MVP language (hi, mr, or) is produced by its own pipeline
+in a dedicated module: `hindi.py`, `marathi.py`, `odia.py`. The registry
+below maps a `pipeline_id` (as declared by the shared language registry
+in ``packages/shared-types/python/languages.py``) to its implementation.
+
+The pipelines all share the same output shape — a list of ``Token`` rows
+with top-K lemma candidates, ambiguity / OOV flags, and an optional
+romanization — so the web service (and future mobile clients) never
+branch on language when rendering or persisting.
+
+Right now every pipeline_id is wired to the canned :class:`StubPipeline`;
+T-2.2 / T-2.3 / T-2.3a will swap each mapping for the real implementation
+without touching the dispatch layer.
+"""
+
+from __future__ import annotations
+
+from app.languages import LANGUAGES, is_supported_language
+
+from .base import Pipeline, PipelineResult
+from .stub import StubPipeline
+
+# Cache of instantiated pipelines keyed by pipeline_id. Building a Stanza
+# model is expensive; we want exactly one instance per pipeline_id per
+# process. This dict is populated lazily by :func:`get_pipeline`.
+_PIPELINE_CACHE: dict[str, Pipeline] = {}
+
+# Factory registry keyed by pipeline_id. Each entry returns a fresh
+# pipeline instance. Keeping factories (not instances) here means we don't
+# pay the model-loading cost for languages the running process never
+# touches.
+_PIPELINE_FACTORIES: dict[str, type[Pipeline]] = {
+    "stanza-hi": StubPipeline,
+    "stanza-mr": StubPipeline,
+    "custom-or": StubPipeline,
+}
+
+
+def get_pipeline(language_code: str) -> Pipeline:
+    """Return the pipeline for a language code.
+
+    Raises :class:`KeyError` for unsupported languages — callers
+    (``/process``) should have validated the code first and translated any
+    error into an HTTP 400.
+    """
+    if not is_supported_language(language_code):
+        raise KeyError(f"Unsupported language: {language_code!r}")
+    pipeline_id = LANGUAGES[language_code].pipeline_id
+    if pipeline_id not in _PIPELINE_CACHE:
+        factory = _PIPELINE_FACTORIES.get(pipeline_id, StubPipeline)
+        _PIPELINE_CACHE[pipeline_id] = factory()
+    return _PIPELINE_CACHE[pipeline_id]
+
+
+def reset_pipeline_cache() -> None:
+    """Test hook: drop cached pipeline instances.
+
+    Useful when a test overrides :data:`_PIPELINE_FACTORIES` and wants to
+    guarantee its factory is called instead of returning a stale cached
+    pipeline from a prior test.
+    """
+    _PIPELINE_CACHE.clear()
+
+
+__all__ = [
+    "Pipeline",
+    "PipelineResult",
+    "StubPipeline",
+    "get_pipeline",
+    "reset_pipeline_cache",
+]

--- a/services/nlp/app/pipelines/base.py
+++ b/services/nlp/app/pipelines/base.py
@@ -1,0 +1,35 @@
+"""Pipeline abstract base.
+
+Every per-language pipeline produces a :class:`PipelineResult` — the list
+of tokens plus the ``pipeline_id`` that the API response echoes back so
+clients can tell which implementation produced the parse. The shape of a
+Token matches :mod:`app.schemas`.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+from app.schemas import Token
+
+
+@dataclass(frozen=True, slots=True)
+class PipelineResult:
+    pipeline_id: str
+    tokens: list[Token]
+
+
+class Pipeline(ABC):
+    """Contract every language pipeline must satisfy."""
+
+    #: Identifier surfaced to clients. Must match the shared language
+    #: registry's ``pipelineId`` field for at least one language code.
+    pipeline_id: str
+
+    @abstractmethod
+    def process(self, text: str) -> PipelineResult:
+        """Tokenize + lemmatize + feature-annotate ``text``."""
+
+
+__all__ = ["Pipeline", "PipelineResult"]

--- a/services/nlp/app/pipelines/stub.py
+++ b/services/nlp/app/pipelines/stub.py
@@ -1,0 +1,45 @@
+"""Canned pipeline used until the real per-language pipelines land.
+
+Tokenizes on whitespace and emits one top-K candidate per token whose
+lemma is just the surface form. Flags every token as OOV so the reader
+surfaces the correction UX (M6) during pre-NLP end-to-end testing.
+
+Kept separate from :mod:`app.main` so that T-2.2 / T-2.3 / T-2.3a can
+plug real Stanza / IndicNLP models in by swapping the registry entry in
+:mod:`app.pipelines.__init__` — no changes to the HTTP layer.
+"""
+
+from __future__ import annotations
+
+from app.schemas import LemmaCandidate, Token
+
+from .base import Pipeline, PipelineResult
+
+
+class StubPipeline(Pipeline):
+    """Whitespace-split, surface-as-lemma, everything OOV."""
+
+    pipeline_id = "stub"
+
+    def process(self, text: str) -> PipelineResult:
+        # NFC normalization is the caller's job (happens in /process before
+        # dispatch). Here we just split; the pipeline is intentionally dumb.
+        surfaces = text.split()
+        tokens = [
+            Token(
+                idx=i,
+                surface=surface,
+                is_word=True,
+                candidates=[
+                    LemmaCandidate(lemma=surface, pos="X", score=1.0, features={}),
+                ],
+                is_ambiguous=False,
+                is_oov=True,
+                romanization=None,
+            )
+            for i, surface in enumerate(surfaces)
+        ]
+        return PipelineResult(pipeline_id=self.pipeline_id, tokens=tokens)
+
+
+__all__ = ["StubPipeline"]

--- a/services/nlp/tests/test_pipelines.py
+++ b/services/nlp/tests/test_pipelines.py
@@ -1,0 +1,72 @@
+"""Tests for the pipeline dispatch layer (T-2.1).
+
+These tests isolate the dispatch behavior from the HTTP layer — they go
+directly against :mod:`app.pipelines` so regressions show up with a
+pinpointed stack trace, not a FastAPI 500.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app import pipelines
+from app.pipelines import Pipeline, PipelineResult, StubPipeline, get_pipeline
+from app.schemas import LemmaCandidate, Token
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    pipelines.reset_pipeline_cache()
+    yield
+    pipelines.reset_pipeline_cache()
+
+
+def test_get_pipeline_returns_stub_for_each_supported_language():
+    for code in ("hi", "mr", "or"):
+        pipe = get_pipeline(code)
+        assert isinstance(pipe, Pipeline)
+        # MVP: every language routes through the stub until real pipelines ship.
+        assert isinstance(pipe, StubPipeline)
+
+
+def test_get_pipeline_reuses_instance_per_pipeline_id():
+    # Both Hindi and Marathi currently route to the same stub pipeline_id
+    # wouldn't be equal — they're distinct pipeline_ids — so we compare
+    # against repeat lookups for the same language instead.
+    a = get_pipeline("hi")
+    b = get_pipeline("hi")
+    assert a is b, "dispatcher must cache the instance per pipeline_id"
+
+
+def test_get_pipeline_rejects_unsupported_language():
+    with pytest.raises(KeyError):
+        get_pipeline("ja")
+
+
+def test_stub_pipeline_whitespace_tokenizes_and_marks_oov():
+    out = StubPipeline().process("नमस्ते दुनिया")
+    assert isinstance(out, PipelineResult)
+    assert [t.surface for t in out.tokens] == ["नमस्ते", "दुनिया"]
+    assert all(t.is_oov for t in out.tokens), "stub must mark every token OOV"
+    assert all(len(t.candidates) == 1 for t in out.tokens)
+    assert isinstance(out.tokens[0].candidates[0], LemmaCandidate)
+
+
+def test_stub_pipeline_returns_valid_token_shape():
+    out = StubPipeline().process("one two")
+    tok: Token = out.tokens[0]
+    assert tok.idx == 0
+    assert tok.is_word is True
+    assert tok.is_ambiguous is False
+    assert tok.romanization is None
+
+
+def test_custom_factory_override_via_registry(monkeypatch):
+    # This is the hook T-2.2 will use: drop-in a real Hindi pipeline without
+    # touching main.py. Verify the dispatcher honors it.
+    class MarkerPipeline(StubPipeline):
+        pipeline_id = "marker"
+
+    monkeypatch.setitem(pipelines._PIPELINE_FACTORIES, "stanza-hi", MarkerPipeline)
+    pipelines.reset_pipeline_cache()
+    assert isinstance(get_pipeline("hi"), MarkerPipeline)

--- a/services/nlp/tests/test_smoke.py
+++ b/services/nlp/tests/test_smoke.py
@@ -37,3 +37,21 @@ def test_process_odia_canned():
 def test_process_rejects_unsupported_language():
     resp = client.post("/process", json={"language": "ja", "text": "hello"})
     assert resp.status_code == 400
+
+
+def test_process_nfc_normalizes_input():
+    # Devanagari क़ (U+0958) is a Unicode composition exclusion — NFC
+    # canonicalizes it to the decomposed form क (U+0915) + nukta (U+093C).
+    # Sending the precomposed form and getting the decomposed surface back
+    # proves the /process endpoint ran NFC normalization.
+    precomposed = "\u0958"
+    canonical = "\u0915\u093c"
+    resp = client.post("/process", json={"language": "hi", "text": precomposed})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["tokens"][0]["surface"] == canonical
+
+
+def test_process_empty_text_rejected_by_validation():
+    resp = client.post("/process", json={"language": "hi", "text": ""})
+    assert resp.status_code == 422


### PR DESCRIPTION
## Summary
- Introduces `app.pipelines` — a `Pipeline` ABC, `PipelineResult` dataclass, a stub `StubPipeline` (whitespace-split, single-candidate, everything OOV), and a `get_pipeline(language_code)` dispatcher that resolves the canonical `pipeline_id` from the shared language registry and caches one instance per pipeline_id.
- `/process` now NFC-normalizes input before dispatch so every future pipeline (T-2.2 / T-2.3 / T-2.3a) can assume canonical input.
- Response echoes the **language registry's** canonical pipeline_id, not the instance's internal id, so the stub stands in transparently during local dev.

## Why this shape
Keeping dispatch + NFC in the HTTP layer and the actual tokenization behind a registry means T-2.2 (Hindi Stanza) plugs in by swapping one factory entry in `app/pipelines/__init__.py` — no `main.py` churn, no cross-cutting refactor. The regression test `test_custom_factory_override_via_registry` pins that contract.

## Test plan
- [x] `pytest tests/` — 18 passed, 100% coverage across `app/languages.py`, `app/main.py`, `app/pipelines/**`, `app/schemas.py`
- [x] NFC regression: posting precomposed क़ (U+0958) returns the decomposed canonical form (U+0915 U+093C) — U+0958 is a Unicode composition exclusion, so this is a real functional test of the normalization path
- [x] Pydantic validation rejects empty text with 422
- [x] Dispatch cache reuses instances per pipeline_id
- [x] `get_pipeline("ja")` raises KeyError
- [x] Monkeypatched factory override proves T-2.2 can swap Hindi without touching main.py

## Depends on
[#121 — T-1.5 onboarding](https://github.com/chickendude/CIA-Reader/pull/121)