### PR TITLE
T-3.5: customize (edit/delete) own translations

### DIFF
--- a/apps/web/src/lib/server/dictionary/translations.test.ts
+++ b/apps/web/src/lib/server/dictionary/translations.test.ts
@@ -9,7 +9,11 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-type Call = { kind: 'select' | 'insert'; payload?: unknown };
+type Call =
+  | { kind: 'select' }
+  | { kind: 'insert'; payload?: unknown }
+  | { kind: 'update'; set?: unknown }
+  | { kind: 'delete' };
 const calls: Call[] = [];
 
 /**
@@ -64,16 +68,41 @@ function makeInsertChain() {
   return chain;
 }
 
+function makeUpdateChain() {
+  const entry: Call = { kind: 'update' };
+  calls.push(entry);
+  const chain: Record<string, unknown> = {};
+  chain.set = vi.fn((v: unknown) => {
+    entry.set = v;
+    return chain;
+  });
+  chain.where = vi.fn(() => chain);
+  chain.returning = vi.fn(() => nextStaged());
+  return chain;
+}
+
+function makeDeleteChain() {
+  calls.push({ kind: 'delete' });
+  const chain: Record<string, unknown> = {};
+  chain.where = vi.fn(() => chain);
+  chain.then = (resolve: (v: unknown) => unknown) => resolve(undefined);
+  return chain;
+}
+
 const selectFn = vi.fn(() => {
   calls.push({ kind: 'select' });
   return makeSelectChain();
 });
 const insertFn = vi.fn(() => makeInsertChain());
+const updateFn = vi.fn(() => makeUpdateChain());
+const deleteFn = vi.fn(() => makeDeleteChain());
 
 vi.mock('../db/index.js', () => ({
   db: {
     select: () => selectFn(),
     insert: () => insertFn(),
+    update: () => updateFn(),
+    delete: () => deleteFn(),
   },
   schema: {
     lemmas: { id: 'lemmas.id' },
@@ -89,9 +118,11 @@ vi.mock('../db/index.js', () => ({
 const {
   MAX_BODY_LEN,
   MAX_PER_USER_PER_WINDOW,
+  deleteUserTranslation,
   submitUserTranslation,
   TranslationRateLimitError,
   TranslationValidationError,
+  updateUserTranslation,
 } = await import('./translations.js');
 
 beforeEach(() => {
@@ -99,6 +130,8 @@ beforeEach(() => {
   staged.length = 0;
   selectFn.mockClear();
   insertFn.mockClear();
+  updateFn.mockClear();
+  deleteFn.mockClear();
 });
 
 afterEach(() => {
@@ -294,5 +327,145 @@ describe('submitUserTranslation — rate limiting', () => {
       expect(e.retryAfterSeconds).toBeGreaterThan(0);
       expect(e.limit).toBe(MAX_PER_USER_PER_WINDOW);
     }
+  });
+});
+
+describe('updateUserTranslation (T-3.5)', () => {
+  const ownRow = {
+    id: 'tr-1',
+    lemmaId: 'lemma-1',
+    source: 'user',
+    submittedBy: 'user-1',
+    parentTranslationId: null,
+    body: 'old body',
+    targetLanguage: 'en',
+    sourceAttribution: null,
+    sourceId: null,
+    hidden: false,
+    createdAt: new Date('2026-04-24'),
+    updatedAt: new Date('2026-04-24'),
+  };
+
+  it('updates the body for the author', async () => {
+    stageSelect([ownRow]);
+    stageSelect([{ ...ownRow, body: 'new body' }]); // update ... returning
+    const updated = await updateUserTranslation('user-1', 'tr-1', {
+      body: '  new   body  ',
+    });
+    expect(updated.body).toBe('new body');
+    const updateCall = calls.find((c) => c.kind === 'update');
+    expect(updateCall?.set).toMatchObject({ body: 'new body' });
+  });
+
+  it('rejects an empty body without touching the DB', async () => {
+    await expect(
+      updateUserTranslation('user-1', 'tr-1', { body: '   ' }),
+    ).rejects.toBeInstanceOf(TranslationValidationError);
+    expect(selectFn).not.toHaveBeenCalled();
+    expect(updateFn).not.toHaveBeenCalled();
+  });
+
+  it('rejects a body over MAX_BODY_LEN characters', async () => {
+    await expect(
+      updateUserTranslation('user-1', 'tr-1', { body: 'x'.repeat(MAX_BODY_LEN + 1) }),
+    ).rejects.toBeInstanceOf(TranslationValidationError);
+  });
+
+  it('returns 404 when the translation does not exist', async () => {
+    stageSelect([]);
+    try {
+      await updateUserTranslation('user-1', 'tr-missing', { body: 'x' });
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TranslationValidationError);
+      expect((err as InstanceType<typeof TranslationValidationError>).status).toBe(404);
+    }
+    expect(updateFn).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when the caller is not the author', async () => {
+    stageSelect([{ ...ownRow, submittedBy: 'someone-else' }]);
+    try {
+      await updateUserTranslation('user-1', 'tr-1', { body: 'x' });
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TranslationValidationError);
+      expect((err as InstanceType<typeof TranslationValidationError>).status).toBe(403);
+    }
+    expect(updateFn).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when the target row is an official translation', async () => {
+    stageSelect([{ ...ownRow, source: 'official_dictionary', submittedBy: null }]);
+    await expect(
+      updateUserTranslation('user-1', 'tr-1', { body: 'x' }),
+    ).rejects.toBeInstanceOf(TranslationValidationError);
+    expect(updateFn).not.toHaveBeenCalled();
+  });
+
+  it('sets updatedAt to the provided clock', async () => {
+    stageSelect([ownRow]);
+    stageSelect([{ ...ownRow, body: 'x' }]);
+    const t = new Date('2026-05-01T00:00:00Z');
+    await updateUserTranslation('user-1', 'tr-1', { body: 'x' }, t);
+    const updateCall = calls.find((c) => c.kind === 'update');
+    expect((updateCall?.set as { updatedAt: Date }).updatedAt).toBe(t);
+  });
+});
+
+describe('deleteUserTranslation (T-3.5)', () => {
+  const ownRow = {
+    id: 'tr-1',
+    lemmaId: 'lemma-1',
+    source: 'user',
+    submittedBy: 'user-1',
+    parentTranslationId: null,
+    body: 'gloss',
+    targetLanguage: 'en',
+    sourceAttribution: null,
+    sourceId: null,
+    hidden: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  it('deletes the row for the author', async () => {
+    stageSelect([ownRow]);
+    await expect(
+      deleteUserTranslation('user-1', 'tr-1'),
+    ).resolves.toBeUndefined();
+    expect(deleteFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 404 when the translation does not exist', async () => {
+    stageSelect([]);
+    try {
+      await deleteUserTranslation('user-1', 'tr-missing');
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TranslationValidationError);
+      expect((err as InstanceType<typeof TranslationValidationError>).status).toBe(404);
+    }
+    expect(deleteFn).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when the caller is not the author', async () => {
+    stageSelect([{ ...ownRow, submittedBy: 'someone-else' }]);
+    try {
+      await deleteUserTranslation('user-1', 'tr-1');
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TranslationValidationError);
+      expect((err as InstanceType<typeof TranslationValidationError>).status).toBe(403);
+    }
+    expect(deleteFn).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when the target row is an official translation', async () => {
+    stageSelect([{ ...ownRow, source: 'curator', submittedBy: 'curator-1' }]);
+    await expect(
+      deleteUserTranslation('user-1', 'tr-1'),
+    ).rejects.toBeInstanceOf(TranslationValidationError);
+    expect(deleteFn).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/server/dictionary/translations.ts
+++ b/apps/web/src/lib/server/dictionary/translations.ts
@@ -41,7 +41,7 @@ export type SubmitTranslationInput = {
 export class TranslationValidationError extends Error {
   constructor(
     message: string,
-    public readonly status: 400 | 404 | 409 = 400,
+    public readonly status: 400 | 403 | 404 | 409 = 400,
   ) {
     super(message);
     this.name = 'TranslationValidationError';
@@ -175,6 +175,92 @@ export async function submitUserTranslation(
     .returning();
   if (!row) throw new Error('Failed to insert translation');
   return row as Translation;
+}
+
+/**
+ * Edit the body of one of the caller's own user-submitted translations
+ * (T-3.5). Guards:
+ *   - Row must exist.
+ *   - Row must have `source='user'` (we never mutate officials in-place —
+ *     those go through the curator dictionary editor instead).
+ *   - Row's `submittedBy` must match the caller.
+ *   - New body must pass the same validation as a fresh submit.
+ *
+ * Not rate-limited: edits are cheap, and the real abuse vector (spam)
+ * is already bounded at create time.
+ */
+export async function updateUserTranslation(
+  userId: string,
+  translationId: string,
+  patch: { body: string },
+  now: Date = new Date(),
+): Promise<Translation> {
+  const body = normalizeBody(patch.body ?? '');
+  if (body.length === 0) {
+    throw new TranslationValidationError('Translation body cannot be empty');
+  }
+  if (body.length > MAX_BODY_LEN) {
+    throw new TranslationValidationError(
+      `Translation body exceeds ${MAX_BODY_LEN} characters`,
+    );
+  }
+  const [existing] = await db
+    .select()
+    .from(schema.translations)
+    .where(eq(schema.translations.id, translationId))
+    .limit(1);
+  if (!existing) {
+    throw new TranslationValidationError(
+      `Translation ${translationId} not found`,
+      404,
+    );
+  }
+  const row = existing as Translation;
+  if (row.source !== 'user' || row.submittedBy !== userId) {
+    throw new TranslationValidationError(
+      'You can only edit your own translations',
+      403,
+    );
+  }
+  const [updated] = await db
+    .update(schema.translations)
+    .set({ body, updatedAt: now })
+    .where(eq(schema.translations.id, translationId))
+    .returning();
+  if (!updated) throw new Error('Failed to update translation');
+  return updated as Translation;
+}
+
+/**
+ * Hard-delete one of the caller's own user-submitted translations
+ * (T-3.5). Curator/admin moderation uses `hidden=true` instead so the
+ * audit trail survives; the author themselves can just remove the row.
+ */
+export async function deleteUserTranslation(
+  userId: string,
+  translationId: string,
+): Promise<void> {
+  const [existing] = await db
+    .select()
+    .from(schema.translations)
+    .where(eq(schema.translations.id, translationId))
+    .limit(1);
+  if (!existing) {
+    throw new TranslationValidationError(
+      `Translation ${translationId} not found`,
+      404,
+    );
+  }
+  const row = existing as Translation;
+  if (row.source !== 'user' || row.submittedBy !== userId) {
+    throw new TranslationValidationError(
+      'You can only delete your own translations',
+      403,
+    );
+  }
+  await db
+    .delete(schema.translations)
+    .where(eq(schema.translations.id, translationId));
 }
 
 export function publicTranslation(row: Translation) {

--- a/apps/web/src/routes/api/v1/translations/[id]/+server.ts
+++ b/apps/web/src/routes/api/v1/translations/[id]/+server.ts
@@ -1,0 +1,59 @@
+/**
+ * PATCH + DELETE /api/v1/translations/:id (T-3.5).
+ *
+ * The author of a user-submitted translation can edit or delete it
+ * here. Officials are untouchable via this route — those go through
+ * the curator dictionary editor (T-3.7). Hiding a community translation
+ * is a moderator action and lives separately.
+ */
+import { error, json } from '@sveltejs/kit';
+import { z } from 'zod';
+
+import { requireUser } from '$lib/server/auth/require-user.js';
+import {
+  deleteUserTranslation,
+  publicTranslation,
+  TranslationValidationError,
+  updateUserTranslation,
+} from '$lib/server/dictionary/translations.js';
+import type { RequestHandler } from './$types';
+import { parseJson } from '../../auth/_helpers.js';
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const patchBody = z.object({
+  body: z.string(),
+});
+
+function mapTranslationError(err: unknown): never {
+  if (err instanceof TranslationValidationError) {
+    throw error(err.status, err.message);
+  }
+  throw err;
+}
+
+export const PATCH: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  const id = event.params.id;
+  if (!id || !UUID_RE.test(id)) throw error(400, 'Invalid translation id');
+  const input = await parseJson(event.request, patchBody);
+  try {
+    const updated = await updateUserTranslation(user.id, id, input);
+    return json({ translation: publicTranslation(updated) });
+  } catch (err) {
+    mapTranslationError(err);
+  }
+};
+
+export const DELETE: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  const id = event.params.id;
+  if (!id || !UUID_RE.test(id)) throw error(400, 'Invalid translation id');
+  try {
+    await deleteUserTranslation(user.id, id);
+    return new Response(null, { status: 204 });
+  } catch (err) {
+    mapTranslationError(err);
+  }
+};

