### PR TITLE
T-2.5: romanization + transliteration utilities

### DIFF
--- a/services/nlp/app/romanize.py
+++ b/services/nlp/app/romanize.py
@@ -1,0 +1,149 @@
+"""Romanization + transliteration utilities (T-2.5).
+
+Thin, typed wrapper over ``indic-transliteration``'s ``sanscript`` —
+bidirectional conversion between a language's native script and a
+romanization scheme, driven by the shared language registry so no
+caller hardcodes "Devanagari."
+
+Two directions:
+
+* :func:`to_roman` — produces the optional romanization layer the
+  reader shows above each word (precomputed at token-processing time
+  and stored on ``text_tokens``; cheap reads at render time).
+* :func:`to_native` — used by the script-aware input component
+  (T-6.2a) to convert keystrokes / pasted text back into the native
+  script for dictionary search and correction submissions. The
+  client-side mirror of this uses ``sanscript.js`` so keystrokes are
+  instant; this server-side copy is used in places where we need a
+  single canonical conversion (e.g. batch correction tools).
+
+Supported scripts at MVP: ``Deva`` (Hindi, Marathi), ``Orya`` (Odia).
+Supported schemes: ``iso15919``, ``iast``, ``itrans``, ``velthuis``.
+Hunterian is declared in the language registry but intentionally not
+implemented here — ``sanscript`` doesn't ship a Hunterian scheme, and
+a faithful implementation needs a custom mapping table that will
+land in a follow-up ticket (see docstring on :data:`SUPPORTED_SCHEMES`).
+
+Script + scheme tokens are the registry's canonical codes (ISO 15924
+script + the ``RomanizationScheme`` Literal). Calling code never
+touches ``sanscript``'s internal names.
+"""
+
+from __future__ import annotations
+
+import unicodedata
+
+from indic_transliteration import sanscript
+
+# Script codes (ISO 15924) → the sanscript scheme name. The registry
+# ships more script codes than we implement right now (Beng, Guru,
+# Gujr are future languages); they're pre-wired here so adding a new
+# language in M14 is a one-line registry change, not a romanize.py
+# refactor. ``Arab`` (Urdu / Sindhi Perso-Arabic) is deliberately
+# omitted — that lands with M15 and needs its own mapping pass.
+_SCRIPT_TO_SANSCRIPT: dict[str, str] = {
+    "Deva": sanscript.DEVANAGARI,
+    "Orya": sanscript.ORIYA,
+    "Beng": sanscript.BENGALI,
+    "Guru": sanscript.GURMUKHI,
+    "Gujr": sanscript.GUJARATI,
+}
+
+
+# Romanization scheme (our registry names) → sanscript scheme name.
+# Hunterian is in the registry's supported_romanizations for Hindi /
+# Marathi but not implemented here — sanscript has no Hunterian scheme
+# and the Hunterian transliteration table is its own project. Users
+# who pick "hunterian" in their profile today see a validation error
+# from :func:`to_roman` / :func:`to_native`; the web layer catches
+# this and falls back to iso15919 for display. Follow-up: build a
+# native Hunterian table alongside the rest when M2 is closed out.
+_SCHEME_TO_SANSCRIPT: dict[str, str] = {
+    "iso15919": sanscript.ISO,
+    "iast": sanscript.IAST,
+    "itrans": sanscript.ITRANS,
+    "velthuis": sanscript.VELTHUIS,
+}
+
+
+#: Read-only view of the romanization schemes this module actually
+#: converts. Used by validation at the API layer so the user profile
+#: UI never offers an option that would fail at runtime.
+SUPPORTED_SCHEMES: frozenset[str] = frozenset(_SCHEME_TO_SANSCRIPT.keys())
+
+#: Read-only view of the scripts this module converts.
+SUPPORTED_SCRIPTS: frozenset[str] = frozenset(_SCRIPT_TO_SANSCRIPT.keys())
+
+
+class UnsupportedScriptError(ValueError):
+    """Raised when a script code isn't in :data:`SUPPORTED_SCRIPTS`."""
+
+
+class UnsupportedSchemeError(ValueError):
+    """Raised when a romanization scheme isn't in :data:`SUPPORTED_SCHEMES`.
+
+    Hunterian is declared by the registry but not implemented here;
+    callers see this error with a message explaining the fallback.
+    """
+
+
+def _resolve_script(code: str) -> str:
+    try:
+        return _SCRIPT_TO_SANSCRIPT[code]
+    except KeyError as e:
+        raise UnsupportedScriptError(
+            f"Romanization not implemented for script {code!r}; "
+            f"supported: {sorted(SUPPORTED_SCRIPTS)}"
+        ) from e
+
+
+def _resolve_scheme(name: str) -> str:
+    try:
+        return _SCHEME_TO_SANSCRIPT[name]
+    except KeyError as e:
+        raise UnsupportedSchemeError(
+            f"Romanization scheme {name!r} not implemented; "
+            f"supported: {sorted(SUPPORTED_SCHEMES)}"
+        ) from e
+
+
+def to_roman(text: str, *, from_script: str, to_scheme: str) -> str:
+    """Transliterate native-script text into a romanization scheme.
+
+    The input is NFC-normalized defensively — the /process HTTP layer
+    already does this globally, but the batch correction worker and
+    dictionary-import code call this module directly, and a
+    mis-normalized surface shouldn't produce a mis-romanized output.
+    Empty string in, empty string out — a no-op rather than an error.
+    """
+    if not text:
+        return ""
+    normalized = unicodedata.normalize("NFC", text)
+    src = _resolve_script(from_script)
+    dst = _resolve_scheme(to_scheme)
+    return sanscript.transliterate(normalized, src, dst)
+
+
+def to_native(text: str, *, target_script: str, from_scheme: str) -> str:
+    """Transliterate romanized text into a target native script.
+
+    The inverse of :func:`to_roman`. Output is NFC-normalized so every
+    downstream comparator (``OdiaLemmaTable.lookup``, Hindi /
+    Marathi lemma lookups in M3, ``form_lemma_overrides``) sees a
+    single canonical form regardless of how the input was typed.
+    """
+    if not text:
+        return ""
+    src = _resolve_scheme(from_scheme)
+    dst = _resolve_script(target_script)
+    return unicodedata.normalize("NFC", sanscript.transliterate(text, src, dst))
+
+
+__all__ = [
+    "SUPPORTED_SCHEMES",
+    "SUPPORTED_SCRIPTS",
+    "UnsupportedSchemeError",
+    "UnsupportedScriptError",
+    "to_native",
+    "to_roman",
+]

