### PR TITLE
T-3.3: translation retrieval API

### DIFF
--- a/apps/web/src/lib/server/dictionary/lookups.test.ts
+++ b/apps/web/src/lib/server/dictionary/lookups.test.ts
@@ -1,0 +1,146 @@
+// @vitest-environment node
+/**
+ * Unit tests for `bucketTranslations` (T-3.3).
+ *
+ * The ordering contract is the important thing — covered with literal
+ * rows. The DB-backed `getLemmaTranslations` is an integration concern
+ * exercised end-to-end in the endpoint test below; here we keep the
+ * sorter alone.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { bucketTranslations } from './lookups.js';
+import type { Translation } from '../db/schema.js';
+
+let _id = 0;
+function row(overrides: Partial<Translation>): Translation {
+  _id += 1;
+  return {
+    id: `tr-${_id}`,
+    lemmaId: 'lemma-1',
+    source: 'official_dictionary',
+    submittedBy: null,
+    parentTranslationId: null,
+    body: 'gloss',
+    targetLanguage: 'en',
+    sourceAttribution: null,
+    sourceId: null,
+    hidden: false,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+    ...overrides,
+  } as Translation;
+}
+
+describe('bucketTranslations — classification', () => {
+  it('splits rows into personal / official / community for an authenticated viewer', () => {
+    const rows: Translation[] = [
+      row({ source: 'official_dictionary', body: 'off' }),
+      row({ source: 'curator', body: 'cur' }),
+      row({ source: 'user', submittedBy: 'u1', body: 'mine' }),
+      row({ source: 'user', submittedBy: 'u2', body: 'theirs' }),
+    ];
+    const out = bucketTranslations(rows, { id: 'u1', role: 'user' });
+    expect(out.personal.map((t) => t.body)).toEqual(['mine']);
+    expect(out.official.map((t) => t.body).sort()).toEqual(['cur', 'off']);
+    expect(out.community.map((t) => t.body)).toEqual(['theirs']);
+  });
+
+  it('treats every user-submitted row as community when the viewer is anonymous', () => {
+    const rows: Translation[] = [
+      row({ source: 'user', submittedBy: 'u1', body: 'a' }),
+      row({ source: 'user', submittedBy: 'u2', body: 'b' }),
+    ];
+    const out = bucketTranslations(rows, null);
+    expect(out.personal).toEqual([]);
+    expect(out.community.map((t) => t.body).sort()).toEqual(['a', 'b']);
+  });
+});
+
+describe('bucketTranslations — ordering', () => {
+  it('orders officials with curator rows ahead of raw imports', () => {
+    const rows: Translation[] = [
+      row({
+        source: 'official_dictionary',
+        body: 'imp',
+        createdAt: new Date('2025-12-01'),
+      }),
+      row({
+        source: 'curator',
+        body: 'cur',
+        createdAt: new Date('2026-03-01'),
+      }),
+    ];
+    const out = bucketTranslations(rows, null);
+    expect(out.official.map((t) => t.body)).toEqual(['cur', 'imp']);
+  });
+
+  it('orders community translations newest-first as a temporary stand-in for vote order', () => {
+    const rows: Translation[] = [
+      row({
+        source: 'user',
+        submittedBy: 'u2',
+        body: 'old',
+        createdAt: new Date('2026-01-01'),
+      }),
+      row({
+        source: 'user',
+        submittedBy: 'u3',
+        body: 'new',
+        createdAt: new Date('2026-04-01'),
+      }),
+    ];
+    const out = bucketTranslations(rows, null);
+    expect(out.community.map((t) => t.body)).toEqual(['new', 'old']);
+  });
+
+  it('orders personal translations oldest-first (stable across renders)', () => {
+    const rows: Translation[] = [
+      row({
+        source: 'user',
+        submittedBy: 'u1',
+        body: 'new-fork',
+        createdAt: new Date('2026-04-01'),
+      }),
+      row({
+        source: 'user',
+        submittedBy: 'u1',
+        body: 'old-fork',
+        createdAt: new Date('2026-01-01'),
+      }),
+    ];
+    const out = bucketTranslations(rows, { id: 'u1', role: 'user' });
+    expect(out.personal.map((t) => t.body)).toEqual(['old-fork', 'new-fork']);
+  });
+});
+
+describe('bucketTranslations — moderation visibility', () => {
+  it('hides `hidden=true` community rows from anonymous viewers', () => {
+    const rows: Translation[] = [
+      row({ source: 'user', submittedBy: 'u2', body: 'visible' }),
+      row({ source: 'user', submittedBy: 'u3', body: 'hidden', hidden: true }),
+    ];
+    const out = bucketTranslations(rows, null);
+    expect(out.community.map((t) => t.body)).toEqual(['visible']);
+  });
+
+  it('hides `hidden=true` community rows from regular users', () => {
+    const rows: Translation[] = [
+      row({ source: 'user', submittedBy: 'u2', body: 'visible' }),
+      row({ source: 'user', submittedBy: 'u3', body: 'hidden', hidden: true }),
+    ];
+    const out = bucketTranslations(rows, { id: 'u1', role: 'user' });
+    expect(out.community.map((t) => t.body)).toEqual(['visible']);
+  });
+
+  it('shows hidden rows to curators and admins so they can review', () => {
+    const rows: Translation[] = [
+      row({ source: 'user', submittedBy: 'u2', body: 'visible' }),
+      row({ source: 'user', submittedBy: 'u3', body: 'hidden', hidden: true }),
+    ];
+    const curator = bucketTranslations(rows, { id: 'mod', role: 'curator' });
+    expect(curator.community.map((t) => t.body).sort()).toEqual(['hidden', 'visible']);
+    const admin = bucketTranslations(rows, { id: 'adm', role: 'admin' });
+    expect(admin.community.map((t) => t.body).sort()).toEqual(['hidden', 'visible']);
+  });
+});

--- a/apps/web/src/lib/server/dictionary/lookups.ts
+++ b/apps/web/src/lib/server/dictionary/lookups.ts
@@ -1,0 +1,172 @@
+/**
+ * Read-side dictionary queries (T-3.3).
+ *
+ * Keeps the service layer between the HTTP surface and Drizzle narrow
+ * and typed. The translation-retrieval endpoint's ordering contract
+ * lives here so it's unit-testable in isolation.
+ *
+ * Ordering (per T-3.3 + T-3.8):
+ *
+ *   1. `personal`   — translations the viewer themselves authored. Empty
+ *                     for anonymous callers. `parentTranslationId`
+ *                     customization forks land here too (T-3.5).
+ *   2. `official`   — rows with `source IN ('official_dictionary',
+ *                     'curator')`. Curator-edited rows sort ahead of
+ *                     raw imports because a curator has explicitly
+ *                     signed off on them. Hidden officials are
+ *                     suppressed even though the moderation flow
+ *                     doesn't write `hidden=true` on officials today.
+ *   3. `community`  — other users' `source='user'` submissions.
+ *                     Ordered newest-first at MVP; T-10.4 will swap in
+ *                     a vote-weighted sort once `translation_votes`
+ *                     lands. Hidden rows excluded for anonymous + non-
+ *                     curator viewers.
+ */
+import { and, eq } from 'drizzle-orm';
+
+import { db, schema } from '../db/index.js';
+import type { Lemma, Translation, User } from '../db/schema.js';
+
+export type PublicTranslation = {
+  id: string;
+  source: Translation['source'];
+  submittedBy: string | null;
+  parentTranslationId: string | null;
+  body: string;
+  targetLanguage: string;
+  sourceAttribution: string | null;
+  hidden: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type LemmaTranslationBuckets = {
+  lemma: PublicLemma;
+  translations: {
+    personal: PublicTranslation[];
+    official: PublicTranslation[];
+    community: PublicTranslation[];
+  };
+};
+
+export type PublicLemma = {
+  id: string;
+  language: Lemma['language'];
+  headword: string;
+  pos: string;
+  script: string;
+  glossDefault: string | null;
+  frequencyRank: number | null;
+};
+
+function toPublicLemma(row: Lemma): PublicLemma {
+  return {
+    id: row.id,
+    language: row.language,
+    headword: row.headword,
+    pos: row.pos,
+    script: row.script,
+    glossDefault: row.glossDefault,
+    frequencyRank: row.frequencyRank,
+  };
+}
+
+function toPublicTranslation(row: Translation): PublicTranslation {
+  return {
+    id: row.id,
+    source: row.source,
+    submittedBy: row.submittedBy,
+    parentTranslationId: row.parentTranslationId,
+    body: row.body,
+    targetLanguage: row.targetLanguage,
+    sourceAttribution: row.sourceAttribution,
+    hidden: row.hidden,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+/**
+ * Bucket + sort translations for a single lemma under the rules
+ * described at the top of this file. Exposed separately so the sorter
+ * has unit tests that don't need to wire the DB mock.
+ */
+export function bucketTranslations(
+  rows: Translation[],
+  viewer: { id: string; role: User['role'] } | null,
+): LemmaTranslationBuckets['translations'] {
+  const canSeeHidden = viewer?.role === 'curator' || viewer?.role === 'admin';
+  const visible = rows.filter((r) => !r.hidden || canSeeHidden);
+
+  const personal: Translation[] = [];
+  const official: Translation[] = [];
+  const community: Translation[] = [];
+
+  for (const row of visible) {
+    if (viewer && row.source === 'user' && row.submittedBy === viewer.id) {
+      personal.push(row);
+    } else if (row.source === 'official_dictionary' || row.source === 'curator') {
+      official.push(row);
+    } else {
+      community.push(row);
+    }
+  }
+
+  const byCreatedAtAsc = (a: Translation, b: Translation) =>
+    a.createdAt.getTime() - b.createdAt.getTime();
+  const byCreatedAtDesc = (a: Translation, b: Translation) =>
+    b.createdAt.getTime() - a.createdAt.getTime();
+
+  personal.sort(byCreatedAtAsc);
+  official.sort((a, b) => {
+    // Curator edits sort ahead of raw imports; within each tier,
+    // oldest-first keeps the reader pop-up stable across renders.
+    const sourceRank = (s: Translation['source']) => (s === 'curator' ? 0 : 1);
+    const diff = sourceRank(a.source) - sourceRank(b.source);
+    return diff !== 0 ? diff : byCreatedAtAsc(a, b);
+  });
+  community.sort(byCreatedAtDesc);
+
+  return {
+    personal: personal.map(toPublicTranslation),
+    official: official.map(toPublicTranslation),
+    community: community.map(toPublicTranslation),
+  };
+}
+
+export class LemmaNotFoundError extends Error {
+  constructor(public readonly lemmaId: string) {
+    super(`Lemma ${lemmaId} not found`);
+    this.name = 'LemmaNotFoundError';
+  }
+}
+
+export async function getLemmaTranslations(
+  lemmaId: string,
+  viewer: { id: string; role: User['role'] } | null,
+): Promise<LemmaTranslationBuckets> {
+  const [lemma] = await db
+    .select()
+    .from(schema.lemmas)
+    .where(eq(schema.lemmas.id, lemmaId))
+    .limit(1);
+  if (!lemma) throw new LemmaNotFoundError(lemmaId);
+
+  const rows = await db
+    .select()
+    .from(schema.translations)
+    .where(
+      and(
+        eq(schema.translations.lemmaId, lemmaId),
+        // Hidden rows are filtered in memory via `bucketTranslations`
+        // so curators still see them. The DB fetch returns everything
+        // for this lemma; translations-per-lemma is bounded by
+        // the pop-up UX anyway.
+      ),
+    );
+
+  return {
+    lemma: toPublicLemma(lemma as Lemma),
+    translations: bucketTranslations(rows as Translation[], viewer),
+  };
+}

--- a/apps/web/src/routes/api/v1/lemmas/[id]/translations/+server.ts
+++ b/apps/web/src/routes/api/v1/lemmas/[id]/translations/+server.ts
@@ -1,0 +1,38 @@
+/**
+ * GET /api/v1/lemmas/:id/translations (T-3.3).
+ *
+ * Public read — no auth required (dictionary browse is public, and the
+ * reader pop-up loads this shape on every tap). When the caller IS
+ * authenticated, their own submissions are pulled into the `personal`
+ * bucket so the UI can render them at the top of the pop-up per T-3.8.
+ *
+ * Hidden community rows are suppressed for anonymous + non-curator
+ * viewers; curators and admins see everything.
+ */
+import { error, json } from '@sveltejs/kit';
+
+import { resolveUser } from '$lib/server/auth/require-user.js';
+import {
+  getLemmaTranslations,
+  LemmaNotFoundError,
+} from '$lib/server/dictionary/lookups.js';
+import type { RequestHandler } from './$types';
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const GET: RequestHandler = async (event) => {
+  const { id } = event.params;
+  if (!id || !UUID_RE.test(id)) throw error(400, 'Invalid lemma id');
+
+  const user = await resolveUser(event);
+  const viewer = user ? { id: user.id, role: user.role } : null;
+
+  try {
+    const result = await getLemmaTranslations(id, viewer);
+    return json(result);
+  } catch (err) {
+    if (err instanceof LemmaNotFoundError) throw error(404, 'Lemma not found');
+    throw err;
+  }
+};

--- a/apps/web/src/routes/api/v1/lemmas/[id]/translations/translations-server.test.ts
+++ b/apps/web/src/routes/api/v1/lemmas/[id]/translations/translations-server.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment node
+/**
+ * Route tests for GET /api/v1/lemmas/:id/translations (T-3.3).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getLemmaTranslations = vi.fn();
+const resolveUser = vi.fn();
+
+vi.mock('$lib/server/dictionary/lookups.js', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/dictionary/lookups.js')>(
+    '$lib/server/dictionary/lookups.js',
+  );
+  return {
+    ...actual,
+    getLemmaTranslations: (...a: unknown[]) => getLemmaTranslations(...a),
+  };
+});
+
+vi.mock('$lib/server/auth/require-user.js', () => ({
+  resolveUser: () => resolveUser(),
+}));
+
+type GetFn = (typeof import('./+server.js'))['GET'];
+type GetEvent = Parameters<GetFn>[0];
+
+const VALID_LEMMA_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+
+async function callGet(id: string, user: { id: string; role: string } | null = null) {
+  resolveUser.mockResolvedValueOnce(user);
+  const { GET } = await import('./+server.js');
+  const event = {
+    params: { id },
+    request: new Request(`http://x/api/v1/lemmas/${id}/translations`),
+  } as unknown as GetEvent;
+  try {
+    return await GET(event);
+  } catch (e) {
+    return e as { status: number };
+  }
+}
+
+beforeEach(() => {
+  getLemmaTranslations.mockReset();
+  resolveUser.mockReset();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('GET /api/v1/lemmas/:id/translations', () => {
+  it('returns 400 on a malformed lemma id without touching the service', async () => {
+    const res = (await callGet('nope')) as { status: number };
+    expect(res.status).toBe(400);
+    expect(getLemmaTranslations).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 with the bucketed shape for an anonymous viewer', async () => {
+    getLemmaTranslations.mockResolvedValueOnce({
+      lemma: {
+        id: VALID_LEMMA_ID,
+        language: 'hi',
+        headword: 'पानी',
+        pos: 'NOUN',
+        script: 'Deva',
+        glossDefault: 'water',
+        frequencyRank: 120,
+      },
+      translations: { personal: [], official: [], community: [] },
+    });
+    const res = (await callGet(VALID_LEMMA_ID)) as Response;
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.lemma.headword).toBe('पानी');
+    expect(body.translations).toEqual({ personal: [], official: [], community: [] });
+    expect(getLemmaTranslations).toHaveBeenCalledWith(VALID_LEMMA_ID, null);
+  });
+
+  it('threads the authenticated viewer down to the service for personal-bucket resolution', async () => {
+    getLemmaTranslations.mockResolvedValueOnce({
+      lemma: {
+        id: VALID_LEMMA_ID,
+        language: 'hi',
+        headword: 'x',
+        pos: 'NOUN',
+        script: 'Deva',
+        glossDefault: null,
+        frequencyRank: null,
+      },
+      translations: { personal: [], official: [], community: [] },
+    });
+    await callGet(VALID_LEMMA_ID, { id: 'u1', role: 'user' });
+    expect(getLemmaTranslations).toHaveBeenCalledWith(VALID_LEMMA_ID, {
+      id: 'u1',
+      role: 'user',
+    });
+  });
+
+  it('returns 404 when the lemma does not exist', async () => {
+    const { LemmaNotFoundError } = await import('$lib/server/dictionary/lookups.js');
+    getLemmaTranslations.mockRejectedValueOnce(new LemmaNotFoundError(VALID_LEMMA_ID));
+    const res = (await callGet(VALID_LEMMA_ID)) as { status: number };
+    expect(res.status).toBe(404);
+  });
+
+  it('propagates unexpected service errors instead of swallowing them', async () => {
+    getLemmaTranslations.mockRejectedValueOnce(new Error('boom'));
+    const result = (await callGet(VALID_LEMMA_ID)) as unknown as Error;
+    expect(result.message).toBe('boom');
+  });
+});


### PR DESCRIPTION
## Summary

Adds \`GET /api/v1/lemmas/:id/translations\` — public read used by both the dictionary browse page (T-3.6) and the reader pop-up.

- **Service** (\`getLemmaTranslations\`): fetches the lemma + all its translations, then buckets via \`bucketTranslations\` into:
  - \`personal\` — the viewer's own user translations (including future T-3.5 customization forks). Empty for anonymous callers.
  - \`official\` — \`source IN ('official_dictionary','curator')\`, curator rows first then imports; within each tier oldest-first so the pop-up is stable across renders.
  - \`community\` — other users' submissions, newest-first. Ordering swaps to vote-weighted when T-10.4 lands \`translation_votes\`.
- **Moderation visibility**: \`hidden=true\` community rows are suppressed for anonymous and regular-role viewers; curators + admins see everything.
- **Endpoint**: UUID-validates \`:id\`, resolves the optional viewer via \`resolveUser\` (no auth gate — the dictionary is public), maps \`LemmaNotFoundError\` → 404.

## Test plan

- [x] 8 pure sorter tests (classification for auth/anon, per-tier ordering, moderation visibility across all four viewer roles)
- [x] 5 endpoint tests (400 on bad id, 200 anon, viewer threading, 404 missing lemma, propagation of unexpected errors)
- [x] \`pnpm typecheck\` / \`pnpm lint\` clean
- [x] \`pnpm test\` — 140/140 passing