### PR TITLE
T-3.4: curator permissions + admin endpoints + audit log

### DIFF
--- a/apps/web/drizzle/0004_fancy_siren.sql
+++ b/apps/web/drizzle/0004_fancy_siren.sql
@@ -1,0 +1,46 @@
+CREATE TYPE "public"."lemma_edit_change_type" AS ENUM('lemma_update', 'lemma_unlock', 'lemma_lock', 'translation_insert', 'translation_update', 'translation_hide', 'translation_unhide', 'form_insert', 'form_delete');--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "curator_languages" (
+	"user_id" uuid NOT NULL,
+	"language" "language" NOT NULL,
+	"granted_by" uuid,
+	"granted_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "curator_languages_user_id_language_pk" PRIMARY KEY("user_id","language")
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "lemma_edit_history" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"lemma_id" uuid NOT NULL,
+	"editor_id" uuid,
+	"change_type" "lemma_edit_change_type" NOT NULL,
+	"change" jsonb NOT NULL,
+	"reason" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "curator_languages" ADD CONSTRAINT "curator_languages_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "curator_languages" ADD CONSTRAINT "curator_languages_granted_by_users_id_fk" FOREIGN KEY ("granted_by") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "lemma_edit_history" ADD CONSTRAINT "lemma_edit_history_lemma_id_lemmas_id_fk" FOREIGN KEY ("lemma_id") REFERENCES "public"."lemmas"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "lemma_edit_history" ADD CONSTRAINT "lemma_edit_history_editor_id_users_id_fk" FOREIGN KEY ("editor_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "curator_languages_user_idx" ON "curator_languages" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "lemma_edit_history_lemma_idx" ON "lemma_edit_history" USING btree ("lemma_id","created_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "lemma_edit_history_editor_idx" ON "lemma_edit_history" USING btree ("editor_id");

--- a/apps/web/drizzle/meta/0004_snapshot.json
+++ b/apps/web/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,1372 @@
+{
+  "id": "d10173e6-e02a-4a7e-b166-8f13b46cfd36",
+  "prevId": "91c4c9c7-5f79-4c9f-a7f3-9f82e837c7b8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.curator_languages": {
+      "name": "curator_languages",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "curator_languages_user_idx": {
+          "name": "curator_languages_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "curator_languages_user_id_users_id_fk": {
+          "name": "curator_languages_user_id_users_id_fk",
+          "tableFrom": "curator_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "curator_languages_granted_by_users_id_fk": {
+          "name": "curator_languages_granted_by_users_id_fk",
+          "tableFrom": "curator_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "curator_languages_user_id_language_pk": {
+          "name": "curator_languages_user_id_language_pk",
+          "columns": [
+            "user_id",
+            "language"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.dictionary_imports": {
+      "name": "dictionary_imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_name": {
+          "name": "source_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_at": {
+          "name": "run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lemmas_created": {
+          "name": "lemmas_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lemmas_updated": {
+          "name": "lemmas_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lemmas_skipped_curator_locked": {
+          "name": "lemmas_skipped_curator_locked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "translations_created": {
+          "name": "translations_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "translations_updated": {
+          "name": "translations_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "dictionary_imports_language_idx": {
+          "name": "dictionary_imports_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemma_edit_history": {
+      "name": "lemma_edit_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "editor_id": {
+          "name": "editor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "lemma_edit_change_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change": {
+          "name": "change",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_edit_history_lemma_idx": {
+          "name": "lemma_edit_history_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_edit_history_editor_idx": {
+          "name": "lemma_edit_history_editor_idx",
+          "columns": [
+            {
+              "expression": "editor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_edit_history_lemma_id_lemmas_id_fk": {
+          "name": "lemma_edit_history_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_edit_history",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lemma_edit_history_editor_id_users_id_fk": {
+          "name": "lemma_edit_history_editor_id_users_id_fk",
+          "tableFrom": "lemma_edit_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "editor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemma_forms": {
+      "name": "lemma_forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "romanization": {
+          "name": "romanization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_forms_lemma_idx": {
+          "name": "lemma_forms_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_forms_surface_idx": {
+          "name": "lemma_forms_surface_idx",
+          "columns": [
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_forms_lemma_id_lemmas_id_fk": {
+          "name": "lemma_forms_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_forms",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemmas": {
+      "name": "lemmas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headword": {
+          "name": "headword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos": {
+          "name": "pos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script": {
+          "name": "script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gloss_default": {
+          "name": "gloss_default",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_rank": {
+          "name": "frequency_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "translation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "curator_locked": {
+          "name": "curator_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemmas_language_idx": {
+          "name": "lemmas_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_language_frequency_idx": {
+          "name": "lemmas_language_frequency_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "frequency_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_source_lookup_idx": {
+          "name": "lemmas_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lemmas_language_headword_pos_uq": {
+          "name": "lemmas_language_headword_pos_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "language",
+            "headword",
+            "pos"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.magic_links": {
+      "name": "magic_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "magic_links_user_idx": {
+          "name": "magic_links_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "magic_links_expires_idx": {
+          "name": "magic_links_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "magic_links_user_id_users_id_fk": {
+          "name": "magic_links_user_id_users_id_fk",
+          "tableFrom": "magic_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by": {
+          "name": "replaced_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "refresh_tokens_user_idx": {
+          "name": "refresh_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_expires_idx": {
+          "name": "refresh_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.translations": {
+      "name": "translations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "translation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_translation_id": {
+          "name": "parent_translation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_language": {
+          "name": "target_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "translations_lemma_idx": {
+          "name": "translations_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translations_submitted_by_idx": {
+          "name": "translations_submitted_by_idx",
+          "columns": [
+            {
+              "expression": "submitted_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translations_source_lookup_idx": {
+          "name": "translations_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "translations_lemma_id_lemmas_id_fk": {
+          "name": "translations_lemma_id_lemmas_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "translations_submitted_by_users_id_fk": {
+          "name": "translations_submitted_by_users_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "translations_parent_translation_id_translations_id_fk": {
+          "name": "translations_parent_translation_id_translations_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "translations",
+          "columnsFrom": [
+            "parent_translation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_languages": {
+      "name": "user_languages",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script_preference": {
+          "name": "script_preference",
+          "type": "script_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "romanization_scheme": {
+          "name": "romanization_scheme",
+          "type": "romanization_scheme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'iso15919'"
+        },
+        "known_words_count_cache": {
+          "name": "known_words_count_cache",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reader_layout_mode": {
+          "name": "reader_layout_mode",
+          "type": "reader_layout_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'page'"
+        },
+        "words_per_page": {
+          "name": "words_per_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 250
+        },
+        "font_family": {
+          "name": "font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_size": {
+          "name": "font_size",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 18
+        },
+        "line_spacing": {
+          "name": "line_spacing",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1.6
+        },
+        "highlight_style": {
+          "name": "highlight_style",
+          "type": "highlight_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'background'"
+        },
+        "baseline": {
+          "name": "baseline",
+          "type": "language_baseline",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_languages_user_id_users_id_fk": {
+          "name": "user_languages_user_id_users_id_fk",
+          "tableFrom": "user_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_languages_user_id_language_pk": {
+          "name": "user_languages_user_id_language_pk",
+          "columns": [
+            "user_id",
+            "language"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_preference": {
+          "name": "theme_preference",
+          "type": "theme_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarded_at": {
+          "name": "onboarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    }
+  },
+  "enums": {
+    "public.highlight_style": {
+      "name": "highlight_style",
+      "schema": "public",
+      "values": [
+        "underline",
+        "background",
+        "colored_text"
+      ]
+    },
+    "public.language": {
+      "name": "language",
+      "schema": "public",
+      "values": [
+        "hi",
+        "mr",
+        "or"
+      ]
+    },
+    "public.language_baseline": {
+      "name": "language_baseline",
+      "schema": "public",
+      "values": [
+        "none",
+        "beginner",
+        "intermediate"
+      ]
+    },
+    "public.lemma_edit_change_type": {
+      "name": "lemma_edit_change_type",
+      "schema": "public",
+      "values": [
+        "lemma_update",
+        "lemma_unlock",
+        "lemma_lock",
+        "translation_insert",
+        "translation_update",
+        "translation_hide",
+        "translation_unhide",
+        "form_insert",
+        "form_delete"
+      ]
+    },
+    "public.reader_layout_mode": {
+      "name": "reader_layout_mode",
+      "schema": "public",
+      "values": [
+        "page",
+        "paged_scroll",
+        "continuous"
+      ]
+    },
+    "public.romanization_scheme": {
+      "name": "romanization_scheme",
+      "schema": "public",
+      "values": [
+        "iso15919",
+        "iast",
+        "hunterian",
+        "itrans"
+      ]
+    },
+    "public.script_preference": {
+      "name": "script_preference",
+      "schema": "public",
+      "values": [
+        "native",
+        "native_with_romanization",
+        "romanization_only"
+      ]
+    },
+    "public.theme_preference": {
+      "name": "theme_preference",
+      "schema": "public",
+      "values": [
+        "system",
+        "light",
+        "dark"
+      ]
+    },
+    "public.translation_source": {
+      "name": "translation_source",
+      "schema": "public",
+      "values": [
+        "official_dictionary",
+        "curator",
+        "user"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "curator",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1777007769949,
       "tag": "0003_high_frog_thor",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1777008698995,
+      "tag": "0004_fancy_siren",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/src/lib/server/db/schema.ts
+++ b/apps/web/src/lib/server/db/schema.ts
@@ -331,6 +331,88 @@ export const dictionaryImports = pgTable(
   }),
 );
 
+/**
+ * Per-language curator grants (T-3.4).
+ *
+ * A user with `role='curator'` has edit rights on a language only when a
+ * row exists here. A user with `role='admin'` is treated as a curator on
+ * every language without needing rows — admin is a superset. Keeping the
+ * grants explicit (rather than baking language lists into `users`) means
+ * add/remove is a single row write and carries its own audit columns
+ * (`granted_by`, `granted_at`).
+ */
+export const curatorLanguages = pgTable(
+  'curator_languages',
+  {
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    language: language('language').notNull(),
+    grantedBy: uuid('granted_by').references(() => users.id, { onDelete: 'set null' }),
+    grantedAt: timestamp('granted_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    pk: primaryKey({ columns: [t.userId, t.language] }),
+    userIdx: index('curator_languages_user_idx').on(t.userId),
+  }),
+);
+
+/**
+ * Audit log for dictionary edits (T-3.4).
+ *
+ * One row per curator action that mutates a lemma, its translations, or
+ * its forms. `change` carries a `{ before, after }` diff so the
+ * dictionary editor (T-3.7) can render "what did this curator change?"
+ * and a revert control without needing a separate history table per
+ * edit kind.
+ *
+ * `reason` is required — curators have to type something before an edit
+ * commits. This is deliberately a soft "why" field, not a machine-
+ * readable code, because the audit trail is for humans first.
+ */
+export const lemmaEditChangeType = pgEnum('lemma_edit_change_type', [
+  'lemma_update',
+  'lemma_unlock',
+  'lemma_lock',
+  'translation_insert',
+  'translation_update',
+  'translation_hide',
+  'translation_unhide',
+  'form_insert',
+  'form_delete',
+]);
+
+export const lemmaEditHistory = pgTable(
+  'lemma_edit_history',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    lemmaId: uuid('lemma_id')
+      .notNull()
+      .references(() => lemmas.id, { onDelete: 'cascade' }),
+    editorId: uuid('editor_id').references(() => users.id, { onDelete: 'set null' }),
+    changeType: lemmaEditChangeType('change_type').notNull(),
+    change: jsonb('change').$type<LemmaEditChangePayload>().notNull(),
+    reason: text('reason').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    lemmaIdx: index('lemma_edit_history_lemma_idx').on(t.lemmaId, t.createdAt),
+    editorIdx: index('lemma_edit_history_editor_idx').on(t.editorId),
+  }),
+);
+
+/**
+ * JSON shape written into `lemma_edit_history.change`. We keep this as a
+ * single type so the revert logic in T-3.7 has one discriminated union
+ * to switch on rather than a grab-bag of optional fields.
+ */
+export type LemmaEditChangePayload = {
+  before?: Record<string, unknown> | null;
+  after?: Record<string, unknown> | null;
+  translationId?: string;
+  formId?: string;
+};
+
 export type User = InferSelectModel<typeof users>;
 export type Session = InferSelectModel<typeof sessions>;
 export type RefreshToken = InferSelectModel<typeof refreshTokens>;
@@ -340,3 +422,5 @@ export type Lemma = InferSelectModel<typeof lemmas>;
 export type LemmaForm = InferSelectModel<typeof lemmaForms>;
 export type Translation = InferSelectModel<typeof translations>;
 export type DictionaryImport = InferSelectModel<typeof dictionaryImports>;
+export type CuratorLanguage = InferSelectModel<typeof curatorLanguages>;
+export type LemmaEditHistoryEntry = InferSelectModel<typeof lemmaEditHistory>;

--- a/apps/web/src/lib/server/dictionary/admin.test.ts
+++ b/apps/web/src/lib/server/dictionary/admin.test.ts
@@ -1,0 +1,226 @@
+// @vitest-environment node
+/**
+ * Tests for the admin write helpers (T-3.4): role changes and curator-
+ * language grants. The db surface is mocked; each test stages the rows
+ * each call should return in the order the service issues them.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Call =
+  | { kind: 'select' }
+  | { kind: 'update'; set?: unknown; where?: unknown }
+  | { kind: 'insert'; values?: unknown; onConflict?: unknown }
+  | { kind: 'delete'; where?: unknown };
+const calls: Call[] = [];
+
+const staged: Array<unknown[]> = [];
+function stage(rows: unknown[]) {
+  staged.push(rows);
+}
+function nextStaged(): unknown[] {
+  const v = staged.shift();
+  if (!v) throw new Error('Test bug: no staged result available');
+  return v;
+}
+
+function makeSelectChain() {
+  const chain: Record<string, unknown> = {};
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.limit = vi.fn(() => chain);
+  chain.then = (resolve: (v: unknown) => unknown) => resolve(nextStaged());
+  return chain;
+}
+
+function makeUpdateChain() {
+  const entry: Call = { kind: 'update' };
+  calls.push(entry);
+  const chain: Record<string, unknown> = {};
+  chain.set = vi.fn((v: unknown) => {
+    entry.set = v;
+    return chain;
+  });
+  chain.where = vi.fn((v: unknown) => {
+    entry.where = v;
+    return chain;
+  });
+  chain.returning = vi.fn(() => nextStaged());
+  return chain;
+}
+
+function makeInsertChain() {
+  const entry: Call = { kind: 'insert' };
+  calls.push(entry);
+  const chain: Record<string, unknown> = {};
+  chain.values = vi.fn((v: unknown) => {
+    entry.values = v;
+    return chain;
+  });
+  chain.onConflictDoNothing = vi.fn((v: unknown) => {
+    entry.onConflict = v;
+    return chain;
+  });
+  // Insert without .returning() must still be awaitable.
+  chain.then = (resolve: (v: unknown) => unknown) => resolve(undefined);
+  return chain;
+}
+
+function makeDeleteChain() {
+  const entry: Call = { kind: 'delete' };
+  calls.push(entry);
+  const chain: Record<string, unknown> = {};
+  chain.where = vi.fn((v: unknown) => {
+    entry.where = v;
+    return chain;
+  });
+  chain.then = (resolve: (v: unknown) => unknown) => resolve(undefined);
+  return chain;
+}
+
+const selectFn = vi.fn(() => {
+  calls.push({ kind: 'select' });
+  return makeSelectChain();
+});
+const updateFn = vi.fn(() => makeUpdateChain());
+const insertFn = vi.fn(() => makeInsertChain());
+const deleteFn = vi.fn(() => makeDeleteChain());
+
+vi.mock('../db/index.js', () => ({
+  db: {
+    select: () => selectFn(),
+    update: () => updateFn(),
+    insert: () => insertFn(),
+    delete: () => deleteFn(),
+  },
+  schema: {
+    users: {
+      id: 'users.id',
+      role: 'users.role',
+    },
+    curatorLanguages: {
+      userId: 'curator_languages.user_id',
+      language: 'curator_languages.language',
+    },
+  },
+}));
+
+const {
+  LastAdminError,
+  UserNotFoundError,
+  grantCuratorLanguage,
+  listCuratorLanguages,
+  revokeCuratorLanguage,
+  setUserRole,
+} = await import('./admin.js');
+
+beforeEach(() => {
+  calls.length = 0;
+  staged.length = 0;
+  selectFn.mockClear();
+  updateFn.mockClear();
+  insertFn.mockClear();
+  deleteFn.mockClear();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('setUserRole', () => {
+  it('promotes a plain user to curator', async () => {
+    stage([{ id: 'u1', role: 'user' }]); // existing user lookup
+    stage([
+      { id: 'u1', email: 'a@b', role: 'curator', updatedAt: new Date() },
+    ]); // update ... returning
+    const updated = await setUserRole('u1', 'curator');
+    expect(updated.role).toBe('curator');
+    expect(updateFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a role change idempotent when target == current', async () => {
+    stage([{ id: 'u1', role: 'curator' }]);
+    stage([{ id: 'u1', email: 'a@b', role: 'curator', updatedAt: new Date() }]);
+    const updated = await setUserRole('u1', 'curator');
+    expect(updated.role).toBe('curator');
+  });
+
+  it('throws UserNotFoundError when the user does not exist', async () => {
+    stage([]); // no user
+    await expect(setUserRole('u-missing', 'curator')).rejects.toBeInstanceOf(
+      UserNotFoundError,
+    );
+    expect(updateFn).not.toHaveBeenCalled();
+  });
+
+  it('allows demoting an admin when other admins exist', async () => {
+    stage([{ id: 'a1', role: 'admin' }]); // existing user
+    stage([{ id: 'a1' }, { id: 'a2' }]); // countAdmins -> 2
+    stage([{ id: 'a1', email: 'a@b', role: 'curator', updatedAt: new Date() }]);
+    const updated = await setUserRole('a1', 'curator');
+    expect(updated.role).toBe('curator');
+  });
+
+  it('refuses to demote the very last admin', async () => {
+    stage([{ id: 'a1', role: 'admin' }]);
+    stage([{ id: 'a1' }]); // countAdmins -> 1
+    await expect(setUserRole('a1', 'user')).rejects.toBeInstanceOf(LastAdminError);
+    expect(updateFn).not.toHaveBeenCalled();
+  });
+
+  it('does NOT count admins when the target role is admin (no demotion)', async () => {
+    stage([{ id: 'u1', role: 'user' }]);
+    stage([{ id: 'u1', email: 'a@b', role: 'admin', updatedAt: new Date() }]);
+    const updated = await setUserRole('u1', 'admin');
+    expect(updated.role).toBe('admin');
+    // Exactly one SELECT (the user lookup) — no countAdmins select.
+    expect(calls.filter((c) => c.kind === 'select')).toHaveLength(1);
+  });
+});
+
+describe('grantCuratorLanguage', () => {
+  it('inserts a grant with onConflictDoNothing so a repeat is a no-op', async () => {
+    stage([{ id: 'u1' }]); // user exists
+    await grantCuratorLanguage('u1', 'hi', 'admin-1');
+    const insertCall = calls.find((c) => c.kind === 'insert');
+    expect(insertCall?.values).toMatchObject({
+      userId: 'u1',
+      language: 'hi',
+      grantedBy: 'admin-1',
+    });
+    expect(insertCall?.onConflict).toBeDefined();
+  });
+
+  it('throws UserNotFoundError when the user does not exist', async () => {
+    stage([]);
+    await expect(
+      grantCuratorLanguage('u-missing', 'hi', 'admin-1'),
+    ).rejects.toBeInstanceOf(UserNotFoundError);
+    expect(insertFn).not.toHaveBeenCalled();
+  });
+});
+
+describe('revokeCuratorLanguage', () => {
+  it('issues a delete against curator_languages', async () => {
+    await revokeCuratorLanguage('u1', 'hi');
+    expect(deleteFn).toHaveBeenCalledTimes(1);
+    expect(calls.find((c) => c.kind === 'delete')?.where).toBeDefined();
+  });
+
+  it('is silent when the grant did not exist (no existence check)', async () => {
+    await expect(revokeCuratorLanguage('u-none', 'or')).resolves.toBeUndefined();
+  });
+});
+
+describe('listCuratorLanguages', () => {
+  it('returns the language codes from the DB rows', async () => {
+    stage([{ language: 'hi' }, { language: 'mr' }]);
+    const langs = await listCuratorLanguages('u1');
+    expect(langs).toEqual(['hi', 'mr']);
+  });
+
+  it('returns [] when the user has no grants', async () => {
+    stage([]);
+    const langs = await listCuratorLanguages('u1');
+    expect(langs).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/server/dictionary/admin.ts
+++ b/apps/web/src/lib/server/dictionary/admin.ts
@@ -1,0 +1,97 @@
+/**
+ * Admin controls for role + curator-language assignments (T-3.4).
+ *
+ * Kept separate from `permissions.ts` because those are read-side
+ * checks; these are write-side ops reachable only by admins. Tests mock
+ * the db surface so neither file touches Postgres directly in CI.
+ */
+import { and, eq } from 'drizzle-orm';
+
+import { db, schema } from '../db/index.js';
+import type { User } from '../db/schema.js';
+import type { LanguageCode } from '@ciareader/shared-types';
+
+export class UserNotFoundError extends Error {
+  constructor(public readonly userId: string) {
+    super(`User ${userId} not found`);
+    this.name = 'UserNotFoundError';
+  }
+}
+
+export class LastAdminError extends Error {
+  constructor() {
+    super('Cannot demote the last admin');
+    this.name = 'LastAdminError';
+  }
+}
+
+async function countAdmins(): Promise<number> {
+  const rows = await db
+    .select({ id: schema.users.id })
+    .from(schema.users)
+    .where(eq(schema.users.role, 'admin'));
+  return rows.length;
+}
+
+export async function setUserRole(userId: string, role: User['role']): Promise<User> {
+  const [existing] = await db
+    .select()
+    .from(schema.users)
+    .where(eq(schema.users.id, userId))
+    .limit(1);
+  if (!existing) throw new UserNotFoundError(userId);
+  const wasAdmin = (existing as User).role === 'admin';
+  const demotingAdmin = wasAdmin && role !== 'admin';
+  if (demotingAdmin) {
+    const n = await countAdmins();
+    if (n <= 1) throw new LastAdminError();
+  }
+  const [updated] = await db
+    .update(schema.users)
+    .set({ role, updatedAt: new Date() })
+    .where(eq(schema.users.id, userId))
+    .returning();
+  return updated as User;
+}
+
+export async function grantCuratorLanguage(
+  userId: string,
+  language: LanguageCode,
+  grantedBy: string,
+): Promise<void> {
+  const [existing] = await db
+    .select({ id: schema.users.id })
+    .from(schema.users)
+    .where(eq(schema.users.id, userId))
+    .limit(1);
+  if (!existing) throw new UserNotFoundError(userId);
+  // Upsert so a repeated grant is a no-op rather than a DB error.
+  await db
+    .insert(schema.curatorLanguages)
+    .values({ userId, language, grantedBy })
+    .onConflictDoNothing({
+      target: [schema.curatorLanguages.userId, schema.curatorLanguages.language],
+    });
+}
+
+export async function revokeCuratorLanguage(
+  userId: string,
+  language: LanguageCode,
+): Promise<void> {
+  await db
+    .delete(schema.curatorLanguages)
+    .where(
+      and(
+        eq(schema.curatorLanguages.userId, userId),
+        eq(schema.curatorLanguages.language, language),
+      ),
+    );
+}
+
+export async function listCuratorLanguages(userId: string): Promise<LanguageCode[]> {
+  const rows = await db
+    .select({ language: schema.curatorLanguages.language })
+    .from(schema.curatorLanguages)
+    .where(eq(schema.curatorLanguages.userId, userId));
+  return rows.map((r) => r.language as LanguageCode);
+}

--- a/apps/web/src/lib/server/dictionary/audit.test.ts
+++ b/apps/web/src/lib/server/dictionary/audit.test.ts
@@ -1,0 +1,227 @@
+// @vitest-environment node
+/**
+ * Tests for the lemma-edit audit log helpers (T-3.4).
+ *
+ * Same fluent-chain fake pattern as `translations.test.ts` — we stage the
+ * rows each DB call should return, then assert the inputs the service
+ * handed to drizzle.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Call = { kind: 'select' | 'insert'; payload?: unknown };
+const calls: Call[] = [];
+
+const staged: Array<unknown[]> = [];
+
+function stage(rows: unknown[]) {
+  staged.push(rows);
+}
+
+function nextStaged(): unknown[] {
+  const v = staged.shift();
+  if (!v) throw new Error('Test bug: no staged result available');
+  return v;
+}
+
+function makeSelectChain() {
+  const chain: Record<string, unknown> = {};
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.orderBy = vi.fn(() => chain);
+  chain.limit = vi.fn(() => chain);
+  chain.then = (resolve: (v: unknown) => unknown) => resolve(nextStaged());
+  return chain;
+}
+
+function makeInsertChain() {
+  const chain = {
+    values: vi.fn((payload: unknown) => {
+      calls.push({ kind: 'insert', payload });
+      return chain;
+    }),
+    returning: vi.fn(() => nextStaged()),
+  };
+  return chain;
+}
+
+const selectFn = vi.fn(() => {
+  calls.push({ kind: 'select' });
+  return makeSelectChain();
+});
+const insertFn = vi.fn(() => makeInsertChain());
+
+vi.mock('../db/index.js', () => ({
+  db: {
+    select: () => selectFn(),
+    insert: () => insertFn(),
+  },
+  schema: {
+    lemmaEditHistory: {
+      id: 'lemma_edit_history.id',
+      lemmaId: 'lemma_edit_history.lemma_id',
+      editorId: 'lemma_edit_history.editor_id',
+      createdAt: 'lemma_edit_history.created_at',
+    },
+    lemmaEditChangeType: {
+      enumValues: [
+        'lemma_update',
+        'lemma_unlock',
+        'lemma_lock',
+        'translation_insert',
+        'translation_update',
+        'translation_hide',
+        'translation_unhide',
+        'form_insert',
+        'form_delete',
+      ],
+    },
+  },
+}));
+
+const { MissingReasonError, listLemmaHistory, recordLemmaEdit } = await import(
+  './audit.js'
+);
+
+beforeEach(() => {
+  calls.length = 0;
+  staged.length = 0;
+  selectFn.mockClear();
+  insertFn.mockClear();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('recordLemmaEdit', () => {
+  it('inserts and returns the audit row on the happy path', async () => {
+    const inserted = {
+      id: 'edit-1',
+      lemmaId: 'lemma-1',
+      editorId: 'curator-1',
+      changeType: 'lemma_update',
+      change: { before: { gloss_default: 'a' }, after: { gloss_default: 'b' } },
+      reason: 'fix typo',
+      createdAt: new Date('2026-04-24'),
+    };
+    stage([inserted]);
+
+    const result = await recordLemmaEdit({
+      lemmaId: 'lemma-1',
+      editorId: 'curator-1',
+      changeType: 'lemma_update',
+      change: { before: { gloss_default: 'a' }, after: { gloss_default: 'b' } },
+      reason: 'fix typo',
+    });
+
+    expect(result.id).toBe('edit-1');
+    const insertCall = calls.find((c) => c.kind === 'insert');
+    expect(insertCall?.payload).toMatchObject({
+      lemmaId: 'lemma-1',
+      editorId: 'curator-1',
+      changeType: 'lemma_update',
+      reason: 'fix typo',
+    });
+  });
+
+  it('trims whitespace off the reason before persisting it', async () => {
+    stage([{ id: 'edit-1' }]);
+    await recordLemmaEdit({
+      lemmaId: 'lemma-1',
+      editorId: 'curator-1',
+      changeType: 'lemma_unlock',
+      change: {},
+      reason: '   unlock for re-import   ',
+    });
+    const insertCall = calls.find((c) => c.kind === 'insert');
+    expect(insertCall?.payload).toMatchObject({ reason: 'unlock for re-import' });
+  });
+
+  it('throws MissingReasonError for an empty reason', async () => {
+    await expect(
+      recordLemmaEdit({
+        lemmaId: 'lemma-1',
+        editorId: 'curator-1',
+        changeType: 'lemma_update',
+        change: {},
+        reason: '',
+      }),
+    ).rejects.toBeInstanceOf(MissingReasonError);
+    expect(insertFn).not.toHaveBeenCalled();
+  });
+
+  it('throws MissingReasonError for a whitespace-only reason', async () => {
+    await expect(
+      recordLemmaEdit({
+        lemmaId: 'lemma-1',
+        editorId: 'curator-1',
+        changeType: 'lemma_update',
+        change: {},
+        reason: '   \t\n  ',
+      }),
+    ).rejects.toBeInstanceOf(MissingReasonError);
+    expect(insertFn).not.toHaveBeenCalled();
+  });
+
+  it('throws MissingReasonError for a reason shorter than the minimum', async () => {
+    await expect(
+      recordLemmaEdit({
+        lemmaId: 'lemma-1',
+        editorId: 'curator-1',
+        changeType: 'lemma_update',
+        change: {},
+        reason: 'ok',
+      }),
+    ).rejects.toBeInstanceOf(MissingReasonError);
+  });
+});
+
+describe('listLemmaHistory', () => {
+  it('returns staged rows for a given lemma', async () => {
+    const rows = [
+      { id: 'edit-2', lemmaId: 'lemma-1', createdAt: new Date('2026-04-24') },
+      { id: 'edit-1', lemmaId: 'lemma-1', createdAt: new Date('2026-04-23') },
+    ];
+    stage(rows);
+    const result = await listLemmaHistory('lemma-1');
+    expect(result.map((r) => r.id)).toEqual(['edit-2', 'edit-1']);
+  });
+
+  it('passes a default limit to the chain when none is provided', async () => {
+    stage([]);
+    const chain = makeSelectChainCapture();
+    selectFn.mockImplementationOnce(() => {
+      calls.push({ kind: 'select' });
+      return chain;
+    });
+    await listLemmaHistory('lemma-1');
+    expect(chain.limit).toHaveBeenCalledWith(50);
+  });
+
+  it('passes an explicit limit when provided', async () => {
+    stage([]);
+    const chain = makeSelectChainCapture();
+    selectFn.mockImplementationOnce(() => {
+      calls.push({ kind: 'select' });
+      return chain;
+    });
+    await listLemmaHistory('lemma-1', 5);
+    expect(chain.limit).toHaveBeenCalledWith(5);
+  });
+});
+
+// Variant that lets us assert on the exact args passed to `.limit(...)`.
+function makeSelectChainCapture() {
+  const chain: Record<string, unknown> = {};
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.orderBy = vi.fn(() => chain);
+  chain.limit = vi.fn(() => chain);
+  chain.then = (resolve: (v: unknown) => unknown) => resolve(nextStaged());
+  return chain as unknown as {
+    from: ReturnType<typeof vi.fn>;
+    where: ReturnType<typeof vi.fn>;
+    orderBy: ReturnType<typeof vi.fn>;
+    limit: ReturnType<typeof vi.fn>;
+  };
+}

--- a/apps/web/src/lib/server/dictionary/audit.ts
+++ b/apps/web/src/lib/server/dictionary/audit.ts
@@ -1,0 +1,70 @@
+/**
+ * Dictionary-edit audit log (T-3.4).
+ *
+ * `recordLemmaEdit` is the single write path into `lemma_edit_history`.
+ * The editor UI (T-3.7) + moderation queue (T-6.6) never write that
+ * table directly — they call through here so the before/after diff,
+ * required reason, and enum discriminator stay consistent.
+ */
+import { desc, eq } from 'drizzle-orm';
+
+import { db, schema } from '../db/index.js';
+import type { LemmaEditHistoryEntry, LemmaEditChangePayload } from '../db/schema.js';
+
+export type LemmaEditChangeType = typeof schema.lemmaEditChangeType.enumValues[number];
+
+export type RecordLemmaEditInput = {
+  lemmaId: string;
+  editorId: string;
+  changeType: LemmaEditChangeType;
+  change: LemmaEditChangePayload;
+  reason: string;
+};
+
+export class MissingReasonError extends Error {
+  constructor() {
+    super('A reason is required for every curator edit');
+    this.name = 'MissingReasonError';
+  }
+}
+
+const MIN_REASON_LEN = 3;
+
+export async function recordLemmaEdit(
+  input: RecordLemmaEditInput,
+): Promise<LemmaEditHistoryEntry> {
+  const reason = input.reason?.trim() ?? '';
+  if (reason.length < MIN_REASON_LEN) {
+    throw new MissingReasonError();
+  }
+  const [row] = await db
+    .insert(schema.lemmaEditHistory)
+    .values({
+      lemmaId: input.lemmaId,
+      editorId: input.editorId,
+      changeType: input.changeType,
+      change: input.change,
+      reason,
+    })
+    .returning();
+  if (!row) throw new Error('Failed to insert audit row');
+  return row as LemmaEditHistoryEntry;
+}
+
+/**
+ * Fetch recent history for one lemma (newest first). The editor shows
+ * these in a sidebar; 50 is more than any single lemma realistically
+ * churns through in a sitting.
+ */
+export async function listLemmaHistory(
+  lemmaId: string,
+  limit = 50,
+): Promise<LemmaEditHistoryEntry[]> {
+  const rows = await db
+    .select()
+    .from(schema.lemmaEditHistory)
+    .where(eq(schema.lemmaEditHistory.lemmaId, lemmaId))
+    .orderBy(desc(schema.lemmaEditHistory.createdAt))
+    .limit(limit);
+  return rows as LemmaEditHistoryEntry[];
+}

--- a/apps/web/src/lib/server/dictionary/permissions.test.ts
+++ b/apps/web/src/lib/server/dictionary/permissions.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment node
+/**
+ * Tests for the dictionary permission helpers (T-3.4).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const staged: Array<unknown[]> = [];
+function stage(rows: unknown[]) {
+  staged.push(rows);
+}
+function nextStaged(): unknown[] {
+  const v = staged.shift();
+  if (!v) throw new Error('Test bug: no staged result available');
+  return v;
+}
+
+function makeSelectChain() {
+  const chain: Record<string, unknown> = {};
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.limit = vi.fn(() => chain);
+  chain.then = (resolve: (v: unknown) => unknown) => resolve(nextStaged());
+  return chain;
+}
+
+vi.mock('../db/index.js', () => ({
+  db: { select: () => makeSelectChain() },
+  schema: {
+    curatorLanguages: {
+      userId: 'curator_languages.user_id',
+      language: 'curator_languages.language',
+    },
+  },
+}));
+
+const {
+  ForbiddenError,
+  canEditDictionary,
+  isAdmin,
+  isCuratorOrAdmin,
+  listGrantedLanguages,
+  requireAdmin,
+  requireCanEditDictionary,
+} = await import('./permissions.js');
+
+beforeEach(() => {
+  staged.length = 0;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('role predicates', () => {
+  it('isAdmin is true only for role=admin', () => {
+    expect(isAdmin(null)).toBe(false);
+    expect(isAdmin({ role: 'user' })).toBe(false);
+    expect(isAdmin({ role: 'curator' })).toBe(false);
+    expect(isAdmin({ role: 'admin' })).toBe(true);
+  });
+
+  it('isCuratorOrAdmin is true for curator + admin', () => {
+    expect(isCuratorOrAdmin(null)).toBe(false);
+    expect(isCuratorOrAdmin({ role: 'user' })).toBe(false);
+    expect(isCuratorOrAdmin({ role: 'curator' })).toBe(true);
+    expect(isCuratorOrAdmin({ role: 'admin' })).toBe(true);
+  });
+
+  it('requireAdmin throws ForbiddenError for non-admins', () => {
+    expect(() => requireAdmin(null)).toThrow(ForbiddenError);
+    expect(() => requireAdmin({ role: 'curator' })).toThrow(ForbiddenError);
+    expect(() => requireAdmin({ role: 'admin' })).not.toThrow();
+  });
+});
+
+describe('canEditDictionary', () => {
+  it('returns false for anonymous viewers', async () => {
+    expect(await canEditDictionary(null, 'hi')).toBe(false);
+  });
+
+  it('returns false for plain users without hitting the DB', async () => {
+    expect(await canEditDictionary({ id: 'u1', role: 'user' }, 'hi')).toBe(false);
+  });
+
+  it('returns true for admins without needing a grant row', async () => {
+    // No staged row — function must short-circuit.
+    expect(await canEditDictionary({ id: 'a1', role: 'admin' }, 'or')).toBe(true);
+  });
+
+  it('returns true for a curator when the grant exists', async () => {
+    stage([{ language: 'hi' }]);
+    expect(await canEditDictionary({ id: 'c1', role: 'curator' }, 'hi')).toBe(true);
+  });
+
+  it('returns false for a curator when no grant exists for that language', async () => {
+    stage([]);
+    expect(await canEditDictionary({ id: 'c1', role: 'curator' }, 'or')).toBe(false);
+  });
+
+  it('requireCanEditDictionary throws when canEditDictionary is false', async () => {
+    stage([]);
+    await expect(
+      requireCanEditDictionary({ id: 'c1', role: 'curator' }, 'or'),
+    ).rejects.toBeInstanceOf(ForbiddenError);
+  });
+
+  it('requireCanEditDictionary is silent when the check passes', async () => {
+    await expect(
+      requireCanEditDictionary({ id: 'a1', role: 'admin' }, 'hi'),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('listGrantedLanguages', () => {
+  it('returns every MVP language for an admin without hitting the DB', async () => {
+    const langs = await listGrantedLanguages({ id: 'a1', role: 'admin' });
+    expect(langs.sort()).toEqual(['hi', 'mr', 'or']);
+  });
+
+  it('returns [] for a plain user', async () => {
+    expect(await listGrantedLanguages({ id: 'u1', role: 'user' })).toEqual([]);
+  });
+
+  it('returns the curator grants from the DB', async () => {
+    stage([{ language: 'hi' }, { language: 'mr' }]);
+    const langs = await listGrantedLanguages({ id: 'c1', role: 'curator' });
+    expect(langs).toEqual(['hi', 'mr']);
+  });
+});

--- a/apps/web/src/lib/server/dictionary/permissions.ts
+++ b/apps/web/src/lib/server/dictionary/permissions.ts
@@ -1,0 +1,95 @@
+/**
+ * Curator / admin permission checks (T-3.4).
+ *
+ * Every dictionary-editing code path routes through one of these helpers
+ * so the logic "who can edit this row?" exists exactly once and can be
+ * tightened (e.g. adding a language-scoped admin role later) without
+ * chasing callsites.
+ *
+ * Rules:
+ *  - `admin` — can edit the dictionary in every language, regardless of
+ *    `curator_languages`.
+ *  - `curator` — can edit the dictionary in a language iff
+ *    `curator_languages` has a matching row. No row = no edit rights for
+ *    that language, even for a curator (the default is opt-in).
+ *  - `user` — cannot edit the dictionary.
+ *
+ * Community moderation (hiding community translations, reviewing parse
+ * reports) is curator-or-admin regardless of language grant, because
+ * those flows are not intrinsically tied to a single language.
+ */
+import { and, eq } from 'drizzle-orm';
+
+import { db, schema } from '../db/index.js';
+import type { User } from '../db/schema.js';
+import type { LanguageCode } from '@ciareader/shared-types';
+
+export class ForbiddenError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ForbiddenError';
+  }
+}
+
+export function isAdmin(user: Pick<User, 'role'> | null | undefined): boolean {
+  return user?.role === 'admin';
+}
+
+export function isCuratorOrAdmin(user: Pick<User, 'role'> | null | undefined): boolean {
+  return user?.role === 'curator' || user?.role === 'admin';
+}
+
+/**
+ * Does the viewer have edit rights on dictionary content for `language`?
+ * Admins always pass; curators need a `curator_languages` grant.
+ */
+export async function canEditDictionary(
+  user: Pick<User, 'id' | 'role'> | null | undefined,
+  language: LanguageCode,
+): Promise<boolean> {
+  if (!user) return false;
+  if (isAdmin(user)) return true;
+  if (user.role !== 'curator') return false;
+  const [row] = await db
+    .select({ language: schema.curatorLanguages.language })
+    .from(schema.curatorLanguages)
+    .where(
+      and(
+        eq(schema.curatorLanguages.userId, user.id),
+        eq(schema.curatorLanguages.language, language),
+      ),
+    )
+    .limit(1);
+  return !!row;
+}
+
+export async function requireCanEditDictionary(
+  user: Pick<User, 'id' | 'role'> | null | undefined,
+  language: LanguageCode,
+): Promise<void> {
+  const ok = await canEditDictionary(user, language);
+  if (!ok) throw new ForbiddenError('You do not have curator rights for this language');
+}
+
+export function requireAdmin(
+  user: Pick<User, 'role'> | null | undefined,
+): asserts user is Pick<User, 'role'> {
+  if (!isAdmin(user)) throw new ForbiddenError('Admin role required');
+}
+
+/**
+ * Fetch the languages a curator is currently granted on. Admins pass
+ * through — they get every MVP language. Used by the dictionary editor's
+ * "which languages can I edit?" affordance.
+ */
+export async function listGrantedLanguages(
+  user: Pick<User, 'id' | 'role'>,
+): Promise<LanguageCode[]> {
+  if (isAdmin(user)) return ['hi', 'mr', 'or'];
+  if (user.role !== 'curator') return [];
+  const rows = await db
+    .select({ language: schema.curatorLanguages.language })
+    .from(schema.curatorLanguages)
+    .where(eq(schema.curatorLanguages.userId, user.id));
+  return rows.map((r) => r.language as LanguageCode);
+}

--- a/apps/web/src/routes/api/v1/admin/users/[id]/curator-languages/+server.ts
+++ b/apps/web/src/routes/api/v1/admin/users/[id]/curator-languages/+server.ts
@@ -1,0 +1,45 @@
+/**
+ * GET/POST /api/v1/admin/users/:id/curator-languages (T-3.4).
+ *
+ * Admin-only. Lists or grants per-language curator rights.
+ * Individual revoke is at `./[language]`.
+ */
+import { error, json } from '@sveltejs/kit';
+import { z } from 'zod';
+
+import { requireUser } from '$lib/server/auth/require-user.js';
+import {
+  grantCuratorLanguage,
+  listCuratorLanguages,
+  UserNotFoundError,
+} from '$lib/server/dictionary/admin.js';
+import { isAdmin } from '$lib/server/dictionary/permissions.js';
+import type { RequestHandler } from './$types';
+import { parseJson } from '../../../../auth/_helpers.js';
+
+const body = z.object({
+  language: z.enum(['hi', 'mr', 'or']),
+});
+
+export const GET: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  if (!isAdmin(user)) throw error(403, 'Admin role required');
+  if (!event.params.id) throw error(400, 'Missing user id');
+  const languages = await listCuratorLanguages(event.params.id);
+  return json({ languages });
+};
+
+export const POST: RequestHandler = async (event) => {
+  const admin = await requireUser(event);
+  if (!isAdmin(admin)) throw error(403, 'Admin role required');
+  if (!event.params.id) throw error(400, 'Missing user id');
+  const input = await parseJson(event.request, body);
+  try {
+    await grantCuratorLanguage(event.params.id, input.language, admin.id);
+    const languages = await listCuratorLanguages(event.params.id);
+    return json({ languages }, { status: 201 });
+  } catch (err) {
+    if (err instanceof UserNotFoundError) throw error(404, 'User not found');
+    throw err;
+  }
+};

--- a/apps/web/src/routes/api/v1/admin/users/[id]/curator-languages/[language]/+server.ts
+++ b/apps/web/src/routes/api/v1/admin/users/[id]/curator-languages/[language]/+server.ts
@@ -1,0 +1,29 @@
+/**
+ * DELETE /api/v1/admin/users/:id/curator-languages/:language (T-3.4).
+ *
+ * Admin-only. Revokes a per-language curator grant. Silent success
+ * whether or not the grant existed — the caller only cares about the
+ * post-condition ("user does not have a grant on `language`").
+ */
+import { error, json } from '@sveltejs/kit';
+
+import { requireUser } from '$lib/server/auth/require-user.js';
+import {
+  listCuratorLanguages,
+  revokeCuratorLanguage,
+} from '$lib/server/dictionary/admin.js';
+import { isAdmin } from '$lib/server/dictionary/permissions.js';
+import type { RequestHandler } from './$types';
+
+const SUPPORTED = new Set(['hi', 'mr', 'or']);
+
+export const DELETE: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  if (!isAdmin(user)) throw error(403, 'Admin role required');
+  const { id, language } = event.params;
+  if (!id) throw error(400, 'Missing user id');
+  if (!language || !SUPPORTED.has(language)) throw error(400, 'Unsupported language');
+  await revokeCuratorLanguage(id, language as 'hi' | 'mr' | 'or');
+  const languages = await listCuratorLanguages(id);
+  return json({ languages });
+};

--- a/apps/web/src/routes/api/v1/admin/users/[id]/curator-languages/[language]/language-server.test.ts
+++ b/apps/web/src/routes/api/v1/admin/users/[id]/curator-languages/[language]/language-server.test.ts
@@ -1,0 +1,117 @@
+// @vitest-environment node
+/**
+ * Route tests for DELETE /api/v1/admin/users/:id/curator-languages/:language (T-3.4).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const listCuratorLanguages = vi.fn();
+const revokeCuratorLanguage = vi.fn();
+const requireUser = vi.fn();
+
+vi.mock('$lib/server/dictionary/admin.js', async () => {
+  const actual =
+    await vi.importActual<typeof import('$lib/server/dictionary/admin.js')>(
+      '$lib/server/dictionary/admin.js',
+    );
+  return {
+    ...actual,
+    listCuratorLanguages: (...a: unknown[]) => listCuratorLanguages(...a),
+    revokeCuratorLanguage: (...a: unknown[]) => revokeCuratorLanguage(...a),
+  };
+});
+
+vi.mock('$lib/server/auth/require-user.js', () => ({
+  requireUser: (...a: unknown[]) => requireUser(...a),
+}));
+
+type DeleteFn = (typeof import('./+server.js'))['DELETE'];
+type DeleteEvent = Parameters<DeleteFn>[0];
+
+async function callDelete(
+  user: { id: string; role?: string } | null = { id: 'a1', role: 'admin' },
+  params: Record<string, string | undefined> = { id: 'u1', language: 'hi' },
+) {
+  if (user) {
+    requireUser.mockResolvedValueOnce(user);
+  } else {
+    requireUser.mockImplementationOnce(() => {
+      throw Object.assign(new Error('Unauthorized'), { status: 401 });
+    });
+  }
+  const { DELETE } = await import('./+server.js');
+  const event = {
+    params,
+    request: new Request(
+      `http://x/api/v1/admin/users/${params.id}/curator-languages/${params.language}`,
+      { method: 'DELETE' },
+    ),
+  } as unknown as DeleteEvent;
+  try {
+    return await DELETE(event);
+  } catch (e) {
+    return e as { status: number };
+  }
+}
+
+beforeEach(() => {
+  listCuratorLanguages.mockReset();
+  revokeCuratorLanguage.mockReset();
+  requireUser.mockReset();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('DELETE /api/v1/admin/users/:id/curator-languages/:language', () => {
+  it('revokes and returns the updated list', async () => {
+    revokeCuratorLanguage.mockResolvedValueOnce(undefined);
+    listCuratorLanguages.mockResolvedValueOnce(['mr']);
+    const res = (await callDelete()) as Response;
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.languages).toEqual(['mr']);
+    expect(revokeCuratorLanguage).toHaveBeenCalledWith('u1', 'hi');
+  });
+
+  it('is silent-success even when the grant did not exist', async () => {
+    revokeCuratorLanguage.mockResolvedValueOnce(undefined);
+    listCuratorLanguages.mockResolvedValueOnce([]);
+    const res = (await callDelete()) as Response;
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.languages).toEqual([]);
+  });
+
+  it('returns 401 when not logged in', async () => {
+    const res = (await callDelete(null)) as { status: number };
+    expect(res.status).toBe(401);
+    expect(revokeCuratorLanguage).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when the caller is not an admin', async () => {
+    const res = (await callDelete({ id: 'c1', role: 'curator' })) as {
+      status: number;
+    };
+    expect(res.status).toBe(403);
+    expect(revokeCuratorLanguage).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 on an unsupported language', async () => {
+    const res = (await callDelete(
+      { id: 'a1', role: 'admin' },
+      { id: 'u1', language: 'bn' },
+    )) as { status: number };
+    expect(res.status).toBe(400);
+    expect(revokeCuratorLanguage).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when the id param is missing', async () => {
+    const res = (await callDelete(
+      { id: 'a1', role: 'admin' },
+      { language: 'hi' },
+    )) as { status: number };
+    expect(res.status).toBe(400);
+    expect(revokeCuratorLanguage).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/routes/api/v1/admin/users/[id]/curator-languages/curator-languages-server.test.ts
+++ b/apps/web/src/routes/api/v1/admin/users/[id]/curator-languages/curator-languages-server.test.ts
@@ -1,0 +1,166 @@
+// @vitest-environment node
+/**
+ * Route tests for GET + POST /api/v1/admin/users/:id/curator-languages (T-3.4).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const listCuratorLanguages = vi.fn();
+const grantCuratorLanguage = vi.fn();
+const requireUser = vi.fn();
+
+vi.mock('$lib/server/dictionary/admin.js', async () => {
+  const actual =
+    await vi.importActual<typeof import('$lib/server/dictionary/admin.js')>(
+      '$lib/server/dictionary/admin.js',
+    );
+  return {
+    ...actual,
+    listCuratorLanguages: (...a: unknown[]) => listCuratorLanguages(...a),
+    grantCuratorLanguage: (...a: unknown[]) => grantCuratorLanguage(...a),
+  };
+});
+
+vi.mock('$lib/server/auth/require-user.js', () => ({
+  requireUser: (...a: unknown[]) => requireUser(...a),
+}));
+
+type GetFn = (typeof import('./+server.js'))['GET'];
+type PostFn = (typeof import('./+server.js'))['POST'];
+type GetEvent = Parameters<GetFn>[0];
+type PostEvent = Parameters<PostFn>[0];
+
+async function callGet(
+  user: { id: string; role?: string } | null = { id: 'a1', role: 'admin' },
+  params: Record<string, string | undefined> = { id: 'u1' },
+) {
+  if (user) {
+    requireUser.mockResolvedValueOnce(user);
+  } else {
+    requireUser.mockImplementationOnce(() => {
+      throw Object.assign(new Error('Unauthorized'), { status: 401 });
+    });
+  }
+  const { GET } = await import('./+server.js');
+  const event = {
+    params,
+    request: new Request('http://x/api/v1/admin/users/u1/curator-languages'),
+  } as unknown as GetEvent;
+  try {
+    return await GET(event);
+  } catch (e) {
+    return e as { status: number };
+  }
+}
+
+async function callPost(
+  body: unknown,
+  user: { id: string; role?: string } | null = { id: 'a1', role: 'admin' },
+  params: Record<string, string | undefined> = { id: 'u1' },
+) {
+  if (user) {
+    requireUser.mockResolvedValueOnce(user);
+  } else {
+    requireUser.mockImplementationOnce(() => {
+      throw Object.assign(new Error('Unauthorized'), { status: 401 });
+    });
+  }
+  const { POST } = await import('./+server.js');
+  const event = {
+    params,
+    request: new Request('http://x/api/v1/admin/users/u1/curator-languages', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+  } as unknown as PostEvent;
+  try {
+    return await POST(event);
+  } catch (e) {
+    return e as { status: number };
+  }
+}
+
+beforeEach(() => {
+  listCuratorLanguages.mockReset();
+  grantCuratorLanguage.mockReset();
+  requireUser.mockReset();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('GET /api/v1/admin/users/:id/curator-languages', () => {
+  it('returns the current grants', async () => {
+    listCuratorLanguages.mockResolvedValueOnce(['hi', 'mr']);
+    const res = (await callGet()) as Response;
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.languages).toEqual(['hi', 'mr']);
+  });
+
+  it('returns 401 when not logged in', async () => {
+    const res = (await callGet(null)) as { status: number };
+    expect(res.status).toBe(401);
+    expect(listCuratorLanguages).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when the caller is not an admin', async () => {
+    const res = (await callGet({ id: 'c1', role: 'curator' })) as {
+      status: number;
+    };
+    expect(res.status).toBe(403);
+    expect(listCuratorLanguages).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when the id param is missing', async () => {
+    const res = (await callGet({ id: 'a1', role: 'admin' }, {})) as {
+      status: number;
+    };
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /api/v1/admin/users/:id/curator-languages', () => {
+  it('grants a language and returns the updated list with 201', async () => {
+    grantCuratorLanguage.mockResolvedValueOnce(undefined);
+    listCuratorLanguages.mockResolvedValueOnce(['hi']);
+    const res = (await callPost({ language: 'hi' })) as Response;
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.languages).toEqual(['hi']);
+    expect(grantCuratorLanguage).toHaveBeenCalledWith('u1', 'hi', 'a1');
+  });
+
+  it('returns 401 when not logged in', async () => {
+    const res = (await callPost({ language: 'hi' }, null)) as {
+      status: number;
+    };
+    expect(res.status).toBe(401);
+    expect(grantCuratorLanguage).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when the caller is not an admin', async () => {
+    const res = (await callPost({ language: 'hi' }, {
+      id: 'c1',
+      role: 'curator',
+    })) as { status: number };
+    expect(res.status).toBe(403);
+    expect(grantCuratorLanguage).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 on an unsupported language', async () => {
+    const res = (await callPost({ language: 'bn' })) as { status: number };
+    expect(res.status).toBe(400);
+    expect(grantCuratorLanguage).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the target user does not exist', async () => {
+    const { UserNotFoundError } = await import(
+      '$lib/server/dictionary/admin.js'
+    );
+    grantCuratorLanguage.mockRejectedValueOnce(new UserNotFoundError('u-missing'));
+    const res = (await callPost({ language: 'hi' })) as { status: number };
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/web/src/routes/api/v1/admin/users/[id]/role/+server.ts
+++ b/apps/web/src/routes/api/v1/admin/users/[id]/role/+server.ts
@@ -1,0 +1,38 @@
+/**
+ * POST /api/v1/admin/users/:id/role (T-3.4).
+ *
+ * Admin-only. Changes a user's role. Refuses to demote the last admin
+ * so the system can't accidentally be orphaned.
+ */
+import { error, json } from '@sveltejs/kit';
+import { z } from 'zod';
+
+import { requireUser } from '$lib/server/auth/require-user.js';
+import {
+  LastAdminError,
+  setUserRole,
+  UserNotFoundError,
+} from '$lib/server/dictionary/admin.js';
+import { isAdmin } from '$lib/server/dictionary/permissions.js';
+import type { RequestHandler } from './$types';
+import { parseJson } from '../../../../auth/_helpers.js';
+
+const body = z.object({
+  role: z.enum(['user', 'curator', 'admin']),
+});
+
+export const POST: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  if (!isAdmin(user)) throw error(403, 'Admin role required');
+  if (!event.params.id) throw error(400, 'Missing user id');
+
+  const input = await parseJson(event.request, body);
+  try {
+    const updated = await setUserRole(event.params.id, input.role);
+    return json({ user: { id: updated.id, email: updated.email, role: updated.role } });
+  } catch (err) {
+    if (err instanceof UserNotFoundError) throw error(404, 'User not found');
+    if (err instanceof LastAdminError) throw error(409, err.message);
+    throw err;
+  }
+};

--- a/apps/web/src/routes/api/v1/admin/users/[id]/role/role-server.test.ts
+++ b/apps/web/src/routes/api/v1/admin/users/[id]/role/role-server.test.ts
@@ -1,0 +1,132 @@
+// @vitest-environment node
+/**
+ * Route tests for POST /api/v1/admin/users/:id/role (T-3.4).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const setUserRole = vi.fn();
+const requireUser = vi.fn();
+
+vi.mock('$lib/server/dictionary/admin.js', async () => {
+  const actual =
+    await vi.importActual<typeof import('$lib/server/dictionary/admin.js')>(
+      '$lib/server/dictionary/admin.js',
+    );
+  return {
+    ...actual,
+    setUserRole: (...a: unknown[]) => setUserRole(...a),
+  };
+});
+
+vi.mock('$lib/server/auth/require-user.js', () => ({
+  requireUser: (...a: unknown[]) => requireUser(...a),
+}));
+
+type PostFn = (typeof import('./+server.js'))['POST'];
+type PostEvent = Parameters<PostFn>[0];
+
+async function callPost(
+  body: unknown,
+  user: { id: string; role?: string } | null = { id: 'a1', role: 'admin' },
+  params: Record<string, string | undefined> = { id: 'u1' },
+) {
+  if (user) {
+    requireUser.mockResolvedValueOnce(user);
+  } else {
+    requireUser.mockImplementationOnce(() => {
+      throw Object.assign(new Error('Unauthorized'), { status: 401 });
+    });
+  }
+  const { POST } = await import('./+server.js');
+  const event = {
+    params,
+    request: new Request('http://x/api/v1/admin/users/u1/role', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+  } as unknown as PostEvent;
+  try {
+    return await POST(event);
+  } catch (e) {
+    return e as { status: number; body?: { message: string } };
+  }
+}
+
+beforeEach(() => {
+  setUserRole.mockReset();
+  requireUser.mockReset();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('POST /api/v1/admin/users/:id/role', () => {
+  it('returns 200 with the public user shape on success', async () => {
+    setUserRole.mockResolvedValueOnce({
+      id: 'u1',
+      email: 'u@example.com',
+      role: 'curator',
+      passwordHash: 'secret',
+    });
+    const res = (await callPost({ role: 'curator' })) as Response;
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.user).toEqual({
+      id: 'u1',
+      email: 'u@example.com',
+      role: 'curator',
+    });
+    // Never leaks the password hash.
+    expect(json.user.passwordHash).toBeUndefined();
+    expect(setUserRole).toHaveBeenCalledWith('u1', 'curator');
+  });
+
+  it('returns 401 when the caller is not logged in', async () => {
+    const res = (await callPost({ role: 'curator' }, null)) as { status: number };
+    expect(res.status).toBe(401);
+    expect(setUserRole).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when the caller is not an admin', async () => {
+    const res = (await callPost(
+      { role: 'curator' },
+      { id: 'c1', role: 'curator' },
+    )) as { status: number };
+    expect(res.status).toBe(403);
+    expect(setUserRole).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when the target id param is missing', async () => {
+    const res = (await callPost(
+      { role: 'curator' },
+      { id: 'a1', role: 'admin' },
+      {},
+    )) as { status: number };
+    expect(res.status).toBe(400);
+    expect(setUserRole).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 on an invalid role', async () => {
+    const res = (await callPost({ role: 'superuser' })) as { status: number };
+    expect(res.status).toBe(400);
+    expect(setUserRole).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the target user does not exist', async () => {
+    const { UserNotFoundError } = await import(
+      '$lib/server/dictionary/admin.js'
+    );
+    setUserRole.mockRejectedValueOnce(new UserNotFoundError('u-missing'));
+    const res = (await callPost({ role: 'curator' })) as { status: number };
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 409 when demoting the last admin', async () => {
+    const { LastAdminError } = await import('$lib/server/dictionary/admin.js');
+    setUserRole.mockRejectedValueOnce(new LastAdminError());
+    const res = (await callPost({ role: 'user' })) as { status: number };
+    expect(res.status).toBe(409);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds the curator / admin permission check (`canEditDictionary` — admin, or curator with a per-language grant) and a last-admin-proof admin write surface for role changes + curator-language grants.
- Introduces `curator_languages` (per-language opt-in grant) and `lemma_edit_history` (audit log with enum change-type + before/after diff + required reason). Every future dictionary/translation edit routes through `recordLemmaEdit` so history stays consistent.
- New API: `POST /api/v1/admin/users/:id/role`; `GET`+`POST /api/v1/admin/users/:id/curator-languages`; `DELETE /api/v1/admin/users/:id/curator-languages/:language`.

## Why
T-3.4 unlocks M3's curator flows by giving us (a) a single read-side check every future editor can route through and (b) the admin-only controls to actually hand out curator rights without orphaning the system.

## Test plan
- [x] `pnpm typecheck` (0 errors, 0 warnings)
- [x] `pnpm lint`
- [x] `pnpm test` — 195 pass (48 new in this PR across 5 files)
- [x] `pnpm test:coverage` — dictionary module: 100% on admin/audit/permissions
- [ ] Manual: smoke the three admin endpoints against a running dev DB once migrations land