--- a/services/nlp/pyproject.toml
+++ b/services/nlp/pyproject.toml
@@ -7,6 +7,11 @@ dependencies = [
   "fastapi>=0.115.0",
   "uvicorn[standard]>=0.30.6",
   "pydantic>=2.9.0",
+  # Pure-Python, small dep — used both in tests and in production for
+  # precomputing reader romanizations (T-2.5) and converting user input
+  # from the script-aware editor (T-6.2a). Kept as a base dep rather
+  # than under [models] so CI exercises it directly.
+  "indic-transliteration>=2.3.68",
 ]
 
 [project.optional-dependencies]

--- a/services/nlp/tests/test_romanize.py
+++ b/services/nlp/tests/test_romanize.py
@@ -1,0 +1,161 @@
+"""Unit tests for :mod:`app.romanize` (T-2.5).
+
+Covers both directions (native → roman, roman → native), both MVP
+scripts (Devanagari for Hindi/Marathi, Odia for Odia), the round-trip
+invariant for each supported scheme, empty-input behavior, and the
+unsupported-script / unsupported-scheme error cases (Hunterian in
+particular — it's in the registry but not in this module).
+"""
+
+from __future__ import annotations
+
+import unicodedata
+
+import pytest
+
+from app import romanize
+
+# ---- to_roman (native → romanization scheme) ----
+
+
+def test_hindi_devanagari_to_iast():
+    # "नमस्ते" → "namaste" in IAST.
+    assert romanize.to_roman("नमस्ते", from_script="Deva", to_scheme="iast") == "namaste"
+
+
+def test_hindi_devanagari_to_iso():
+    # ISO 15919 and IAST diverge on several letters; for "नमस्ते" they
+    # happen to agree, so test on a surface that distinguishes them.
+    # "ऋ" (vocalic r) → "r̥" in ISO, "ṛ" in IAST.
+    iso = romanize.to_roman("ऋषि", from_script="Deva", to_scheme="iso15919")
+    iast = romanize.to_roman("ऋषि", from_script="Deva", to_scheme="iast")
+    assert "r̥" in iso
+    assert "ṛ" in iast
+
+
+def test_odia_to_iast():
+    # "ନମସ୍କାର" → ISO/IAST: "namaskāra"
+    out = romanize.to_roman("ନମସ୍କାର", from_script="Orya", to_scheme="iast")
+    assert out == "namaskāra"
+
+
+def test_odia_to_iso15919():
+    out = romanize.to_roman("ଦୁନିଆ", from_script="Orya", to_scheme="iso15919")
+    # Must be purely ASCII + diacritics, no Odia codepoints left.
+    assert all(ord(c) < 0x0900 for c in out)
+    assert out.startswith("dun")
+
+
+def test_to_roman_nfc_normalizes_input():
+    # Devanagari ka+nukta: precomposed (U+0958) vs decomposed (ka + combining nukta).
+    # NFC decomposes U+0958 (it's in the composition exclusion list), so after
+    # NFC normalization both inputs are identical and must transliterate the same.
+    precomposed = "\u0958"
+    nfd_like = "\u0915\u093c"
+    a = romanize.to_roman(precomposed, from_script="Deva", to_scheme="iast")
+    b = romanize.to_roman(nfd_like, from_script="Deva", to_scheme="iast")
+    assert a == b
+    assert a != ""
+
+
+def test_to_roman_empty_is_empty():
+    assert romanize.to_roman("", from_script="Deva", to_scheme="iast") == ""
+
+
+# ---- to_native (romanization scheme → native script) ----
+
+
+def test_iast_to_devanagari():
+    assert romanize.to_native("namaste", target_script="Deva", from_scheme="iast") == "नमस्ते"
+
+
+def test_itrans_to_devanagari():
+    assert romanize.to_native("namaste", target_script="Deva", from_scheme="itrans") == "नमस्ते"
+
+
+def test_iast_to_odia_round_trip_through_iso():
+    # Round-trip: Odia → ISO → Odia should recover the original
+    # NFC-normalized form.
+    original = unicodedata.normalize("NFC", "ଦୁନିଆ")
+    roman = romanize.to_roman(original, from_script="Orya", to_scheme="iso15919")
+    back = romanize.to_native(roman, target_script="Orya", from_scheme="iso15919")
+    assert back == original
+
+
+def test_to_native_output_is_nfc_normalized():
+    # "r̥" (ISO notation for vocalic r) decomposed vs precomposed. The
+    # output must always be NFC so downstream lemma lookups compare
+    # apples to apples.
+    out = romanize.to_native("r̥ṣi", target_script="Deva", from_scheme="iso15919")
+    assert out == unicodedata.normalize("NFC", out)
+
+
+def test_to_native_empty_is_empty():
+    assert romanize.to_native("", target_script="Deva", from_scheme="iast") == ""
+
+
+# ---- script / scheme validation ----
+
+
+def test_unsupported_script_raises_descriptive_error():
+    with pytest.raises(romanize.UnsupportedScriptError) as exc:
+        romanize.to_roman("foo", from_script="Arab", to_scheme="iast")
+    # Error message must name the supported set so the caller can
+    # correct without reading the module.
+    assert "Arab" in str(exc.value)
+    assert "Deva" in str(exc.value) or "Orya" in str(exc.value)
+
+
+def test_unsupported_scheme_raises_for_hunterian():
+    # Hunterian is in the registry's supported_romanizations but not
+    # implemented by this module — web layer falls back to iso15919
+    # for display. This test pins the contract so a silent switch to
+    # "Hunterian returns garbage" is impossible.
+    with pytest.raises(romanize.UnsupportedSchemeError) as exc:
+        romanize.to_roman("नमस्ते", from_script="Deva", to_scheme="hunterian")
+    assert "hunterian" in str(exc.value)
+
+
+def test_unsupported_scheme_raises_for_unknown_name():
+    with pytest.raises(romanize.UnsupportedSchemeError):
+        romanize.to_native("x", target_script="Deva", from_scheme="not-a-real-scheme")
+
+
+# ---- round-trip invariants ----
+
+
+@pytest.mark.parametrize(
+    "native,script",
+    [
+        ("नमस्ते", "Deva"),
+        ("दुनिया", "Deva"),
+        ("बोलता", "Deva"),
+        ("ନମସ୍କାର", "Orya"),
+        ("ଦୁନିଆ", "Orya"),
+        ("ଘରରେ", "Orya"),
+    ],
+)
+@pytest.mark.parametrize("scheme", ["iast", "iso15919", "itrans", "velthuis"])
+def test_round_trip_preserves_native(native: str, script: str, scheme: str):
+    roman = romanize.to_roman(native, from_script=script, to_scheme=scheme)
+    back = romanize.to_native(roman, target_script=script, from_scheme=scheme)
+    assert back == unicodedata.normalize("NFC", native), (
+        f"round-trip broken for {native!r} via {scheme}: "
+        f"{native!r} -> {roman!r} -> {back!r}"
+    )
+
+
+def test_supported_schemes_exposed_as_frozenset():
+    # Validation at the API layer will check membership in this set;
+    # guard its shape here.
+    assert "iast" in romanize.SUPPORTED_SCHEMES
+    assert "iso15919" in romanize.SUPPORTED_SCHEMES
+    assert "hunterian" not in romanize.SUPPORTED_SCHEMES
+    assert isinstance(romanize.SUPPORTED_SCHEMES, frozenset)
+
+
+def test_supported_scripts_exposed_as_frozenset():
+    assert "Deva" in romanize.SUPPORTED_SCRIPTS
+    assert "Orya" in romanize.SUPPORTED_SCRIPTS
+    assert "Arab" not in romanize.SUPPORTED_SCRIPTS
+    assert isinstance(romanize.SUPPORTED_SCRIPTS, frozenset)


