### PR TITLE
T-2.3: Marathi pipeline + shared Stanza UD base

### DIFF
--- a/services/nlp/Dockerfile
+++ b/services/nlp/Dockerfile
@@ -16,12 +16,12 @@ COPY packages/shared-types/python /opt/shared-types
 
 ENV PYTHONPATH=/opt/shared-types:/srv/nlp
 
-# Pre-download the Stanza Hindi model at image-build time so the first
-# /process request doesn't pay a multi-hundred-megabyte download and so
-# production stays offline-safe (the pipeline is constructed with
-# download_method=None). Future languages (mr, or) will be added here
-# as their pipelines ship.
-RUN python -c "import stanza; stanza.download('hi', processors='tokenize,pos,lemma', verbose=False)"
+# Pre-download the Stanza models at image-build time so the first
+# /process request doesn't pay a multi-hundred-megabyte download and
+# so production stays offline-safe (each build_*_pipeline constructs
+# stanza.Pipeline with download_method=None). Odia (T-2.3a) is a
+# custom IndicNLP-based pipeline and doesn't need a Stanza download.
+RUN python -c "import stanza; [stanza.download(lang, processors='tokenize,pos,lemma', verbose=False) for lang in ('hi', 'mr')]"
 
 EXPOSE 8000
 

--- a/services/nlp/app/pipelines/__init__.py
+++ b/services/nlp/app/pipelines/__init__.py
@@ -23,6 +23,7 @@ from app.languages import LANGUAGES, is_supported_language
 
 from .base import Pipeline, PipelineResult
 from .hindi import build_hindi_pipeline
+from .marathi import build_marathi_pipeline
 from .stub import StubPipeline
 
 # Cache of instantiated pipelines keyed by pipeline_id. Building a Stanza
@@ -37,7 +38,7 @@ _PIPELINE_CACHE: dict[str, Pipeline] = {}
 # loading cost for languages the running process never touches.
 _PIPELINE_FACTORIES: dict[str, Callable[[], Pipeline]] = {
     "stanza-hi": build_hindi_pipeline,
-    "stanza-mr": StubPipeline,
+    "stanza-mr": build_marathi_pipeline,
     "custom-or": StubPipeline,
 }
 

