### PR TITLE
T-2.3b: Odia golden-file corpus + language-agnostic eval harness

### DIFF
--- a/services/nlp/app/eval/__init__.py
+++ b/services/nlp/app/eval/__init__.py
@@ -1,0 +1,19 @@
+"""Per-language pipeline evaluation harness.
+
+Used by T-2.3b (Odia golden-file corpus) and by T-2.8 when CI accuracy
+thresholds are enforced. The harness is deliberately language-agnostic:
+it operates on a :class:`GoldenCorpus` + any :class:`Pipeline`, so the
+same code path grades Hindi (T-2.2), Marathi (T-2.3), and Odia (T-2.3a).
+"""
+
+from __future__ import annotations
+
+from .corpus import EvalResult, GoldenCorpus, GoldenSentence, GoldenToken, evaluate
+
+__all__ = [
+    "EvalResult",
+    "GoldenCorpus",
+    "GoldenSentence",
+    "GoldenToken",
+    "evaluate",
+]

--- a/services/nlp/app/eval/corpus.py
+++ b/services/nlp/app/eval/corpus.py
@@ -1,0 +1,223 @@
+"""Golden-file corpus loader + pipeline evaluator.
+
+The corpus format is the one documented in the JSON fixtures (see
+``app/pipelines/odia/data/golden_corpus.json``). Each entry asserts
+only what the contributor is confident about — missing keys are
+"don't-care" slots, so a sentence can pin the lemma without pinning
+every morphology feature.
+
+Accuracy is reported as a set of per-field rates (lemma, pos, feats,
+is_oov, is_ambiguous) plus an overall "lemma + pos" joint rate, which
+is the one T-2.8 thresholds in CI against. Per-sentence token counts
+need not match — a divergence is a failure with a descriptive reason
+so a human can spot what drifted.
+"""
+
+from __future__ import annotations
+
+import json
+import unicodedata
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from app.pipelines.base import Pipeline
+
+
+@dataclass(frozen=True, slots=True)
+class GoldenToken:
+    """Expected analysis for a single token. Missing fields are not checked."""
+
+    surface: str
+    lemma: str | None = None
+    pos: str | None = None
+    features: dict[str, str] | None = None
+    is_oov: bool | None = None
+    is_ambiguous: bool | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class GoldenSentence:
+    id: str
+    text: str
+    tokens: tuple[GoldenToken, ...]
+    source: str | None = None
+    comment: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class GoldenCorpus:
+    sentences: tuple[GoldenSentence, ...]
+
+    def __len__(self) -> int:
+        return len(self.sentences)
+
+
+def load_corpus(path: Path) -> GoldenCorpus:
+    raw: dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))
+    sentences: list[GoldenSentence] = []
+    for entry in raw.get("sentences", []):
+        tokens = tuple(
+            GoldenToken(
+                surface=unicodedata.normalize("NFC", t["surface"]),
+                lemma=_nfc_or_none(t.get("lemma")),
+                pos=t.get("pos"),
+                features=t.get("features"),
+                is_oov=t.get("is_oov"),
+                is_ambiguous=t.get("is_ambiguous"),
+            )
+            for t in entry["tokens"]
+        )
+        sentences.append(
+            GoldenSentence(
+                id=entry["id"],
+                text=unicodedata.normalize("NFC", entry["text"]),
+                tokens=tokens,
+                source=entry.get("source"),
+                comment=entry.get("comment"),
+            )
+        )
+    return GoldenCorpus(sentences=tuple(sentences))
+
+
+def _nfc_or_none(value: str | None) -> str | None:
+    return unicodedata.normalize("NFC", value) if value else None
+
+
+@dataclass
+class _Counter:
+    correct: int = 0
+    total: int = 0
+
+    def add(self, ok: bool) -> None:
+        self.total += 1
+        if ok:
+            self.correct += 1
+
+    @property
+    def rate(self) -> float:
+        return self.correct / self.total if self.total else 1.0
+
+
+@dataclass
+class EvalResult:
+    """Aggregated per-field accuracy + a list of human-readable failures.
+
+    ``failures`` is capped at ~50 entries by the caller if needed; the
+    list is intentionally verbose so a CI failure points the reviewer
+    at a specific golden sentence rather than just "accuracy dropped."
+    """
+
+    sentence_count: int = 0
+    token_count: int = 0
+    lemma: _Counter = field(default_factory=_Counter)
+    pos: _Counter = field(default_factory=_Counter)
+    features: _Counter = field(default_factory=_Counter)
+    is_oov: _Counter = field(default_factory=_Counter)
+    is_ambiguous: _Counter = field(default_factory=_Counter)
+    joint_lemma_pos: _Counter = field(default_factory=_Counter)
+    failures: list[str] = field(default_factory=list)
+
+    def summary(self) -> dict[str, float]:
+        return {
+            "lemma_accuracy": self.lemma.rate,
+            "pos_accuracy": self.pos.rate,
+            "features_accuracy": self.features.rate,
+            "is_oov_accuracy": self.is_oov.rate,
+            "is_ambiguous_accuracy": self.is_ambiguous.rate,
+            "joint_lemma_pos_accuracy": self.joint_lemma_pos.rate,
+        }
+
+
+def evaluate(pipeline: Pipeline, corpus: GoldenCorpus) -> EvalResult:
+    result = EvalResult()
+
+    for sentence in corpus.sentences:
+        result.sentence_count += 1
+        pipeline_result = pipeline.process(sentence.text)
+        actual_tokens = pipeline_result.tokens
+
+        if len(actual_tokens) != len(sentence.tokens):
+            result.failures.append(
+                f"[{sentence.id}] token count mismatch — "
+                f"expected {len(sentence.tokens)}, got {len(actual_tokens)}"
+            )
+            # Token count mismatch: skip per-token scoring but still count
+            # the sentence so a systematic tokenizer regression trips this.
+            continue
+
+        for expected, actual in zip(sentence.tokens, actual_tokens, strict=True):
+            result.token_count += 1
+            top = actual.candidates[0] if actual.candidates else None
+
+            lemma_ok = _check(
+                expected.lemma,
+                top.lemma if top else None,
+                result.lemma,
+                sentence.id,
+                expected.surface,
+                "lemma",
+                result.failures,
+            )
+            pos_ok = _check(
+                expected.pos,
+                top.pos if top else None,
+                result.pos,
+                sentence.id,
+                expected.surface,
+                "pos",
+                result.failures,
+            )
+            if expected.lemma is not None and expected.pos is not None:
+                result.joint_lemma_pos.add(lemma_ok and pos_ok)
+
+            if expected.features is not None:
+                got = top.features if top else {}
+                ok = all(got.get(k) == v for k, v in expected.features.items())
+                result.features.add(ok)
+                if not ok:
+                    result.failures.append(
+                        f"[{sentence.id}:{expected.surface}] features "
+                        f"expected subset {expected.features}, got {got}"
+                    )
+
+            _check(
+                expected.is_oov,
+                actual.is_oov,
+                result.is_oov,
+                sentence.id,
+                expected.surface,
+                "is_oov",
+                result.failures,
+            )
+            _check(
+                expected.is_ambiguous,
+                actual.is_ambiguous,
+                result.is_ambiguous,
+                sentence.id,
+                expected.surface,
+                "is_ambiguous",
+                result.failures,
+            )
+
+    return result
+
+
+def _check(
+    expected: Any,
+    actual: Any,
+    counter: _Counter,
+    sentence_id: str,
+    surface: str,
+    field_name: str,
+    failures: list[str],
+) -> bool:
+    if expected is None:
+        return True
+    ok = expected == actual
+    counter.add(ok)
+    if not ok:
+        failures.append(
+            f"[{sentence_id}:{surface}] {field_name} expected {expected!r}, got {actual!r}"
+        )
+    return ok

