### PR TITLE
T-2.4: morphology gloss formatter

### DIFF
--- a/services/nlp/app/gloss.py
+++ b/services/nlp/app/gloss.py
@@ -1,0 +1,198 @@
+"""Morphology gloss formatter (T-2.4).
+
+Converts UD-style feature dicts into the human-readable strings the
+reader's word pop-up shows ("3sg fem present habitual of bolnā"). The
+pop-up component (M5) is the only current consumer — it already knows
+how to italicize the lemma, bold the features, etc., so the formatter
+returns a plain string and leaves styling to the UI layer.
+
+The templates are intentionally compact and LingQ-like: each feature
+maps to a short abbreviation (``Sing`` → ``sg``, ``Pres`` → ``present``,
+``3`` → ``3``). That's a stable, internationally-readable vocabulary
+for the MVP's target audience (English-speaking learners of Hindi /
+Marathi / Odia). When M6 / M14 add native-language gloss preferences,
+the formatter grows a language-of-explanation argument; for now
+English is the one output language so we don't build infrastructure
+for a choice that doesn't exist yet.
+"""
+
+from __future__ import annotations
+
+# Abbreviations for UD feature values. Missing keys fall back to the raw
+# UD token, which is verbose but never wrong — better than silently
+# dropping an unknown feature.
+
+_PERSON: dict[str, str] = {"1": "1", "2": "2", "3": "3"}
+_NUMBER: dict[str, str] = {"Sing": "sg", "Plur": "pl", "Dual": "du"}
+_GENDER: dict[str, str] = {"Masc": "masc", "Fem": "fem", "Neut": "neut"}
+_TENSE: dict[str, str] = {"Pres": "present", "Past": "past", "Fut": "future"}
+_ASPECT: dict[str, str] = {
+    "Prog": "progressive",
+    "Perf": "perfect",
+    "Hab": "habitual",
+    "Imp": "imperfective",
+}
+_MOOD: dict[str, str] = {
+    "Imp": "imperative",
+    "Sub": "subjunctive",
+    "Cnd": "conditional",
+    "Ind": "indicative",
+}
+_VERB_FORM: dict[str, str] = {
+    "Inf": "infinitive",
+    "Part": "participle",
+    "Conv": "converb",
+    "Ger": "gerund",
+    "Fin": "",  # finite verb — the tense/aspect/person already conveys this
+}
+_CASE: dict[str, str] = {
+    "Nom": "nominative",
+    "Acc": "accusative",
+    "Gen": "genitive",
+    "Dat": "dative",
+    "Loc": "locative",
+    "Abl": "ablative",
+    "Ins": "instrumental",
+    "Voc": "vocative",
+}
+_DEGREE: dict[str, str] = {"Cmp": "comparative", "Sup": "superlative", "Pos": ""}
+_VOICE: dict[str, str] = {"Act": "active", "Pass": "passive"}
+
+
+def _translate(value: str, table: dict[str, str]) -> str:
+    return table.get(value, value)
+
+
+def _verb_gloss(features: dict[str, str]) -> str:
+    """Compose the slot order for verbs: person+number, gender, tense,
+    aspect, mood, voice, verb-form.
+    """
+    parts: list[str] = []
+
+    person = features.get("Person")
+    number = features.get("Number")
+    if person and number:
+        # "3sg", "1pl" — canonical person+number compact form.
+        parts.append(f"{_translate(person, _PERSON)}{_translate(number, _NUMBER)}")
+    elif person:
+        parts.append(_translate(person, _PERSON))
+    elif number:
+        parts.append(_translate(number, _NUMBER))
+
+    if (gender := features.get("Gender")) is not None:
+        parts.append(_translate(gender, _GENDER))
+    if (tense := features.get("Tense")) is not None:
+        parts.append(_translate(tense, _TENSE))
+    if (aspect := features.get("Aspect")) is not None:
+        parts.append(_translate(aspect, _ASPECT))
+    if (mood := features.get("Mood")) is not None:
+        parts.append(_translate(mood, _MOOD))
+    if (voice := features.get("Voice")) is not None:
+        parts.append(_translate(voice, _VOICE))
+    if (vf := features.get("VerbForm")) is not None:
+        translated = _translate(vf, _VERB_FORM)
+        if translated:
+            parts.append(translated)
+    return " ".join(p for p in parts if p)
+
+
+def _noun_gloss(features: dict[str, str]) -> str:
+    parts: list[str] = []
+    if (number := features.get("Number")) is not None:
+        parts.append(_translate(number, _NUMBER))
+    if (gender := features.get("Gender")) is not None:
+        parts.append(_translate(gender, _GENDER))
+    if (case := features.get("Case")) is not None:
+        parts.append(_translate(case, _CASE))
+    return " ".join(p for p in parts if p)
+
+
+def _adj_gloss(features: dict[str, str]) -> str:
+    parts: list[str] = []
+    if (degree := features.get("Degree")) is not None:
+        translated = _translate(degree, _DEGREE)
+        if translated:
+            parts.append(translated)
+    if (number := features.get("Number")) is not None:
+        parts.append(_translate(number, _NUMBER))
+    if (gender := features.get("Gender")) is not None:
+        parts.append(_translate(gender, _GENDER))
+    if (case := features.get("Case")) is not None:
+        parts.append(_translate(case, _CASE))
+    return " ".join(p for p in parts if p)
+
+
+_POS_LABEL: dict[str, str] = {
+    "NOUN": "noun",
+    "PROPN": "proper noun",
+    "VERB": "verb",
+    "ADJ": "adjective",
+    "ADV": "adverb",
+    "PRON": "pronoun",
+    "DET": "determiner",
+    "ADP": "postposition",
+    "CCONJ": "conjunction",
+    "SCONJ": "subordinator",
+    "PART": "particle",
+    "INTJ": "interjection",
+    "NUM": "number",
+    "X": "unknown word",
+    "PUNCT": "punctuation",
+    "SYM": "symbol",
+}
+
+
+def format_gloss(
+    *,
+    pos: str | None,
+    features: dict[str, str] | None,
+    lemma: str | None,
+) -> str:
+    """Return a short reader-facing gloss for a token.
+
+    Examples:
+
+    * VERB + ``{Person:3, Number:Sing, Gender:Fem, Tense:Pres,
+      Aspect:Hab}`` + lemma ``bolnā`` → ``"3sg fem present habitual
+      of bolnā"``.
+    * NOUN + ``{Number:Plur, Case:Loc}`` + lemma ``ghar`` →
+      ``"pl locative of ghar"``.
+    * ADJ + ``{Degree:Cmp}`` + lemma ``baḍa`` → ``"comparative of baḍa"``.
+    * PUNCT or empty-feature content word → ``"punctuation"`` /
+      ``"noun"`` / ``"verb"`` — the POS label alone.
+    * Everything missing → ``""`` (caller decides what to render).
+
+    ``pos`` and ``lemma`` are optional so we degrade gracefully on
+    malformed input (mid-pipeline test doubles, partial corrections).
+    Production data always has both.
+    """
+    features = features or {}
+    pos = pos or "X"
+
+    if pos in {"PUNCT", "SYM"}:
+        return _POS_LABEL.get(pos, pos.lower())
+
+    if pos == "VERB":
+        body = _verb_gloss(features)
+    elif pos == "NOUN" or pos == "PROPN":
+        body = _noun_gloss(features)
+    elif pos == "ADJ":
+        body = _adj_gloss(features)
+    else:
+        body = ""
+
+    label = _POS_LABEL.get(pos, pos.lower())
+
+    if not body:
+        # No enriching features: fall back to "<pos> <lemma>" or just
+        # the POS label if we don't have a lemma either.
+        if lemma:
+            return f"{label} {lemma}".strip()
+        return label
+
+    if lemma:
+        return f"{body} of {lemma}"
+    return body
+
+
+__all__ = ["format_gloss"]