--- a/services/nlp/app/pipelines/hindi.py
+++ b/services/nlp/app/pipelines/hindi.py
@@ -1,8 +1,11 @@
 """Hindi pipeline backed by Stanza's ``hi`` UD model.
 
 Stanza handles tokenization, POS tagging, lemmatization, and UD-style
-morphology features. We wrap its output in our common :class:`Token`
-shape so the HTTP layer doesn't branch per language.
+morphology features. All of the output-shaping logic (feature parsing,
+OOV heuristics, idx sequencing) lives in
+:class:`app.pipelines.stanza_ud.StanzaUDPipeline` so this module is a
+thin wrapper that sets the canonical ``pipeline_id`` and provides a
+factory that constructs the real Stanza model at startup.
 
 Top-K caveat (see T-2.2 in the plan): Stanza's lemmatizer exposes a
 single best lemma per word. Real top-K lemma candidates with softmax-
@@ -22,100 +25,13 @@ happens in M3 and will refine ``is_oov`` at that point.
 
 from __future__ import annotations
 
-from typing import Any, Protocol
-
-from app.schemas import LemmaCandidate, Token
-
-from .base import Pipeline, PipelineResult
+from .stanza_ud import StanzaUDPipeline
 
 
-class _StanzaLike(Protocol):
-    """The subset of Stanza's ``Pipeline`` callable we depend on.
-
-    Using a structural type lets tests inject a lightweight fake without
-    importing stanza (and without having to install torch in CI). The
-    production code path lazy-imports stanza in :func:`build_hindi_pipeline`.
-    """
-
-    def __call__(self, text: str) -> Any: ...  # noqa: D401,E704
-
-
-# UD UPOS tags where "lemma equals surface" does NOT imply OOV. A proper
-# noun's lemma is its surface by design; punctuation / symbols / digits
-# legitimately don't have dictionary lemmas; ``X`` is Stanza's other-
-# language marker and is effectively a code-switch signal.
-_NON_OOV_UPOS: frozenset[str] = frozenset({"PUNCT", "SYM", "NUM", "PROPN", "X"})
-
-# UD UPOS tags that aren't lexical words. The Token schema exposes
-# ``is_word`` so the reader can skip these when counting known-words.
-_NON_WORD_UPOS: frozenset[str] = frozenset({"PUNCT", "SYM"})
-
-
-def _parse_feats(feats: str | None) -> dict[str, str]:
-    """Turn Stanza's ``"Tense=Pres|Number=Sing"`` into a plain dict.
-
-    Stanza uses ``None`` (or an empty string) when a word has no features.
-    Malformed pairs are skipped rather than raising — morphology drift
-    between Stanza model versions shouldn't 500 a /process call.
-    """
-    if not feats:
-        return {}
-    out: dict[str, str] = {}
-    for pair in feats.split("|"):
-        if "=" not in pair:
-            continue
-        key, _, value = pair.partition("=")
-        key = key.strip()
-        value = value.strip()
-        if key:
-            out[key] = value
-    return out
-
-
-class HindiPipeline(Pipeline):
+class HindiPipeline(StanzaUDPipeline):
     """Stanza-backed Hindi tokenizer + lemmatizer + morphology."""
 
     pipeline_id = "stanza-hi"
-
-    def __init__(self, nlp: _StanzaLike) -> None:
-        # The stanza model is injected (built by :func:`build_hindi_pipeline`
-        # in production; a fake in tests) so this class has no direct import
-        # dependency on stanza — keeps the module importable in CI without
-        # stanza + torch installed.
-        self._nlp = nlp
-
-    def process(self, text: str) -> PipelineResult:
-        doc = self._nlp(text)
-        tokens: list[Token] = []
-        idx = 0
-        for sentence in doc.sentences:
-            for word in sentence.words:
-                surface = word.text
-                lemma = word.lemma or surface
-                upos = (word.upos or "X").upper()
-                features = _parse_feats(word.feats)
-                is_word = upos not in _NON_WORD_UPOS
-                is_oov = lemma == surface and upos not in _NON_OOV_UPOS
-                tokens.append(
-                    Token(
-                        idx=idx,
-                        surface=surface,
-                        is_word=is_word,
-                        candidates=[
-                            LemmaCandidate(
-                                lemma=lemma,
-                                pos=upos,
-                                score=1.0,
-                                features=features,
-                            ),
-                        ],
-                        is_ambiguous=False,
-                        is_oov=is_oov,
-                        romanization=None,
-                    )
-                )
-                idx += 1
-        return PipelineResult(pipeline_id=self.pipeline_id, tokens=tokens)
 
 
 def build_hindi_pipeline() -> HindiPipeline:  # pragma: no cover

--- a/services/nlp/app/pipelines/marathi.py
+++ b/services/nlp/app/pipelines/marathi.py
@@ -1,0 +1,127 @@
+"""Marathi pipeline backed by Stanza's ``mr`` UD model.
+
+Output shape and OOV / ambiguity contract match the Hindi pipeline — the
+same :class:`StanzaUDPipeline` base handles tokenization / lemma / POS /
+morphology feature extraction.
+
+Marathi accuracy caveat (from the plan): Stanza's ``mr`` model runs at
+~75–85% real-world accuracy versus ~90% for Hindi, so we expect
+``is_oov`` to fire more often. The correction UX in M6 carries the
+weight of that. No pipeline-side workarounds here — the correct place
+to improve parse quality is crowdsourced overrides (T-2.7 / T-6.7) and
+the dictionary (M3), not by guessing in the tokenizer.
+
+**IndicNLP fallback**: Stanza's Marathi tokenizer has known issues on
+short, punctuation-heavy, or informal inputs where it can emit zero
+tokens for non-empty text. When that happens we fall back to
+IndicNLP's ``indic_tokenize.trivial_tokenize(..., lang='mr')`` (which
+is already script-aware and handles Devanagari clitics) to at least
+surface the words with ``is_oov=True``. The fallback is injected so
+tests don't need IndicNLP installed.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from app.schemas import LemmaCandidate, Token
+
+from .base import PipelineResult
+from .stanza_ud import NON_WORD_UPOS, StanzaLike, StanzaUDPipeline
+
+MarathiTokenizer = Callable[[str], list[str]]
+
+
+# Minimal set of characters treated as punctuation by the fallback
+# tokenizer. This deliberately undershoots — punctuation-heavy surfaces
+# aren't the common case for the fallback path, and being strict here
+# keeps the function side-effect-free without pulling in
+# unicodedata.category checks on every char.
+_FALLBACK_PUNCT: frozenset[str] = frozenset(
+    ".,;:!?\u0964\u0965\"'()[]{}<>/\\|-—–"
+)
+
+
+def _is_fallback_punct(surface: str) -> bool:
+    return bool(surface) and all(c in _FALLBACK_PUNCT for c in surface)
+
+
+def _fallback_token(idx: int, surface: str) -> Token:
+    is_punct = _is_fallback_punct(surface)
+    upos = "PUNCT" if is_punct else "X"
+    return Token(
+        idx=idx,
+        surface=surface,
+        # NON_WORD_UPOS is imported so the reader's is_word predicate
+        # stays consistent with the Stanza path for the same UPOS.
+        is_word=upos not in NON_WORD_UPOS,
+        candidates=[LemmaCandidate(lemma=surface, pos=upos, score=1.0, features={})],
+        is_ambiguous=False,
+        # Fallback tokens are by definition OOV — Stanza produced nothing,
+        # so there's no dictionary lemma. Punctuation is exempt by the
+        # same rule the Stanza path uses.
+        is_oov=not is_punct,
+        romanization=None,
+    )
+
+
+class MarathiPipeline(StanzaUDPipeline):
+    """Stanza-backed Marathi pipeline with an IndicNLP fallback tokenizer."""
+
+    pipeline_id = "stanza-mr"
+
+    def __init__(
+        self,
+        nlp: StanzaLike,
+        *,
+        fallback_tokenizer: MarathiTokenizer,
+    ) -> None:
+        super().__init__(nlp=nlp)
+        self._fallback_tokenizer = fallback_tokenizer
+
+    def process(self, text: str) -> PipelineResult:
+        result = super().process(text)
+        # Fallback only triggers when Stanza produced no tokens for
+        # clearly non-empty input. The common "whitespace-only" case
+        # still returns an empty token list as expected.
+        if text.strip() and not result.tokens:
+            return self._fallback_process(text)
+        return result
+
+    def _fallback_process(self, text: str) -> PipelineResult:
+        surfaces = self._fallback_tokenizer(text)
+        tokens = [_fallback_token(i, s) for i, s in enumerate(surfaces) if s]
+        return PipelineResult(pipeline_id=self.pipeline_id, tokens=tokens)
+
+
+def _indicnlp_marathi_tokenize(text: str) -> list[str]:  # pragma: no cover
+    """Production fallback: IndicNLP's trivial tokenizer for Marathi."""
+    from indicnlp.tokenize import indic_tokenize
+
+    return list(indic_tokenize.trivial_tokenize(text, lang="mr"))
+
+
+def build_marathi_pipeline() -> MarathiPipeline:  # pragma: no cover
+    """Construct a :class:`MarathiPipeline` with a real Stanza model.
+
+    Registered in :mod:`app.pipelines.__init__` as the ``stanza-mr``
+    factory. Lazy-imports stanza and IndicNLP so CI doesn't need either.
+    The Docker image pre-downloads the Marathi Stanza model at build
+    time; ``download_method=None`` keeps request paths offline-safe.
+    """
+    import stanza
+
+    nlp = stanza.Pipeline(
+        lang="mr",
+        processors="tokenize,pos,lemma",
+        tokenize_no_ssplit=False,
+        download_method=None,
+        verbose=False,
+    )
+    return MarathiPipeline(
+        nlp=nlp,
+        fallback_tokenizer=_indicnlp_marathi_tokenize,
+    )
+
+
+__all__ = ["MarathiPipeline", "MarathiTokenizer", "build_marathi_pipeline"]