--- a/services/nlp/app/pipelines/odia/data/golden_corpus.json
+++ b/services/nlp/app/pipelines/odia/data/golden_corpus.json
@@ -1,0 +1,186 @@
+{
+  "__description__": "Odia golden-file corpus (T-2.3b). Each entry pairs an Odia sentence with its expected per-token analysis. Serves as (a) an eval set for T-2.3a pipeline iteration, (b) a regression guard for future rule-table / lemma-seed edits, and (c) the fixture T-2.8 CI accuracy thresholds run against. Format per entry: 'text' is the whole sentence (NFC-normalized Odia script). 'tokens' is an ordered list — one entry per whitespace-separated surface — with optional expectations: 'lemma', 'pos', 'features' (subset check — only keys present are checked), 'is_oov', 'is_ambiguous'. A missing key means 'do not enforce'. This lets contributors add a sentence and assert only what they're sure of. The seed is deliberately small + paradigm-focused: it only uses lemmas from seed_lemmas.json so the eval is reproducible without the Odia WordNet import (T-3.1). Expanded corpora land post-T-3.1, ideally reviewed by a native Odia speaker. Known gaps documented in docs/dictionary-sources.md.",
+  "sentences": [
+    {
+      "id": "greeting-01",
+      "source": "hand-written",
+      "text": "ନମସ୍କାର ଦୁନିଆ",
+      "tokens": [
+        { "surface": "ନମସ୍କାର", "lemma": "ନମସ୍କାର", "pos": "INTJ", "is_oov": false },
+        { "surface": "ଦୁନିଆ", "lemma": "ଦୁନିଆ", "pos": "NOUN", "is_oov": false }
+      ]
+    },
+    {
+      "id": "noun-nom-01",
+      "source": "hand-written",
+      "text": "ଘର ବଡ଼",
+      "tokens": [
+        { "surface": "ଘର", "lemma": "ଘର", "pos": "NOUN", "is_oov": false },
+        { "surface": "ବଡ଼", "lemma": "ବଡ଼", "pos": "ADJ", "is_oov": false }
+      ]
+    },
+    {
+      "id": "noun-loc-01",
+      "source": "hand-written",
+      "text": "ଘରରେ ବହି",
+      "tokens": [
+        { "surface": "ଘରରେ", "lemma": "ଘର", "pos": "NOUN", "features": { "Case": "Loc" }, "is_oov": false },
+        { "surface": "ବହି", "lemma": "ବହି", "pos": "NOUN", "is_oov": false }
+      ]
+    },
+    {
+      "id": "noun-acc-01",
+      "source": "hand-written",
+      "text": "ପିଲାକୁ ବହି",
+      "tokens": [
+        { "surface": "ପିଲାକୁ", "lemma": "ପିଲା", "pos": "NOUN", "features": { "Case": "Acc" }, "is_oov": false },
+        { "surface": "ବହି", "lemma": "ବହି", "pos": "NOUN", "is_oov": false }
+      ]
+    },
+    {
+      "id": "noun-gen-01",
+      "source": "hand-written",
+      "text": "ଘରର ପିଲା",
+      "tokens": [
+        { "surface": "ଘରର", "lemma": "ଘର", "pos": "NOUN", "features": { "Case": "Gen" }, "is_oov": false },
+        { "surface": "ପିଲା", "lemma": "ପିଲା", "pos": "NOUN", "is_oov": false }
+      ]
+    },
+    {
+      "id": "noun-abl-01",
+      "source": "hand-written",
+      "text": "ଘରରୁ ପିଲା",
+      "tokens": [
+        { "surface": "ଘରରୁ", "lemma": "ଘର", "pos": "NOUN", "features": { "Case": "Abl" }, "is_oov": false },
+        { "surface": "ପିଲା", "lemma": "ପିଲା", "pos": "NOUN", "is_oov": false }
+      ]
+    },
+    {
+      "id": "noun-plural-nom-01",
+      "source": "hand-written",
+      "text": "ପିଲାମାନେ ଭଲ",
+      "tokens": [
+        { "surface": "ପିଲାମାନେ", "lemma": "ପିଲା", "pos": "NOUN", "features": { "Number": "Plur", "Case": "Nom" }, "is_oov": false },
+        { "surface": "ଭଲ", "lemma": "ଭଲ", "pos": "ADJ", "is_oov": false }
+      ]
+    },
+    {
+      "id": "noun-plural-acc-01",
+      "source": "hand-written",
+      "text": "ପିଲାମାନଙ୍କୁ ଦେଖ",
+      "tokens": [
+        { "surface": "ପିଲାମାନଙ୍କୁ", "lemma": "ପିଲା", "pos": "NOUN", "features": { "Number": "Plur", "Case": "Acc" }, "is_oov": false },
+        { "surface": "ଦେଖ", "lemma": "ଦେଖ", "pos": "VERB", "is_oov": false }
+      ]
+    },
+    {
+      "id": "noun-plural-gen-01",
+      "source": "hand-written",
+      "text": "ପିଲାମାନଙ୍କ ବହି",
+      "tokens": [
+        { "surface": "ପିଲାମାନଙ୍କ", "lemma": "ପିଲା", "pos": "NOUN", "features": { "Number": "Plur", "Case": "Gen" }, "is_oov": false },
+        { "surface": "ବହି", "lemma": "ବହି", "pos": "NOUN", "is_oov": false }
+      ]
+    },
+    {
+      "id": "verb-fut-3-01",
+      "source": "hand-written",
+      "text": "ସେ ଦେଖିବେ",
+      "tokens": [
+        { "surface": "ସେ", "lemma": "ସେ", "pos": "PRON", "is_oov": false },
+        { "surface": "ଦେଖିବେ", "lemma": "ଦେଖ", "pos": "VERB", "features": { "Tense": "Fut", "Person": "3" }, "is_oov": false }
+      ]
+    },
+    {
+      "id": "verb-inf-01",
+      "source": "hand-written",
+      "text": "ବହି ପଢ଼ିବା ଭଲ",
+      "tokens": [
+        { "surface": "ବହି", "lemma": "ବହି", "pos": "NOUN", "is_oov": false },
+        { "surface": "ପଢ଼ିବା", "lemma": "ପଢ଼", "pos": "VERB", "features": { "VerbForm": "Inf" }, "is_oov": false },
+        { "surface": "ଭଲ", "lemma": "ଭଲ", "pos": "ADJ", "is_oov": false }
+      ]
+    },
+    {
+      "id": "verb-past-3sg-01",
+      "source": "hand-written",
+      "text": "ସେ ଦେଖିଲା",
+      "tokens": [
+        { "surface": "ସେ", "lemma": "ସେ", "pos": "PRON", "is_oov": false },
+        { "surface": "ଦେଖିଲା", "lemma": "ଦେଖ", "pos": "VERB", "features": { "Tense": "Past", "Number": "Sing" }, "is_oov": false }
+      ]
+    },
+    {
+      "id": "verb-past-3pl-01",
+      "source": "hand-written",
+      "text": "ସେ ଦେଖିଲେ",
+      "tokens": [
+        { "surface": "ସେ", "lemma": "ସେ", "pos": "PRON", "is_oov": false },
+        { "surface": "ଦେଖିଲେ", "lemma": "ଦେଖ", "pos": "VERB", "features": { "Tense": "Past", "Person": "3" }, "is_oov": false }
+      ]
+    },
+    {
+      "id": "verb-pres-3pl-01",
+      "source": "hand-written",
+      "text": "ସେ ଦେଖନ୍ତି",
+      "tokens": [
+        { "surface": "ସେ", "lemma": "ସେ", "pos": "PRON", "is_oov": false },
+        { "surface": "ଦେଖନ୍ତି", "lemma": "ଦେଖ", "pos": "VERB", "features": { "Tense": "Pres", "Person": "3", "Number": "Plur" }, "is_oov": false }
+      ]
+    },
+    {
+      "id": "adj-cmp-01",
+      "source": "hand-written",
+      "text": "ବଡ଼ତର ଘର",
+      "tokens": [
+        { "surface": "ବଡ଼ତର", "lemma": "ବଡ଼", "pos": "ADJ", "features": { "Degree": "Cmp" }, "is_oov": false },
+        { "surface": "ଘର", "lemma": "ଘର", "pos": "NOUN", "is_oov": false }
+      ]
+    },
+    {
+      "id": "adj-sup-01",
+      "source": "hand-written",
+      "text": "ବଡ଼ତମ ଘର",
+      "tokens": [
+        { "surface": "ବଡ଼ତମ", "lemma": "ବଡ଼", "pos": "ADJ", "features": { "Degree": "Sup" }, "is_oov": false },
+        { "surface": "ଘର", "lemma": "ଘର", "pos": "NOUN", "is_oov": false }
+      ]
+    },
+    {
+      "id": "pron-01",
+      "source": "hand-written",
+      "text": "ମୁଁ ଜାଣ",
+      "tokens": [
+        { "surface": "ମୁଁ", "lemma": "ମୁଁ", "pos": "PRON", "is_oov": false },
+        { "surface": "ଜାଣ", "lemma": "ଜାଣ", "pos": "VERB", "is_oov": false }
+      ]
+    },
+    {
+      "id": "punct-01",
+      "source": "hand-written",
+      "text": "ନମସ୍କାର ।",
+      "tokens": [
+        { "surface": "ନମସ୍କାର", "lemma": "ନମସ୍କାର", "pos": "INTJ", "is_oov": false },
+        { "surface": "।", "pos": "PUNCT", "is_oov": false }
+      ]
+    },
+    {
+      "id": "ambiguous-01",
+      "source": "hand-written",
+      "comment": "'ଘରର' legitimately reads as either the Gen form of 'ଘର' OR a lemma in its own right if the dictionary adds it. With only 'ଘର' in seed the reading is unambiguous; this guard-rails against future seed edits accidentally introducing spurious ambiguity.",
+      "text": "ଘରର",
+      "tokens": [
+        { "surface": "ଘରର", "lemma": "ଘର", "pos": "NOUN", "features": { "Case": "Gen" }, "is_ambiguous": false, "is_oov": false }
+      ]
+    },
+    {
+      "id": "oov-01",
+      "source": "hand-written",
+      "comment": "A deliberately out-of-seed surface. Pipeline should flag is_oov=true with a fallback X candidate. Regression guard against the OOV fallback silently disappearing.",
+      "text": "ଜଣେ",
+      "tokens": [
+        { "surface": "ଜଣେ", "is_oov": true }
+      ]
+    }
+  ]
+}

