### PR TITLE
T-2.6: arq async job queue

### DIFF
--- a/services/nlp/app/worker/__init__.py
+++ b/services/nlp/app/worker/__init__.py
@@ -1,0 +1,101 @@
+"""Async job queue for offline NLP work (T-2.6).
+
+SvelteKit enqueues jobs — text upload, bulk re-processing (T-6.8),
+correction aggregation (T-6.7), and eventually Whisper alignment
+(M16) — into Redis. A Python ``arq`` worker in this module dequeues
+and runs them, writing the results back to Postgres.
+
+The worker is intentionally kept separate from the ``/process``
+HTTP endpoint: the latter is synchronous and serves the tap-to-translate
+pop-up (millisecond latency); the worker handles multi-second jobs
+(loading a 600MB Stanza model, tokenizing a full EPUB chapter,
+cross-referencing form_lemma_overrides). Keeping them in separate
+processes means one slow Stanza load can't wedge the request path,
+and we can scale the two independently on Hetzner.
+
+This module only owns the queue machinery and the job dispatch. The
+actual job implementations live in :mod:`app.worker.jobs`; the I/O
+boundary (text fetching, token persistence, status flipping) lives in
+:mod:`app.worker.store` as protocols the jobs depend on. That split
+means the job logic is unit-testable without a real Redis or Postgres,
+and M4 can wire real implementations without touching the job
+functions themselves.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from arq.connections import RedisSettings
+
+from .jobs import JOB_FUNCTIONS, process_text
+
+
+def redis_settings_from_env() -> RedisSettings:
+    """Build :class:`RedisSettings` from the NLP service's env vars.
+
+    Defaults match the Compose network: ``redis://redis:6379/0``. In
+    local dev (outside Compose) ``REDIS_URL`` overrides the host.
+    """
+    url = os.environ.get("REDIS_URL")
+    if url:
+        return RedisSettings.from_dsn(url)
+    return RedisSettings(
+        host=os.environ.get("REDIS_HOST", "redis"),
+        port=int(os.environ.get("REDIS_PORT", "6379")),
+        database=int(os.environ.get("REDIS_DB", "0")),
+        password=os.environ.get("REDIS_PASSWORD") or None,
+    )
+
+
+async def on_startup(ctx: dict[str, Any]) -> None:
+    """Arq ``on_startup`` hook — runs once per worker process.
+
+    The production wiring (M4) attaches a Postgres connection pool and
+    a TextStore / TokenStore implementation to ``ctx`` here so the
+    job functions can reach them via their context argument.
+    """
+    # Populated by M4; kept as a no-op now so the worker boots in CI
+    # without a Postgres dependency.
+    ctx.setdefault("store", None)
+
+
+async def on_shutdown(ctx: dict[str, Any]) -> None:
+    # Symmetric with on_startup — real implementations close DB pools
+    # here so arq's SIGTERM path doesn't leave connections dangling.
+    store = ctx.get("store")
+    if store is not None and hasattr(store, "aclose"):
+        await store.aclose()
+
+
+class WorkerSettings:
+    """Arq worker entry point.
+
+    Run via ``python -m arq app.worker.WorkerSettings``. The Docker
+    Compose service (M4 / M13) wraps that in a supervisor with
+    restart-on-failure and appropriate log forwarding.
+    """
+
+    functions = JOB_FUNCTIONS
+    on_startup = on_startup
+    on_shutdown = on_shutdown
+    redis_settings = redis_settings_from_env()
+    # Keep ``max_jobs`` low for the MVP node — a single Stanza model
+    # pins ~600MB RAM, and the box has 4 GB usable. Future scaling
+    # tunable via WORKER_MAX_JOBS.
+    max_jobs = int(os.environ.get("WORKER_MAX_JOBS", "2"))
+    # Long per-job timeout because tokenizing a 200-page EPUB chapter
+    # can legitimately run 30-60s end-to-end. Reports > 10 min mean
+    # something is stuck; arq kills the job.
+    job_timeout = int(os.environ.get("WORKER_JOB_TIMEOUT_SEC", "600"))
+
+
+__all__ = [
+    "JOB_FUNCTIONS",
+    "WorkerSettings",
+    "on_shutdown",
+    "on_startup",
+    "process_text",
+    "redis_settings_from_env",
+]

--- a/services/nlp/app/worker/jobs.py
+++ b/services/nlp/app/worker/jobs.py
@@ -1,0 +1,99 @@
+"""Job functions executed by the arq worker (T-2.6).
+
+Currently one job: :func:`process_text`. It takes a ``text_id`` and
+the ids of its chapters, loads each chapter's raw text, runs the
+per-language pipeline, and writes tokens back via the injected store.
+
+The worker context carries the wiring (``store`` for text + token I/O,
+``text_store`` / ``token_store`` separately when they come from
+different backends). Jobs never touch Redis directly — arq handles
+queue plumbing — and they never import a DB client; that's an
+intentional seam so the jobs remain testable against in-memory
+fakes (see :mod:`tests.test_worker_jobs`).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from app.pipelines import get_pipeline
+
+from .store import TextStore, TokenStore
+
+
+@dataclass(frozen=True, slots=True)
+class ProcessTextResult:
+    text_id: str
+    chapters_processed: int
+    tokens_written: int
+
+
+def _store(ctx: dict[str, Any], key: str) -> Any:
+    store = ctx.get(key) or ctx.get("store")
+    if store is None:
+        raise RuntimeError(
+            f"Worker context missing required store; expected ctx[{key!r}] "
+            f"or ctx['store'] to be attached by on_startup."
+        )
+    return store
+
+
+async def process_text(
+    ctx: dict[str, Any],
+    *,
+    text_id: str,
+    chapter_ids: Sequence[str],
+) -> ProcessTextResult:
+    """Tokenize and persist a text's chapters.
+
+    The flow mirrors the plan: mark the text as processing, loop over
+    each chapter running its language's pipeline, write the resulting
+    tokens, then mark ready. Any exception flips the text to ``failed``
+    with a truncated error message, and arq's own retry / DLQ machinery
+    logs the traceback for on-call investigation.
+
+    The per-chapter loop does **not** parallelize — Stanza models are
+    not thread-safe and a single model instance is pinned per
+    pipeline_id in the process-wide cache. Running chapters
+    sequentially against the same cached model is both correct and
+    memory-cheap.
+    """
+    text_store: TextStore = _store(ctx, "text_store")
+    token_store: TokenStore = _store(ctx, "token_store")
+    job_id: str = ctx.get("job_id", "unknown-job")
+
+    await token_store.record_job_started(job_id=job_id, text_id=text_id)
+    await text_store.mark_processing(text_id)
+
+    try:
+        tokens_written = 0
+        for chapter_id in chapter_ids:
+            payload = await text_store.load_chapter(chapter_id)
+            pipeline = get_pipeline(payload.language)
+            result = pipeline.process(payload.text)
+            await token_store.write_tokens(chapter_id, result.tokens)
+            tokens_written += len(result.tokens)
+
+        await text_store.mark_ready(text_id)
+        await token_store.record_job_finished(job_id=job_id)
+    except Exception as exc:
+        # Truncate the message so a Stanza stacktrace doesn't blow out
+        # the DB column — the full traceback is in the worker log.
+        message = str(exc)[:500] or type(exc).__name__
+        await text_store.mark_failed(text_id, message)
+        await token_store.record_job_failed(job_id=job_id, error=message)
+        raise
+
+    return ProcessTextResult(
+        text_id=text_id,
+        chapters_processed=len(chapter_ids),
+        tokens_written=tokens_written,
+    )
+
+
+JOB_FUNCTIONS = [process_text]
+
+
+__all__ = ["JOB_FUNCTIONS", "ProcessTextResult", "process_text"]