--- a/services/nlp/app/pipelines/stanza_ud.py
+++ b/services/nlp/app/pipelines/stanza_ud.py
@@ -1,0 +1,122 @@
+"""Shared output-shaping for Stanza UD-style pipelines.
+
+Hindi (T-2.2) and Marathi (T-2.3) both run Stanza's UD pipeline and
+produce the same :class:`Token` shape. The language-agnostic parts —
+iterating over ``doc.sentences[*].words``, parsing UD ``feats`` into a
+dict, applying the OOV / ``is_word`` POS heuristics — live here so one
+subclass can't accidentally diverge from the other's contract.
+
+Each concrete per-language class (``HindiPipeline``, ``MarathiPipeline``)
+is a thin subclass that sets ``pipeline_id`` and is constructed with an
+already-initialized stanza-like ``nlp`` object. The real model loading
+happens in the corresponding ``build_<lang>_pipeline`` factory.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from app.schemas import LemmaCandidate, Token
+
+from .base import Pipeline, PipelineResult
+
+
+class StanzaLike(Protocol):
+    """The subset of Stanza's ``Pipeline`` callable we depend on.
+
+    Using a structural type lets tests inject a lightweight fake without
+    importing stanza (and without having to install torch in CI). The
+    production code path lazy-imports stanza in each ``build_*_pipeline``.
+    """
+
+    def __call__(self, text: str) -> Any: ...  # noqa: D401,E704
+
+
+# UD UPOS tags where "lemma equals surface" does NOT imply OOV. A proper
+# noun's lemma is its surface by design; punctuation / symbols / digits
+# legitimately don't have dictionary lemmas; ``X`` is Stanza's other-
+# language marker and is effectively a code-switch signal.
+NON_OOV_UPOS: frozenset[str] = frozenset({"PUNCT", "SYM", "NUM", "PROPN", "X"})
+
+# UD UPOS tags that aren't lexical words. The reader uses ``is_word`` to
+# skip these when counting known-words and when rendering the pop-up.
+NON_WORD_UPOS: frozenset[str] = frozenset({"PUNCT", "SYM"})
+
+
+def parse_feats(feats: str | None) -> dict[str, str]:
+    """Turn Stanza's ``"Tense=Pres|Number=Sing"`` string into a dict.
+
+    Stanza uses ``None`` (or an empty string) when a word has no
+    features. Malformed pairs are skipped rather than raising —
+    morphology drift between Stanza model versions shouldn't 500 a
+    ``/process`` call.
+    """
+    if not feats:
+        return {}
+    out: dict[str, str] = {}
+    for pair in feats.split("|"):
+        if "=" not in pair:
+            continue
+        key, _, value = pair.partition("=")
+        key = key.strip()
+        value = value.strip()
+        if key:
+            out[key] = value
+    return out
+
+
+class StanzaUDPipeline(Pipeline):
+    """Base class that turns a Stanza doc into our :class:`Token` list."""
+
+    # Subclasses set their own canonical pipeline_id, used to echo back
+    # which implementation produced the parse.
+    pipeline_id: str
+
+    def __init__(self, nlp: StanzaLike) -> None:
+        self._nlp = nlp
+
+    def process(self, text: str) -> PipelineResult:
+        doc = self._nlp(text)
+        tokens = list(self._tokens_from_doc(doc))
+        return PipelineResult(pipeline_id=self.pipeline_id, tokens=tokens)
+
+    def _tokens_from_doc(self, doc: Any) -> list[Token]:
+        tokens: list[Token] = []
+        idx = 0
+        for sentence in doc.sentences:
+            for word in sentence.words:
+                surface = word.text
+                lemma = word.lemma or surface
+                upos = (word.upos or "X").upper()
+                features = parse_feats(word.feats)
+                is_word = upos not in NON_WORD_UPOS
+                is_oov = lemma == surface and upos not in NON_OOV_UPOS
+                tokens.append(
+                    Token(
+                        idx=idx,
+                        surface=surface,
+                        is_word=is_word,
+                        candidates=[
+                            LemmaCandidate(
+                                lemma=lemma,
+                                pos=upos,
+                                score=1.0,
+                                features=features,
+                            ),
+                        ],
+                        is_ambiguous=False,
+                        is_oov=is_oov,
+                        romanization=None,
+                    )
+                )
+                idx += 1
+        return tokens
+
+
+__all__ = [
+    "NON_OOV_UPOS",
+    "NON_WORD_UPOS",
+    "StanzaLike",
+    "StanzaUDPipeline",
+    "parse_feats",
+]

--- a/services/nlp/pyproject.toml
+++ b/services/nlp/pyproject.toml
@@ -23,6 +23,9 @@ dev = [
 # fake stanza object instead of loading the real model.
 models = [
   "stanza>=1.8.0",
+  # IndicNLP is the Marathi tokenizer fallback (T-2.3) and will also
+  # underpin the Odia tokenizer (T-2.3a). Small, pure-Python dep.
+  "indic-nlp-library>=0.92",
 ]
 
 [build-system]

--- a/services/nlp/tests/conftest.py
+++ b/services/nlp/tests/conftest.py
@@ -41,6 +41,7 @@ import pytest  # noqa: E402
 
 from app import pipelines  # noqa: E402
 from app.pipelines.hindi import HindiPipeline  # noqa: E402
+from app.pipelines.marathi import MarathiPipeline  # noqa: E402
 
 
 @dataclass
@@ -77,21 +78,42 @@ class _WhitespaceFakeStanza:
         return _FakeDoc(sentences=[_FakeSentence(words=words)] if words else [])
 
 
-@pytest.fixture(autouse=True)
-def _fake_hindi_factory():
-    """Replace the real Hindi factory with a whitespace-fake for the test."""
-    original = pipelines._PIPELINE_FACTORIES.get("stanza-hi")
+def _fallback_split(text: str) -> list[str]:
+    """Minimal fallback tokenizer used by the Marathi fake."""
+    return text.split()
 
-    def _factory() -> HindiPipeline:
+
+@pytest.fixture(autouse=True)
+def _fake_stanza_factories():
+    """Replace the real Stanza-backed factories with whitespace fakes.
+
+    Applies to both ``stanza-hi`` (T-2.2) and ``stanza-mr`` (T-2.3).
+    Dedicated tests for each pipeline still instantiate with their own
+    fakes when they need specific UPOS / features / fallback behavior.
+    """
+    originals = {
+        "stanza-hi": pipelines._PIPELINE_FACTORIES.get("stanza-hi"),
+        "stanza-mr": pipelines._PIPELINE_FACTORIES.get("stanza-mr"),
+    }
+
+    def _hi_factory() -> HindiPipeline:
         return HindiPipeline(nlp=_WhitespaceFakeStanza())
 
-    pipelines._PIPELINE_FACTORIES["stanza-hi"] = _factory
+    def _mr_factory() -> MarathiPipeline:
+        return MarathiPipeline(
+            nlp=_WhitespaceFakeStanza(),
+            fallback_tokenizer=_fallback_split,
+        )
+
+    pipelines._PIPELINE_FACTORIES["stanza-hi"] = _hi_factory
+    pipelines._PIPELINE_FACTORIES["stanza-mr"] = _mr_factory
     pipelines.reset_pipeline_cache()
     try:
         yield
     finally:
-        if original is None:
-            pipelines._PIPELINE_FACTORIES.pop("stanza-hi", None)
-        else:
-            pipelines._PIPELINE_FACTORIES["stanza-hi"] = original
+        for pipeline_id, original in originals.items():
+            if original is None:
+                pipelines._PIPELINE_FACTORIES.pop(pipeline_id, None)
+            else:
+                pipelines._PIPELINE_FACTORIES[pipeline_id] = original
         pipelines.reset_pipeline_cache()

--- a/services/nlp/tests/test_hindi_pipeline.py
+++ b/services/nlp/tests/test_hindi_pipeline.py
@@ -6,13 +6,20 @@ feature parsing, POS-aware ``is_word`` / ``is_oov``, token indexing
 across sentences — without a ~600MB model download. The trade-off is
 we're testing our adapter, not Stanza itself; Stanza's own accuracy is
 covered by the golden-file suite (T-2.8).
+
+The shared output-shaping logic was extracted into
+:mod:`app.pipelines.stanza_ud` in T-2.3 so Marathi could reuse it; the
+feature-parsing tests target ``parse_feats`` at its new public home but
+the HindiPipeline behavior tests stay here to pin down the
+language-specific contract.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from app.pipelines.hindi import HindiPipeline, _parse_feats
+from app.pipelines.hindi import HindiPipeline
+from app.pipelines.stanza_ud import parse_feats
 
 
 @dataclass
@@ -50,23 +57,23 @@ def _pipe(doc: FakeDoc) -> tuple[HindiPipeline, FakeStanza]:
     return HindiPipeline(nlp=fake), fake
 
 
-# --- _parse_feats --------------------------------------------------------
+# --- parse_feats --------------------------------------------------------
 
 
 def test_parse_feats_none_returns_empty():
-    assert _parse_feats(None) == {}
+    assert parse_feats(None) == {}
 
 
 def test_parse_feats_empty_string_returns_empty():
-    assert _parse_feats("") == {}
+    assert parse_feats("") == {}
 
 
 def test_parse_feats_single_pair():
-    assert _parse_feats("Number=Sing") == {"Number": "Sing"}
+    assert parse_feats("Number=Sing") == {"Number": "Sing"}
 
 
 def test_parse_feats_multiple_pairs():
-    out = _parse_feats("Tense=Pres|Number=Sing|Person=3|Gender=Fem|Aspect=Hab")
+    out = parse_feats("Tense=Pres|Number=Sing|Person=3|Gender=Fem|Aspect=Hab")
     assert out == {
         "Tense": "Pres",
         "Number": "Sing",
@@ -79,7 +86,7 @@ def test_parse_feats_multiple_pairs():
 def test_parse_feats_skips_malformed_pairs():
     # Defensive: a stray token or missing "=" from a Stanza model update
     # shouldn't surface as a 500 on /process.
-    out = _parse_feats("Tense=Pres|bogus|Number=Sing|=orphan")
+    out = parse_feats("Tense=Pres|bogus|Number=Sing|=orphan")
     assert out == {"Tense": "Pres", "Number": "Sing"}
 
 

--- a/services/nlp/tests/test_marathi_pipeline.py
+++ b/services/nlp/tests/test_marathi_pipeline.py
@@ -1,0 +1,167 @@
+"""Unit tests for :class:`app.pipelines.marathi.MarathiPipeline` (T-2.3).
+
+The tokenization / lemma / POS / feature shaping is shared with Hindi
+and already covered by ``test_hindi_pipeline.py``; this file focuses on
+the Marathi-specific pieces:
+
+- The ``pipeline_id`` is the canonical ``stanza-mr`` string.
+- The IndicNLP fallback fires when Stanza yields zero tokens for
+  non-empty input, and only then.
+- Fallback tokens are marked OOV for content, not for punctuation,
+  mirroring the Stanza path's is_oov rule.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+from app.pipelines.marathi import MarathiPipeline
+
+
+@dataclass
+class FakeWord:
+    text: str
+    lemma: str | None = None
+    upos: str = "NOUN"
+    feats: str | None = None
+
+
+@dataclass
+class FakeSentence:
+    words: list[FakeWord] = field(default_factory=list)
+
+
+@dataclass
+class FakeDoc:
+    sentences: list[FakeSentence] = field(default_factory=list)
+
+
+class FakeStanza:
+    def __init__(self, doc: FakeDoc) -> None:
+        self._doc = doc
+
+    def __call__(self, text: str) -> FakeDoc:
+        return self._doc
+
+
+def _track_calls() -> tuple[list[str], Callable[[str], list[str]]]:
+    calls: list[str] = []
+
+    def _tokenize(text: str) -> list[str]:
+        calls.append(text)
+        return text.split()
+
+    return calls, _tokenize
+
+
+def test_pipeline_id_is_stanza_mr():
+    calls, fb = _track_calls()
+    pipe = MarathiPipeline(
+        nlp=FakeStanza(FakeDoc(sentences=[FakeSentence(words=[FakeWord("एक")])])),
+        fallback_tokenizer=fb,
+    )
+    assert pipe.process("x").pipeline_id == "stanza-mr"
+    # Stanza produced tokens, so fallback never ran.
+    assert calls == []
+
+
+def test_fallback_does_not_fire_when_stanza_returns_tokens():
+    calls, fb = _track_calls()
+    doc = FakeDoc(
+        sentences=[FakeSentence(words=[FakeWord(text="बोलतो", lemma="बोलणे", upos="VERB")])]
+    )
+    pipe = MarathiPipeline(nlp=FakeStanza(doc), fallback_tokenizer=fb)
+    result = pipe.process("बोलतो")
+    assert calls == []
+    assert len(result.tokens) == 1
+    assert result.tokens[0].candidates[0].lemma == "बोलणे"
+
+
+def test_fallback_does_not_fire_on_whitespace_only_input():
+    # Whitespace-only is legitimately empty — we shouldn't synthesize
+    # tokens from it via the fallback just because Stanza also returned
+    # nothing.
+    calls, fb = _track_calls()
+    pipe = MarathiPipeline(nlp=FakeStanza(FakeDoc(sentences=[])), fallback_tokenizer=fb)
+    result = pipe.process("   \t\n  ")
+    assert calls == []
+    assert result.tokens == []
+
+
+def test_fallback_fires_when_stanza_returns_empty_for_non_empty_input():
+    # The failure mode the fallback exists to cover: Stanza's mr model
+    # emitting zero tokens (via zero sentences) for a short / informal
+    # input where IndicNLP would tokenize fine.
+    calls, fb = _track_calls()
+    pipe = MarathiPipeline(nlp=FakeStanza(FakeDoc(sentences=[])), fallback_tokenizer=fb)
+    result = pipe.process("नमस्कार जग")
+    assert calls == ["नमस्कार जग"]
+    assert [t.surface for t in result.tokens] == ["नमस्कार", "जग"]
+    # Fallback tokens are all content (UPOS=X) and OOV.
+    assert all(t.is_word for t in result.tokens)
+    assert all(t.is_oov for t in result.tokens)
+    assert all(t.candidates[0].pos == "X" for t in result.tokens)
+    assert all(t.candidates[0].lemma == t.surface for t in result.tokens)
+
+
+def test_fallback_preserves_token_indexes():
+    calls, fb = _track_calls()
+    pipe = MarathiPipeline(nlp=FakeStanza(FakeDoc(sentences=[])), fallback_tokenizer=fb)
+    result = pipe.process("एक दोन तीन")
+    assert [t.idx for t in result.tokens] == [0, 1, 2]
+
+
+def test_fallback_marks_punctuation_correctly():
+    # Devanagari danda (।) and a Latin full stop should both be
+    # recognized as punctuation by the fallback tagger, mirroring the
+    # is_word / is_oov contract used by the Stanza path.
+    def fb(text: str) -> list[str]:
+        return ["नमस्कार", "।", "."]
+
+    pipe = MarathiPipeline(nlp=FakeStanza(FakeDoc(sentences=[])), fallback_tokenizer=fb)
+    result = pipe.process("नमस्कार ।")
+    assert [t.surface for t in result.tokens] == ["नमस्कार", "।", "."]
+    assert result.tokens[0].is_word is True
+    assert result.tokens[0].is_oov is True
+    # Punctuation: is_word=False, is_oov=False
+    assert result.tokens[1].is_word is False
+    assert result.tokens[1].is_oov is False
+    assert result.tokens[2].is_word is False
+    assert result.tokens[2].is_oov is False
+
+
+def test_fallback_drops_empty_surfaces():
+    # A fallback tokenizer that returns stray empty strings (e.g. because
+    # IndicNLP split on a trailing newline) shouldn't emit empty tokens —
+    # those are illegal in the Token schema (surface is non-empty).
+    def fb(_text: str) -> list[str]:
+        return ["एक", "", "दो"]
+
+    pipe = MarathiPipeline(nlp=FakeStanza(FakeDoc(sentences=[])), fallback_tokenizer=fb)
+    result = pipe.process("whatever")
+    assert [t.surface for t in result.tokens] == ["एक", "दो"]
+
+
+def test_marathi_pipeline_reuses_stanza_output_shaping():
+    # Sanity check: when Stanza does produce tokens, the result looks
+    # identical in shape to Hindi — same LemmaCandidate, same UPOS-driven
+    # is_word / is_oov rules. Regression guard so MarathiPipeline doesn't
+    # silently diverge from StanzaUDPipeline.
+    calls, fb = _track_calls()
+    doc = FakeDoc(
+        sentences=[
+            FakeSentence(
+                words=[
+                    FakeWord(text="माझे", lemma="माझे", upos="PRON", feats="Number=Sing"),
+                    FakeWord(text="।", lemma="।", upos="PUNCT"),
+                ]
+            )
+        ]
+    )
+    pipe = MarathiPipeline(nlp=FakeStanza(doc), fallback_tokenizer=fb)
+    result = pipe.process("माझे ।")
+    assert result.tokens[0].candidates[0].features == {"Number": "Sing"}
+    assert result.tokens[0].is_oov is True  # PRON + lemma==surface
+    assert result.tokens[1].is_word is False
+    assert result.tokens[1].is_oov is False