--- a/services/nlp/tests/test_eval_corpus.py
+++ b/services/nlp/tests/test_eval_corpus.py
@@ -1,0 +1,226 @@
+"""Unit tests for the language-agnostic :mod:`app.eval` harness (T-2.3b).
+
+The Odia-specific corpus tests live in :mod:`test_odia_golden`; this
+suite exercises the harness itself so a future Hindi / Marathi corpus
+doesn't have to re-prove its plumbing.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from app.eval import evaluate
+from app.eval.corpus import (
+    EvalResult,
+    GoldenCorpus,
+    GoldenSentence,
+    GoldenToken,
+    load_corpus,
+)
+from app.pipelines.base import Pipeline, PipelineResult
+from app.schemas import LemmaCandidate, Token
+
+
+class _ScriptedPipeline(Pipeline):
+    """Returns a pre-canned token list per input text."""
+
+    pipeline_id = "scripted"
+
+    def __init__(self, scripts: dict[str, list[Token]]) -> None:
+        self._scripts = scripts
+
+    def process(self, text: str) -> PipelineResult:
+        return PipelineResult(
+            pipeline_id=self.pipeline_id,
+            tokens=list(self._scripts.get(text, [])),
+        )
+
+
+def _tok(
+    idx: int,
+    surface: str,
+    lemma: str,
+    pos: str,
+    features: dict[str, str] | None = None,
+    is_oov: bool = False,
+    is_ambiguous: bool = False,
+) -> Token:
+    return Token(
+        idx=idx,
+        surface=surface,
+        is_word=pos not in {"PUNCT", "SYM"},
+        candidates=[
+            LemmaCandidate(lemma=lemma, pos=pos, score=1.0, features=features or {}),
+        ],
+        is_ambiguous=is_ambiguous,
+        is_oov=is_oov,
+        romanization=None,
+    )
+
+
+def _sentence(
+    sid: str,
+    text: str,
+    *tokens: GoldenToken,
+) -> GoldenSentence:
+    return GoldenSentence(id=sid, text=text, tokens=tokens)
+
+
+def test_all_expectations_met_yields_perfect_scores():
+    corpus = GoldenCorpus(
+        sentences=(
+            _sentence(
+                "a",
+                "foo bar",
+                GoldenToken(surface="foo", lemma="foo", pos="NOUN"),
+                GoldenToken(surface="bar", lemma="bar", pos="VERB"),
+            ),
+        )
+    )
+    pipeline = _ScriptedPipeline(
+        {
+            "foo bar": [
+                _tok(0, "foo", "foo", "NOUN"),
+                _tok(1, "bar", "bar", "VERB"),
+            ]
+        }
+    )
+    result = evaluate(pipeline, corpus)
+    assert result.failures == []
+    summary = result.summary()
+    assert summary["lemma_accuracy"] == 1.0
+    assert summary["pos_accuracy"] == 1.0
+    assert summary["joint_lemma_pos_accuracy"] == 1.0
+
+
+def test_lemma_mismatch_counted_and_reported():
+    corpus = GoldenCorpus(
+        sentences=(
+            _sentence(
+                "a",
+                "x",
+                GoldenToken(surface="x", lemma="expected", pos="NOUN"),
+            ),
+        )
+    )
+    pipeline = _ScriptedPipeline({"x": [_tok(0, "x", "got", "NOUN")]})
+    result = evaluate(pipeline, corpus)
+    assert result.lemma.rate == 0.0
+    assert result.pos.rate == 1.0
+    assert result.joint_lemma_pos.rate == 0.0
+    assert any("lemma expected 'expected'" in f for f in result.failures)
+
+
+def test_missing_expected_field_is_not_checked():
+    # GoldenToken with no `pos` set means POS is a don't-care — so the
+    # pipeline can return anything without contributing to pos accuracy.
+    corpus = GoldenCorpus(
+        sentences=(_sentence("a", "x", GoldenToken(surface="x", lemma="x")),)
+    )
+    pipeline = _ScriptedPipeline({"x": [_tok(0, "x", "x", "WEIRD_POS")]})
+    result = evaluate(pipeline, corpus)
+    assert result.pos.total == 0
+    # don't-care fields return 1.0 on an empty counter.
+    assert result.pos.rate == 1.0
+
+
+def test_features_is_a_subset_check_not_exact():
+    # Expected {Case: Loc} must match even if the actual dict has extra
+    # keys — the rule set is allowed to grow features without rewriting
+    # every corpus entry.
+    corpus = GoldenCorpus(
+        sentences=(
+            _sentence(
+                "a",
+                "x",
+                GoldenToken(surface="x", lemma="x", features={"Case": "Loc"}),
+            ),
+        )
+    )
+    pipeline = _ScriptedPipeline(
+        {"x": [_tok(0, "x", "x", "NOUN", features={"Case": "Loc", "Number": "Sing"})]}
+    )
+    result = evaluate(pipeline, corpus)
+    assert result.features.rate == 1.0
+
+
+def test_features_mismatch_recorded():
+    corpus = GoldenCorpus(
+        sentences=(
+            _sentence(
+                "a",
+                "x",
+                GoldenToken(surface="x", features={"Case": "Loc"}),
+            ),
+        )
+    )
+    pipeline = _ScriptedPipeline(
+        {"x": [_tok(0, "x", "x", "NOUN", features={"Case": "Gen"})]}
+    )
+    result = evaluate(pipeline, corpus)
+    assert result.features.rate == 0.0
+    assert any("features expected subset" in f for f in result.failures)
+
+
+def test_token_count_mismatch_reports_descriptive_failure():
+    corpus = GoldenCorpus(
+        sentences=(
+            _sentence(
+                "a",
+                "x",
+                GoldenToken(surface="x"),
+                GoldenToken(surface="y"),
+            ),
+        )
+    )
+    pipeline = _ScriptedPipeline({"x": [_tok(0, "x", "x", "NOUN")]})
+    result = evaluate(pipeline, corpus)
+    assert any("token count mismatch" in f for f in result.failures)
+    # Per-token counters should not have been polluted by the bad row.
+    assert result.token_count == 0
+
+
+def test_is_oov_expectation_enforced():
+    corpus = GoldenCorpus(
+        sentences=(
+            _sentence("a", "x", GoldenToken(surface="x", is_oov=True)),
+        )
+    )
+    ok_pipeline = _ScriptedPipeline({"x": [_tok(0, "x", "x", "X", is_oov=True)]})
+    bad_pipeline = _ScriptedPipeline({"x": [_tok(0, "x", "x", "NOUN", is_oov=False)]})
+    assert evaluate(ok_pipeline, corpus).is_oov.rate == 1.0
+    assert evaluate(bad_pipeline, corpus).is_oov.rate == 0.0
+
+
+def test_load_corpus_nfc_normalizes(tmp_path: Path):
+    # Write a corpus file with an NFD-form entry and confirm it
+    # materialises as NFC. Protects the invariant that the harness
+    # compares apples to apples regardless of how contributors typed.
+    import unicodedata
+
+    nfc = "ଘରରେ"
+    nfd = unicodedata.normalize("NFD", nfc)
+    data = {
+        "sentences": [
+            {
+                "id": "nfd-guard",
+                "text": nfd,
+                "tokens": [{"surface": nfd, "lemma": nfd}],
+            }
+        ]
+    }
+    path = tmp_path / "corpus.json"
+    path.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+    corpus = load_corpus(path)
+    assert corpus.sentences[0].text == nfc
+    assert corpus.sentences[0].tokens[0].surface == nfc
+    assert corpus.sentences[0].tokens[0].lemma == nfc
+
+
+def test_eval_result_summary_handles_empty_counters():
+    # Sanity: a corpus that enforces nothing still returns a summary
+    # (all rates default to 1.0 rather than NaN-ing).
+    result = EvalResult()
+    summary = result.summary()
+    assert all(0.0 <= v <= 1.0 for v in summary.values())

--- a/services/nlp/tests/test_odia_golden.py
+++ b/services/nlp/tests/test_odia_golden.py
@@ -1,0 +1,104 @@
+"""Odia golden-file corpus tests (T-2.3b).
+
+The corpus at ``app/pipelines/odia/data/golden_corpus.json`` pairs Odia
+sentences with expected per-token analyses. This suite runs the custom
+Odia pipeline over the corpus and enforces a minimum joint
+lemma+POS accuracy.
+
+The threshold here is deliberately a sanity floor — T-2.8 raises it
+(≥70% for Odia per the plan) and wires it into CI. Right now the
+corpus is hand-written against the seed lemma table so we expect near-
+perfect scores; a drop means either the seed, the morph rules, or the
+tokenizer regressed. The eval harness is language-agnostic so Hindi /
+Marathi corpora can slot in later without a rewrite.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.eval import GoldenCorpus, evaluate
+from app.eval.corpus import load_corpus
+from app.pipelines.odia import OdiaPipeline
+from app.pipelines.odia.lemmas import default_lemma_table
+
+_CORPUS_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "app"
+    / "pipelines"
+    / "odia"
+    / "data"
+    / "golden_corpus.json"
+)
+
+
+def _split(text: str) -> list[str]:
+    return text.split()
+
+
+def _load() -> GoldenCorpus:
+    return load_corpus(_CORPUS_PATH)
+
+
+def _pipeline() -> OdiaPipeline:
+    return OdiaPipeline(tokenizer=_split, lemmas=default_lemma_table())
+
+
+def test_corpus_loads_and_is_non_empty():
+    corpus = _load()
+    assert len(corpus) >= 15, "corpus shrank — did a data PR accidentally drop entries?"
+    # Spot-check the smoke-test sentence is still in here.
+    assert any(s.text == "ନମସ୍କାର ଦୁନିଆ" for s in corpus.sentences)
+
+
+def test_corpus_entries_have_unique_ids():
+    corpus = _load()
+    ids = [s.id for s in corpus.sentences]
+    assert len(ids) == len(set(ids)), "duplicate golden sentence ids — merge them"
+
+
+def test_odia_pipeline_meets_joint_lemma_pos_floor():
+    # Hand-written corpus + hand-written rules → this should be basically
+    # perfect. T-2.8 will swap this for the ≥70% real-world accuracy
+    # threshold when the corpus grows to include harder sentences.
+    result = evaluate(_pipeline(), _load())
+    summary = result.summary()
+    assert (
+        summary["joint_lemma_pos_accuracy"] >= 0.95
+    ), f"joint lemma+POS accuracy regressed: {summary}\nfailures:\n" + "\n".join(
+        result.failures[:20]
+    )
+
+
+def test_odia_pipeline_feature_accuracy_is_high():
+    result = evaluate(_pipeline(), _load())
+    summary = result.summary()
+    # Feature subset matching — set loose enough to tolerate future
+    # corpus entries that test hard features we haven't modeled yet.
+    assert (
+        summary["features_accuracy"] >= 0.80
+    ), f"feature accuracy regressed: {summary}\nfailures:\n" + "\n".join(
+        result.failures[:20]
+    )
+
+
+def test_oov_detection_is_accurate():
+    # The OOV expectations in the corpus must be met — if they drift
+    # the reader will silently flip between "unknown word" and "word"
+    # states for the same input.
+    result = evaluate(_pipeline(), _load())
+    summary = result.summary()
+    assert (
+        summary["is_oov_accuracy"] >= 0.95
+    ), f"OOV detection regressed: {summary}\nfailures:\n" + "\n".join(
+        result.failures[:20]
+    )
+
+
+def test_token_counts_match_for_every_sentence():
+    # A tokenizer change that splits or joins differently from the
+    # corpus would silently tank all per-token scores. Guard the
+    # invariant explicitly so the message is actionable.
+    result = evaluate(_pipeline(), _load())
+    count_failures = [f for f in result.failures if "token count mismatch" in f]
+    assert count_failures == [], "tokenization drift:\n" + "\n".join(count_failures)