--- a/apps/web/src/routes/api/v1/translations/[id]/translation-id-server.test.ts
+++ b/apps/web/src/routes/api/v1/translations/[id]/translation-id-server.test.ts
@@ -1,0 +1,220 @@
+// @vitest-environment node
+/**
+ * Route tests for PATCH + DELETE /api/v1/translations/:id (T-3.5).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const updateUserTranslation = vi.fn();
+const deleteUserTranslation = vi.fn();
+const requireUser = vi.fn();
+
+vi.mock('$lib/server/dictionary/translations.js', async () => {
+  const actual = await vi.importActual<
+    typeof import('$lib/server/dictionary/translations.js')
+  >('$lib/server/dictionary/translations.js');
+  return {
+    ...actual,
+    updateUserTranslation: (...a: unknown[]) => updateUserTranslation(...a),
+    deleteUserTranslation: (...a: unknown[]) => deleteUserTranslation(...a),
+  };
+});
+
+vi.mock('$lib/server/auth/require-user.js', () => ({
+  requireUser: (...a: unknown[]) => requireUser(...a),
+}));
+
+type PatchFn = (typeof import('./+server.js'))['PATCH'];
+type DeleteFn = (typeof import('./+server.js'))['DELETE'];
+type PatchEvent = Parameters<PatchFn>[0];
+type DeleteEvent = Parameters<DeleteFn>[0];
+
+const VALID_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+
+async function callPatch(
+  body: unknown,
+  user: { id: string } | null = { id: 'user-1' },
+  id = VALID_ID,
+) {
+  if (user) {
+    requireUser.mockResolvedValueOnce(user);
+  } else {
+    requireUser.mockImplementationOnce(() => {
+      throw Object.assign(new Error('Unauthorized'), { status: 401 });
+    });
+  }
+  const { PATCH } = await import('./+server.js');
+  const event = {
+    params: { id },
+    request: new Request(`http://x/api/v1/translations/${id}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+  } as unknown as PatchEvent;
+  try {
+    return await PATCH(event);
+  } catch (e) {
+    return e as { status: number };
+  }
+}
+
+async function callDelete(
+  user: { id: string } | null = { id: 'user-1' },
+  id = VALID_ID,
+) {
+  if (user) {
+    requireUser.mockResolvedValueOnce(user);
+  } else {
+    requireUser.mockImplementationOnce(() => {
+      throw Object.assign(new Error('Unauthorized'), { status: 401 });
+    });
+  }
+  const { DELETE } = await import('./+server.js');
+  const event = {
+    params: { id },
+    request: new Request(`http://x/api/v1/translations/${id}`, {
+      method: 'DELETE',
+    }),
+  } as unknown as DeleteEvent;
+  try {
+    return await DELETE(event);
+  } catch (e) {
+    return e as { status: number };
+  }
+}
+
+beforeEach(() => {
+  updateUserTranslation.mockReset();
+  deleteUserTranslation.mockReset();
+  requireUser.mockReset();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('PATCH /api/v1/translations/:id', () => {
+  it('returns 200 with the public translation on success', async () => {
+    updateUserTranslation.mockResolvedValueOnce({
+      id: VALID_ID,
+      lemmaId: 'lemma-1',
+      source: 'user',
+      submittedBy: 'user-1',
+      parentTranslationId: null,
+      body: 'new gloss',
+      targetLanguage: 'en',
+      sourceAttribution: null,
+      sourceId: null,
+      hidden: false,
+      createdAt: new Date('2026-04-24'),
+      updatedAt: new Date('2026-04-24'),
+    });
+    const res = (await callPatch({ body: 'new gloss' })) as Response;
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.translation.body).toBe('new gloss');
+    expect(updateUserTranslation).toHaveBeenCalledWith('user-1', VALID_ID, {
+      body: 'new gloss',
+    });
+  });
+
+  it('returns 401 when not logged in', async () => {
+    const res = (await callPatch({ body: 'x' }, null)) as { status: number };
+    expect(res.status).toBe(401);
+    expect(updateUserTranslation).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a malformed UUID', async () => {
+    const res = (await callPatch(
+      { body: 'x' },
+      { id: 'user-1' },
+      'not-a-uuid',
+    )) as { status: number };
+    expect(res.status).toBe(400);
+    expect(updateUserTranslation).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when the body is missing from the request', async () => {
+    const res = (await callPatch({})) as { status: number };
+    expect(res.status).toBe(400);
+    expect(updateUserTranslation).not.toHaveBeenCalled();
+  });
+
+  it('maps TranslationValidationError(403) to a 403 response', async () => {
+    const { TranslationValidationError } = await import(
+      '$lib/server/dictionary/translations.js'
+    );
+    updateUserTranslation.mockRejectedValueOnce(
+      new TranslationValidationError('You can only edit your own translations', 403),
+    );
+    const res = (await callPatch({ body: 'x' })) as { status: number };
+    expect(res.status).toBe(403);
+  });
+
+  it('maps TranslationValidationError(404) to a 404 response', async () => {
+    const { TranslationValidationError } = await import(
+      '$lib/server/dictionary/translations.js'
+    );
+    updateUserTranslation.mockRejectedValueOnce(
+      new TranslationValidationError('not found', 404),
+    );
+    const res = (await callPatch({ body: 'x' })) as { status: number };
+    expect(res.status).toBe(404);
+  });
+
+  it('maps validation failures (empty body) to 400', async () => {
+    const { TranslationValidationError } = await import(
+      '$lib/server/dictionary/translations.js'
+    );
+    updateUserTranslation.mockRejectedValueOnce(
+      new TranslationValidationError('Translation body cannot be empty'),
+    );
+    const res = (await callPatch({ body: '' })) as { status: number };
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('DELETE /api/v1/translations/:id', () => {
+  it('returns 204 on successful delete', async () => {
+    deleteUserTranslation.mockResolvedValueOnce(undefined);
+    const res = (await callDelete()) as Response;
+    expect(res.status).toBe(204);
+    expect(deleteUserTranslation).toHaveBeenCalledWith('user-1', VALID_ID);
+  });
+
+  it('returns 401 when not logged in', async () => {
+    const res = (await callDelete(null)) as { status: number };
+    expect(res.status).toBe(401);
+    expect(deleteUserTranslation).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a malformed UUID', async () => {
+    const res = (await callDelete({ id: 'user-1' }, 'nope')) as {
+      status: number;
+    };
+    expect(res.status).toBe(400);
+    expect(deleteUserTranslation).not.toHaveBeenCalled();
+  });
+
+  it('maps TranslationValidationError(403) to a 403 response', async () => {
+    const { TranslationValidationError } = await import(
+      '$lib/server/dictionary/translations.js'
+    );
+    deleteUserTranslation.mockRejectedValueOnce(
+      new TranslationValidationError('not yours', 403),
+    );
+    const res = (await callDelete()) as { status: number };
+    expect(res.status).toBe(403);
+  });
+
+  it('maps TranslationValidationError(404) to a 404 response', async () => {
+    const { TranslationValidationError } = await import(
+      '$lib/server/dictionary/translations.js'
+    );
+    deleteUserTranslation.mockRejectedValueOnce(
+      new TranslationValidationError('not found', 404),
+    );
+    const res = (await callDelete()) as { status: number };
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds \`updateUserTranslation\` + \`deleteUserTranslation\` service methods.
- Adds PATCH + DELETE \`/api/v1/translations/:id\` so the author of a user-submitted translation can edit the body or remove the row.
- The fork/customize step itself (create a user-owned translation with \`parentTranslationId\` set) already works via T-3.2's POST; T-3.5 closes the loop by letting the fork stay editable afterwards.

## Ownership rules
- \`source\` must be \`'user'\` and \`submittedBy\` must match the caller — otherwise 403.
- Curator edits to officials still go through the dictionary editor (T-3.7), not here.
- Hiding a community row stays a moderator action, not a user-deletable one.

## Test plan
- [x] \`pnpm typecheck\` / \`pnpm lint\` — clean
- [x] \`pnpm test\` — 218 pass (14 new: 11 service-level, 13 endpoint)
- [x] \`pnpm test:coverage\` — \`translations.ts\`: 100% stmts, 91.8% branches