--- a/services/nlp/tests/test_pipelines.py
+++ b/services/nlp/tests/test_pipelines.py
@@ -12,6 +12,7 @@ import pytest
 from app import pipelines
 from app.pipelines import Pipeline, PipelineResult, StubPipeline, get_pipeline
 from app.pipelines.hindi import HindiPipeline
+from app.pipelines.marathi import MarathiPipeline
 from app.schemas import LemmaCandidate, Token
 
 
@@ -23,17 +24,19 @@ def _clear_cache():
 
 
 def test_get_pipeline_returns_stub_for_languages_still_on_stub():
-    # After T-2.2 Hindi routes to HindiPipeline; Marathi (T-2.3) and Odia
-    # (T-2.3a) still use the stub until their own pipelines ship.
-    for code in ("mr", "or"):
-        pipe = get_pipeline(code)
-        assert isinstance(pipe, Pipeline)
-        assert isinstance(pipe, StubPipeline)
+    # After T-2.2 / T-2.3, Hindi and Marathi route to their real Stanza-
+    # backed pipelines; Odia (T-2.3a) is still on the stub.
+    pipe = get_pipeline("or")
+    assert isinstance(pipe, Pipeline)
+    assert isinstance(pipe, StubPipeline)
 
 
 def test_get_pipeline_returns_hindi_pipeline_for_hi():
