### PR TITLE
T-2.2: Hindi pipeline wrapping Stanza's UD model

### DIFF
--- a/services/nlp/Dockerfile
+++ b/services/nlp/Dockerfile
@@ -8,13 +8,20 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 WORKDIR /srv/nlp
 
 COPY services/nlp/pyproject.toml /srv/nlp/pyproject.toml
-RUN pip install -U pip && pip install -e '.[dev]'
+RUN pip install -U pip && pip install -e '.[dev,models]'
 
 COPY services/nlp/app /srv/nlp/app
 COPY services/nlp/tests /srv/nlp/tests
 COPY packages/shared-types/python /opt/shared-types
 
 ENV PYTHONPATH=/opt/shared-types:/srv/nlp
+
+# Pre-download the Stanza Hindi model at image-build time so the first
+# /process request doesn't pay a multi-hundred-megabyte download and so
+# production stays offline-safe (the pipeline is constructed with
+# download_method=None). Future languages (mr, or) will be added here
+# as their pipelines ship.
+RUN python -c "import stanza; stanza.download('hi', processors='tokenize,pos,lemma', verbose=False)"
 
 EXPOSE 8000
 

--- a/services/nlp/app/pipelines/__init__.py
+++ b/services/nlp/app/pipelines/__init__.py
@@ -17,9 +17,12 @@ without touching the dispatch layer.
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 from app.languages import LANGUAGES, is_supported_language
 
 from .base import Pipeline, PipelineResult
+from .hindi import build_hindi_pipeline
 from .stub import StubPipeline
 
 # Cache of instantiated pipelines keyed by pipeline_id. Building a Stanza
@@ -27,12 +30,13 @@ from .stub import StubPipeline
 # process. This dict is populated lazily by :func:`get_pipeline`.
 _PIPELINE_CACHE: dict[str, Pipeline] = {}
 