--- a/services/nlp/tests/test_gloss.py
+++ b/services/nlp/tests/test_gloss.py
@@ -1,0 +1,203 @@
+"""Unit tests for the morphology gloss formatter (T-2.4).
+
+These tests target the reader-facing contract from the plan:
+
+* Verbs compose person+number compactly ("3sg"), then gender, tense,
+  aspect.
+* Nouns compose number → gender → case.
+* Adjectives lead with degree, then number/gender/case agreement.
+* Punctuation / symbol tokens return a plain label.
+* Unknown UD feature values fall through as-is rather than being
+  silently dropped — better to show ``"Novel_feat"`` in the UI than to
+  pretend we understood it.
+"""
+
+from __future__ import annotations
+
+from app.gloss import format_gloss
+
+
+def test_hindi_verb_3sg_fem_present_habitual():
+    # The canonical example from the plan:
+    # "boltī hai — 3sg fem present habitual of bolnā".
+    out = format_gloss(
+        pos="VERB",
+        features={
+            "Person": "3",
+            "Number": "Sing",
+            "Gender": "Fem",
+            "Tense": "Pres",
+            "Aspect": "Hab",
+        },
+        lemma="bolnā",
+    )
+    assert out == "3sg fem present habitual of bolnā"
+
+
+def test_verb_past_3pl_no_gender():
+    out = format_gloss(
+        pos="VERB",
+        features={"Person": "3", "Number": "Plur", "Tense": "Past"},
+        lemma="ଦେଖ",
+    )
+    assert out == "3pl past of ଦେଖ"
+
+
+def test_verb_infinitive():
+    # VerbForm=Inf surfaces as "infinitive"; no person/number/tense for
+    # a bare infinitive. "infinitive of <lemma>" reads cleanly.
+    out = format_gloss(
+        pos="VERB",
+        features={"VerbForm": "Inf"},
+        lemma="पढ़ना",
+    )
+    assert out == "infinitive of पढ़ना"
+
+
+def test_verb_finite_form_is_not_appended():
+    # VerbForm=Fin is redundant — the tense / aspect already conveys
+    # finiteness — so it should not add a "finite" word to the gloss.
+    out = format_gloss(
+        pos="VERB",
+        features={"Person": "1", "Number": "Sing", "Tense": "Pres", "VerbForm": "Fin"},
+        lemma="बोलना",
+    )
+    assert out == "1sg present of बोलना"
+
+
+def test_noun_plural_locative():
+    out = format_gloss(
+        pos="NOUN",
+        features={"Number": "Plur", "Case": "Loc"},
+        lemma="ଘର",
+    )
+    assert out == "pl locative of ଘର"
+
+
+def test_noun_with_no_features_falls_back_to_pos_plus_lemma():
+    out = format_gloss(pos="NOUN", features={}, lemma="ଦୁନିଆ")
+    assert out == "noun ଦୁନିଆ"
+
+
+def test_adjective_comparative():
+    out = format_gloss(pos="ADJ", features={"Degree": "Cmp"}, lemma="ବଡ଼")
+    assert out == "comparative of ବଡ଼"
+
+
+def test_adjective_positive_degree_is_elided():
+    # Degree=Pos is the default and doesn't need to be shown. The
+    # adjective should just render as "adjective <lemma>".
+    out = format_gloss(pos="ADJ", features={"Degree": "Pos"}, lemma="ଭଲ")
+    assert out == "adjective ଭଲ"
+
+
+def test_punctuation_returns_plain_label():
+    out = format_gloss(pos="PUNCT", features={}, lemma="।")
+    assert out == "punctuation"
+
+
+def test_unknown_pos_returns_lowered_pos_label():
+    # Not in _POS_LABEL → fall back to lowercased UD tag rather than
+    # erroring. The reader pop-up should still render something.
+    out = format_gloss(pos="NOVELPOS", features={}, lemma="foo")
+    assert out == "novelpos foo"
+
+
+def test_missing_lemma_and_no_features_returns_pos_only():
+    # OOV content words without a lemma still get a gloss string
+    # (the UI will prefer the surface as a fallback alongside this).
+    out = format_gloss(pos="NOUN", features={}, lemma=None)
+    assert out == "noun"
+
+
+def test_missing_pos_defaults_to_x():
+    out = format_gloss(pos=None, features={}, lemma="something")
+    assert out == "unknown word something"
+
+
+def test_unknown_ud_value_passes_through_verbatim():
+    # We shouldn't silently drop a feature value we don't know — better
+    # to show the raw UD token than to lie to the reader.
+    out = format_gloss(
+        pos="VERB",
+        features={"Person": "4", "Number": "Sing", "Tense": "Past"},
+        lemma="test",
+    )
+    # "4sg past of test" — "4" isn't in _PERSON so it passes through.
+    assert out == "4sg past of test"
+
+
+def test_proper_noun_uses_same_slot_order_as_noun():
+    # PROPN shares the noun template; the label changes to "proper noun".
+    out = format_gloss(
+        pos="PROPN",
+        features={"Number": "Sing", "Case": "Nom"},
+        lemma="Kolkata",
+    )
+    assert out == "sg nominative of Kolkata"
+
+
+def test_noun_gender_slot():
+    # Gender between number and case: "sg fem locative of X".
+    out = format_gloss(
+        pos="NOUN",
+        features={"Number": "Sing", "Gender": "Fem", "Case": "Loc"},
+        lemma="बोली",
+    )
+    assert out == "sg fem locative of बोली"
+
+
+def test_adjective_agreement_with_number_and_case():
+    # ADJ with comparative degree AND agreement features shows all slots.
+    out = format_gloss(
+        pos="ADJ",
+        features={"Degree": "Cmp", "Number": "Sing", "Case": "Nom"},
+        lemma="big",
+    )
+    assert out == "comparative sg nominative of big"
+
+
+def test_verb_imperative_mood_and_passive_voice():
+    # Covers Mood + Voice slots, both optional and rarely populated
+    # together but individually common (imperatives, passives).
+    out = format_gloss(
+        pos="VERB",
+        features={
+            "Person": "2",
+            "Number": "Sing",
+            "Mood": "Imp",
+            "Voice": "Pass",
+        },
+        lemma="read",
+    )
+    assert out == "2sg imperative passive of read"
+
+
+def test_verb_person_without_number():
+    # Person alone (e.g. an imperative with no explicit number) still
+    # produces a readable "3 of <lemma>" gloss.
+    out = format_gloss(
+        pos="VERB", features={"Person": "3"}, lemma="do"
+    )
+    assert out == "3 of do"
+
+
+def test_verb_number_without_person():
+    # Plural-only marking (e.g. some nominalized forms) shouldn't be
+    # dropped on the floor.
+    out = format_gloss(
+        pos="VERB", features={"Number": "Plur"}, lemma="do"
+    )
+    assert out == "pl of do"
+
+
+def test_gloss_without_lemma_returns_body_alone():
+    # When a feature set is populated but the lemma is missing (e.g.
+    # a test double with partial data), we should still return the
+    # feature-body string rather than nothing.
+    out = format_gloss(
+        pos="VERB",
+        features={"Person": "3", "Number": "Sing", "Tense": "Pres"},
+        lemma=None,
+    )
+    assert out == "3sg present"