-    pipe = get_pipeline("hi")
-    assert isinstance(pipe, HindiPipeline)
+    assert isinstance(get_pipeline("hi"), HindiPipeline)
+
+
+def test_get_pipeline_returns_marathi_pipeline_for_mr():
+    assert isinstance(get_pipeline("mr"), MarathiPipeline)
 
 
 def test_get_pipeline_reuses_instance_per_pipeline_id():


### PR DESCRIPTION
## Summary
- Extract the Stanza-common output-shaping logic (doc iteration, UD feature parsing, POS-driven `is_word` / `is_oov` rules) into a new `StanzaUDPipeline` base. Hindi becomes a thin subclass; Marathi is a sibling subclass with the same contract plus an IndicNLP fallback.
- `MarathiPipeline` routes to an injected fallback tokenizer when Stanza returns zero sentences for non-empty input — a known failure mode on short / informal / punctuation-heavy Marathi text. Fallback uses IndicNLP's `trivial_tokenize(..., lang='mr')` in production; tests inject a simple split-based fake.
- Runtime deps: `indic-nlp-library` joins `stanza` in the `[models]` optional-deps group. Dockerfile pre-downloads both Hindi and Marathi Stanza models at image build time.

## Design
Marathi's real-world lemma accuracy is lower than Hindi (~75–85% vs ~90%), so `is_oov` will fire more often. That's expected and handled by M6's correction UX + T-6.7 crowdsourced overrides — the plan explicitly calls out not adding pipeline-side guessing. The IndicNLP fallback is specifically scoped to one failure mode (Stanza yields zero tokens for valid input), not a general ensemble.

`is_ambiguous` stays `False` until dictionary candidates land (M3) — the downstream UX (M6) only branches on this flag, so the reader degrades to "no alternates chevron" for now.

Punctuation detection in the fallback path (Devanagari danda + Latin) mirrors the Stanza path's `is_word` / `is_oov` rule, so tokens look identical to the reader regardless of which code path produced them.

## Test plan
- [x] `pytest tests/` — 43 passed, 99% branch coverage
- [x] Marathi routes to `MarathiPipeline` (replaces stub)
- [x] Fallback does NOT fire when Stanza returns tokens
- [x] Fallback does NOT fire on whitespace-only input
- [x] Fallback DOES fire when Stanza returns zero tokens for non-empty input — correct surfaces, `is_oov=True` for content, `is_oov=False` for punctuation
- [x] Fallback preserves contiguous token indexes
- [x] Fallback drops empty-string surfaces from the tokenizer
- [x] Shared Stanza path produces identical output shape to Hindi (regression guard against MarathiPipeline drift)
- [x] `ruff check` clean
- [x] Conftest autouse fixture now injects fakes for both `stanza-hi` and `stanza-mr`

## Depends on
[#123 — T-2.2 Hindi pipeline](https://github.com/chickendude/CIA-Reader/pull/123)