### PR DESCRIPTION
## Summary
- New 20-sentence Odia golden corpus at `services/nlp/app/pipelines/odia/data/golden_corpus.json` covering noun cases (Nom/Loc/Acc/Gen/Abl, plural Nom/Acc/Gen), verb forms (Fut 3rd, Past 3sg/3pl, Pres 3pl, Inf), adjective degree (Cmp/Sup), pronouns, punctuation, and OOV fallback. All entries use lemmas from the T-2.3a seed so CI is reproducible without the T-3.1 WordNet import. Each token expectation is optional — contributors only pin what they're confident about.
- New language-agnostic eval harness at `services/nlp/app/eval/corpus.py`. Reports per-field accuracy (lemma, pos, features, is_oov, is_ambiguous) + a joint lemma+POS rate that T-2.8 will CI-threshold for all three languages.
- Harness has descriptive failure messages — a regression points at the specific sentence instead of "accuracy dropped."
- Corpus uses hand-written sentences only; classic-literature / Wikipedia ingestion is deferred until after T-3.1 Odia WordNet import enables broader lemma coverage, ideally with a native-speaker review pass at that point.

## Test plan
- [x] `test_odia_golden.py` (6 tests): corpus loads, unique ids, joint lemma+POS floor ≥0.95, features ≥0.80, is_oov ≥0.95, zero tokenization drift.
- [x] `test_eval_corpus.py` (9 tests): perfect-score path, lemma mismatch recorded, don't-care fields, features subset semantics, features mismatch recorded, token-count mismatch reports descriptive failure, is_oov enforcement, NFC normalization on load, empty-counter summary.
- [x] Full suite: 81 passed, 99.10% coverage.
- [x] ruff clean on app + tests.

Targets `feat/t-2.3a-odia-pipeline` — stacked PR chain.