### PR TITLE
T-2.8: golden-file tests + CI accuracy thresholds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,42 @@ jobs:
           path: services/nlp/.coverage
           if-no-files-found: ignore
 
+  nlp-accuracy:
+    # Real-pipeline lemma-accuracy gate (T-2.8). Installs [models],
+    # downloads the Hindi + Marathi Stanza UD models, caches them, and
+    # enforces >=90% Hi / >=80% Mr / >=70% Or. Lives in its own job so
+    # the main `nlp` lane stays fast; this one trades latency for the
+    # only real end-to-end quality signal we have before release.
+    name: nlp (real-pipeline accuracy thresholds)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - run: pip install -U pip && pip install -e 'services/nlp[dev,models]'
+      - name: Cache Stanza UD models
+        uses: actions/cache@v4
+        with:
+          path: ~/stanza_resources
+          key: stanza-models-hi-mr-v1-${{ hashFiles('services/nlp/pyproject.toml') }}
+      - name: Download Stanza Hi + Mr models
+        run: |
+          python - <<'PY'
+          import stanza
+          for lang in ("hi", "mr"):
+              stanza.download(lang, processors="tokenize,pos,lemma", verbose=False)
+          PY
+      - name: Run real-pipeline accuracy thresholds
+        working-directory: services/nlp
+        env:
+          PYTHONPATH: ${{ github.workspace }}/packages/shared-types/python
+        # Override the pyproject default (`-m 'not real_models'`) so
+        # only the threshold suite runs in this job. Coverage is
+        # irrelevant here — the default job enforces the floor already.
+        run: pytest -m real_models --no-cov -o addopts=""
+
   registry-parity:
     name: language registry parity (TS vs Python)
     runs-on: ubuntu-latest

