### PR TITLE
T-3.2: translation submission API

### DIFF
--- a/apps/web/src/lib/server/dictionary/translations.test.ts
+++ b/apps/web/src/lib/server/dictionary/translations.test.ts
@@ -1,0 +1,298 @@
+// @vitest-environment node
+/**
+ * Unit tests for `submitUserTranslation` (T-3.2).
+ *
+ * Mocks the drizzle `db` surface to a fluent fake whose return values we
+ * stage per-call. The service calls the DB in a fixed order per happy /
+ * error path; the stubs below mirror that order explicitly so a drift
+ * breaks loudly.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Call = { kind: 'select' | 'insert'; payload?: unknown };
+const calls: Call[] = [];
+
+/**
+ * Staged reads — each pushed value is returned by the NEXT `.limit(…)`
+ * (for selects) or `.returning(…)` (for inserts). The service calls:
+ *   1. select on lemmas (existence check)
+ *   2. optional select on translations (parent check)
+ *   3. select count from translations (rate limit)
+ *   4. insert into translations ... returning
+ */
+const staged: Array<unknown[] | { err: Error }> = [];
+
+function stageSelect(rows: unknown[]) {
+  staged.push(rows);
+}
+function stageInsert(rows: unknown[]) {
+  staged.push(rows);
+}
+
+function nextStaged(): unknown[] {
+  const v = staged.shift();
+  if (!v) throw new Error('Test bug: no staged result available');
+  if (v && typeof v === 'object' && 'err' in v) throw (v as { err: Error }).err;
+  return v as unknown[];
+}
+
+// The chain is awaitable at any point — both `.limit(1)` (used by
+// existence checks) and `.where(...)` (used by the rate-limit count)
+// resolve to the next staged result. Drizzle's real builder behaves
+// the same way; this keeps the fake flexible to either shape.
+function makeSelectChain() {
+  const chain: Record<string, unknown> = {};
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.limit = vi.fn(() => chain);
+  chain.then = (resolve: (v: unknown) => unknown) => resolve(nextStaged());
+  return chain as unknown as {
+    from: (...a: unknown[]) => typeof chain;
+    where: (...a: unknown[]) => typeof chain;
+    limit: (...a: unknown[]) => typeof chain;
+  };
+}
+
+function makeInsertChain() {
+  const chain = {
+    values: vi.fn((payload: unknown) => {
+      calls.push({ kind: 'insert', payload });
+      return chain;
+    }),
+    returning: vi.fn(() => nextStaged()),
+  };
+  return chain;
+}
+
+const selectFn = vi.fn(() => {
+  calls.push({ kind: 'select' });
+  return makeSelectChain();
+});
+const insertFn = vi.fn(() => makeInsertChain());
+
+vi.mock('../db/index.js', () => ({
+  db: {
+    select: () => selectFn(),
+    insert: () => insertFn(),
+  },
+  schema: {
+    lemmas: { id: 'lemmas.id' },
+    translations: {
+      id: 'translations.id',
+      lemmaId: 'translations.lemma_id',
+      submittedBy: 'translations.submitted_by',
+      createdAt: 'translations.created_at',
+    },
+  },
+}));
+
+const {
+  MAX_BODY_LEN,
+  MAX_PER_USER_PER_WINDOW,
+  submitUserTranslation,
+  TranslationRateLimitError,
+  TranslationValidationError,
+} = await import('./translations.js');
+
+beforeEach(() => {
+  calls.length = 0;
+  staged.length = 0;
+  selectFn.mockClear();
+  insertFn.mockClear();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('submitUserTranslation — happy path', () => {
+  it('normalizes whitespace, tags source=user, and returns the inserted row', async () => {
+    stageSelect([{ id: 'lemma-1' }]); // lemma existence check
+    stageSelect([{ n: 3 }]); // rate-limit count
+    const inserted = {
+      id: 'tr-1',
+      lemmaId: 'lemma-1',
+      source: 'user',
+      submittedBy: 'user-1',
+      parentTranslationId: null,
+      body: 'to speak',
+      targetLanguage: 'en',
+      sourceAttribution: null,
+      sourceId: null,
+      hidden: false,
+      createdAt: new Date('2026-04-24'),
+      updatedAt: new Date('2026-04-24'),
+    };
+    stageInsert([inserted]);
+
+    const result = await submitUserTranslation('user-1', {
+      lemmaId: 'lemma-1',
+      body: '  to   speak  ',
+    });
+
+    expect(result.id).toBe('tr-1');
+    const insertCall = calls.find((c) => c.kind === 'insert');
+    expect(insertCall?.payload).toMatchObject({
+      lemmaId: 'lemma-1',
+      source: 'user',
+      submittedBy: 'user-1',
+      body: 'to speak', // whitespace collapsed
+      targetLanguage: 'en',
+      parentTranslationId: null,
+    });
+  });
+
+  it('includes parent check when parentTranslationId is provided', async () => {
+    stageSelect([{ id: 'lemma-1' }]);
+    stageSelect([{ id: 'parent-1', lemmaId: 'lemma-1' }]);
+    stageSelect([{ n: 0 }]);
+    stageInsert([
+      {
+        id: 'tr-1',
+        lemmaId: 'lemma-1',
+        source: 'user',
+        submittedBy: 'user-1',
+        parentTranslationId: 'parent-1',
+        body: 'revised',
+        targetLanguage: 'en',
+        sourceAttribution: null,
+        sourceId: null,
+        hidden: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+
+    const result = await submitUserTranslation('user-1', {
+      lemmaId: 'lemma-1',
+      body: 'revised',
+      parentTranslationId: 'parent-1',
+    });
+
+    expect(result.parentTranslationId).toBe('parent-1');
+    // 3 selects: lemma, parent, rate-limit count.
+    expect(calls.filter((c) => c.kind === 'select')).toHaveLength(3);
+  });
+
+  it('lowercases targetLanguage', async () => {
+    stageSelect([{ id: 'lemma-1' }]);
+    stageSelect([{ n: 0 }]);
+    stageInsert([
+      {
+        id: 'tr-1',
+        lemmaId: 'lemma-1',
+        source: 'user',
+        submittedBy: 'user-1',
+        parentTranslationId: null,
+        body: 'water',
+        targetLanguage: 'en',
+        sourceAttribution: null,
+        sourceId: null,
+        hidden: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+
+    await submitUserTranslation('user-1', {
+      lemmaId: 'lemma-1',
+      body: 'water',
+      targetLanguage: 'EN',
+    });
+
+    const insertCall = calls.find((c) => c.kind === 'insert');
+    expect(insertCall?.payload).toMatchObject({ targetLanguage: 'en' });
+  });
+});
+
+describe('submitUserTranslation — validation errors', () => {
+  it('rejects an empty body without touching the DB', async () => {
+    await expect(
+      submitUserTranslation('user-1', { lemmaId: 'lemma-1', body: '   ' }),
+    ).rejects.toBeInstanceOf(TranslationValidationError);
+    expect(selectFn).not.toHaveBeenCalled();
+  });
+
+  it('rejects a body over MAX_BODY_LEN characters', async () => {
+    await expect(
+      submitUserTranslation('user-1', {
+        lemmaId: 'lemma-1',
+        body: 'x'.repeat(MAX_BODY_LEN + 1),
+      }),
+    ).rejects.toBeInstanceOf(TranslationValidationError);
+  });
+
+  it('rejects a malformed target language', async () => {
+    await expect(
+      submitUserTranslation('user-1', {
+        lemmaId: 'lemma-1',
+        body: 'water',
+        targetLanguage: 'english',
+      }),
+    ).rejects.toBeInstanceOf(TranslationValidationError);
+  });
+
+  it('returns a 404-flavoured error when the lemma does not exist', async () => {
+    stageSelect([]); // no lemma
+    try {
+      await submitUserTranslation('user-1', { lemmaId: 'lemma-missing', body: 'x' });
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TranslationValidationError);
+      expect((err as InstanceType<typeof TranslationValidationError>).status).toBe(404);
+    }
+  });
+
+  it('rejects a parent translation that belongs to a different lemma', async () => {
+    stageSelect([{ id: 'lemma-1' }]);
+    stageSelect([{ id: 'parent-1', lemmaId: 'lemma-OTHER' }]);
+    await expect(
+      submitUserTranslation('user-1', {
+        lemmaId: 'lemma-1',
+        body: 'x',
+        parentTranslationId: 'parent-1',
+      }),
+    ).rejects.toBeInstanceOf(TranslationValidationError);
+  });
+
+  it('rejects a missing parent translation', async () => {
+    stageSelect([{ id: 'lemma-1' }]);
+    stageSelect([]); // parent missing
+    try {
+      await submitUserTranslation('user-1', {
+        lemmaId: 'lemma-1',
+        body: 'x',
+        parentTranslationId: 'parent-missing',
+      });
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TranslationValidationError);
+      expect((err as InstanceType<typeof TranslationValidationError>).status).toBe(404);
+    }
+  });
+});
+
+describe('submitUserTranslation — rate limiting', () => {
+  it('throws TranslationRateLimitError when the user hit the window cap', async () => {
+    stageSelect([{ id: 'lemma-1' }]);
+    stageSelect([{ n: MAX_PER_USER_PER_WINDOW }]);
+    await expect(
+      submitUserTranslation('user-1', { lemmaId: 'lemma-1', body: 'x' }),
+    ).rejects.toBeInstanceOf(TranslationRateLimitError);
+    // Rate-limit rejection means NO insert was attempted.
+    expect(insertFn).not.toHaveBeenCalled();
+  });
+
+  it('includes a retryAfterSeconds hint roughly equal to the window size', async () => {
+    stageSelect([{ id: 'lemma-1' }]);
+    stageSelect([{ n: MAX_PER_USER_PER_WINDOW + 5 }]);
+    try {
+      await submitUserTranslation('user-1', { lemmaId: 'lemma-1', body: 'x' });
+    } catch (err) {
+      expect(err).toBeInstanceOf(TranslationRateLimitError);
+      const e = err as InstanceType<typeof TranslationRateLimitError>;
+      expect(e.retryAfterSeconds).toBeGreaterThan(0);
+      expect(e.limit).toBe(MAX_PER_USER_PER_WINDOW);
+    }
+  });
+});

--- a/apps/web/src/lib/server/dictionary/translations.ts
+++ b/apps/web/src/lib/server/dictionary/translations.ts
@@ -1,0 +1,194 @@
+/**
+ * User-submitted translation service (T-3.2).
+ *
+ * Wraps the minimum surface needed by the public `POST /api/v1/translations`
+ * endpoint: input validation against the schema, existence checks for the
+ * referenced lemma + optional parent translation, per-user rate limiting
+ * against a rolling window, and the final insert.
+ *
+ * Rate-limit strategy is deliberately simple: count rows in `translations`
+ * with `submittedBy = userId AND createdAt > now() - window`. A Postgres
+ * index on `submitted_by` already exists (T-3.1) so the count is cheap
+ * even once the table is large. We'll graduate to a Redis bucket in M11
+ * if the DB cost becomes real; until then the simpler approach is
+ * easier to reason about and leaves an auditable trail.
+ */
+import { and, count, eq, gt } from 'drizzle-orm';
+
+import { db, schema } from '../db/index.js';
+import type { Translation } from '../db/schema.js';
+
+/**
+ * Hard ceilings for user-submitted translations.
+ *
+ * - `MAX_BODY_LEN`: keep submissions sentence-sized. Dictionary glosses
+ *   don't need paragraphs; anything longer is usually noise or abuse.
+ * - `MAX_PER_USER_PER_WINDOW` / `WINDOW_MS`: soft deterrent against
+ *   translation-spam bots. Legitimate users don't submit 30+ translations
+ *   per hour.
+ */
+export const MAX_BODY_LEN = 500;
+export const MAX_PER_USER_PER_WINDOW = 30;
+export const WINDOW_MS = 60 * 60 * 1_000; // 1 hour
+
+export type SubmitTranslationInput = {
+  lemmaId: string;
+  body: string;
+  parentTranslationId?: string | null;
+  targetLanguage?: string;
+};
+
+export class TranslationValidationError extends Error {
+  constructor(
+    message: string,
+    public readonly status: 400 | 404 | 409 = 400,
+  ) {
+    super(message);
+    this.name = 'TranslationValidationError';
+  }
+}
+
+export class TranslationRateLimitError extends Error {
+  constructor(
+    public readonly retryAfterSeconds: number,
+    public readonly limit: number = MAX_PER_USER_PER_WINDOW,
+  ) {
+    super('Translation submission rate limit exceeded');
+    this.name = 'TranslationRateLimitError';
+  }
+}
+
+function normalizeBody(body: string): string {
+  // Strip leading/trailing whitespace and collapse internal runs so
+  // "  to  speak  " doesn't get stored verbatim.
+  return body.trim().replace(/\s+/g, ' ');
+}
+
+function validateInput(input: SubmitTranslationInput): {
+  body: string;
+  targetLanguage: string;
+} {
+  const body = normalizeBody(input.body ?? '');
+  if (body.length === 0) {
+    throw new TranslationValidationError('Translation body cannot be empty');
+  }
+  if (body.length > MAX_BODY_LEN) {
+    throw new TranslationValidationError(
+      `Translation body exceeds ${MAX_BODY_LEN} characters`,
+    );
+  }
+  const targetLanguage = (input.targetLanguage ?? 'en').toLowerCase();
+  // ISO-639-1/2-ish: two or three ASCII letters. Good enough to reject
+  // obvious garbage while not needing a full registry enum at MVP.
+  if (!/^[a-z]{2,3}$/.test(targetLanguage)) {
+    throw new TranslationValidationError(
+      'targetLanguage must be a 2- or 3-letter ISO language code',
+    );
+  }
+  return { body, targetLanguage };
+}
+
+async function assertLemmaExists(lemmaId: string): Promise<void> {
+  const [row] = await db
+    .select({ id: schema.lemmas.id })
+    .from(schema.lemmas)
+    .where(eq(schema.lemmas.id, lemmaId))
+    .limit(1);
+  if (!row) {
+    throw new TranslationValidationError(`Lemma ${lemmaId} not found`, 404);
+  }
+}
+
+async function assertParentBelongsToLemma(
+  parentId: string,
+  lemmaId: string,
+): Promise<void> {
+  const [row] = await db
+    .select({ id: schema.translations.id, lemmaId: schema.translations.lemmaId })
+    .from(schema.translations)
+    .where(eq(schema.translations.id, parentId))
+    .limit(1);
+  if (!row) {
+    throw new TranslationValidationError(
+      `parentTranslationId ${parentId} not found`,
+      404,
+    );
+  }
+  if (row.lemmaId !== lemmaId) {
+    throw new TranslationValidationError(
+      'parentTranslationId belongs to a different lemma',
+    );
+  }
+}
+
+async function assertUnderRateLimit(userId: string, now: Date): Promise<void> {
+  const since = new Date(now.getTime() - WINDOW_MS);
+  const [{ n } = { n: 0 }] = await db
+    .select({ n: count() })
+    .from(schema.translations)
+    .where(
+      and(
+        eq(schema.translations.submittedBy, userId),
+        gt(schema.translations.createdAt, since),
+      ),
+    );
+  if (Number(n) >= MAX_PER_USER_PER_WINDOW) {
+    throw new TranslationRateLimitError(Math.ceil(WINDOW_MS / 1_000));
+  }
+}
+
+/**
+ * Insert a new user-submitted translation.
+ *
+ * The endpoint layer (and this service) guarantee `source='user'` and
+ * `submittedBy=userId`, so a caller cannot impersonate an official
+ * import by hand. `parentTranslationId` is how T-3.5 will implement
+ * "customize an official translation"; the parent is kept for display
+ * provenance only — the fork is a real, independently-editable row.
+ */
+export async function submitUserTranslation(
+  userId: string,
+  input: SubmitTranslationInput,
+  now: Date = new Date(),
+): Promise<Translation> {
+  const { body, targetLanguage } = validateInput(input);
+  await assertLemmaExists(input.lemmaId);
+  if (input.parentTranslationId) {
+    await assertParentBelongsToLemma(input.parentTranslationId, input.lemmaId);
+  }
+  await assertUnderRateLimit(userId, now);
+
+  const [row] = await db
+    .insert(schema.translations)
+    .values({
+      lemmaId: input.lemmaId,
+      source: 'user',
+      submittedBy: userId,
+      parentTranslationId: input.parentTranslationId ?? null,
+      body,
+      targetLanguage,
+      // Officials carry an attribution string and an upstream id; user
+      // submissions carry neither.
+      sourceAttribution: null,
+      sourceId: null,
+    })
+    .returning();
+  if (!row) throw new Error('Failed to insert translation');
+  return row as Translation;
+}
+
+export function publicTranslation(row: Translation) {
+  return {
+    id: row.id,
+    lemmaId: row.lemmaId,
+    source: row.source,
+    submittedBy: row.submittedBy,
+    parentTranslationId: row.parentTranslationId,
+    body: row.body,
+    targetLanguage: row.targetLanguage,
+    sourceAttribution: row.sourceAttribution,
+    hidden: row.hidden,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}

--- a/apps/web/src/routes/api/v1/translations/+server.ts
+++ b/apps/web/src/routes/api/v1/translations/+server.ts
@@ -1,0 +1,67 @@
+/**
+ * POST /api/v1/translations (T-3.2).
+ *
+ * Submits a user-authored translation against a lemma. Consumes the same
+ * auth surface (session cookie OR bearer access token) as every other
+ * v1 endpoint via `requireUser`. Rate-limited per-user against a rolling
+ * one-hour window; see `submitUserTranslation` for the exact bounds.
+ */
+import { error, json } from '@sveltejs/kit';
+import { z } from 'zod';
+
+import { requireUser } from '$lib/server/auth/require-user.js';
+import { parseJson } from '../auth/_helpers.js';
+import {
+  MAX_BODY_LEN,
+  publicTranslation,
+  submitUserTranslation,
+  TranslationRateLimitError,
+  TranslationValidationError,
+} from '$lib/server/dictionary/translations.js';
+import type { RequestHandler } from './$types';
+
+const body = z.object({
+  lemmaId: z.string().uuid(),
+  body: z.string().min(1).max(MAX_BODY_LEN),
+  // Optional — present for T-3.5's "customize an official" flow.
+  parentTranslationId: z.string().uuid().nullish(),
+  targetLanguage: z.string().min(2).max(3).optional(),
+});
+
+export const POST: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  const input = await parseJson(event.request, body);
+
+  try {
+    const translation = await submitUserTranslation(user.id, {
+      lemmaId: input.lemmaId,
+      body: input.body,
+      parentTranslationId: input.parentTranslationId ?? null,
+      targetLanguage: input.targetLanguage,
+    });
+    return json({ translation: publicTranslation(translation) }, { status: 201 });
+  } catch (err) {
+    if (err instanceof TranslationRateLimitError) {
+      return json(
+        {
+          error: 'rate_limited',
+          message: 'Too many translations submitted. Try again later.',
+          limit: err.limit,
+          retryAfterSeconds: err.retryAfterSeconds,
+        },
+        {
+          status: 429,
+          headers: {
+            'Retry-After': String(err.retryAfterSeconds),
+            'X-RateLimit-Limit': String(err.limit),
+            'X-RateLimit-Remaining': '0',
+          },
+        },
+      );
+    }
+    if (err instanceof TranslationValidationError) {
+      throw error(err.status, err.message);
+    }
+    throw err;
+  }
+};

--- a/apps/web/src/routes/api/v1/translations/translations-server.test.ts
+++ b/apps/web/src/routes/api/v1/translations/translations-server.test.ts
@@ -1,0 +1,146 @@
+// @vitest-environment node
+/**
+ * Route tests for POST /api/v1/translations (T-3.2).
+ *
+ * The service layer's behavior is already covered by
+ * `translations.test.ts`; here we only care about the HTTP shape — auth
+ * gate, status codes, rate-limit headers, and JSON envelope.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const submitUserTranslation = vi.fn();
+const requireUser = vi.fn();
+
+vi.mock('$lib/server/dictionary/translations.js', async () => {
+  const actual = await vi.importActual<
+    typeof import('$lib/server/dictionary/translations.js')
+  >('$lib/server/dictionary/translations.js');
+  return {
+    ...actual,
+    submitUserTranslation: (...a: unknown[]) => submitUserTranslation(...a),
+  };
+});
+
+vi.mock('$lib/server/auth/require-user.js', () => ({
+  requireUser: (...a: unknown[]) => requireUser(...a),
+}));
+
+type PostFn = (typeof import('./+server.js'))['POST'];
+type PostEvent = Parameters<PostFn>[0];
+
+async function callPost(body: unknown, user: { id: string } | null = { id: 'u1' }) {
+  if (user) {
+    requireUser.mockResolvedValueOnce(user);
+  } else {
+    requireUser.mockImplementationOnce(() => {
+      throw Object.assign(new Error('Unauthorized'), { status: 401 });
+    });
+  }
+  const { POST } = await import('./+server.js');
+  const event = {
+    request: new Request('http://x/api/v1/translations', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+  } as unknown as PostEvent;
+  try {
+    return await POST(event);
+  } catch (e) {
+    // `throw error(...)` in SvelteKit produces an HttpError-shaped object.
+    return e as { status: number; body?: { message: string } };
+  }
+}
+
+beforeEach(() => {
+  submitUserTranslation.mockReset();
+  requireUser.mockReset();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('POST /api/v1/translations', () => {
+  it('returns 201 with the public translation shape on success', async () => {
+    submitUserTranslation.mockResolvedValueOnce({
+      id: 'tr-1',
+      lemmaId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      source: 'user',
+      submittedBy: 'u1',
+      parentTranslationId: null,
+      body: 'to speak',
+      targetLanguage: 'en',
+      sourceAttribution: null,
+      sourceId: null,
+      hidden: false,
+      createdAt: new Date('2026-04-24T00:00:00Z'),
+      updatedAt: new Date('2026-04-24T00:00:00Z'),
+    });
+
+    const res = (await callPost({
+      lemmaId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      body: 'to speak',
+    })) as Response;
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.translation).toMatchObject({
+      id: 'tr-1',
+      source: 'user',
+      submittedBy: 'u1',
+      body: 'to speak',
+    });
+    // Never leaks sourceId on user submissions (it's always null, but
+    // ensure we send the stable public shape).
+    expect(json.translation.sourceId).toBeUndefined();
+  });
+
+  it('propagates auth failures as 401', async () => {
+    const res = (await callPost(
+      { lemmaId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', body: 'x' },
+      null,
+    )) as { status: number };
+    expect(res.status).toBe(401);
+    expect(submitUserTranslation).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when the body fails Zod validation (e.g. non-uuid lemmaId)', async () => {
+    const res = (await callPost({ lemmaId: 'not-a-uuid', body: 'x' })) as {
+      status: number;
+    };
+    expect(res.status).toBe(400);
+    expect(submitUserTranslation).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 with the validation message when the service rejects the input', async () => {
+    const { TranslationValidationError } = await import(
+      '$lib/server/dictionary/translations.js'
+    );
+    submitUserTranslation.mockRejectedValueOnce(
+      new TranslationValidationError('Lemma not found', 404),
+    );
+    const res = (await callPost({
+      lemmaId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      body: 'x',
+    })) as { status: number };
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 429 with Retry-After when the user is rate-limited', async () => {
+    const { TranslationRateLimitError } = await import(
+      '$lib/server/dictionary/translations.js'
+    );
+    submitUserTranslation.mockRejectedValueOnce(new TranslationRateLimitError(3600, 30));
+    const res = (await callPost({
+      lemmaId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      body: 'x',
+    })) as Response;
+    expect(res.status).toBe(429);
+    expect(res.headers.get('retry-after')).toBe('3600');
+    expect(res.headers.get('x-ratelimit-limit')).toBe('30');
+    expect(res.headers.get('x-ratelimit-remaining')).toBe('0');
+    const json = await res.json();
+    expect(json.error).toBe('rate_limited');
+    expect(json.retryAfterSeconds).toBe(3600);
+  });
+});


### PR DESCRIPTION
## Summary

Adds \`POST /api/v1/translations\` for user-authored translation submissions.

- **Service** (\`submitUserTranslation\`): validates body (trim/collapse whitespace, ≤500 chars, non-empty), asserts the referenced lemma exists, asserts any \`parentTranslationId\` belongs to the same lemma, and enforces a rolling per-user rate limit (30 submissions / hour). Inserts with \`source='user'\` and \`submittedBy=userId\` hard-coded so a caller cannot impersonate an official import.
- **Endpoint**: Zod-validated body. Auth via \`requireUser\` — session cookie OR bearer token. Maps \`TranslationValidationError\` → 400/404 and \`TranslationRateLimitError\` → 429 with \`Retry-After\`, \`X-RateLimit-Limit\`, and \`X-RateLimit-Remaining\` headers.
- **Rate-limit design**: DB count against a rolling window, keyed on the existing \`translations.submitted_by\` index. Cheap at current scale; can graduate to a Redis bucket in M11 without moving the API surface.

## Test plan

- [x] 11 service tests (happy path, whitespace normalization, parent validation, all error branches, rate-limit trigger)
- [x] 5 endpoint tests (201 / 401 / 400 / 404 / 429 with correct headers and envelope)
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 127/127 passing