### PR DESCRIPTION
## Summary
- New `services/nlp/app/gloss.py` converts UD feature dicts into the short reader-facing strings the M5 word pop-up will render ("3sg fem present habitual of bolnā", "pl locative of ଘର", "comparative of ବଡ଼").
- Per-POS slot order — VERB: person+number → gender → tense → aspect → mood → voice → verb-form. NOUN/PROPN: number → gender → case. ADJ: degree → number → gender → case. PUNCT/SYM: plain label.
- Unknown feature values pass through verbatim instead of being dropped — a novel UD tag shouldn't silently disappear from the UI.
- `VerbForm=Fin` and `Degree=Pos` are elided as redundant defaults — "finite" / "positive" would be noise.
- English-only output. A language-of-explanation parameter slots in when M6 / M14 add native-language gloss preferences; didn't build that scaffolding before it's needed.

## Test plan
- [x] 20 tests covering: the canonical plan example (3sg fem present habitual), past 3pl without gender, infinitive, finite-form elision, noun plural locative, featureless noun fallback, adjective comparative, positive-degree elision, punctuation, unknown POS fallback, missing lemma, missing POS, unknown UD value pass-through, proper-noun template, noun with gender, adjective agreement, mood+voice (imperative+passive), person-alone, number-alone, body-without-lemma.
- [x] Full suite: 101 passed, 98.79% coverage.
- [x] ruff clean on app + tests.

Targets `feat/t-2.3b-odia-golden-corpus` — stacked PR chain.