--- a/services/nlp/app/worker/store.py
+++ b/services/nlp/app/worker/store.py
@@ -1,0 +1,64 @@
+"""Store protocols for worker jobs (T-2.6).
+
+Jobs operate on three I/O abstractions:
+
+* :class:`TextStore` — fetches the raw text of a chapter by id, and
+  flips the parent ``texts.status`` column through pending →
+  processing → ready / failed.
+* :class:`TokenStore` — persists the tokenized output (one row per
+  token) and records the per-job ``nlp_jobs`` bookkeeping.
+* :class:`JobEvents` — optional callback hook so the web UI's
+  processing-status UX (M4) can receive progress events via SSE.
+
+Keeping these as ``Protocol`` classes (instead of concrete Postgres
+implementations) means:
+
+1. Unit tests wire in-memory fakes without spinning up a DB — so
+   ``test_worker_jobs`` can run in CI against the same logic that
+   production exercises.
+2. M4 can slot in real Drizzle-backed implementations without
+   touching any job code.
+3. Future storage swaps (e.g. a read-through cache for bulk reprocess
+   in T-6.8) don't require re-writing the jobs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from app.schemas import Token
+
+
+@dataclass(frozen=True, slots=True)
+class ChapterPayload:
+    """Payload returned by :meth:`TextStore.load_chapter`."""
+
+    chapter_id: str
+    language: str
+    text: str
+
+
+class TextStore(Protocol):
+    async def load_chapter(self, chapter_id: str) -> ChapterPayload: ...
+
+    async def mark_processing(self, text_id: str) -> None: ...
+
+    async def mark_ready(self, text_id: str) -> None: ...
+
+    async def mark_failed(self, text_id: str, error: str) -> None: ...
+
+
+class TokenStore(Protocol):
+    async def write_tokens(
+        self, chapter_id: str, tokens: list[Token]
+    ) -> None: ...
+
+    async def record_job_started(self, job_id: str, text_id: str) -> None: ...
+
+    async def record_job_finished(self, job_id: str) -> None: ...
+
+    async def record_job_failed(self, job_id: str, error: str) -> None: ...
+
+
+__all__ = ["ChapterPayload", "TextStore", "TokenStore"]

--- a/services/nlp/pyproject.toml
+++ b/services/nlp/pyproject.toml
@@ -12,12 +12,19 @@ dependencies = [
   # from the script-aware editor (T-6.2a). Kept as a base dep rather
   # than under [models] so CI exercises it directly.
   "indic-transliteration>=2.3.68",
+  # Python-native Redis job queue for async NLP work (T-2.6). The
+  # worker process imports RedisSettings at module load; keep it in
+  # base deps so tests that import app.worker don't need [models].
+  "arq>=0.26.0",
 ]
 
 [project.optional-dependencies]
 dev = [
   "pytest>=8.3.3",
   "pytest-cov>=5.0.0",
+  # arq worker jobs are async coroutines; tests exercise them directly
+  # (asyncio_mode=auto in pytest config picks up bare async defs too).
+  "pytest-asyncio>=0.24.0",
   "httpx>=0.27.2",
   "ruff>=0.6.9",
   "mypy>=1.11.2",

--- a/services/nlp/tests/test_worker_jobs.py
+++ b/services/nlp/tests/test_worker_jobs.py
@@ -1,0 +1,225 @@
+"""Tests for :mod:`app.worker.jobs` (T-2.6).
+
+These tests run the real job logic against in-memory fakes — no Redis,
+no Postgres. That's deliberate: the wiring to Redis lives in
+:mod:`arq.worker.Worker` itself (we have no reason to re-test it), and
+the Postgres wiring lands in M4. What changes per-job, and what we
+have to cover here, is the sequence of store calls the job makes on
+the golden and failure paths.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.schemas import Token
+from app.worker.jobs import process_text
+from app.worker.store import ChapterPayload
+
+
+class _FakeTextStore:
+    def __init__(self, chapters: dict[str, ChapterPayload]) -> None:
+        self._chapters = chapters
+        self.calls: list[tuple[str, tuple]] = []
+
+    async def load_chapter(self, chapter_id: str) -> ChapterPayload:
+        self.calls.append(("load_chapter", (chapter_id,)))
+        return self._chapters[chapter_id]
+
+    async def mark_processing(self, text_id: str) -> None:
+        self.calls.append(("mark_processing", (text_id,)))
+
+    async def mark_ready(self, text_id: str) -> None:
+        self.calls.append(("mark_ready", (text_id,)))
+
+    async def mark_failed(self, text_id: str, error: str) -> None:
+        self.calls.append(("mark_failed", (text_id, error)))
+
+
+class _FakeTokenStore:
+    def __init__(self) -> None:
+        self.tokens_by_chapter: dict[str, list[Token]] = {}
+        self.calls: list[tuple[str, tuple]] = []
+
+    async def write_tokens(self, chapter_id: str, tokens: list[Token]) -> None:
+        self.tokens_by_chapter[chapter_id] = list(tokens)
+        self.calls.append(("write_tokens", (chapter_id, len(tokens))))
+
+    async def record_job_started(self, *, job_id: str, text_id: str) -> None:
+        self.calls.append(("record_job_started", (job_id, text_id)))
+
+    async def record_job_finished(self, *, job_id: str) -> None:
+        self.calls.append(("record_job_finished", (job_id,)))
+
+    async def record_job_failed(self, *, job_id: str, error: str) -> None:
+        self.calls.append(("record_job_failed", (job_id, error)))
+
+
+class _ExplodingTextStore(_FakeTextStore):
+    async def load_chapter(self, chapter_id: str) -> ChapterPayload:
+        self.calls.append(("load_chapter", (chapter_id,)))
+        raise RuntimeError("storage unavailable")
+
+
+def _ctx(text_store, token_store):
+    return {
+        "job_id": "test-job-1",
+        "text_store": text_store,
+        "token_store": token_store,
+    }
+
+
+@pytest.mark.asyncio
+async def test_process_text_happy_path_marks_processing_then_ready():
+    text_store = _FakeTextStore(
+        {
+            "ch-1": ChapterPayload(chapter_id="ch-1", language="hi", text="नमस्ते दुनिया"),
+            "ch-2": ChapterPayload(chapter_id="ch-2", language="hi", text="ठीक है"),
+        }
+    )
+    token_store = _FakeTokenStore()
+
+    result = await process_text(
+        _ctx(text_store, token_store),
+        text_id="text-1",
+        chapter_ids=["ch-1", "ch-2"],
+    )
+
+    assert result.text_id == "text-1"
+    assert result.chapters_processed == 2
+    # 2 tokens in each chapter (whitespace-split fake Stanza from conftest)
+    assert result.tokens_written == 4
+
+    # Marker sequence: processing before loading chapters, ready after
+    # all are written, job bookkeeping brackets the work.
+    sequence = [call[0] for call in text_store.calls]
+    assert sequence == [
+        "mark_processing",
+        "load_chapter",
+        "load_chapter",
+        "mark_ready",
+    ]
+    token_sequence = [call[0] for call in token_store.calls]
+    assert token_sequence == [
+        "record_job_started",
+        "write_tokens",
+        "write_tokens",
+        "record_job_finished",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_process_text_writes_tokens_for_each_chapter():
+    text_store = _FakeTextStore(
+        {
+            "ch-1": ChapterPayload(chapter_id="ch-1", language="or", text="ନମସ୍କାର ଦୁନିଆ"),
+        }
+    )
+    token_store = _FakeTokenStore()
+
+    await process_text(
+        _ctx(text_store, token_store),
+        text_id="text-or",
+        chapter_ids=["ch-1"],
+    )
+
+    assert "ch-1" in token_store.tokens_by_chapter
+    # The real Odia pipeline should produce non-empty tokens for a
+    # recognised greeting.
+    assert len(token_store.tokens_by_chapter["ch-1"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_process_text_marks_failed_on_store_error_and_reraises():
+    text_store = _ExplodingTextStore({})
+    token_store = _FakeTokenStore()
+
+    with pytest.raises(RuntimeError, match="storage unavailable"):
+        await process_text(
+            _ctx(text_store, token_store),
+            text_id="text-fail",
+            chapter_ids=["ch-1"],
+        )
+
+    # Failure bookkeeping must have fired even though we re-raise.
+    assert ("mark_failed", ("text-fail", "storage unavailable")) in text_store.calls
+    assert any(call[0] == "record_job_failed" for call in token_store.calls)
+    # And mark_ready must NOT have fired.
+    assert "mark_ready" not in [c[0] for c in text_store.calls]
+
+
+@pytest.mark.asyncio
+async def test_process_text_error_message_is_truncated_to_500_chars():
+    text_store = _ExplodingTextStore({})
+    text_store.load_chapter = _long_error  # type: ignore[assignment]
+    token_store = _FakeTokenStore()
+
+    with pytest.raises(RuntimeError):
+        await process_text(
+            _ctx(text_store, token_store),
+            text_id="t",
+            chapter_ids=["c"],
+        )
+
+    mark_failed = next(c for c in text_store.calls if c[0] == "mark_failed")
+    _, (_, msg) = mark_failed
+    assert len(msg) <= 500
+    assert msg == "x" * 500
+
+
+async def _long_error(chapter_id: str) -> ChapterPayload:
+    raise RuntimeError("x" * 1000)
+
+
+@pytest.mark.asyncio
+async def test_process_text_requires_text_store_in_ctx():
+    with pytest.raises(RuntimeError, match="Worker context missing required store"):
+        await process_text(
+            {"job_id": "j"},
+            text_id="t",
+            chapter_ids=["c"],
+        )
+
+
+@pytest.mark.asyncio
+async def test_process_text_accepts_unified_store_key():
+    # ctx['store'] satisfies both roles when a single DB client
+    # implements both protocols — saves wiring noise in production.
+    class _Combined(_FakeTextStore, _FakeTokenStore):  # type: ignore[misc]
+        def __init__(self, chapters):
+            _FakeTextStore.__init__(self, chapters)
+            _FakeTokenStore.__init__(self)
+
+    combined = _Combined(
+        {
+            "ch-1": ChapterPayload(chapter_id="ch-1", language="hi", text="नमस्ते"),
+        }
+    )
+    await process_text(
+        {"job_id": "j", "store": combined},
+        text_id="t",
+        chapter_ids=["ch-1"],
+    )
+    assert "ch-1" in combined.tokens_by_chapter
+
+
+@pytest.mark.asyncio
+async def test_process_text_dispatches_per_chapter_language():
+    # Two chapters in different languages — the dispatcher should run
+    # each one through its own pipeline. Smoke against the real cache.
+    text_store = _FakeTextStore(
+        {
+            "hi-ch": ChapterPayload(chapter_id="hi-ch", language="hi", text="एक दो"),
+            "or-ch": ChapterPayload(chapter_id="or-ch", language="or", text="ନମସ୍କାର"),
+        }
+    )
+    token_store = _FakeTokenStore()
+    await process_text(
+        _ctx(text_store, token_store),
+        text_id="mixed",
+        chapter_ids=["hi-ch", "or-ch"],
+    )
+    # Both chapters have tokens written — exactly 2 write_tokens calls.
+    writes = [c for c in token_store.calls if c[0] == "write_tokens"]
+    assert len(writes) == 2
+    assert {c[1][0] for c in writes} == {"hi-ch", "or-ch"}


### PR DESCRIPTION
## Summary
- Adds the async worker skeleton so upload handlers can enqueue long NLP jobs (tokenize, lemmatize, precompute romanizations) off the `/process` request path. `python -m arq app.worker.WorkerSettings` boots the worker; Redis config is driven by `REDIS_URL` with Compose defaults.
- `process_text(text_id, chapter_ids)` is the first job: flips `texts.status` pending → processing → ready, dispatches each chapter to the registered pipeline via the language registry, persists tokens through an injected `TokenStore`. Failure path marks `failed` with a 500-char-truncated error (fits the DB column) and re-raises so arq keeps the full traceback in the worker log.
- `TextStore` / `TokenStore` stay as `Protocol` classes. Jobs never import a DB client — that boundary is how M4 plugs real Postgres in without touching job logic, and it's how tests run against in-memory fakes today.

## Test plan
- [x] 7 unit tests in `tests/test_worker_jobs.py` cover happy-path store-call sequence, per-chapter token writes, failure bookkeeping (`mark_failed` + `record_job_failed` + no `mark_ready`), 500-char error truncation, missing-`ctx` guard, unified `ctx['store']` shortcut, and per-chapter language dispatch (Hindi + Odia mixed).
- [x] Full pytest suite green: 148 passed, total coverage 96.82% (`app/worker/jobs.py` at 100%).
- [x] `ruff check` clean on `app/` + `tests/`.
- [ ] Real Redis + Postgres wiring verified in M4 when `on_startup` attaches a live pool.

## Notes
- `arq` moved into base deps because `app.worker.__init__` imports `RedisSettings` at module load; keeping it out of `[models]` lets tests import the module without pulling Stanza.
- `pytest-asyncio` added to dev deps — `asyncio_mode = "auto"` was already configured in `pyproject.toml` but the plugin itself wasn't installed, so the `@pytest.mark.asyncio`-decorated jobs tests silently no-op'd without it.