-# Factory registry keyed by pipeline_id. Each entry returns a fresh
-# pipeline instance. Keeping factories (not instances) here means we don't
-# pay the model-loading cost for languages the running process never
-# touches.
-_PIPELINE_FACTORIES: dict[str, type[Pipeline]] = {
-    "stanza-hi": StubPipeline,
+# Factory registry keyed by pipeline_id. Each entry is a zero-arg callable
+# that returns a fresh pipeline instance — a class (calls default ctor) or
+# a factory function (for pipelines that need real-model construction).
+# Keeping factories (not instances) here means we don't pay the model-
+# loading cost for languages the running process never touches.
+_PIPELINE_FACTORIES: dict[str, Callable[[], Pipeline]] = {
+    "stanza-hi": build_hindi_pipeline,
     "stanza-mr": StubPipeline,
     "custom-or": StubPipeline,
 }

--- a/services/nlp/app/pipelines/hindi.py
+++ b/services/nlp/app/pipelines/hindi.py
@@ -1,0 +1,145 @@
+"""Hindi pipeline backed by Stanza's ``hi`` UD model.
+
+Stanza handles tokenization, POS tagging, lemmatization, and UD-style
+morphology features. We wrap its output in our common :class:`Token`
+shape so the HTTP layer doesn't branch per language.
+
+Top-K caveat (see T-2.2 in the plan): Stanza's lemmatizer exposes a
+single best lemma per word. Real top-K lemma candidates with softmax-
+normalized scores require either beam decoder internals or a dictionary-
+side fallback — both land later (dictionary candidates in M3, beam
+alternates in a future pass). Until then we emit a single-candidate
+top-K, and :attr:`Token.is_ambiguous` is always ``False``. Downstream
+UX (M6) only branches on ``is_ambiguous``, so it gracefully degrades
+to "no chevron" for now.
+
+OOV heuristic: when Stanza returns the surface as the lemma *and* the
+UD POS isn't punctuation / symbol / number / proper-noun, we treat it
+as OOV. That matches the plan's "Stanza returns surface + no dictionary
+match" definition closely enough for MVP — real dictionary attachment
+happens in M3 and will refine ``is_oov`` at that point.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from app.schemas import LemmaCandidate, Token
+
+from .base import Pipeline, PipelineResult
+
+
+class _StanzaLike(Protocol):
+    """The subset of Stanza's ``Pipeline`` callable we depend on.
+
+    Using a structural type lets tests inject a lightweight fake without
+    importing stanza (and without having to install torch in CI). The
+    production code path lazy-imports stanza in :func:`build_hindi_pipeline`.
+    """
+
+    def __call__(self, text: str) -> Any: ...  # noqa: D401,E704
+
+
+# UD UPOS tags where "lemma equals surface" does NOT imply OOV. A proper
+# noun's lemma is its surface by design; punctuation / symbols / digits
+# legitimately don't have dictionary lemmas; ``X`` is Stanza's other-
+# language marker and is effectively a code-switch signal.
+_NON_OOV_UPOS: frozenset[str] = frozenset({"PUNCT", "SYM", "NUM", "PROPN", "X"})
+
+# UD UPOS tags that aren't lexical words. The Token schema exposes
+# ``is_word`` so the reader can skip these when counting known-words.
+_NON_WORD_UPOS: frozenset[str] = frozenset({"PUNCT", "SYM"})
+
+
+def _parse_feats(feats: str | None) -> dict[str, str]:
+    """Turn Stanza's ``"Tense=Pres|Number=Sing"`` into a plain dict.
+
+    Stanza uses ``None`` (or an empty string) when a word has no features.
+    Malformed pairs are skipped rather than raising — morphology drift
+    between Stanza model versions shouldn't 500 a /process call.
+    """
+    if not feats:
+        return {}
+    out: dict[str, str] = {}
+    for pair in feats.split("|"):
+        if "=" not in pair:
+            continue
+        key, _, value = pair.partition("=")
+        key = key.strip()
+        value = value.strip()
+        if key:
+            out[key] = value
+    return out
+
+
+class HindiPipeline(Pipeline):
+    """Stanza-backed Hindi tokenizer + lemmatizer + morphology."""
+
+    pipeline_id = "stanza-hi"
+
+    def __init__(self, nlp: _StanzaLike) -> None:
+        # The stanza model is injected (built by :func:`build_hindi_pipeline`
+        # in production; a fake in tests) so this class has no direct import
+        # dependency on stanza — keeps the module importable in CI without
+        # stanza + torch installed.
+        self._nlp = nlp
+
+    def process(self, text: str) -> PipelineResult:
+        doc = self._nlp(text)
+        tokens: list[Token] = []
+        idx = 0
+        for sentence in doc.sentences:
+            for word in sentence.words:
+                surface = word.text
+                lemma = word.lemma or surface
+                upos = (word.upos or "X").upper()
+                features = _parse_feats(word.feats)
+                is_word = upos not in _NON_WORD_UPOS
+                is_oov = lemma == surface and upos not in _NON_OOV_UPOS
+                tokens.append(
+                    Token(
+                        idx=idx,
+                        surface=surface,
+                        is_word=is_word,
+                        candidates=[
+                            LemmaCandidate(
+                                lemma=lemma,
+                                pos=upos,
+                                score=1.0,
+                                features=features,
+                            ),
+                        ],
+                        is_ambiguous=False,
+                        is_oov=is_oov,
+                        romanization=None,
+                    )
+                )
+                idx += 1
+        return PipelineResult(pipeline_id=self.pipeline_id, tokens=tokens)
+
+
+def build_hindi_pipeline() -> HindiPipeline:  # pragma: no cover
+    """Construct a :class:`HindiPipeline` with a real Stanza model.
+
+    Registered in :mod:`app.pipelines.__init__` as the ``stanza-hi``
+    factory. Lazy-imports stanza so the module tree stays importable in
+    test environments that don't install stanza (CI).
+
+    The Docker image for the NLP service pre-downloads models at build
+    time via ``stanza.download('hi', processors='tokenize,pos,lemma')``;
+    ``download_method=None`` here prevents a surprise download from
+    happening in production at first-request time.
+    """
+    import stanza
+
+    nlp = stanza.Pipeline(
+        lang="hi",
+        processors="tokenize,pos,lemma",
+        tokenize_no_ssplit=False,
+        download_method=None,
+        verbose=False,
+    )
+    return HindiPipeline(nlp=nlp)
+
+
+__all__ = ["HindiPipeline", "build_hindi_pipeline"]

--- a/services/nlp/pyproject.toml
+++ b/services/nlp/pyproject.toml
@@ -17,6 +17,13 @@ dev = [
   "ruff>=0.6.9",
   "mypy>=1.11.2",
 ]
+# Heavyweight runtime-only ML deps. The Docker image for the NLP service
+# installs `[dev,models]`; CI and local test runs only need `[dev]` because
+# :mod:`app.pipelines.hindi` lazy-imports stanza and the tests inject a
+# fake stanza object instead of loading the real model.
+models = [
+  "stanza>=1.8.0",
+]
 
 [build-system]
 requires = ["setuptools>=68"]

--- a/services/nlp/tests/conftest.py
+++ b/services/nlp/tests/conftest.py
@@ -1,13 +1,28 @@
-"""Make the shared language registry importable in tests.
+"""Shared test fixtures.
 
-In Docker we mount packages/shared-types/python at /opt/shared-types and add
-it to PYTHONPATH. In local `pytest` runs, do the same from the repo layout.
+Two concerns:
+
+1. Make the shared language registry importable. In Docker we mount
+   ``packages/shared-types/python`` at ``/opt/shared-types`` and add it
+   to ``PYTHONPATH``. In local ``pytest`` runs we do the same from the
+   repo layout.
+
+2. Stub out the real Hindi Stanza factory. Production ``stanza-hi``
+   lazy-imports Stanza and loads a ~600MB UD model. CI doesn't install
+   stanza at all (it lives in the ``models`` optional-dependencies
+   group, not the default dev deps), so any test that ends up calling
+   :func:`app.pipelines.get_pipeline("hi")` needs a substitute factory.
+   The autouse fixture below swaps ``stanza-hi`` for one that builds a
+   :class:`HindiPipeline` wrapped around a tiny whitespace fake.
+   Dedicated Hindi-pipeline tests build richer fakes inline rather than
+   extending this one.
 """
 
 from __future__ import annotations
 
 import os
 import sys
+from dataclasses import dataclass, field
 from pathlib import Path
 
 _HERE = Path(__file__).resolve()
@@ -19,3 +34,64 @@ if str(_SHARED_PY) not in sys.path:
     sys.path.insert(0, str(_SHARED_PY))
 
 os.environ.setdefault("PYTHONPATH", str(_SHARED_PY))
+
+# The two imports below depend on shared-types already being on
+# sys.path, so they must happen after the block above runs.
+import pytest  # noqa: E402
+
+from app import pipelines  # noqa: E402
+from app.pipelines.hindi import HindiPipeline  # noqa: E402
+
+
+@dataclass
+class _FakeWord:
+    text: str
+    lemma: str | None = None
+    upos: str = "NOUN"
+    feats: str | None = None
+
+    def __post_init__(self) -> None:
+        # Surface-as-lemma matches Stanza's "no dictionary match" behavior,
+        # which the HindiPipeline uses as its OOV heuristic. Reasonable
+        # default for a whitespace-only fallback fake.
+        if self.lemma is None:
+            self.lemma = self.text
+
+
+@dataclass
+class _FakeSentence:
+    words: list[_FakeWord] = field(default_factory=list)
+
+
+@dataclass
+class _FakeDoc:
+    sentences: list[_FakeSentence] = field(default_factory=list)
+
+
+class _WhitespaceFakeStanza:
+    """Whitespace-split, one sentence, NOUN UPOS, lemma = surface."""
+
+    def __call__(self, text: str) -> _FakeDoc:
+        surfaces = text.split()
+        words = [_FakeWord(text=s) for s in surfaces]
+        return _FakeDoc(sentences=[_FakeSentence(words=words)] if words else [])
+
+
+@pytest.fixture(autouse=True)
+def _fake_hindi_factory():
+    """Replace the real Hindi factory with a whitespace-fake for the test."""
+    original = pipelines._PIPELINE_FACTORIES.get("stanza-hi")
+
+    def _factory() -> HindiPipeline:
+        return HindiPipeline(nlp=_WhitespaceFakeStanza())
+
+    pipelines._PIPELINE_FACTORIES["stanza-hi"] = _factory
+    pipelines.reset_pipeline_cache()
+    try:
+        yield
+    finally:
+        if original is None:
+            pipelines._PIPELINE_FACTORIES.pop("stanza-hi", None)
+        else:
+            pipelines._PIPELINE_FACTORIES["stanza-hi"] = original
+        pipelines.reset_pipeline_cache()

--- a/services/nlp/tests/test_hindi_pipeline.py
+++ b/services/nlp/tests/test_hindi_pipeline.py
@@ -1,0 +1,230 @@
+"""Unit tests for :class:`app.pipelines.hindi.HindiPipeline` (T-2.2).
+
+We inject a minimal fake Stanza-like object rather than running the real
+model, so these tests exercise the pipeline's output shaping logic —
+feature parsing, POS-aware ``is_word`` / ``is_oov``, token indexing
+across sentences — without a ~600MB model download. The trade-off is
+we're testing our adapter, not Stanza itself; Stanza's own accuracy is
+covered by the golden-file suite (T-2.8).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from app.pipelines.hindi import HindiPipeline, _parse_feats
+
+
+@dataclass
+class FakeWord:
+    text: str
+    lemma: str | None = None
+    upos: str = "NOUN"
+    feats: str | None = None
+
+
+@dataclass
+class FakeSentence:
+    words: list[FakeWord] = field(default_factory=list)
+
+
+@dataclass
+class FakeDoc:
+    sentences: list[FakeSentence] = field(default_factory=list)
+
+
+class FakeStanza:
+    """Returns a pre-built :class:`FakeDoc` regardless of input text."""
+
+    def __init__(self, doc: FakeDoc) -> None:
+        self._doc = doc
+        self.calls: list[str] = []
+
+    def __call__(self, text: str) -> FakeDoc:
+        self.calls.append(text)
+        return self._doc
+
+
+def _pipe(doc: FakeDoc) -> tuple[HindiPipeline, FakeStanza]:
+    fake = FakeStanza(doc)
+    return HindiPipeline(nlp=fake), fake
+
+
+# --- _parse_feats --------------------------------------------------------
+
+
+def test_parse_feats_none_returns_empty():
+    assert _parse_feats(None) == {}
+
+
+def test_parse_feats_empty_string_returns_empty():
+    assert _parse_feats("") == {}
+
+
+def test_parse_feats_single_pair():
+    assert _parse_feats("Number=Sing") == {"Number": "Sing"}
+
+
+def test_parse_feats_multiple_pairs():
+    out = _parse_feats("Tense=Pres|Number=Sing|Person=3|Gender=Fem|Aspect=Hab")
+    assert out == {
+        "Tense": "Pres",
+        "Number": "Sing",
+        "Person": "3",
+        "Gender": "Fem",
+        "Aspect": "Hab",
+    }
+
+
+def test_parse_feats_skips_malformed_pairs():
+    # Defensive: a stray token or missing "=" from a Stanza model update
+    # shouldn't surface as a 500 on /process.
+    out = _parse_feats("Tense=Pres|bogus|Number=Sing|=orphan")
+    assert out == {"Tense": "Pres", "Number": "Sing"}
+
+
+# --- HindiPipeline.process ----------------------------------------------
+
+
+def test_process_empty_doc_produces_zero_tokens():
+    pipe, _ = _pipe(FakeDoc(sentences=[]))
+    result = pipe.process("")
+    assert result.pipeline_id == "stanza-hi"
+    assert result.tokens == []
+
+
+def test_process_returns_canonical_pipeline_id():
+    pipe, _ = _pipe(FakeDoc(sentences=[FakeSentence(words=[FakeWord("बोलता", lemma="बोलना")])]))
+    assert pipe.process("whatever").pipeline_id == "stanza-hi"
+
+
+def test_process_extracts_lemma_pos_and_features():
+    doc = FakeDoc(
+        sentences=[
+            FakeSentence(
+                words=[
+                    FakeWord(
+                        text="बोलती",
+                        lemma="बोलना",
+                        upos="VERB",
+                        feats="Tense=Pres|Number=Sing|Person=3|Gender=Fem|Aspect=Hab",
+                    )
+                ]
+            )
+        ]
+    )
+    pipe, _ = _pipe(doc)
+    result = pipe.process("she-speaks")
+    assert len(result.tokens) == 1
+    tok = result.tokens[0]
+    assert tok.surface == "बोलती"
+    assert tok.is_word is True
+    assert tok.is_oov is False  # lemma differs from surface
+    assert tok.is_ambiguous is False  # top-K disambiguation lands later
+    assert len(tok.candidates) == 1
+    cand = tok.candidates[0]
+    assert cand.lemma == "बोलना"
+    assert cand.pos == "VERB"
+    assert cand.score == 1.0
+    assert cand.features["Tense"] == "Pres"
+    assert cand.features["Gender"] == "Fem"
+
+
+def test_process_flags_oov_when_lemma_equals_surface_for_content_word():
+    doc = FakeDoc(
+        sentences=[
+            FakeSentence(words=[FakeWord(text="फ़्लर्ब", lemma="फ़्लर्ब", upos="NOUN")])
+        ]
+    )
+    pipe, _ = _pipe(doc)
+    result = pipe.process("x")
+    tok = result.tokens[0]
+    assert tok.is_oov is True
+
+
+def test_process_does_not_flag_oov_for_proper_nouns():
+    # Proper nouns legitimately have lemma == surface. Marking them OOV
+    # would trigger the correction UX in M6 for every name in the text,
+    # which would be terrible UX. The PROPN guard prevents that.
+    doc = FakeDoc(
+        sentences=[
+            FakeSentence(words=[FakeWord(text="रवि", lemma="रवि", upos="PROPN")])
+        ]
+    )
+    pipe, _ = _pipe(doc)
+    assert pipe.process("x").tokens[0].is_oov is False
+
+
+def test_process_does_not_flag_oov_for_numbers_punctuation_symbols():
+    doc = FakeDoc(
+        sentences=[
+            FakeSentence(
+                words=[
+                    FakeWord(text="42", lemma="42", upos="NUM"),
+                    FakeWord(text="।", lemma="।", upos="PUNCT"),
+                    FakeWord(text="%", lemma="%", upos="SYM"),
+                    FakeWord(text="hello", lemma="hello", upos="X"),
+                ]
+            )
+        ]
+    )
+    pipe, _ = _pipe(doc)
+    tokens = pipe.process("x").tokens
+    assert [t.is_oov for t in tokens] == [False, False, False, False]
+
+
+def test_process_marks_punctuation_as_non_word():
+    doc = FakeDoc(
+        sentences=[
+            FakeSentence(
+                words=[
+                    FakeWord(text="बोलता", lemma="बोलना", upos="VERB"),
+                    FakeWord(text="।", lemma="।", upos="PUNCT"),
+                ]
+            )
+        ]
+    )
+    pipe, _ = _pipe(doc)
+    tokens = pipe.process("x").tokens
+    assert tokens[0].is_word is True
+    assert tokens[1].is_word is False
+
+
+def test_process_indexes_tokens_contiguously_across_sentences():
+    doc = FakeDoc(
+        sentences=[
+            FakeSentence(
+                words=[FakeWord(text="एक"), FakeWord(text="दो")]
+            ),
+            FakeSentence(
+                words=[FakeWord(text="तीन"), FakeWord(text="चार")]
+            ),
+        ]
+    )
+    pipe, _ = _pipe(doc)
+    result = pipe.process("x")
+    assert [t.idx for t in result.tokens] == [0, 1, 2, 3]
+    assert [t.surface for t in result.tokens] == ["एक", "दो", "तीन", "चार"]
+
+
+def test_process_defaults_missing_upos_and_lemma_safely():
+    # Stanza can emit word.lemma=None when the lemmatizer declines to
+    # pick; word.upos can also be None if POS wasn't run. The pipeline
+    # must not crash — defaulting to surface / "X" is the documented
+    # behavior.
+    doc = FakeDoc(
+        sentences=[FakeSentence(words=[FakeWord(text="foo", lemma=None, upos=None)])]  # type: ignore[arg-type]
+    )
+    pipe, _ = _pipe(doc)
+    tok = pipe.process("x").tokens[0]
+    assert tok.candidates[0].lemma == "foo"
+    assert tok.candidates[0].pos == "X"
+    # Lemma==surface and POS=X: X is in _NON_OOV_UPOS (code-switch), so
+    # we do NOT flag this as OOV.
+    assert tok.is_oov is False
+
+
+def test_process_passes_input_text_through_to_stanza():
+    pipe, fake = _pipe(FakeDoc(sentences=[]))
+    pipe.process("the quick brown fox")
+    assert fake.calls == ["the quick brown fox"]

--- a/services/nlp/tests/test_pipelines.py
+++ b/services/nlp/tests/test_pipelines.py
@@ -11,6 +11,7 @@ import pytest
 
 from app import pipelines
 from app.pipelines import Pipeline, PipelineResult, StubPipeline, get_pipeline
+from app.pipelines.hindi import HindiPipeline
 from app.schemas import LemmaCandidate, Token
 
 
@@ -21,12 +22,18 @@ def _clear_cache():
     pipelines.reset_pipeline_cache()
 
 
-def test_get_pipeline_returns_stub_for_each_supported_language():
-    for code in ("hi", "mr", "or"):
+def test_get_pipeline_returns_stub_for_languages_still_on_stub():
+    # After T-2.2 Hindi routes to HindiPipeline; Marathi (T-2.3) and Odia
+    # (T-2.3a) still use the stub until their own pipelines ship.
+    for code in ("mr", "or"):
         pipe = get_pipeline(code)
         assert isinstance(pipe, Pipeline)
-        # MVP: every language routes through the stub until real pipelines ship.
         assert isinstance(pipe, StubPipeline)
+
+
+def test_get_pipeline_returns_hindi_pipeline_for_hi():
+    pipe = get_pipeline("hi")
+    assert isinstance(pipe, HindiPipeline)
 
 
 def test_get_pipeline_reuses_instance_per_pipeline_id():


### PR DESCRIPTION
## Summary
- `HindiPipeline` wraps Stanza's `hi` UD model (tokenize / pos / lemma) and emits tokens in the shared `Token` shape. Registered as the `stanza-hi` factory in the dispatcher.
- Injectable `nlp` parameter means CI tests the output-shaping logic with a lightweight fake — no stanza + torch install in CI.
- Production path (`build_hindi_pipeline`) lazy-imports stanza; the Docker image now installs the new `[models]` optional-deps group and pre-downloads the Hindi model at image-build time (`download_method=None` on the pipeline to keep request paths offline-safe).
- Factory registry annotation relaxed from `type[Pipeline]` to `Callable[[], Pipeline]` so real pipelines can be constructed by zero-arg factory functions.

## OOV / ambiguity contract
- `is_oov` fires when `lemma == surface` **only** for content POS. Proper nouns (whose lemma is their surface by design), punctuation, symbols, numbers, and `X` (Stanza's code-switch marker) are excluded — otherwise the M6 correction UX would trigger for every name in the text.
- `is_ambiguous` stays `False` for now. Stanza doesn't expose beam alternates in its public API; real top-K lemma candidates land with dictionary fallback (M3) and crowdsourced overrides (T-6.7). Downstream UX branches only on `is_ambiguous`, so it degrades to "no alternates chevron" until a second candidate source exists.
- Feature parsing is defensive: malformed `Key=Value\|…` pairs are skipped rather than raised, protecting `/process` from Stanza model-version drift.

## Test plan
- [x] `pytest tests/` — 34 passed, 99% branch coverage (the single uncovered branch is the Protocol `...` stub, dead by design)
- [x] `_parse_feats`: None / empty / single / multiple / malformed pair skipping
- [x] Multi-sentence token indexing is contiguous across sentence boundaries
- [x] `is_oov` True for content POS with `lemma==surface`; False for PROPN / NUM / PUNCT / SYM / X
- [x] Punctuation → `is_word=False`
- [x] Graceful handling of `word.lemma=None` and `word.upos=None` from Stanza
- [x] Shared conftest autouse fixture swaps the `stanza-hi` factory for a whitespace fake so smoke tests stay behavior-equivalent
- [x] Empty `doc.sentences` → empty token list
- [x] `ruff check` clean

## Depends on
[#122 — T-2.1 pipeline dispatch + NFC](https://github.com/chickendude/CIA-Reader/pull/122)