--- a/services/nlp/pyproject.toml
+++ b/services/nlp/pyproject.toml
@@ -57,7 +57,14 @@ select = ["E", "F", "I", "B", "UP", "N", "W"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
-addopts = "--cov=app --cov-report=term-missing --cov-fail-under=70"
+# `real_models` accuracy tests (T-2.8) need Stanza + the 600MB Hi/Mr
+# UD models downloaded. They run in the dedicated `nlp-accuracy` CI
+# job — the default `pytest` invocation opts out so local dev and the
+# main `nlp` CI job don't have to pay the install cost.
+addopts = "--cov=app --cov-report=term-missing --cov-fail-under=70 -m 'not real_models'"
+markers = [
+  "real_models: tests that load real Stanza / IndicNLP models; skipped by default, run via `pytest -m real_models` with `[models]` installed.",
+]
 
 [tool.coverage.run]
 branch = true

--- a/services/nlp/tests/golden/hindi_corpus.json
+++ b/services/nlp/tests/golden/hindi_corpus.json
@@ -1,0 +1,184 @@
+{
+  "__description__": "Hindi golden-file corpus (T-2.8). Scored against the real Stanza UD Hindi model in the `nlp-accuracy` CI job — the default pytest run skips the real_models-marked tests. Format is the one at app/pipelines/odia/data/golden_corpus.json: per-token expectations are optional (missing fields mean 'don't enforce'), so contributors can pin only what they're confident about. These sentences are deliberately kept small and common-vocabulary so lemma expectations match Stanza's UD output; expand post-MVP as the pipeline quality becomes load-bearing on curriculum coverage.",
+  "sentences": [
+    {
+      "id": "hi-001",
+      "source": "hand-written",
+      "text": "यह किताब है।",
+      "tokens": [
+        { "surface": "यह", "pos": "PRON" },
+        { "surface": "किताब", "lemma": "किताब", "pos": "NOUN" },
+        { "surface": "है", "lemma": "है", "pos": "AUX" },
+        { "surface": "।", "pos": "PUNCT" }
+      ]
+    },
+    {
+      "id": "hi-002",
+      "source": "hand-written",
+      "text": "मैं हिंदी पढ़ता हूँ।",
+      "tokens": [
+        { "surface": "मैं", "pos": "PRON" },
+        { "surface": "हिंदी", "pos": "PROPN" },
+        { "surface": "पढ़ता", "lemma": "पढ़", "pos": "VERB" },
+        { "surface": "हूँ", "pos": "AUX" },
+        { "surface": "।", "pos": "PUNCT" }
+      ]
+    },
+    {
+      "id": "hi-003",
+      "source": "hand-written",
+      "text": "राम स्कूल जाता है।",
+      "tokens": [
+        { "surface": "राम", "pos": "PROPN" },
+        { "surface": "स्कूल", "lemma": "स्कूल", "pos": "NOUN" },
+        { "surface": "जाता", "lemma": "जा", "pos": "VERB" },
+        { "surface": "है", "pos": "AUX" },
+        { "surface": "।", "pos": "PUNCT" }
+      ]
+    },
+    {
+      "id": "hi-004",
+      "source": "hand-written",
+      "text": "वह पानी पीती है।",
+      "tokens": [
+        { "surface": "वह", "pos": "PRON" },
+        { "surface": "पानी", "lemma": "पानी", "pos": "NOUN" },
+        { "surface": "पीती", "lemma": "पी", "pos": "VERB" },
+        { "surface": "है", "pos": "AUX" },
+        { "surface": "।", "pos": "PUNCT" }
+      ]
+    },
+    {
+      "id": "hi-005",
+      "source": "hand-written",
+      "text": "बच्चे खेल रहे हैं।",
+      "tokens": [
+        { "surface": "बच्चे", "lemma": "बच्चा", "pos": "NOUN" },
+        { "surface": "खेल", "lemma": "खेल", "pos": "VERB" },
+        { "surface": "रहे", "pos": "AUX" },
+        { "surface": "हैं", "pos": "AUX" },
+        { "surface": "।", "pos": "PUNCT" }
+      ]
+    },
+    {
+      "id": "hi-006",
+      "source": "hand-written",
+      "text": "मेरा घर बड़ा है।",
+      "tokens": [
+        { "surface": "मेरा", "pos": "PRON" },
+        { "surface": "घर", "lemma": "घर", "pos": "NOUN" },
+        { "surface": "बड़ा", "lemma": "बड़ा", "pos": "ADJ" },
+        { "surface": "है", "pos": "AUX" },
+        { "surface": "।", "pos": "PUNCT" }
+      ]
+    },
+    {
+      "id": "hi-007",
+      "source": "hand-written",
+      "text": "पिताजी घर आए।",
+      "tokens": [
+        { "surface": "पिताजी", "pos": "NOUN" },
+        { "surface": "घर", "lemma": "घर", "pos": "NOUN" },
+        { "surface": "आए", "lemma": "आ", "pos": "VERB" },
+        { "surface": "।", "pos": "PUNCT" }
+      ]
+    },
+    {
+      "id": "hi-008",
+      "source": "hand-written",
+      "text": "मैंने सेब खाया।",
+      "tokens": [
+        { "surface": "मैंने", "pos": "PRON" },
+        { "surface": "सेब", "lemma": "सेब", "pos": "NOUN" },
+        { "surface": "खाया", "lemma": "खा", "pos": "VERB" },
+        { "surface": "।", "pos": "PUNCT" }
+      ]
+    },
+    {
+      "id": "hi-009",
+      "source": "hand-written",
+      "text": "वह किताब पढ़ेगी।",
+      "tokens": [
+        { "surface": "वह", "pos": "PRON" },
+        { "surface": "किताब", "lemma": "किताब", "pos": "NOUN" },
+        { "surface": "पढ़ेगी", "lemma": "पढ़", "pos": "VERB" },
+        { "surface": "।", "pos": "PUNCT" }
+      ]
+    },
+    {
+      "id": "hi-010",
+      "source": "hand-written",
+      "text": "लड़कियाँ गाना गा रही हैं।",
+      "tokens": [
+        { "surface": "लड़कियाँ", "lemma": "लड़की", "pos": "NOUN" },
+        { "surface": "गाना", "pos": "NOUN" },
+        { "surface": "गा", "lemma": "गा", "pos": "VERB" },
+        { "surface": "रही", "pos": "AUX" },
+        { "surface": "हैं", "pos": "AUX" },
+        { "surface": "।", "pos": "PUNCT" }
+      ]
+    },
+    {
+      "id": "hi-011",
+      "source": "hand-written",
+      "text": "आज मौसम अच्छा है।",
+      "tokens": [
+        { "surface": "आज", "pos": "ADV" },
+        { "surface": "मौसम", "lemma": "मौसम", "pos": "NOUN" },
+        { "surface": "अच्छा", "lemma": "अच्छा", "pos": "ADJ" },
+        { "surface": "है", "pos": "AUX" },
+        { "surface": "।", "pos": "PUNCT" }
+      ]
+    },
+    {
+      "id": "hi-012",
+      "source": "hand-written",
+      "text": "हम कल बाज़ार जाएँगे।",
+      "tokens": [
+        { "surface": "हम", "pos": "PRON" },
+        { "surface": "कल", "pos": "ADV" },
+        { "surface": "बाज़ार", "lemma": "बाज़ार", "pos": "NOUN" },
+        { "surface": "जाएँगे", "lemma": "जा", "pos": "VERB" },
+        { "surface": "।", "pos": "PUNCT" }
+      ]
+    },
+    {
+      "id": "hi-013",
+      "source": "hand-written",
+      "text": "मुझे हिंदी अच्छी लगती है।",
+      "tokens": [
+        { "surface": "मुझे", "pos": "PRON" },
+        { "surface": "हिंदी", "pos": "PROPN" },
+        { "surface": "अच्छी", "lemma": "अच्छा", "pos": "ADJ" },
+        { "surface": "लगती", "lemma": "लग", "pos": "VERB" },
+        { "surface": "है", "pos": "AUX" },
+        { "surface": "।", "pos": "PUNCT" }
+      ]
+    },
+    {
+      "id": "hi-014",
+      "source": "hand-written",
+      "comment": "Ambiguity sanity case: 'सोना' can be noun (gold) or verb (to sleep). In this sentence the verb-adjacent AUX 'हूँ' forces the verb reading; the test doesn't pin is_ambiguous because Stanza UD doesn't currently expose homograph ambiguity the way our top-K softmax does — candidate ambiguity is a later quality bar.",
+      "text": "मैं अभी सोता हूँ।",
+      "tokens": [
+        { "surface": "मैं", "pos": "PRON" },
+        { "surface": "अभी", "pos": "ADV" },
+        { "surface": "सोता", "lemma": "सो", "pos": "VERB" },
+        { "surface": "हूँ", "pos": "AUX" },
+        { "surface": "।", "pos": "PUNCT" }
+      ]
+    },
+    {
+      "id": "hi-015",
+      "source": "hand-written",
+      "text": "बच्चा दूध पीता है।",
+      "tokens": [
+        { "surface": "बच्चा", "lemma": "बच्चा", "pos": "NOUN" },
+        { "surface": "दूध", "lemma": "दूध", "pos": "NOUN" },
+        { "surface": "पीता", "lemma": "पी", "pos": "VERB" },
+        { "surface": "है", "pos": "AUX" },
+        { "surface": "।", "pos": "PUNCT" }
+      ]
+    }
+  ]
+}

--- a/services/nlp/tests/golden/marathi_corpus.json
+++ b/services/nlp/tests/golden/marathi_corpus.json
@@ -1,0 +1,140 @@
+{
+  "__description__": "Marathi golden-file corpus (T-2.8). Scored against the real Stanza UD Marathi model in the `nlp-accuracy` CI job. Threshold is lower than Hindi (≥80% vs ≥90%) because the stanza-mr model is noisier in the wild — matches the quality-bar in the plan. Grows post-MVP.",
+  "sentences": [
+    {
+      "id": "mr-001",
+      "source": "hand-written",
+      "text": "मी मराठी शिकतो.",
+      "tokens": [
+        { "surface": "मी", "pos": "PRON" },
+        { "surface": "मराठी", "pos": "PROPN" },
+        { "surface": "शिकतो", "lemma": "शिक", "pos": "VERB" },
+        { "surface": ".", "pos": "PUNCT" }
+      ]
+    },
+    {
+      "id": "mr-002",
+      "source": "hand-written",
+      "text": "ती शाळेत जाते.",
+      "tokens": [
+        { "surface": "ती", "pos": "PRON" },
+        { "surface": "शाळेत", "lemma": "शाळा", "pos": "NOUN" },
+        { "surface": "जाते", "lemma": "जा", "pos": "VERB" },
+        { "surface": ".", "pos": "PUNCT" }
+      ]
+    },
+    {
+      "id": "mr-003",
+      "source": "hand-written",
+      "text": "मुले खेळत आहेत.",
+      "tokens": [
+        { "surface": "मुले", "lemma": "मूल", "pos": "NOUN" },
+        { "surface": "खेळत", "lemma": "खेळ", "pos": "VERB" },
+        { "surface": "आहेत", "pos": "AUX" },
+        { "surface": ".", "pos": "PUNCT" }
+      ]
+    },
+    {
+      "id": "mr-004",
+      "source": "hand-written",
+      "text": "आज पाऊस पडतो आहे.",
+      "tokens": [
+        { "surface": "आज", "pos": "ADV" },
+        { "surface": "पाऊस", "lemma": "पाऊस", "pos": "NOUN" },
+        { "surface": "पडतो", "lemma": "पड", "pos": "VERB" },
+        { "surface": "आहे", "pos": "AUX" },
+        { "surface": ".", "pos": "PUNCT" }
+      ]
+    },
+    {
+      "id": "mr-005",
+      "source": "hand-written",
+      "text": "माझे घर मोठे आहे.",
+      "tokens": [
+        { "surface": "माझे", "pos": "PRON" },
+        { "surface": "घर", "lemma": "घर", "pos": "NOUN" },
+        { "surface": "मोठे", "lemma": "मोठा", "pos": "ADJ" },
+        { "surface": "आहे", "pos": "AUX" },
+        { "surface": ".", "pos": "PUNCT" }
+      ]
+    },
+    {
+      "id": "mr-006",
+      "source": "hand-written",
+      "text": "राम पुस्तक वाचतो.",
+      "tokens": [
+        { "surface": "राम", "pos": "PROPN" },
+        { "surface": "पुस्तक", "lemma": "पुस्तक", "pos": "NOUN" },
+        { "surface": "वाचतो", "lemma": "वाच", "pos": "VERB" },
+        { "surface": ".", "pos": "PUNCT" }
+      ]
+    },
+    {
+      "id": "mr-007",
+      "source": "hand-written",
+      "text": "आम्ही उद्या बाजारात जाऊ.",
+      "tokens": [
+        { "surface": "आम्ही", "pos": "PRON" },
+        { "surface": "उद्या", "pos": "ADV" },
+        { "surface": "बाजारात", "lemma": "बाजार", "pos": "NOUN" },
+        { "surface": "जाऊ", "lemma": "जा", "pos": "VERB" },
+        { "surface": ".", "pos": "PUNCT" }
+      ]
+    },
+    {
+      "id": "mr-008",
+      "source": "hand-written",
+      "text": "तिने सफरचंद खाल्ले.",
+      "tokens": [
+        { "surface": "तिने", "pos": "PRON" },
+        { "surface": "सफरचंद", "lemma": "सफरचंद", "pos": "NOUN" },
+        { "surface": "खाल्ले", "lemma": "खा", "pos": "VERB" },
+        { "surface": ".", "pos": "PUNCT" }
+      ]
+    },
+    {
+      "id": "mr-009",
+      "source": "hand-written",
+      "text": "मुलगी गाणे गाते.",
+      "tokens": [
+        { "surface": "मुलगी", "lemma": "मुलगी", "pos": "NOUN" },
+        { "surface": "गाणे", "lemma": "गाणे", "pos": "NOUN" },
+        { "surface": "गाते", "lemma": "गा", "pos": "VERB" },
+        { "surface": ".", "pos": "PUNCT" }
+      ]
+    },
+    {
+      "id": "mr-010",
+      "source": "hand-written",
+      "text": "मला मराठी आवडते.",
+      "tokens": [
+        { "surface": "मला", "pos": "PRON" },
+        { "surface": "मराठी", "pos": "PROPN" },
+        { "surface": "आवडते", "lemma": "आवड", "pos": "VERB" },
+        { "surface": ".", "pos": "PUNCT" }
+      ]
+    },
+    {
+      "id": "mr-011",
+      "source": "hand-written",
+      "text": "तो पाणी पितो.",
+      "tokens": [
+        { "surface": "तो", "pos": "PRON" },
+        { "surface": "पाणी", "lemma": "पाणी", "pos": "NOUN" },
+        { "surface": "पितो", "lemma": "पि", "pos": "VERB" },
+        { "surface": ".", "pos": "PUNCT" }
+      ]
+    },
+    {
+      "id": "mr-012",
+      "source": "hand-written",
+      "text": "आई घरी आली.",
+      "tokens": [
+        { "surface": "आई", "lemma": "आई", "pos": "NOUN" },
+        { "surface": "घरी", "lemma": "घर", "pos": "NOUN" },
+        { "surface": "आली", "lemma": "ये", "pos": "VERB" },
+        { "surface": ".", "pos": "PUNCT" }
+      ]
+    }
+  ]
+}

--- a/services/nlp/tests/test_accuracy_thresholds.py
+++ b/services/nlp/tests/test_accuracy_thresholds.py
@@ -1,0 +1,157 @@
+"""Per-language lemma-accuracy thresholds (T-2.8).
+
+Two layers of coverage:
+
+1. **Corpus-structure sanity** — always on. Loads every language's
+   golden-file JSON, checks IDs are unique and the file isn't empty.
+   Catches malformed JSON and duplicate-id merges before CI has to
+   spin up Stanza. Runs in the default ``pytest`` invocation.
+
+2. **Real-pipeline accuracy** — marked ``@pytest.mark.real_models``,
+   skipped by default. In the ``nlp-accuracy`` CI job we install
+   ``[models]`` (Stanza + IndicNLP), download the Hindi and Marathi
+   UD models, and run these. The thresholds — ≥90% Hindi, ≥80%
+   Marathi, ≥70% Odia lemma accuracy — come straight from the plan
+   and are the release gate for the whole pipeline milestone.
+
+Why not merge the two? Because CI signal latency matters. The main
+``nlp`` job must stay under a minute so PR feedback is fast; model
+download + inference adds 5-10 minutes and needs its own lane.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.eval import evaluate
+from app.eval.corpus import load_corpus
+from app.pipelines import get_pipeline, reset_pipeline_cache
+from app.pipelines.odia import OdiaPipeline
+from app.pipelines.odia.lemmas import default_lemma_table
+
+_GOLDEN_DIR = Path(__file__).resolve().parent / "golden"
+_HINDI_CORPUS = _GOLDEN_DIR / "hindi_corpus.json"
+_MARATHI_CORPUS = _GOLDEN_DIR / "marathi_corpus.json"
+_ODIA_CORPUS = (
+    Path(__file__).resolve().parent.parent
+    / "app"
+    / "pipelines"
+    / "odia"
+    / "data"
+    / "golden_corpus.json"
+)
+
+# Per-language lemma-accuracy floors. Stay in sync with the M2 release
+# gate in the plan. Raising these as pipeline quality improves is a
+# follow-up — lowering them is not allowed without an explicit PR.
+HINDI_LEMMA_FLOOR = 0.90
+MARATHI_LEMMA_FLOOR = 0.80
+ODIA_LEMMA_FLOOR = 0.70
+
+
+# ---- corpus-structure sanity (default suite) ----
+
+
+@pytest.mark.parametrize(
+    "path",
+    [_HINDI_CORPUS, _MARATHI_CORPUS, _ODIA_CORPUS],
+    ids=["hindi", "marathi", "odia"],
+)
+def test_corpus_loads_and_has_unique_ids(path: Path):
+    corpus = load_corpus(path)
+    assert len(corpus) > 0, f"{path.name} is empty"
+    ids = [s.id for s in corpus.sentences]
+    assert len(ids) == len(set(ids)), (
+        f"{path.name} has duplicate sentence ids — merge them instead of duplicating"
+    )
+    # Every sentence must have at least one token, otherwise the eval
+    # harness quietly scores it as a no-op and the corpus stops catching
+    # regressions.
+    for sentence in corpus.sentences:
+        assert len(sentence.tokens) > 0, (
+            f"{path.name}:{sentence.id} has zero expected tokens"
+        )
+
+
+# ---- Odia accuracy floor (runs in default suite — no Stanza needed) ----
+
+
+def test_odia_lemma_accuracy_meets_floor():
+    # Odia uses the hand-rolled pipeline (IndicNLP tokenizer + rule-based
+    # morph + seed lemma table) so no heavyweight model download is
+    # required; the whitespace-split tokenizer works because the golden
+    # sentences are space-delimited by construction. That's what makes
+    # the ≥70% floor enforceable in the default CI lane — unlike Hi/Mr.
+    pipeline = OdiaPipeline(tokenizer=str.split, lemmas=default_lemma_table())
+    result = evaluate(pipeline, load_corpus(_ODIA_CORPUS))
+    summary = result.summary()
+    assert summary["lemma_accuracy"] >= ODIA_LEMMA_FLOOR, (
+        f"Odia lemma accuracy regressed: {summary}\n"
+        "First failures:\n" + "\n".join(result.failures[:20])
+    )
+
+
+# ---- real-model accuracy (skipped unless -m real_models) ----
+
+
+@pytest.fixture
+def _clean_pipeline_cache():
+    # The conftest autouse fixture swaps the real factories with fakes;
+    # real-model tests re-import the real factories and reset the cache
+    # so ``get_pipeline`` actually goes to Stanza. The fixture also
+    # restores state afterwards so later tests in the same worker don't
+    # see a contaminated cache.
+    from app import pipelines
+    from app.pipelines.hindi import build_hindi_pipeline
+    from app.pipelines.marathi import build_marathi_pipeline
+    from app.pipelines.odia import build_odia_pipeline
+
+    saved = dict(pipelines._PIPELINE_FACTORIES)
+    pipelines._PIPELINE_FACTORIES["stanza-hi"] = build_hindi_pipeline
+    pipelines._PIPELINE_FACTORIES["stanza-mr"] = build_marathi_pipeline
+    pipelines._PIPELINE_FACTORIES["custom-or"] = build_odia_pipeline
+    reset_pipeline_cache()
+    try:
+        yield
+    finally:
+        pipelines._PIPELINE_FACTORIES.clear()
+        pipelines._PIPELINE_FACTORIES.update(saved)
+        reset_pipeline_cache()
+
+
+@pytest.mark.real_models
+def test_hindi_real_pipeline_meets_lemma_floor(_clean_pipeline_cache):
+    pipeline = get_pipeline("hi")
+    result = evaluate(pipeline, load_corpus(_HINDI_CORPUS))
+    summary = result.summary()
+    assert summary["lemma_accuracy"] >= HINDI_LEMMA_FLOOR, (
+        f"Hindi lemma accuracy regressed: {summary}\n"
+        "First failures:\n" + "\n".join(result.failures[:30])
+    )
+
+
+@pytest.mark.real_models
+def test_marathi_real_pipeline_meets_lemma_floor(_clean_pipeline_cache):
+    pipeline = get_pipeline("mr")
+    result = evaluate(pipeline, load_corpus(_MARATHI_CORPUS))
+    summary = result.summary()
+    assert summary["lemma_accuracy"] >= MARATHI_LEMMA_FLOOR, (
+        f"Marathi lemma accuracy regressed: {summary}\n"
+        "First failures:\n" + "\n".join(result.failures[:30])
+    )
+
+
+@pytest.mark.real_models
+def test_odia_real_pipeline_meets_lemma_floor(_clean_pipeline_cache):
+    # Also runs Odia under the real pipeline (IndicNLP tokenizer, not
+    # the whitespace fake) so the nlp-accuracy job catches any
+    # IndicNLP-tokenization drift the default suite would miss.
+    pipeline = get_pipeline("or")
+    result = evaluate(pipeline, load_corpus(_ODIA_CORPUS))
+    summary = result.summary()
+    assert summary["lemma_accuracy"] >= ODIA_LEMMA_FLOOR, (
+        f"Odia (real pipeline) lemma accuracy regressed: {summary}\n"
+        "First failures:\n" + "\n".join(result.failures[:30])
+    )


### PR DESCRIPTION
## Summary
- Wires the M2 release gate — ≥90% Hindi / ≥80% Marathi / ≥70% Odia lemma accuracy — into CI. Values come directly from the plan and should only move *up* going forward; a regression PR lowering them needs explicit justification.
- Adds small hand-written golden corpora for Hindi and Marathi under `services/nlp/tests/golden/`. Same format the Odia corpus from T-2.3b uses; missing fields are don't-care, so contributors can grow the corpora without over-committing to features.
- Introduces a `real_models` pytest marker. The default `pytest` invocation (local dev, main `nlp` CI job) excludes it so tests stay under a minute. The new `nlp-accuracy` CI job installs `[models]`, caches Stanza resources across runs, downloads the Hi + Mr UD models, and runs the marked tests.
- Odia's accuracy floor can be enforced in the default suite (the Odia pipeline is pure-Python, no 600MB download), so it lives in the always-on lane.

## Test plan
- [x] `pytest` green: 166 passed, 3 `real_models` tests deselected. Total coverage 96.99%.
- [x] `ruff check` clean.
- [x] Structure sanity: corpus loads for all three languages, IDs unique, every sentence has ≥1 token.
- [x] Odia lemma accuracy against the seed pipeline clears the 0.70 floor.
- [ ] `nlp-accuracy` job proves out on first CI run — may need a follow-up calibration PR if hand-written Hindi/Marathi annotations disagree with real Stanza output. Corpus is deliberately small so any drift is easy to fix one entry at a time.

## Notes
- Threshold constants (`HINDI_LEMMA_FLOOR` etc.) live at module level in `test_accuracy_thresholds.py` so they're grep-able from a release checklist.
- The `_clean_pipeline_cache` fixture undoes the conftest autouse swap that replaces real Stanza factories with fakes — `real_models` tests need the real Stanza factory active.