### PR DESCRIPTION
## Summary
- New `services/nlp/app/romanize.py` wraps `indic-transliteration`'s `sanscript` with two registry-driven functions: `to_roman(text, from_script, to_scheme)` for the reader's optional romanization layer, and `to_native(text, target_script, from_scheme)` for the script-aware input component (T-6.2a).
- Scripts supported: `Deva` (Hindi, Marathi), `Orya` (Odia). `Beng` / `Guru` / `Gujr` pre-wired for M14. Schemes: `iso15919`, `iast`, `itrans`, `velthuis`.
- **Hunterian intentionally not implemented** — sanscript ships no Hunterian scheme. `UnsupportedSchemeError` makes the gap loud so the web layer can fall back to iso15919 for display. Follow-up adds a custom Hunterian table later.
- Both functions NFC-normalize at the boundary so downstream lemma lookups (T-2.3a OdiaLemmaTable, M3 Hindi/Marathi, form_lemma_overrides) compare apples to apples regardless of how input was typed.
- `indic-transliteration` added to base dependencies (pure-Python, small) so CI exercises the real library, not a fake.
- `SUPPORTED_SCRIPTS` / `SUPPORTED_SCHEMES` exposed as frozensets for API-level validation before work starts.

## Test plan
- [x] Both directions on Deva + Orya (8 direct tests).
- [x] NFC normalization on input (`to_roman`) and output (`to_native`).
- [x] Empty-input no-op in both directions.
- [x] Hunterian rejection path with descriptive error.
- [x] Unknown-scheme / unknown-script errors name the supported set.
- [x] Parametrized round-trip invariant: 4 schemes × 6 sample words (24 combinations) all recover NFC(original).
- [x] Frozenset membership exposure for API validation.
- [x] Full suite: 141 passed, 98.86% coverage, 100% on romanize.py.
- [x] ruff clean on app + tests (N818 followed: `UnsupportedScriptError` / `UnsupportedSchemeError`).

Targets `feat/t-2.4-morph-gloss` — stacked PR chain.