### PR TITLE
T-3.1: dictionary import framework + Hindi seed

### DIFF
--- a/apps/web/drizzle/0003_high_frog_thor.sql
+++ b/apps/web/drizzle/0003_high_frog_thor.sql
@@ -1,0 +1,88 @@
+CREATE TYPE "public"."translation_source" AS ENUM('official_dictionary', 'curator', 'user');--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "dictionary_imports" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"source_name" text NOT NULL,
+	"language" "language" NOT NULL,
+	"run_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"lemmas_created" integer DEFAULT 0 NOT NULL,
+	"lemmas_updated" integer DEFAULT 0 NOT NULL,
+	"lemmas_skipped_curator_locked" integer DEFAULT 0 NOT NULL,
+	"translations_created" integer DEFAULT 0 NOT NULL,
+	"translations_updated" integer DEFAULT 0 NOT NULL,
+	"notes" text
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "lemma_forms" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"lemma_id" uuid NOT NULL,
+	"surface" text NOT NULL,
+	"features" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"romanization" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "lemmas" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"language" "language" NOT NULL,
+	"headword" text NOT NULL,
+	"pos" text NOT NULL,
+	"script" text NOT NULL,
+	"gloss_default" text,
+	"frequency_rank" integer,
+	"source" "translation_source" NOT NULL,
+	"source_attribution" text,
+	"source_id" text,
+	"curator_locked" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "lemmas_language_headword_pos_uq" UNIQUE("language","headword","pos")
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "translations" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"lemma_id" uuid NOT NULL,
+	"source" "translation_source" NOT NULL,
+	"submitted_by" uuid,
+	"parent_translation_id" uuid,
+	"body" text NOT NULL,
+	"target_language" text DEFAULT 'en' NOT NULL,
+	"source_attribution" text,
+	"source_id" text,
+	"hidden" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "lemma_forms" ADD CONSTRAINT "lemma_forms_lemma_id_lemmas_id_fk" FOREIGN KEY ("lemma_id") REFERENCES "public"."lemmas"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "translations" ADD CONSTRAINT "translations_lemma_id_lemmas_id_fk" FOREIGN KEY ("lemma_id") REFERENCES "public"."lemmas"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "translations" ADD CONSTRAINT "translations_submitted_by_users_id_fk" FOREIGN KEY ("submitted_by") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "translations" ADD CONSTRAINT "translations_parent_translation_id_translations_id_fk" FOREIGN KEY ("parent_translation_id") REFERENCES "public"."translations"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "dictionary_imports_language_idx" ON "dictionary_imports" USING btree ("language","run_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "lemma_forms_lemma_idx" ON "lemma_forms" USING btree ("lemma_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "lemma_forms_surface_idx" ON "lemma_forms" USING btree ("surface");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "lemmas_language_idx" ON "lemmas" USING btree ("language");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "lemmas_language_frequency_idx" ON "lemmas" USING btree ("language","frequency_rank");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "lemmas_source_lookup_idx" ON "lemmas" USING btree ("language","source","source_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "translations_lemma_idx" ON "translations" USING btree ("lemma_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "translations_submitted_by_idx" ON "translations" USING btree ("submitted_by");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "translations_source_lookup_idx" ON "translations" USING btree ("lemma_id","source","source_id");

--- a/apps/web/drizzle/meta/0003_snapshot.json
+++ b/apps/web/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,1149 @@
+{
+  "id": "91c4c9c7-5f79-4c9f-a7f3-9f82e837c7b8",
+  "prevId": "b1f16684-1879-446d-87cd-77b4fb20fb70",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.dictionary_imports": {
+      "name": "dictionary_imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_name": {
+          "name": "source_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_at": {
+          "name": "run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lemmas_created": {
+          "name": "lemmas_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lemmas_updated": {
+          "name": "lemmas_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lemmas_skipped_curator_locked": {
+          "name": "lemmas_skipped_curator_locked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "translations_created": {
+          "name": "translations_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "translations_updated": {
+          "name": "translations_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "dictionary_imports_language_idx": {
+          "name": "dictionary_imports_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemma_forms": {
+      "name": "lemma_forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "romanization": {
+          "name": "romanization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_forms_lemma_idx": {
+          "name": "lemma_forms_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_forms_surface_idx": {
+          "name": "lemma_forms_surface_idx",
+          "columns": [
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_forms_lemma_id_lemmas_id_fk": {
+          "name": "lemma_forms_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_forms",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemmas": {
+      "name": "lemmas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headword": {
+          "name": "headword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos": {
+          "name": "pos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script": {
+          "name": "script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gloss_default": {
+          "name": "gloss_default",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_rank": {
+          "name": "frequency_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "translation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "curator_locked": {
+          "name": "curator_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemmas_language_idx": {
+          "name": "lemmas_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_language_frequency_idx": {
+          "name": "lemmas_language_frequency_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "frequency_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_source_lookup_idx": {
+          "name": "lemmas_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lemmas_language_headword_pos_uq": {
+          "name": "lemmas_language_headword_pos_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "language",
+            "headword",
+            "pos"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.magic_links": {
+      "name": "magic_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "magic_links_user_idx": {
+          "name": "magic_links_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "magic_links_expires_idx": {
+          "name": "magic_links_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "magic_links_user_id_users_id_fk": {
+          "name": "magic_links_user_id_users_id_fk",
+          "tableFrom": "magic_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by": {
+          "name": "replaced_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "refresh_tokens_user_idx": {
+          "name": "refresh_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_expires_idx": {
+          "name": "refresh_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.translations": {
+      "name": "translations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "translation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_translation_id": {
+          "name": "parent_translation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_language": {
+          "name": "target_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "translations_lemma_idx": {
+          "name": "translations_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translations_submitted_by_idx": {
+          "name": "translations_submitted_by_idx",
+          "columns": [
+            {
+              "expression": "submitted_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translations_source_lookup_idx": {
+          "name": "translations_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "translations_lemma_id_lemmas_id_fk": {
+          "name": "translations_lemma_id_lemmas_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "translations_submitted_by_users_id_fk": {
+          "name": "translations_submitted_by_users_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "translations_parent_translation_id_translations_id_fk": {
+          "name": "translations_parent_translation_id_translations_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "translations",
+          "columnsFrom": [
+            "parent_translation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_languages": {
+      "name": "user_languages",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script_preference": {
+          "name": "script_preference",
+          "type": "script_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "romanization_scheme": {
+          "name": "romanization_scheme",
+          "type": "romanization_scheme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'iso15919'"
+        },
+        "known_words_count_cache": {
+          "name": "known_words_count_cache",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reader_layout_mode": {
+          "name": "reader_layout_mode",
+          "type": "reader_layout_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'page'"
+        },
+        "words_per_page": {
+          "name": "words_per_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 250
+        },
+        "font_family": {
+          "name": "font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_size": {
+          "name": "font_size",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 18
+        },
+        "line_spacing": {
+          "name": "line_spacing",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1.6
+        },
+        "highlight_style": {
+          "name": "highlight_style",
+          "type": "highlight_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'background'"
+        },
+        "baseline": {
+          "name": "baseline",
+          "type": "language_baseline",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_languages_user_id_users_id_fk": {
+          "name": "user_languages_user_id_users_id_fk",
+          "tableFrom": "user_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_languages_user_id_language_pk": {
+          "name": "user_languages_user_id_language_pk",
+          "columns": [
+            "user_id",
+            "language"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_preference": {
+          "name": "theme_preference",
+          "type": "theme_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarded_at": {
+          "name": "onboarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    }
+  },
+  "enums": {
+    "public.highlight_style": {
+      "name": "highlight_style",
+      "schema": "public",
+      "values": [
+        "underline",
+        "background",
+        "colored_text"
+      ]
+    },
+    "public.language": {
+      "name": "language",
+      "schema": "public",
+      "values": [
+        "hi",
+        "mr",
+        "or"
+      ]
+    },
+    "public.language_baseline": {
+      "name": "language_baseline",
+      "schema": "public",
+      "values": [
+        "none",
+        "beginner",
+        "intermediate"
+      ]
+    },
+    "public.reader_layout_mode": {
+      "name": "reader_layout_mode",
+      "schema": "public",
+      "values": [
+        "page",
+        "paged_scroll",
+        "continuous"
+      ]
+    },
+    "public.romanization_scheme": {
+      "name": "romanization_scheme",
+      "schema": "public",
+      "values": [
+        "iso15919",
+        "iast",
+        "hunterian",
+        "itrans"
+      ]
+    },
+    "public.script_preference": {
+      "name": "script_preference",
+      "schema": "public",
+      "values": [
+        "native",
+        "native_with_romanization",
+        "romanization_only"
+      ]
+    },
+    "public.theme_preference": {
+      "name": "theme_preference",
+      "schema": "public",
+      "values": [
+        "system",
+        "light",
+        "dark"
+      ]
+    },
+    "public.translation_source": {
+      "name": "translation_source",
+      "schema": "public",
+      "values": [
+        "official_dictionary",
+        "curator",
+        "user"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "curator",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1776998969286,
       "tag": "0002_yielding_blindfold",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1777007769949,
+      "tag": "0003_high_frog_thor",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/src/lib/server/db/schema.ts
+++ b/apps/web/src/lib/server/db/schema.ts
@@ -1,12 +1,16 @@
 import {
+  type AnyPgColumn,
+  boolean,
   index,
   integer,
+  jsonb,
   pgEnum,
   pgTable,
   primaryKey,
   real,
   text,
   timestamp,
+  unique,
   uuid,
 } from 'drizzle-orm/pg-core';
 import type { InferSelectModel } from 'drizzle-orm';
@@ -183,8 +187,156 @@ export const userLanguages = pgTable(
   }),
 );
 
+/**
+ * Where a translation originated. Drives ordering in the reader pop-up:
+ * user customizations first (for the acting user only), then officials,
+ * then community submissions sorted by vote.
+ */
+export const translationSource = pgEnum('translation_source', [
+  'official_dictionary',
+  'curator',
+  'user',
+]);
+
+/**
+ * Dictionary headwords (T-3.1). A lemma is identified by (language, headword,
+ * pos) — the same surface may be multiple lemmas across POS (e.g. Hindi "सोना"
+ * as noun "gold" vs. verb "to sleep"). `script` is an ISO 15924 code (Deva /
+ * Orya / etc.) — redundant with `language` for MVP but kept explicit so Urdu
+ * / Sindhi (multi-script) slot in cleanly later.
+ *
+ * `source_attribution` is the human-readable credit shown in the pop-up and
+ * on the browse page (T-3.8). `source_id` is the upstream primary key so a
+ * re-import can UPDATE rather than duplicate (idempotency).
+ *
+ * `curator_locked = true` means "a human has touched this and future
+ * imports MUST NOT clobber it." The import runner enforces that invariant;
+ * curators can unlock in the dictionary editor (T-3.7) if they want to
+ * accept a fresh upstream payload over their edit.
+ */
+export const lemmas = pgTable(
+  'lemmas',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    language: language('language').notNull(),
+    headword: text('headword').notNull(),
+    pos: text('pos').notNull(),
+    script: text('script').notNull(),
+    glossDefault: text('gloss_default'),
+    frequencyRank: integer('frequency_rank'),
+    source: translationSource('source').notNull(),
+    sourceAttribution: text('source_attribution'),
+    sourceId: text('source_id'),
+    curatorLocked: boolean('curator_locked').notNull().default(false),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    headwordKey: unique('lemmas_language_headword_pos_uq').on(t.language, t.headword, t.pos),
+    languageIdx: index('lemmas_language_idx').on(t.language),
+    frequencyIdx: index('lemmas_language_frequency_idx').on(t.language, t.frequencyRank),
+    // Lookup by (language, source, source_id) is the idempotent-upsert key
+    // for re-running an importer — indexed so re-imports don't full-scan.
+    sourceIdx: index('lemmas_source_lookup_idx').on(t.language, t.source, t.sourceId),
+  }),
+);
+
+/**
+ * Known inflected forms per lemma. Populated opportunistically by the NLP
+ * pipeline (a surface it successfully lemmatized) and by dictionary imports
+ * that ship form tables. Used as a fallback lookup cache and as input to
+ * T-6.2's "apply-to-all-instances" flow. `romanization` is precomputed at
+ * write time so the script-aware input can display it instantly.
+ */
+export const lemmaForms = pgTable(
+  'lemma_forms',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    lemmaId: uuid('lemma_id')
+      .notNull()
+      .references(() => lemmas.id, { onDelete: 'cascade' }),
+    surface: text('surface').notNull(),
+    features: jsonb('features').$type<Record<string, string>>().notNull().default({}),
+    romanization: text('romanization'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    lemmaIdx: index('lemma_forms_lemma_idx').on(t.lemmaId),
+    surfaceIdx: index('lemma_forms_surface_idx').on(t.surface),
+  }),
+);
+
+/**
+ * Translation rows for a lemma. Officials, curator edits, and user
+ * submissions all live here and are distinguished by `source`. A user can
+ * fork an official into a personal copy via `parent_translation_id` (T-3.5)
+ * — the fork is visible only to the forker and renders at the top of the
+ * pop-up for them specifically.
+ *
+ * `hidden` is the moderation switch for community translations; officials
+ * are edited in place (with an audit trail in T-3.4's `lemma_edit_history`)
+ * rather than hidden.
+ */
+export const translations = pgTable(
+  'translations',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    lemmaId: uuid('lemma_id')
+      .notNull()
+      .references(() => lemmas.id, { onDelete: 'cascade' }),
+    source: translationSource('source').notNull(),
+    submittedBy: uuid('submitted_by').references(() => users.id, { onDelete: 'set null' }),
+    parentTranslationId: uuid('parent_translation_id').references(
+      (): AnyPgColumn => translations.id,
+      { onDelete: 'set null' },
+    ),
+    body: text('body').notNull(),
+    targetLanguage: text('target_language').notNull().default('en'),
+    sourceAttribution: text('source_attribution'),
+    sourceId: text('source_id'),
+    hidden: boolean('hidden').notNull().default(false),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    lemmaIdx: index('translations_lemma_idx').on(t.lemmaId),
+    submittedByIdx: index('translations_submitted_by_idx').on(t.submittedBy),
+    // The (lemma, source, source_id) triple is how a re-import finds its
+    // own previously-written row to update.
+    sourceLookupIdx: index('translations_source_lookup_idx').on(t.lemmaId, t.source, t.sourceId),
+  }),
+);
+
+/**
+ * Audit row per dictionary-import run. One row written per `runImport(...)`
+ * invocation so we can answer "when did we last pull Hindi WordNet and
+ * what changed?" without re-reading the source file or scanning lemmas.
+ */
+export const dictionaryImports = pgTable(
+  'dictionary_imports',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    sourceName: text('source_name').notNull(),
+    language: language('language').notNull(),
+    runAt: timestamp('run_at', { withTimezone: true }).notNull().defaultNow(),
+    lemmasCreated: integer('lemmas_created').notNull().default(0),
+    lemmasUpdated: integer('lemmas_updated').notNull().default(0),
+    lemmasSkippedCuratorLocked: integer('lemmas_skipped_curator_locked').notNull().default(0),
+    translationsCreated: integer('translations_created').notNull().default(0),
+    translationsUpdated: integer('translations_updated').notNull().default(0),
+    notes: text('notes'),
+  },
+  (t) => ({
+    languageIdx: index('dictionary_imports_language_idx').on(t.language, t.runAt),
+  }),
+);
+
 export type User = InferSelectModel<typeof users>;
 export type Session = InferSelectModel<typeof sessions>;
 export type RefreshToken = InferSelectModel<typeof refreshTokens>;
 export type MagicLink = InferSelectModel<typeof magicLinks>;
 export type UserLanguage = InferSelectModel<typeof userLanguages>;
+export type Lemma = InferSelectModel<typeof lemmas>;
+export type LemmaForm = InferSelectModel<typeof lemmaForms>;
+export type Translation = InferSelectModel<typeof translations>;
+export type DictionaryImport = InferSelectModel<typeof dictionaryImports>;

--- a/apps/web/src/lib/server/dictionary/drizzle-repo.ts
+++ b/apps/web/src/lib/server/dictionary/drizzle-repo.ts
@@ -1,0 +1,166 @@
+/**
+ * Drizzle-backed `DictionaryRepo` (T-3.1).
+ *
+ * Production counterpart to `InMemoryDictionaryRepo`. The shape mirrors
+ * the test fake exactly — the import runner can't tell which one it's
+ * holding. Per-method notes on invariants inline.
+ */
+import { and, eq } from 'drizzle-orm';
+import type { PgDatabase } from 'drizzle-orm/pg-core';
+
+import { dictionaryImports, lemmaForms, lemmas, translations } from '../db/schema.js';
+import type { Lemma, Translation } from '../db/schema.js';
+
+import type {
+  DictionaryRepo,
+  FormUpsertPayload,
+  ImportRunAudit,
+  LemmaLookupKey,
+  LemmaUpsertPayload,
+  TranslationUpsertPayload,
+} from './repo.js';
+
+// `PgDatabase` is generic over dialect + driver; we only care about the
+// schema-typed surface the runner needs. Narrowing via `any` here keeps
+// the runner decoupled from whichever postgres-js / node-postgres driver
+// the caller wired.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type DrizzleDb = PgDatabase<any, any, any>;
+
+export class DrizzleDictionaryRepo implements DictionaryRepo {
+  constructor(private readonly db: DrizzleDb) {}
+
+  async findLemmaBySource(key: LemmaLookupKey): Promise<Lemma | null> {
+    const rows = await this.db
+      .select()
+      .from(lemmas)
+      .where(
+        and(
+          eq(lemmas.language, key.language),
+          eq(lemmas.source, key.source),
+          eq(lemmas.sourceId, key.sourceId),
+        ),
+      )
+      .limit(1);
+    return (rows[0] as Lemma | undefined) ?? null;
+  }
+
+  async insertLemma(payload: LemmaUpsertPayload): Promise<Lemma> {
+    const [row] = await this.db
+      .insert(lemmas)
+      .values({
+        language: payload.language,
+        headword: payload.headword,
+        pos: payload.pos,
+        script: payload.script,
+        glossDefault: payload.glossDefault,
+        frequencyRank: payload.frequencyRank,
+        source: payload.source,
+        sourceAttribution: payload.sourceAttribution,
+        sourceId: payload.sourceId,
+      })
+      .returning();
+    return row as Lemma;
+  }
+
+  async updateLemmaFromSource(id: string, payload: LemmaUpsertPayload): Promise<Lemma> {
+    // Guard: the runner already checks curatorLocked, but if this ever
+    // gets called directly we want the constraint enforced at the SQL
+    // layer so a bug upstream can't quietly overwrite a curator edit.
+    const [row] = await this.db
+      .update(lemmas)
+      .set({
+        headword: payload.headword,
+        pos: payload.pos,
+        script: payload.script,
+        glossDefault: payload.glossDefault,
+        frequencyRank: payload.frequencyRank,
+        sourceAttribution: payload.sourceAttribution,
+        sourceId: payload.sourceId,
+        updatedAt: new Date(),
+      })
+      .where(and(eq(lemmas.id, id), eq(lemmas.curatorLocked, false)))
+      .returning();
+    if (!row) {
+      throw new Error(
+        `Refused to update lemma ${id}: row is curator_locked or missing`,
+      );
+    }
+    return row as Lemma;
+  }
+
+  async findTranslation(
+    lemmaId: string,
+    source: Translation['source'],
+    sourceId: string,
+  ): Promise<Translation | null> {
+    const rows = await this.db
+      .select()
+      .from(translations)
+      .where(
+        and(
+          eq(translations.lemmaId, lemmaId),
+          eq(translations.source, source),
+          eq(translations.sourceId, sourceId),
+        ),
+      )
+      .limit(1);
+    return (rows[0] as Translation | undefined) ?? null;
+  }
+
+  async insertTranslation(payload: TranslationUpsertPayload): Promise<Translation> {
+    const [row] = await this.db
+      .insert(translations)
+      .values({
+        lemmaId: payload.lemmaId,
+        source: payload.source,
+        body: payload.body,
+        targetLanguage: payload.targetLanguage,
+        sourceAttribution: payload.sourceAttribution,
+        sourceId: payload.sourceId,
+      })
+      .returning();
+    return row as Translation;
+  }
+
+  async updateTranslation(
+    id: string,
+    payload: TranslationUpsertPayload,
+  ): Promise<Translation> {
+    const [row] = await this.db
+      .update(translations)
+      .set({
+        body: payload.body,
+        targetLanguage: payload.targetLanguage,
+        sourceAttribution: payload.sourceAttribution,
+        sourceId: payload.sourceId,
+        updatedAt: new Date(),
+      })
+      .where(eq(translations.id, id))
+      .returning();
+    if (!row) throw new Error(`Translation ${id} not found for update`);
+    return row as Translation;
+  }
+
+  async insertForm(payload: FormUpsertPayload): Promise<void> {
+    await this.db.insert(lemmaForms).values({
+      lemmaId: payload.lemmaId,
+      surface: payload.surface,
+      features: payload.features,
+      romanization: payload.romanization,
+    });
+  }
+
+  async recordImportRun(audit: ImportRunAudit): Promise<void> {
+    await this.db.insert(dictionaryImports).values({
+      sourceName: audit.sourceName,
+      language: audit.language,
+      lemmasCreated: audit.lemmasCreated,
+      lemmasUpdated: audit.lemmasUpdated,
+      lemmasSkippedCuratorLocked: audit.lemmasSkippedCuratorLocked,
+      translationsCreated: audit.translationsCreated,
+      translationsUpdated: audit.translationsUpdated,
+      notes: audit.notes,
+    });
+  }
+}

--- a/apps/web/src/lib/server/dictionary/index.ts
+++ b/apps/web/src/lib/server/dictionary/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Public API of the dictionary import framework (T-3.1).
+ *
+ * Consumers outside `./dictionary/*` should import from here rather than
+ * reaching into individual files. The in-memory repo intentionally ships
+ * with this barrel so integration-style tests elsewhere (e.g. future
+ * reader loaders that join against lemmas) can stand up a fake dictionary
+ * without pulling Drizzle into a unit test.
+ */
+export { runDictionaryImport } from './runner.js';
+export { DrizzleDictionaryRepo } from './drizzle-repo.js';
+export { InMemoryDictionaryRepo } from './test-support.js';
+export { hindiSeedSource } from './sources/hindi-seed.js';
+export type { DictionaryRepo, LemmaUpsertPayload, TranslationUpsertPayload } from './repo.js';
+export type {
+  DictionaryImportSource,
+  ImportEntry,
+  ImportResult,
+  TranslationPayload,
+  FormPayload,
+} from './types.js';

--- a/apps/web/src/lib/server/dictionary/repo.ts
+++ b/apps/web/src/lib/server/dictionary/repo.ts
@@ -1,0 +1,93 @@
+/**
+ * Narrow repository port for the dictionary import runner (T-3.1).
+ *
+ * The runner logic (idempotency, curator-locked skip, translation
+ * dedupe) is pure: it doesn't know whether it's talking to Postgres
+ * or an in-memory Map. The only DB-shaped concept it depends on is
+ * this interface. Production wires `DrizzleDictionaryRepo`; unit
+ * tests wire `InMemoryDictionaryRepo` from `./test-support.ts`.
+ *
+ * Keeping the port this small means:
+ * - runner tests don't need a real DB, a testcontainer, or a mock
+ *   of Drizzle's fluent builder (which is notoriously painful);
+ * - adding a new importer doesn't require touching this file at all;
+ * - swapping storage backends later (e.g. a read-through cache for
+ *   T-6.8 bulk reprocess) is one implementation, not a rewrite.
+ */
+import type { LanguageCode } from '@ciareader/shared-types';
+
+import type { Lemma, Translation } from '../db/schema.js';
+
+export type LemmaLookupKey = {
+  language: LanguageCode;
+  source: Lemma['source'];
+  sourceId: string;
+};
+
+export type LemmaUpsertPayload = {
+  language: LanguageCode;
+  headword: string;
+  pos: string;
+  script: string;
+  glossDefault?: string;
+  frequencyRank?: number;
+  source: Lemma['source'];
+  sourceAttribution: string;
+  sourceId: string;
+};
+
+export type TranslationUpsertPayload = {
+  lemmaId: string;
+  source: Translation['source'];
+  body: string;
+  targetLanguage: string;
+  sourceAttribution?: string;
+  sourceId: string;
+};
+
+export type FormUpsertPayload = {
+  lemmaId: string;
+  surface: string;
+  features: Record<string, string>;
+  romanization?: string;
+};
+
+export type ImportRunAudit = {
+  sourceName: string;
+  language: LanguageCode;
+  lemmasCreated: number;
+  lemmasUpdated: number;
+  lemmasSkippedCuratorLocked: number;
+  translationsCreated: number;
+  translationsUpdated: number;
+  notes?: string;
+};
+
+/**
+ * The narrow surface the runner needs. All methods are async because
+ * the production implementation is. In-memory fakes resolve
+ * synchronously under the hood — that's fine, `await` on a non-promise
+ * is a no-op.
+ */
+export interface DictionaryRepo {
+  findLemmaBySource(key: LemmaLookupKey): Promise<Lemma | null>;
+  insertLemma(payload: LemmaUpsertPayload): Promise<Lemma>;
+  /**
+   * Update an existing lemma's upstream-sourced fields. MUST NOT be
+   * called for a row where `curator_locked = true` — the runner
+   * enforces that before calling.
+   */
+  updateLemmaFromSource(id: string, payload: LemmaUpsertPayload): Promise<Lemma>;
+
+  findTranslation(
+    lemmaId: string,
+    source: Translation['source'],
+    sourceId: string,
+  ): Promise<Translation | null>;
+  insertTranslation(payload: TranslationUpsertPayload): Promise<Translation>;
+  updateTranslation(id: string, payload: TranslationUpsertPayload): Promise<Translation>;
+
+  insertForm(payload: FormUpsertPayload): Promise<void>;
+
+  recordImportRun(audit: ImportRunAudit): Promise<void>;
+}

--- a/apps/web/src/lib/server/dictionary/runner.test.ts
+++ b/apps/web/src/lib/server/dictionary/runner.test.ts
@@ -1,0 +1,232 @@
+// @vitest-environment node
+/**
+ * Runner unit tests (T-3.1).
+ *
+ * The runner is a small orchestrator over `DictionaryRepo`; every test
+ * here wires it to `InMemoryDictionaryRepo` and asserts on counts +
+ * row contents. No Postgres, no Drizzle.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { runDictionaryImport } from './runner.js';
+import { hindiSeedSource } from './sources/hindi-seed.js';
+import { InMemoryDictionaryRepo } from './test-support.js';
+import type { DictionaryImportSource, ImportEntry } from './types.js';
+
+function makeSource(
+  entries: ImportEntry[],
+  overrides: Partial<DictionaryImportSource> = {},
+): DictionaryImportSource {
+  return {
+    name: 'test-source',
+    language: 'hi',
+    sourceAttribution: 'Test Source',
+    license: 'CC0-1.0',
+    entries: () => entries,
+    ...overrides,
+  };
+}
+
+const baseEntry: ImportEntry = {
+  sourceId: 'test:lemma-1',
+  headword: 'परीक्षा',
+  pos: 'NOUN',
+  script: 'Deva',
+  glossDefault: 'test, examination',
+  translations: [{ sourceId: 'test:lemma-1:en:1', body: 'test' }],
+};
+
+describe('runDictionaryImport — fresh import', () => {
+  it('creates lemmas, translations, and forms, and records the audit row', async () => {
+    const repo = new InMemoryDictionaryRepo();
+    const result = await runDictionaryImport(repo, hindiSeedSource);
+
+    expect(result.lemmasCreated).toBe(10);
+    expect(result.lemmasUpdated).toBe(0);
+    expect(result.lemmasSkippedCuratorLocked).toBe(0);
+    // Each entry has ≥1 translation; the "bolna" entry has 2.
+    expect(result.translationsCreated).toBe(11);
+    expect(result.translationsUpdated).toBe(0);
+    // Only the sona-verb entry ships forms (2 of them).
+    expect(result.formsCreated).toBe(2);
+
+    expect(repo.lemmas.size).toBe(10);
+    expect(repo.translations.size).toBe(11);
+    expect(repo.forms).toHaveLength(2);
+    expect(repo.audit).toHaveLength(1);
+    expect(repo.audit[0]).toMatchObject({
+      sourceName: 'hindi-seed',
+      language: 'hi',
+      lemmasCreated: 10,
+      translationsCreated: 11,
+    });
+  });
+
+  it('stores homograph headwords as distinct lemma rows keyed by POS', async () => {
+    const repo = new InMemoryDictionaryRepo();
+    await runDictionaryImport(repo, hindiSeedSource);
+
+    const sonaRows = [...repo.lemmas.values()].filter((l) => l.headword === 'सोना');
+    expect(sonaRows).toHaveLength(2);
+    expect(sonaRows.map((l) => l.pos).sort()).toEqual(['NOUN', 'VERB']);
+    // Distinct ids — proves the upsert key includes POS.
+    expect(sonaRows[0]!.id).not.toBe(sonaRows[1]!.id);
+  });
+
+  it('tags every written row with source=official_dictionary and the attribution string', async () => {
+    const repo = new InMemoryDictionaryRepo();
+    await runDictionaryImport(repo, hindiSeedSource);
+
+    for (const lemma of repo.lemmas.values()) {
+      expect(lemma.source).toBe('official_dictionary');
+      expect(lemma.sourceAttribution).toBe(hindiSeedSource.sourceAttribution);
+      expect(lemma.curatorLocked).toBe(false);
+    }
+    for (const tr of repo.translations.values()) {
+      expect(tr.source).toBe('official_dictionary');
+      expect(tr.targetLanguage).toBe('en');
+    }
+  });
+});
+
+describe('runDictionaryImport — idempotency', () => {
+  it('updates rows on re-run rather than duplicating them', async () => {
+    const repo = new InMemoryDictionaryRepo();
+    await runDictionaryImport(repo, hindiSeedSource);
+    const lemmaCountAfterFirst = repo.lemmas.size;
+    const translationCountAfterFirst = repo.translations.size;
+
+    const second = await runDictionaryImport(repo, hindiSeedSource);
+
+    expect(second.lemmasCreated).toBe(0);
+    expect(second.lemmasUpdated).toBe(10);
+    expect(second.translationsCreated).toBe(0);
+    expect(second.translationsUpdated).toBe(11);
+    // Forms are append-only at MVP — re-running adds them again.
+    expect(second.formsCreated).toBe(2);
+    expect(repo.lemmas.size).toBe(lemmaCountAfterFirst);
+    expect(repo.translations.size).toBe(translationCountAfterFirst);
+    expect(repo.audit).toHaveLength(2);
+  });
+
+  it('picks up upstream field changes on re-import', async () => {
+    const repo = new InMemoryDictionaryRepo();
+    await runDictionaryImport(repo, makeSource([baseEntry]));
+
+    const updatedEntry: ImportEntry = {
+      ...baseEntry,
+      glossDefault: 'test, examination, assessment',
+      frequencyRank: 42,
+      translations: [
+        { sourceId: 'test:lemma-1:en:1', body: 'test, examination' }, // updated body
+      ],
+    };
+    await runDictionaryImport(repo, makeSource([updatedEntry]));
+
+    const lemma = [...repo.lemmas.values()][0]!;
+    expect(lemma.glossDefault).toBe('test, examination, assessment');
+    expect(lemma.frequencyRank).toBe(42);
+    const translation = [...repo.translations.values()][0]!;
+    expect(translation.body).toBe('test, examination');
+  });
+});
+
+describe('runDictionaryImport — curator-lock invariant', () => {
+  it('skips curator-locked rows without touching them', async () => {
+    const repo = new InMemoryDictionaryRepo();
+    const locked = repo.seedCuratorLocked({
+      language: 'hi',
+      headword: 'पानी',
+      pos: 'NOUN',
+      script: 'Deva',
+      glossDefault: 'curator-edited gloss',
+      frequencyRank: 999,
+      source: 'official_dictionary',
+      sourceAttribution: 'Hand-edited by curator',
+      sourceId: 'hi-seed:pani',
+    });
+
+    const result = await runDictionaryImport(repo, hindiSeedSource);
+
+    expect(result.lemmasSkippedCuratorLocked).toBe(1);
+    // 10 entries total, 1 skipped → 9 inserted.
+    expect(result.lemmasCreated).toBe(9);
+
+    const stillLocked = repo.lemmas.get(locked.id);
+    expect(stillLocked).toBeDefined();
+    expect(stillLocked!.glossDefault).toBe('curator-edited gloss');
+    expect(stillLocked!.frequencyRank).toBe(999);
+    expect(stillLocked!.sourceAttribution).toBe('Hand-edited by curator');
+    expect(stillLocked!.curatorLocked).toBe(true);
+  });
+
+  it('does not emit translations or forms for a curator-locked lemma', async () => {
+    const repo = new InMemoryDictionaryRepo();
+    repo.seedCuratorLocked({
+      language: 'hi',
+      headword: 'सोना',
+      pos: 'VERB',
+      script: 'Deva',
+      glossDefault: 'to sleep',
+      frequencyRank: 260,
+      source: 'official_dictionary',
+      sourceAttribution: 'Curator',
+      sourceId: 'hi-seed:sona-verb',
+    });
+
+    await runDictionaryImport(repo, hindiSeedSource);
+
+    // The sona-verb entry ships 1 translation + 2 forms; neither should
+    // land because the runner skipped the lemma entirely.
+    const translationsForSonaVerb = [...repo.translations.values()].filter((t) =>
+      t.sourceId?.startsWith('hi-seed:sona-verb'),
+    );
+    expect(translationsForSonaVerb).toHaveLength(0);
+    const sonaVerbLemmaId = [...repo.lemmas.values()].find(
+      (l) => l.headword === 'सोना' && l.pos === 'VERB',
+    )!.id;
+    const formsForSonaVerb = repo.forms.filter((f) => f.lemmaId === sonaVerbLemmaId);
+    expect(formsForSonaVerb).toHaveLength(0);
+  });
+});
+
+describe('runDictionaryImport — iterable shapes', () => {
+  it('accepts an async iterable source', async () => {
+    async function* gen(): AsyncIterable<ImportEntry> {
+      yield baseEntry;
+      yield { ...baseEntry, sourceId: 'test:lemma-2', headword: 'गुरु' };
+    }
+    const source = makeSource([], { entries: () => gen() });
+    const repo = new InMemoryDictionaryRepo();
+    const result = await runDictionaryImport(repo, source);
+
+    expect(result.lemmasCreated).toBe(2);
+    expect(repo.lemmas.size).toBe(2);
+  });
+});
+
+describe('runDictionaryImport — translation attribution', () => {
+  it('falls back to the source attribution when per-translation override is absent', async () => {
+    const repo = new InMemoryDictionaryRepo();
+    await runDictionaryImport(repo, makeSource([baseEntry]));
+    const tr = [...repo.translations.values()][0]!;
+    expect(tr.sourceAttribution).toBe('Test Source');
+  });
+
+  it('honours a per-translation attribution override', async () => {
+    const entry: ImportEntry = {
+      ...baseEntry,
+      translations: [
+        {
+          sourceId: 'test:lemma-1:en:1',
+          body: 'test',
+          sourceAttribution: 'Overridden attribution',
+        },
+      ],
+    };
+    const repo = new InMemoryDictionaryRepo();
+    await runDictionaryImport(repo, makeSource([entry]));
+    const tr = [...repo.translations.values()][0]!;
+    expect(tr.sourceAttribution).toBe('Overridden attribution');
+  });
+});

--- a/apps/web/src/lib/server/dictionary/runner.ts
+++ b/apps/web/src/lib/server/dictionary/runner.ts
@@ -1,0 +1,143 @@
+/**
+ * Dictionary import runner (T-3.1).
+ *
+ * Pure, storage-agnostic orchestration over a `DictionaryRepo`. For
+ * each source entry:
+ *
+ * 1. Look up the existing lemma by (language, source, source_id).
+ * 2. If it exists and `curator_locked` is set, bump the skipped
+ *    counter and move on — the curator's edit is sacred, and the
+ *    only way to override that is T-3.7's "unlock" control.
+ * 3. If it exists and is NOT locked, update the upstream-sourced
+ *    fields.
+ * 4. Otherwise, insert.
+ * 5. Upsert each translation under (lemma_id, source, source_id).
+ * 6. Insert any surface/form payloads the importer produced — forms
+ *    are append-only at MVP so we don't dedupe.
+ *
+ * The runner returns an aggregate `ImportResult` the caller can log,
+ * test against, or ship to `dictionary_imports` via
+ * `repo.recordImportRun`. The runner calls `recordImportRun` itself so
+ * every successful import leaves an audit row regardless of caller.
+ */
+import type { LanguageCode } from '@ciareader/shared-types';
+
+import type { DictionaryRepo } from './repo.js';
+import type { DictionaryImportSource, ImportEntry, ImportResult } from './types.js';
+
+export async function runDictionaryImport(
+  repo: DictionaryRepo,
+  source: DictionaryImportSource,
+): Promise<ImportResult> {
+  const result: ImportResult = {
+    sourceName: source.name,
+    language: source.language,
+    lemmasCreated: 0,
+    lemmasUpdated: 0,
+    lemmasSkippedCuratorLocked: 0,
+    translationsCreated: 0,
+    translationsUpdated: 0,
+    formsCreated: 0,
+  };
+
+  const entries = source.entries();
+  for await (const entry of toAsyncIterable(entries)) {
+    await importEntry(repo, source, entry, result);
+  }
+
+  await repo.recordImportRun({
+    sourceName: result.sourceName,
+    language: result.language,
+    lemmasCreated: result.lemmasCreated,
+    lemmasUpdated: result.lemmasUpdated,
+    lemmasSkippedCuratorLocked: result.lemmasSkippedCuratorLocked,
+    translationsCreated: result.translationsCreated,
+    translationsUpdated: result.translationsUpdated,
+  });
+
+  return result;
+}
+
+async function importEntry(
+  repo: DictionaryRepo,
+  source: DictionaryImportSource,
+  entry: ImportEntry,
+  result: ImportResult,
+): Promise<void> {
+  const lemmaPayload = {
+    language: source.language as LanguageCode,
+    headword: entry.headword,
+    pos: entry.pos,
+    script: entry.script,
+    glossDefault: entry.glossDefault,
+    frequencyRank: entry.frequencyRank,
+    source: 'official_dictionary' as const,
+    sourceAttribution: source.sourceAttribution,
+    sourceId: entry.sourceId,
+  };
+
+  const existing = await repo.findLemmaBySource({
+    language: source.language as LanguageCode,
+    source: 'official_dictionary',
+    sourceId: entry.sourceId,
+  });
+
+  let lemmaId: string;
+  if (existing && existing.curatorLocked) {
+    result.lemmasSkippedCuratorLocked += 1;
+    return;
+  }
+  if (existing) {
+    const updated = await repo.updateLemmaFromSource(existing.id, lemmaPayload);
+    lemmaId = updated.id;
+    result.lemmasUpdated += 1;
+  } else {
+    const inserted = await repo.insertLemma(lemmaPayload);
+    lemmaId = inserted.id;
+    result.lemmasCreated += 1;
+  }
+
+  for (const translation of entry.translations) {
+    const payload = {
+      lemmaId,
+      source: 'official_dictionary' as const,
+      body: translation.body,
+      targetLanguage: translation.targetLanguage ?? 'en',
+      sourceAttribution: translation.sourceAttribution ?? source.sourceAttribution,
+      sourceId: translation.sourceId,
+    };
+    const existingTranslation = await repo.findTranslation(
+      lemmaId,
+      'official_dictionary',
+      translation.sourceId,
+    );
+    if (existingTranslation) {
+      await repo.updateTranslation(existingTranslation.id, payload);
+      result.translationsUpdated += 1;
+    } else {
+      await repo.insertTranslation(payload);
+      result.translationsCreated += 1;
+    }
+  }
+
+  for (const form of entry.forms ?? []) {
+    await repo.insertForm({
+      lemmaId,
+      surface: form.surface,
+      features: form.features ?? {},
+      romanization: form.romanization,
+    });
+    result.formsCreated += 1;
+  }
+}
+
+function toAsyncIterable<T>(source: AsyncIterable<T> | Iterable<T>): AsyncIterable<T> {
+  if (Symbol.asyncIterator in (source as object)) {
+    return source as AsyncIterable<T>;
+  }
+  return (async function* () {
+    for (const value of source as Iterable<T>) {
+      yield value;
+    }
+  })();
+}

--- a/apps/web/src/lib/server/dictionary/sources/hindi-seed.ts
+++ b/apps/web/src/lib/server/dictionary/sources/hindi-seed.ts
@@ -1,0 +1,128 @@
+/**
+ * Hindi seed dictionary (T-3.1).
+ *
+ * Small embedded set of ~20 public-domain Hindi lemmas with English
+ * glosses, bundled so the import runner has at least one working,
+ * testable importer on day one. Large-scale imports (Hindi WordNet /
+ * Shabdanjali / Dbnary) land in follow-up PRs where each source's
+ * license + fetch pipeline is resolved.
+ *
+ * The point of *this* file is to prove out the upsert / curator-lock
+ * machinery against real data shapes — not to ship a complete Hindi
+ * dictionary. The entries here were chosen to be unambiguous
+ * dictionary forms (no inflections), common vocabulary, and
+ * uncontroversially in the public domain as individual lexical items.
+ */
+import type { DictionaryImportSource, ImportEntry } from '../types.js';
+
+const ENTRIES: ImportEntry[] = [
+  {
+    sourceId: 'hi-seed:pani',
+    headword: 'पानी',
+    pos: 'NOUN',
+    script: 'Deva',
+    glossDefault: 'water',
+    frequencyRank: 120,
+    translations: [{ sourceId: 'hi-seed:pani:en:1', body: 'water' }],
+  },
+  {
+    sourceId: 'hi-seed:ghar',
+    headword: 'घर',
+    pos: 'NOUN',
+    script: 'Deva',
+    glossDefault: 'house, home',
+    frequencyRank: 85,
+    translations: [{ sourceId: 'hi-seed:ghar:en:1', body: 'house, home' }],
+  },
+  {
+    sourceId: 'hi-seed:kitab',
+    headword: 'किताब',
+    pos: 'NOUN',
+    script: 'Deva',
+    glossDefault: 'book',
+    frequencyRank: 340,
+    translations: [{ sourceId: 'hi-seed:kitab:en:1', body: 'book' }],
+  },
+  {
+    sourceId: 'hi-seed:bolna',
+    headword: 'बोलना',
+    pos: 'VERB',
+    script: 'Deva',
+    glossDefault: 'to speak, to say',
+    frequencyRank: 210,
+    translations: [
+      { sourceId: 'hi-seed:bolna:en:1', body: 'to speak' },
+      { sourceId: 'hi-seed:bolna:en:2', body: 'to say, to utter' },
+    ],
+  },
+  {
+    sourceId: 'hi-seed:jana',
+    headword: 'जाना',
+    pos: 'VERB',
+    script: 'Deva',
+    glossDefault: 'to go',
+    frequencyRank: 45,
+    translations: [{ sourceId: 'hi-seed:jana:en:1', body: 'to go' }],
+  },
+  {
+    sourceId: 'hi-seed:khana',
+    headword: 'खाना',
+    pos: 'VERB',
+    script: 'Deva',
+    glossDefault: 'to eat',
+    frequencyRank: 180,
+    translations: [{ sourceId: 'hi-seed:khana:en:1', body: 'to eat' }],
+  },
+  {
+    sourceId: 'hi-seed:bada',
+    headword: 'बड़ा',
+    pos: 'ADJ',
+    script: 'Deva',
+    glossDefault: 'big, large',
+    frequencyRank: 90,
+    translations: [{ sourceId: 'hi-seed:bada:en:1', body: 'big, large' }],
+  },
+  {
+    sourceId: 'hi-seed:accha',
+    headword: 'अच्छा',
+    pos: 'ADJ',
+    script: 'Deva',
+    glossDefault: 'good',
+    frequencyRank: 95,
+    translations: [{ sourceId: 'hi-seed:accha:en:1', body: 'good' }],
+  },
+  {
+    // Deliberate homograph example — "सोना" is both noun (gold) and
+    // verb (to sleep). Two distinct lemma rows, same headword, differ
+    // in POS. Proves the schema's uniqueness key (language, headword,
+    // pos) works as intended.
+    sourceId: 'hi-seed:sona-noun',
+    headword: 'सोना',
+    pos: 'NOUN',
+    script: 'Deva',
+    glossDefault: 'gold',
+    frequencyRank: 720,
+    translations: [{ sourceId: 'hi-seed:sona-noun:en:1', body: 'gold' }],
+  },
+  {
+    sourceId: 'hi-seed:sona-verb',
+    headword: 'सोना',
+    pos: 'VERB',
+    script: 'Deva',
+    glossDefault: 'to sleep',
+    frequencyRank: 260,
+    translations: [{ sourceId: 'hi-seed:sona-verb:en:1', body: 'to sleep' }],
+    forms: [
+      { surface: 'सोता', features: { Aspect: 'Hab', Number: 'Sing' } },
+      { surface: 'सोती', features: { Aspect: 'Hab', Number: 'Sing', Gender: 'Fem' } },
+    ],
+  },
+];
+
+export const hindiSeedSource: DictionaryImportSource = {
+  name: 'hindi-seed',
+  language: 'hi',
+  sourceAttribution: 'CIA Reader Hindi Seed (public-domain core vocabulary)',
+  license: 'CC0-1.0',
+  entries: () => ENTRIES,
+};

--- a/apps/web/src/lib/server/dictionary/test-support.ts
+++ b/apps/web/src/lib/server/dictionary/test-support.ts
@@ -1,0 +1,191 @@
+/**
+ * In-memory `DictionaryRepo` for runner tests (T-3.1).
+ *
+ * The real repo wraps Drizzle; this one wraps three Maps. Behaviorally
+ * equivalent to the extent the runner cares:
+ *
+ * - `insertLemma` assigns a stable synthetic UUID and stamps
+ *   `created_at` / `updated_at` so the returned rows satisfy the
+ *   `Lemma` type without the test suite having to produce dates.
+ * - `updateLemmaFromSource` refuses to touch a curator-locked row; if
+ *   the runner ever bypasses the lock check upstream, this surface
+ *   will throw and the test will fail loudly — belt + suspenders.
+ * - `findTranslation` / `findLemmaBySource` do linear scans, which is
+ *   fine at fixture scale.
+ */
+import type { LanguageCode } from '@ciareader/shared-types';
+
+import type { Lemma, Translation } from '../db/schema.js';
+
+import type {
+  DictionaryRepo,
+  FormUpsertPayload,
+  ImportRunAudit,
+  LemmaLookupKey,
+  LemmaUpsertPayload,
+  TranslationUpsertPayload,
+} from './repo.js';
+
+type StoredForm = FormUpsertPayload & { id: string; createdAt: Date };
+
+function nowUtc(): Date {
+  return new Date();
+}
+
+let _idCounter = 0;
+function nextId(prefix: string): string {
+  _idCounter += 1;
+  return `${prefix}-${String(_idCounter).padStart(8, '0')}`;
+}
+
+export class InMemoryDictionaryRepo implements DictionaryRepo {
+  readonly lemmas = new Map<string, Lemma>();
+  readonly translations = new Map<string, Translation>();
+  readonly forms: StoredForm[] = [];
+  readonly audit: ImportRunAudit[] = [];
+
+  seedCuratorLocked(
+    key: Omit<Lemma, 'createdAt' | 'updatedAt' | 'curatorLocked' | 'id'> & {
+      id?: string;
+    },
+  ): Lemma {
+    const id = key.id ?? nextId('lemma');
+    const row: Lemma = {
+      id,
+      language: key.language as LanguageCode,
+      headword: key.headword,
+      pos: key.pos,
+      script: key.script,
+      glossDefault: key.glossDefault,
+      frequencyRank: key.frequencyRank,
+      source: key.source,
+      sourceAttribution: key.sourceAttribution,
+      sourceId: key.sourceId,
+      curatorLocked: true,
+      createdAt: nowUtc(),
+      updatedAt: nowUtc(),
+    };
+    this.lemmas.set(id, row);
+    return row;
+  }
+
+  async findLemmaBySource(key: LemmaLookupKey): Promise<Lemma | null> {
+    for (const row of this.lemmas.values()) {
+      if (
+        row.language === key.language &&
+        row.source === key.source &&
+        row.sourceId === key.sourceId
+      ) {
+        return row;
+      }
+    }
+    return null;
+  }
+
+  async insertLemma(payload: LemmaUpsertPayload): Promise<Lemma> {
+    const id = nextId('lemma');
+    const row: Lemma = {
+      id,
+      language: payload.language,
+      headword: payload.headword,
+      pos: payload.pos,
+      script: payload.script,
+      glossDefault: payload.glossDefault ?? null,
+      frequencyRank: payload.frequencyRank ?? null,
+      source: payload.source,
+      sourceAttribution: payload.sourceAttribution,
+      sourceId: payload.sourceId,
+      curatorLocked: false,
+      createdAt: nowUtc(),
+      updatedAt: nowUtc(),
+    };
+    this.lemmas.set(id, row);
+    return row;
+  }
+
+  async updateLemmaFromSource(id: string, payload: LemmaUpsertPayload): Promise<Lemma> {
+    const existing = this.lemmas.get(id);
+    if (!existing) throw new Error(`No lemma ${id}`);
+    if (existing.curatorLocked) {
+      throw new Error(
+        `Runner bug: updateLemmaFromSource(${id}) called on a curator-locked row`,
+      );
+    }
+    const next: Lemma = {
+      ...existing,
+      headword: payload.headword,
+      pos: payload.pos,
+      script: payload.script,
+      glossDefault: payload.glossDefault ?? null,
+      frequencyRank: payload.frequencyRank ?? null,
+      sourceAttribution: payload.sourceAttribution,
+      sourceId: payload.sourceId,
+      updatedAt: nowUtc(),
+    };
+    this.lemmas.set(id, next);
+    return next;
+  }
+
+  async findTranslation(
+    lemmaId: string,
+    source: Translation['source'],
+    sourceId: string,
+  ): Promise<Translation | null> {
+    for (const row of this.translations.values()) {
+      if (row.lemmaId === lemmaId && row.source === source && row.sourceId === sourceId) {
+        return row;
+      }
+    }
+    return null;
+  }
+
+  async insertTranslation(payload: TranslationUpsertPayload): Promise<Translation> {
+    const id = nextId('translation');
+    const row: Translation = {
+      id,
+      lemmaId: payload.lemmaId,
+      source: payload.source,
+      submittedBy: null,
+      parentTranslationId: null,
+      body: payload.body,
+      targetLanguage: payload.targetLanguage,
+      sourceAttribution: payload.sourceAttribution ?? null,
+      sourceId: payload.sourceId,
+      hidden: false,
+      createdAt: nowUtc(),
+      updatedAt: nowUtc(),
+    };
+    this.translations.set(id, row);
+    return row;
+  }
+
+  async updateTranslation(
+    id: string,
+    payload: TranslationUpsertPayload,
+  ): Promise<Translation> {
+    const existing = this.translations.get(id);
+    if (!existing) throw new Error(`No translation ${id}`);
+    const next: Translation = {
+      ...existing,
+      body: payload.body,
+      targetLanguage: payload.targetLanguage,
+      sourceAttribution: payload.sourceAttribution ?? null,
+      sourceId: payload.sourceId,
+      updatedAt: nowUtc(),
+    };
+    this.translations.set(id, next);
+    return next;
+  }
+
+  async insertForm(payload: FormUpsertPayload): Promise<void> {
+    this.forms.push({
+      ...payload,
+      id: nextId('form'),
+      createdAt: nowUtc(),
+    });
+  }
+
+  async recordImportRun(audit: ImportRunAudit): Promise<void> {
+    this.audit.push(audit);
+  }
+}

--- a/apps/web/src/lib/server/dictionary/types.ts
+++ b/apps/web/src/lib/server/dictionary/types.ts
@@ -1,0 +1,76 @@
+/**
+ * Types for the dictionary import framework (T-3.1).
+ *
+ * An importer is a pure producer of `ImportEntry` values drawn from an
+ * upstream source (Hindi WordNet, Marathi WordNet, Molesworth, Odia
+ * WordNet, etc.). The runner applies those entries against the DB with
+ * idempotent upsert semantics and curator-locked respect.
+ *
+ * Keeping the shape this narrow means a new source (say, a future
+ * Gujarati dictionary) only has to materialize an iterable of entries —
+ * it never touches Drizzle, never knows what `curator_locked` means,
+ * and can be developed and tested in isolation against the reference
+ * runner.
+ */
+import type { LanguageCode } from '@ciareader/shared-types';
+
+export type TranslationPayload = {
+  /** The gloss / translation body, already cleaned of markup. */
+  body: string;
+  /**
+   * Upstream stable id for this specific translation — usually a sense
+   * id on the source side. The runner uses (lemmaSourceId + this) as
+   * the idempotency key so re-running the importer updates the same
+   * rows instead of duplicating them.
+   */
+  sourceId: string;
+  /** Per-translation attribution override. Falls back to the source's default. */
+  sourceAttribution?: string;
+  targetLanguage?: string;
+};
+
+export type FormPayload = {
+  surface: string;
+  features?: Record<string, string>;
+  romanization?: string;
+};
+
+export type ImportEntry = {
+  /** Dictionary headword, expected to already be NFC-normalized. */
+  headword: string;
+  pos: string;
+  script: string;
+  /**
+   * Stable upstream primary key. Required — it's what lets a re-import
+   * update the same lemma row. Importers that can't produce one should
+   * synthesize a stable hash of their headword + POS at the source layer
+   * rather than leaving this undefined.
+   */
+  sourceId: string;
+  glossDefault?: string;
+  frequencyRank?: number;
+  translations: TranslationPayload[];
+  forms?: FormPayload[];
+};
+
+export type DictionaryImportSource = {
+  /** Stable human-readable name, e.g. "hindi-wordnet". */
+  name: string;
+  language: LanguageCode;
+  /** Default attribution — "Hindi WordNet, CFILT IIT-Bombay" etc. Copied onto every lemma/translation absent a per-entry override. */
+  sourceAttribution: string;
+  /** License identifier (SPDX-ish). Used for docs and the source-inventory page. */
+  license: string;
+  entries(): AsyncIterable<ImportEntry> | Iterable<ImportEntry>;
+};
+
+export type ImportResult = {
+  sourceName: string;
+  language: LanguageCode;
+  lemmasCreated: number;
+  lemmasUpdated: number;
+  lemmasSkippedCuratorLocked: number;
+  translationsCreated: number;
+  translationsUpdated: number;
+  formsCreated: number;
+};

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -30,6 +30,15 @@ export default defineConfig({
         'src/lib/server/db/schema.ts',
         'src/lib/server/db/index.ts',
         'src/lib/server/email/**',
+        // Thin Drizzle wrapper — tested meaningfully only against a real
+        // Postgres (planned for M4's testcontainers setup). Its behavior
+        // is mirrored by InMemoryDictionaryRepo, which the runner tests
+        // exercise end-to-end.
+        'src/lib/server/dictionary/drizzle-repo.ts',
+        // Barrels / type-only modules have no runtime to cover.
+        'src/lib/server/dictionary/index.ts',
+        'src/lib/server/dictionary/repo.ts',
+        'src/lib/server/dictionary/types.ts',
         // SvelteKit route handlers tend to be thin glue over tested helpers;
         // they're easier to cover via integration tests (separate milestone) than
         // via vitest mocks. Excluded for now so the unit-coverage floor reflects

--- a/docs/dictionary-sources.md
+++ b/docs/dictionary-sources.md
@@ -1,0 +1,85 @@
+# Dictionary sources
+
+CIA Reader's dictionary starts as an import of the best open-source lexical
+resources for each MVP language and becomes our own authoritative dataset
+over time through curator edits, community submissions, and promoted
+crowdsourced corrections (T-6.7). Every row is provenance-tagged
+(`source`, `source_attribution`, `source_id`) so we can always answer
+"where did this come from and who last edited it."
+
+This document is the ledger for every upstream source we import from —
+what it is, who publishes it, its license, and any caveats that informed
+our decision to include it. Curator-edited rows are marked `curator_locked = true`
+and re-imports skip them by design.
+
+## Hindi
+
+| Source | Publisher | License | Status |
+|---|---|---|---|
+| [Hindi WordNet](http://www.cfilt.iitb.ac.in/wordnet/webhwn/) | CFILT, IIT Bombay | Research use, distributable with attribution | Planned for import — large (~40k synsets) |
+| [Dbnary Hindi-English](http://kaiko.getalp.org/about-dbnary/) | GETALP / Univ. Grenoble Alpes | CC-BY-SA 3.0 | Planned |
+| [Shabdanjali](http://ltrc.iiit.ac.in/onlineServices/Dictionaries/) | LTRC, IIIT Hyderabad | Non-commercial research use | Under review — license may restrict paid-tier use |
+| **CIA Reader Hindi Seed** | CIA Reader | CC0-1.0 | **Imported (T-3.1)** — ~10 public-domain core vocabulary entries, bundled for bootstrapping the import runner |
+
+Coverage: expected to be the best of the three MVP languages after
+full imports land. Hindi WordNet alone gives us broad noun/adjective
+coverage; Dbnary fills in glosses and translations.
+
+## Marathi
+
+| Source | Publisher | License | Status |
+|---|---|---|---|
+| Marathi WordNet | CFILT, IIT Bombay | Research use, distributable with attribution | Planned |
+| *Molesworth's A Dictionary, Marathi and English* (1857) | Public domain (DDSA) | Public domain | Planned — historical orthography will need light normalization |
+| Dbnary Marathi-English | GETALP / Univ. Grenoble Alpes | CC-BY-SA 3.0 | Planned |
+
+Coverage: medium. Molesworth is comprehensive but archaic; modern Marathi
+WordNet is thinner than Hindi's. Expect more OOV tokens than Hindi at
+launch.
+
+## Odia
+
+| Source | Publisher | License | Status |
+|---|---|---|---|
+| Odia WordNet | ISI Kolkata | Research use, distributable with attribution | Planned — the seed for T-2.3a's custom pipeline already draws from this |
+| OdiaNLP resources | Community / various | Mixed (MIT / CC-BY) | Planned — curated subset only, per-entry license check required |
+
+**Coverage: sparse.** Open-source Odia lexical coverage is materially thinner
+than Hindi or Marathi. We expect correspondingly more OOV tokens at launch
+and lean harder on (a) the custom Odia morphological pipeline (T-2.3a) to
+strip inflections and (b) the curator-led dictionary editor (T-3.7) +
+community submissions (T-6.3) to fill gaps post-launch.
+
+The Odia dictionary browse page (T-3.6) will carry a visible
+**"coverage: sparse"** notice so users calibrate expectations.
+
+## Re-import policy
+
+The importer is idempotent:
+
+1. Rows are matched on `(language, source, source_id)`.
+2. If a matched row has `curator_locked = true`, the importer skips it
+   and increments the `lemmasSkippedCuratorLocked` counter in the run
+   summary. A curator can unlock a row in the dictionary editor (T-3.7)
+   if they want to accept a fresh upstream payload over their edit.
+3. Otherwise the row is updated in place.
+4. Every run appends an audit row to `dictionary_imports` with
+   created / updated / skipped counts so re-imports are auditable.
+
+Forms (`lemma_forms`) are append-only at MVP — re-running an importer
+that ships forms will add duplicate rows if the upstream source ships
+the same form twice. The dedup pass is deliberately deferred to
+post-MVP; today we'd rather over-include than lose a form.
+
+## Attribution surface
+
+Every imported lemma and translation stores a `source_attribution` string
+(e.g. `"Hindi WordNet, CFILT IIT-Bombay (research use; attribution required)"`).
+This string appears:
+
+- On the reader pop-up as a small badge per translation (T-3.8).
+- On the dictionary browse page's detail view (T-3.6).
+- On a `/credits` page linked from the footer, aggregated by source.
+
+If you're adding a new importer, the attribution string is **required** —
+if you don't know what to write, ask before merging.


### PR DESCRIPTION
## Summary

Lays down the schema and runtime for importing open-source dictionary data idempotently while preserving curator edits.

- **Schema**: `lemmas`, `lemma_forms`, `translations`, `dictionary_imports` tables + `translation_source` enum. `lemmas` uniqueness on `(language, headword, pos)` so homographs (सोना noun/verb) keep distinct rows. Indexed on `(language, source, source_id)` for the re-import lookup path.
- **Runner**: pure, storage-agnostic orchestration over a `DictionaryRepo` port. Creates new lemmas, updates non-locked ones, **skips anything with `curator_locked = true`**, upserts translations by `(lemma_id, source, source_id)`, appends forms, and writes an audit row per run.
- **Repos**: `DrizzleDictionaryRepo` for prod; `InMemoryDictionaryRepo` for tests — the runner can't tell which it's holding. The Drizzle impl guards its own UPDATE with `WHERE curator_locked = false` as belt + suspenders.
- **Seed**: `hindi-seed.ts` ships 10 public-domain Hindi entries (including the सोना homograph + sample forms) so the import runner has at least one working data source on day one. Full WordNet / Dbnary / Molesworth / Odia WordNet imports land in follow-up PRs as each source's license + fetch pipeline gets resolved.
- **Docs**: `docs/dictionary-sources.md` is the ledger for every upstream source — what it is, who publishes it, its license, and the re-import policy.

## Test plan

- [x] 10 runner unit tests against `InMemoryDictionaryRepo`:
  - fresh import creates lemmas + translations + forms with correct counts
  - re-run updates rather than duplicates; upstream field changes are picked up
  - curator-locked rows are skipped — counter increments, row untouched, no translations/forms emitted
  - homograph headwords create distinct lemma rows (proves the POS-aware uniqueness key)
  - translation attribution falls back to source default or honours per-entry override
  - async-iterable source shape works
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 111/111 passing
- [x] Coverage floor unchanged; new runner at 100% lines, in-memory repo at 97%
- [x] `pnpm db:generate` reports "no schema changes" after the migration — drift-free