### PR TITLE
T-3.7: curator dictionary editor + merge/split + moderation UI

### DIFF
--- a/apps/web/drizzle/0005_powerful_lady_bullseye.sql
+++ b/apps/web/drizzle/0005_powerful_lady_bullseye.sql
@@ -1,0 +1,2 @@
+ALTER TYPE "public"."lemma_edit_change_type" ADD VALUE 'lemma_merge';--> statement-breakpoint
+ALTER TYPE "public"."lemma_edit_change_type" ADD VALUE 'lemma_split';

--- a/apps/web/drizzle/meta/0005_snapshot.json
+++ b/apps/web/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,1374 @@
+{
+  "id": "8fbc7081-12d4-4469-8d40-9327ade2045b",
+  "prevId": "d10173e6-e02a-4a7e-b166-8f13b46cfd36",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.curator_languages": {
+      "name": "curator_languages",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "curator_languages_user_idx": {
+          "name": "curator_languages_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "curator_languages_user_id_users_id_fk": {
+          "name": "curator_languages_user_id_users_id_fk",
+          "tableFrom": "curator_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "curator_languages_granted_by_users_id_fk": {
+          "name": "curator_languages_granted_by_users_id_fk",
+          "tableFrom": "curator_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "curator_languages_user_id_language_pk": {
+          "name": "curator_languages_user_id_language_pk",
+          "columns": [
+            "user_id",
+            "language"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.dictionary_imports": {
+      "name": "dictionary_imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_name": {
+          "name": "source_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_at": {
+          "name": "run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lemmas_created": {
+          "name": "lemmas_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lemmas_updated": {
+          "name": "lemmas_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lemmas_skipped_curator_locked": {
+          "name": "lemmas_skipped_curator_locked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "translations_created": {
+          "name": "translations_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "translations_updated": {
+          "name": "translations_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "dictionary_imports_language_idx": {
+          "name": "dictionary_imports_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemma_edit_history": {
+      "name": "lemma_edit_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "editor_id": {
+          "name": "editor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "lemma_edit_change_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change": {
+          "name": "change",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_edit_history_lemma_idx": {
+          "name": "lemma_edit_history_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_edit_history_editor_idx": {
+          "name": "lemma_edit_history_editor_idx",
+          "columns": [
+            {
+              "expression": "editor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_edit_history_lemma_id_lemmas_id_fk": {
+          "name": "lemma_edit_history_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_edit_history",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lemma_edit_history_editor_id_users_id_fk": {
+          "name": "lemma_edit_history_editor_id_users_id_fk",
+          "tableFrom": "lemma_edit_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "editor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemma_forms": {
+      "name": "lemma_forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "romanization": {
+          "name": "romanization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_forms_lemma_idx": {
+          "name": "lemma_forms_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_forms_surface_idx": {
+          "name": "lemma_forms_surface_idx",
+          "columns": [
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_forms_lemma_id_lemmas_id_fk": {
+          "name": "lemma_forms_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_forms",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemmas": {
+      "name": "lemmas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headword": {
+          "name": "headword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos": {
+          "name": "pos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script": {
+          "name": "script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gloss_default": {
+          "name": "gloss_default",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_rank": {
+          "name": "frequency_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "translation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "curator_locked": {
+          "name": "curator_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemmas_language_idx": {
+          "name": "lemmas_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_language_frequency_idx": {
+          "name": "lemmas_language_frequency_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "frequency_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_source_lookup_idx": {
+          "name": "lemmas_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lemmas_language_headword_pos_uq": {
+          "name": "lemmas_language_headword_pos_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "language",
+            "headword",
+            "pos"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.magic_links": {
+      "name": "magic_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "magic_links_user_idx": {
+          "name": "magic_links_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "magic_links_expires_idx": {
+          "name": "magic_links_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "magic_links_user_id_users_id_fk": {
+          "name": "magic_links_user_id_users_id_fk",
+          "tableFrom": "magic_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by": {
+          "name": "replaced_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "refresh_tokens_user_idx": {
+          "name": "refresh_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_expires_idx": {
+          "name": "refresh_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.translations": {
+      "name": "translations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "translation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_translation_id": {
+          "name": "parent_translation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_language": {
+          "name": "target_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "translations_lemma_idx": {
+          "name": "translations_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translations_submitted_by_idx": {
+          "name": "translations_submitted_by_idx",
+          "columns": [
+            {
+              "expression": "submitted_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translations_source_lookup_idx": {
+          "name": "translations_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "translations_lemma_id_lemmas_id_fk": {
+          "name": "translations_lemma_id_lemmas_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "translations_submitted_by_users_id_fk": {
+          "name": "translations_submitted_by_users_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "translations_parent_translation_id_translations_id_fk": {
+          "name": "translations_parent_translation_id_translations_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "translations",
+          "columnsFrom": [
+            "parent_translation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_languages": {
+      "name": "user_languages",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script_preference": {
+          "name": "script_preference",
+          "type": "script_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "romanization_scheme": {
+          "name": "romanization_scheme",
+          "type": "romanization_scheme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'iso15919'"
+        },
+        "known_words_count_cache": {
+          "name": "known_words_count_cache",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reader_layout_mode": {
+          "name": "reader_layout_mode",
+          "type": "reader_layout_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'page'"
+        },
+        "words_per_page": {
+          "name": "words_per_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 250
+        },
+        "font_family": {
+          "name": "font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_size": {
+          "name": "font_size",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 18
+        },
+        "line_spacing": {
+          "name": "line_spacing",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1.6
+        },
+        "highlight_style": {
+          "name": "highlight_style",
+          "type": "highlight_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'background'"
+        },
+        "baseline": {
+          "name": "baseline",
+          "type": "language_baseline",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_languages_user_id_users_id_fk": {
+          "name": "user_languages_user_id_users_id_fk",
+          "tableFrom": "user_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_languages_user_id_language_pk": {
+          "name": "user_languages_user_id_language_pk",
+          "columns": [
+            "user_id",
+            "language"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_preference": {
+          "name": "theme_preference",
+          "type": "theme_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarded_at": {
+          "name": "onboarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    }
+  },
+  "enums": {
+    "public.highlight_style": {
+      "name": "highlight_style",
+      "schema": "public",
+      "values": [
+        "underline",
+        "background",
+        "colored_text"
+      ]
+    },
+    "public.language": {
+      "name": "language",
+      "schema": "public",
+      "values": [
+        "hi",
+        "mr",
+        "or"
+      ]
+    },
+    "public.language_baseline": {
+      "name": "language_baseline",
+      "schema": "public",
+      "values": [
+        "none",
+        "beginner",
+        "intermediate"
+      ]
+    },
+    "public.lemma_edit_change_type": {
+      "name": "lemma_edit_change_type",
+      "schema": "public",
+      "values": [
+        "lemma_update",
+        "lemma_unlock",
+        "lemma_lock",
+        "translation_insert",
+        "translation_update",
+        "translation_hide",
+        "translation_unhide",
+        "form_insert",
+        "form_delete",
+        "lemma_merge",
+        "lemma_split"
+      ]
+    },
+    "public.reader_layout_mode": {
+      "name": "reader_layout_mode",
+      "schema": "public",
+      "values": [
+        "page",
+        "paged_scroll",
+        "continuous"
+      ]
+    },
+    "public.romanization_scheme": {
+      "name": "romanization_scheme",
+      "schema": "public",
+      "values": [
+        "iso15919",
+        "iast",
+        "hunterian",
+        "itrans"
+      ]
+    },
+    "public.script_preference": {
+      "name": "script_preference",
+      "schema": "public",
+      "values": [
+        "native",
+        "native_with_romanization",
+        "romanization_only"
+      ]
+    },
+    "public.theme_preference": {
+      "name": "theme_preference",
+      "schema": "public",
+      "values": [
+        "system",
+        "light",
+        "dark"
+      ]
+    },
+    "public.translation_source": {
+      "name": "translation_source",
+      "schema": "public",
+      "values": [
+        "official_dictionary",
+        "curator",
+        "user"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "curator",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1777008698995,
       "tag": "0004_fancy_siren",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1777010005356,
+      "tag": "0005_powerful_lady_bullseye",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/src/lib/server/db/schema.ts
+++ b/apps/web/src/lib/server/db/schema.ts
@@ -380,6 +380,12 @@ export const lemmaEditChangeType = pgEnum('lemma_edit_change_type', [
   'translation_unhide',
   'form_insert',
   'form_delete',
+  // T-3.7: merge and split write to the history of *both* lemmas so the
+  // timeline is complete from either side. `change` carries a full
+  // snapshot of the loser (for merge) or of the translations/forms that
+  // moved (for split), so a revert has enough information to reconstruct.
+  'lemma_merge',
+  'lemma_split',
 ]);
 
 export const lemmaEditHistory = pgTable(
@@ -402,15 +408,42 @@ export const lemmaEditHistory = pgTable(
 );
 
 /**
- * JSON shape written into `lemma_edit_history.change`. We keep this as a
- * single type so the revert logic in T-3.7 has one discriminated union
- * to switch on rather than a grab-bag of optional fields.
+ * JSON shape written into `lemma_edit_history.change`. Kept as an open
+ * record so merge/split (T-3.7) can store richer payloads without a
+ * schema migration — the revert logic in the UI discriminates on
+ * `change_type` and knows which fields to expect per type.
+ *
+ * Common fields:
+ *   - `before` / `after`: lemma or translation snapshots for diff view.
+ *   - `translationId` / `formId`: set when the edit targets a specific
+ *     child row.
+ *
+ * Merge-specific (`change_type = 'lemma_merge'`):
+ *   - `direction`: 'winner' | 'loser' (audit is written under both).
+ *   - On the winner row: `mergedFrom` (loser snapshot),
+ *     `translationsMoved`, `formsMoved` (full snapshots).
+ *   - On the loser row: `translationIds`, `formIds` (ids only, for
+ *     backlinks).
+ *
+ * Split-specific (`change_type = 'lemma_split'`):
+ *   - `direction`: 'source' | 'created'.
+ *   - On the source row: `splitInto` (snapshot of the newly created
+ *     lemma), plus the moved `translationIds` / `formIds`.
+ *   - On the created row: `splitFrom` (snapshot of the source lemma).
  */
 export type LemmaEditChangePayload = {
   before?: Record<string, unknown> | null;
   after?: Record<string, unknown> | null;
   translationId?: string;
   formId?: string;
+  translationIds?: string[];
+  formIds?: string[];
+  translationsMoved?: Array<Record<string, unknown>>;
+  formsMoved?: Array<Record<string, unknown>>;
+  mergedFrom?: Record<string, unknown>;
+  splitInto?: Record<string, unknown>;
+  splitFrom?: Record<string, unknown>;
+  direction?: 'winner' | 'loser' | 'source' | 'created';
 };
 
 export type User = InferSelectModel<typeof users>;

--- a/apps/web/src/lib/server/dictionary/curator.test.ts
+++ b/apps/web/src/lib/server/dictionary/curator.test.ts
@@ -1,0 +1,570 @@
+// @vitest-environment node
+/**
+ * Unit tests for the curator dictionary editor service (T-3.7).
+ *
+ * The service issues a consistent pattern of DB calls per mutator:
+ *   1. SELECT the target lemma (loadLemma) — always first.
+ *   2. Permission check (may hit DB for non-admin curators via
+ *      requireCanEditDictionary; admins short-circuit).
+ *   3. The actual UPDATE/INSERT/DELETE.
+ *   4. INSERT into lemma_edit_history via recordLemmaEdit.
+ *
+ * We stage each SELECT's rows in order and assert the written payloads
+ * via a `calls` log. Admin editors skip the permission-check SELECT.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Call =
+  | { kind: 'select' }
+  | { kind: 'update'; set?: unknown }
+  | { kind: 'insert'; values?: unknown }
+  | { kind: 'delete' };
+const calls: Call[] = [];
+
+const staged: Array<unknown[]> = [];
+function stage(rows: unknown[]) {
+  staged.push(rows);
+}
+function nextStaged(): unknown[] {
+  const v = staged.shift();
+  if (!v) throw new Error('Test bug: no staged result available');
+  return v;
+}
+
+function makeSelectChain() {
+  const chain: Record<string, unknown> = {};
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.limit = vi.fn(() => chain);
+  chain.orderBy = vi.fn(() => chain);
+  chain.then = (resolve: (v: unknown) => unknown) => resolve(nextStaged());
+  return chain;
+}
+
+function makeUpdateChain() {
+  const entry: Call = { kind: 'update' };
+  calls.push(entry);
+  const chain: Record<string, unknown> = {};
+  chain.set = vi.fn((v: unknown) => {
+    entry.set = v;
+    return chain;
+  });
+  chain.where = vi.fn(() => chain);
+  chain.returning = vi.fn(() => nextStaged());
+  // Support updates without .returning() (rewires in merge/split).
+  chain.then = (resolve: (v: unknown) => unknown) => resolve(undefined);
+  return chain;
+}
+
+function makeInsertChain() {
+  const entry: Call = { kind: 'insert' };
+  calls.push(entry);
+  const chain: Record<string, unknown> = {};
+  chain.values = vi.fn((v: unknown) => {
+    entry.values = v;
+    return chain;
+  });
+  chain.returning = vi.fn(() => nextStaged());
+  chain.then = (resolve: (v: unknown) => unknown) => resolve(undefined);
+  return chain;
+}
+
+function makeDeleteChain() {
+  calls.push({ kind: 'delete' });
+  const chain: Record<string, unknown> = {};
+  chain.where = vi.fn(() => chain);
+  chain.then = (resolve: (v: unknown) => unknown) => resolve(undefined);
+  return chain;
+}
+
+const selectFn = vi.fn(() => {
+  calls.push({ kind: 'select' });
+  return makeSelectChain();
+});
+const updateFn = vi.fn(() => makeUpdateChain());
+const insertFn = vi.fn(() => makeInsertChain());
+const deleteFn = vi.fn(() => makeDeleteChain());
+
+vi.mock('../db/index.js', () => ({
+  db: {
+    select: () => selectFn(),
+    update: () => updateFn(),
+    insert: () => insertFn(),
+    delete: () => deleteFn(),
+  },
+  schema: {
+    lemmas: { id: 'lemmas.id', language: 'lemmas.language' },
+    translations: {
+      id: 'translations.id',
+      lemmaId: 'translations.lemma_id',
+    },
+    lemmaForms: {
+      id: 'lemma_forms.id',
+      lemmaId: 'lemma_forms.lemma_id',
+    },
+    lemmaEditHistory: {
+      id: 'lemma_edit_history.id',
+      lemmaId: 'lemma_edit_history.lemma_id',
+      editorId: 'lemma_edit_history.editor_id',
+      changeType: 'lemma_edit_history.change_type',
+      reason: 'lemma_edit_history.reason',
+      createdAt: 'lemma_edit_history.created_at',
+    },
+    curatorLanguages: {
+      userId: 'curator_languages.user_id',
+      language: 'curator_languages.language',
+    },
+  },
+}));
+
+const {
+  CuratorValidationError,
+  getLemmaEditorView,
+  mergeLemmas,
+  setLemmaLock,
+  setTranslationHidden,
+  splitLemma,
+  updateLemma,
+  updateTranslation,
+} = await import('./curator.js');
+
+const { MissingReasonError } = await import('./audit.js');
+const { ForbiddenError } = await import('./permissions.js');
+
+const ADMIN = { id: 'admin-1', role: 'admin' as const };
+
+function lemmaRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'lemma-1',
+    language: 'hi',
+    headword: 'बोलना',
+    pos: 'verb',
+    script: 'Deva',
+    glossDefault: 'to speak',
+    frequencyRank: 42,
+    source: 'official_dictionary',
+    sourceAttribution: 'Hindi WordNet',
+    sourceId: 'hwn:12345',
+    curatorLocked: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function translationRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'tr-1',
+    lemmaId: 'lemma-1',
+    source: 'user',
+    submittedBy: 'user-42',
+    parentTranslationId: null,
+    body: 'to speak',
+    targetLanguage: 'en',
+    sourceAttribution: null,
+    sourceId: null,
+    hidden: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  calls.length = 0;
+  staged.length = 0;
+  selectFn.mockClear();
+  updateFn.mockClear();
+  insertFn.mockClear();
+  deleteFn.mockClear();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// -----------------------------------------------------------------------
+// updateLemma
+// -----------------------------------------------------------------------
+
+describe('updateLemma', () => {
+  it('rejects an empty reason (via MissingReasonError on audit)', async () => {
+    stage([lemmaRow()]); // loadLemma
+    stage([{ ...lemmaRow(), glossDefault: 'updated' }]); // update .returning
+    await expect(
+      updateLemma(ADMIN, 'lemma-1', { glossDefault: 'updated' }, '  '),
+    ).rejects.toBeInstanceOf(MissingReasonError);
+  });
+
+  it('returns 404 when the lemma does not exist', async () => {
+    stage([]); // loadLemma -> empty
+    await expect(
+      updateLemma(ADMIN, 'missing', { glossDefault: 'x' }, 'typo fix'),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('rejects a non-curator non-admin', async () => {
+    stage([lemmaRow()]); // loadLemma
+    stage([]); // permission check: no curator_languages row
+    await expect(
+      updateLemma(
+        { id: 'plain', role: 'user' },
+        'lemma-1',
+        { glossDefault: 'x' },
+        'typo fix',
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenError);
+  });
+
+  it('normalizes headword, locks the row, and records a diff', async () => {
+    stage([lemmaRow()]); // loadLemma
+    const updated = {
+      ...lemmaRow(),
+      headword: 'बोलना',
+      glossDefault: 'to say',
+      curatorLocked: true,
+    };
+    stage([updated]); // .returning from update
+    stage([{ id: 'hist-1' }]); // insert history .returning
+
+    const row = await updateLemma(
+      ADMIN,
+      'lemma-1',
+      { headword: '  बोलना  ', glossDefault: 'to say' },
+      'Reword the gloss to match the canonical register',
+    );
+    expect(row.glossDefault).toBe('to say');
+
+    const updCall = calls.find(
+      (c): c is Extract<Call, { kind: 'update' }> => c.kind === 'update',
+    );
+    expect(updCall?.set).toMatchObject({
+      headword: 'बोलना',
+      glossDefault: 'to say',
+      curatorLocked: true,
+    });
+    const histInsert = calls.find(
+      (c): c is Extract<Call, { kind: 'insert' }> =>
+        c.kind === 'insert' &&
+        (c.values as { changeType?: string } | undefined)?.changeType ===
+          'lemma_update',
+    );
+    expect(histInsert).toBeDefined();
+  });
+
+  it('rejects a negative frequencyRank', async () => {
+    await expect(
+      updateLemma(ADMIN, 'lemma-1', { frequencyRank: -1 }, 'typo fix'),
+    ).rejects.toBeInstanceOf(CuratorValidationError);
+  });
+
+  it('rejects a malformed ISO 15924 script', async () => {
+    await expect(
+      updateLemma(ADMIN, 'lemma-1', { script: 'deva' }, 'typo fix'),
+    ).rejects.toBeInstanceOf(CuratorValidationError);
+  });
+});
+
+// -----------------------------------------------------------------------
+// setLemmaLock
+// -----------------------------------------------------------------------
+
+describe('setLemmaLock', () => {
+  it('is a no-op when the flag already matches', async () => {
+    stage([lemmaRow({ curatorLocked: true })]); // loadLemma
+    const row = await setLemmaLock(ADMIN, 'lemma-1', true, 'reason noop');
+    expect(row.curatorLocked).toBe(true);
+    expect(calls.find((c) => c.kind === 'update')).toBeUndefined();
+  });
+
+  it('writes lemma_unlock audit when unlocking', async () => {
+    stage([lemmaRow({ curatorLocked: true })]);
+    stage([lemmaRow({ curatorLocked: false })]);
+    stage([{ id: 'hist-1' }]);
+    await setLemmaLock(ADMIN, 'lemma-1', false, 'Re-open for fresh import');
+    const histInsert = calls.find(
+      (c): c is Extract<Call, { kind: 'insert' }> =>
+        c.kind === 'insert' &&
+        (c.values as { changeType?: string } | undefined)?.changeType ===
+          'lemma_unlock',
+    );
+    expect(histInsert).toBeDefined();
+  });
+});
+
+// -----------------------------------------------------------------------
+// updateTranslation
+// -----------------------------------------------------------------------
+
+describe('updateTranslation', () => {
+  it('promotes a user translation to curator and audits it', async () => {
+    stage([translationRow()]); // loadTranslation
+    stage([lemmaRow()]); // loadLemma via parent
+    const updated = { ...translationRow(), source: 'curator', body: 'to speak' };
+    stage([updated]); // update returning
+    stage([{ id: 'hist-1' }]);
+
+    const row = await updateTranslation(
+      ADMIN,
+      'tr-1',
+      { promoteToCurator: true },
+      'Endorsing a strong community gloss',
+    );
+    expect(row.source).toBe('curator');
+    const updCall = calls.find(
+      (c): c is Extract<Call, { kind: 'update' }> => c.kind === 'update',
+    );
+    expect(updCall?.set).toMatchObject({ source: 'curator' });
+  });
+
+  it('refuses to re-tag an imported official translation as curator', async () => {
+    stage([translationRow({ source: 'official_dictionary' })]);
+    stage([lemmaRow()]);
+    await expect(
+      updateTranslation(
+        ADMIN,
+        'tr-1',
+        { promoteToCurator: true },
+        'trying to re-tag',
+      ),
+    ).rejects.toMatchObject({ status: 409 });
+  });
+
+  it('validates the body length', async () => {
+    await expect(
+      updateTranslation(
+        ADMIN,
+        'tr-1',
+        { body: 'x'.repeat(600) },
+        'too long',
+      ),
+    ).rejects.toBeInstanceOf(CuratorValidationError);
+  });
+});
+
+// -----------------------------------------------------------------------
+// setTranslationHidden
+// -----------------------------------------------------------------------
+
+describe('setTranslationHidden', () => {
+  it('refuses to hide a non-community translation', async () => {
+    stage([translationRow({ source: 'curator' })]);
+    stage([lemmaRow()]);
+    await expect(
+      setTranslationHidden(ADMIN, 'tr-1', true, 'abuse'),
+    ).rejects.toMatchObject({ status: 409 });
+  });
+
+  it('hides a community translation and audits it', async () => {
+    stage([translationRow()]);
+    stage([lemmaRow()]);
+    stage([translationRow({ hidden: true })]);
+    stage([{ id: 'hist-1' }]);
+
+    await setTranslationHidden(ADMIN, 'tr-1', true, 'Spam submission');
+    const histInsert = calls.find(
+      (c): c is Extract<Call, { kind: 'insert' }> =>
+        c.kind === 'insert' &&
+        (c.values as { changeType?: string } | undefined)?.changeType ===
+          'translation_hide',
+    );
+    expect(histInsert).toBeDefined();
+  });
+
+  it('is a no-op when the flag already matches', async () => {
+    stage([translationRow({ hidden: true })]);
+    stage([lemmaRow()]);
+    const row = await setTranslationHidden(
+      ADMIN,
+      'tr-1',
+      true,
+      'already hidden',
+    );
+    expect(row.hidden).toBe(true);
+    expect(calls.find((c) => c.kind === 'update')).toBeUndefined();
+  });
+});
+
+// -----------------------------------------------------------------------
+// mergeLemmas
+// -----------------------------------------------------------------------
+
+describe('mergeLemmas', () => {
+  it('rejects merging a lemma into itself', async () => {
+    await expect(
+      mergeLemmas(
+        ADMIN,
+        { winnerId: 'lemma-1', loserId: 'lemma-1' },
+        'selfsame',
+      ),
+    ).rejects.toBeInstanceOf(CuratorValidationError);
+  });
+
+  it('rejects a cross-language merge', async () => {
+    stage([lemmaRow({ id: 'lemma-1', language: 'hi' })]); // winner load
+    stage([lemmaRow({ id: 'lemma-2', language: 'mr' })]); // loser load
+    await expect(
+      mergeLemmas(
+        ADMIN,
+        { winnerId: 'lemma-1', loserId: 'lemma-2' },
+        'cross lang mistake',
+      ),
+    ).rejects.toMatchObject({ status: 409 });
+  });
+
+  it('rewires translations + forms, deletes the loser, and audits both sides', async () => {
+    stage([lemmaRow({ id: 'lemma-1' })]); // winner
+    stage([lemmaRow({ id: 'lemma-2', headword: 'बोल' })]); // loser
+    stage([translationRow({ id: 'tr-1', lemmaId: 'lemma-2' })]); // loser translations
+    stage([{ id: 'form-1', lemmaId: 'lemma-2', surface: 'bola' }]); // loser forms
+    stage([{ id: 'hist-loser' }]); // audit loser insert
+    stage([{ id: 'hist-winner' }]); // audit winner insert
+
+    const result = await mergeLemmas(
+      ADMIN,
+      { winnerId: 'lemma-1', loserId: 'lemma-2' },
+      'Duplicate import — canonical entry is lemma-1',
+    );
+
+    expect(result.translationsMoved).toBe(1);
+    expect(result.formsMoved).toBe(1);
+    // Exactly one delete call (the loser).
+    expect(calls.filter((c) => c.kind === 'delete')).toHaveLength(1);
+    // Two merge audit inserts (one per direction).
+    const mergeAudits = calls.filter(
+      (c): c is Extract<Call, { kind: 'insert' }> =>
+        c.kind === 'insert' &&
+        (c.values as { changeType?: string } | undefined)?.changeType ===
+          'lemma_merge',
+    );
+    expect(mergeAudits).toHaveLength(2);
+    const directions = mergeAudits.map(
+      (c) =>
+        (c.values as { change?: { direction?: string } } | undefined)?.change
+          ?.direction,
+    );
+    expect(directions).toContain('loser');
+    expect(directions).toContain('winner');
+  });
+});
+
+// -----------------------------------------------------------------------
+// splitLemma
+// -----------------------------------------------------------------------
+
+describe('splitLemma', () => {
+  it('requires at least one translation or form to move', async () => {
+    stage([lemmaRow()]); // loadLemma
+    await expect(
+      splitLemma(
+        ADMIN,
+        {
+          fromLemmaId: 'lemma-1',
+          newLemma: { headword: 'सोना', pos: 'noun' },
+        },
+        'split gold from sleep',
+      ),
+    ).rejects.toBeInstanceOf(CuratorValidationError);
+  });
+
+  it('rejects translation ids that do not belong to the source lemma', async () => {
+    stage([lemmaRow({ id: 'lemma-1' })]); // loadLemma
+    stage([{ id: 'tr-1', lemmaId: 'lemma-999' }]); // translation belongs elsewhere
+    await expect(
+      splitLemma(
+        ADMIN,
+        {
+          fromLemmaId: 'lemma-1',
+          newLemma: { headword: 'सोना', pos: 'noun' },
+          translationIds: ['tr-1'],
+        },
+        'split gold from sleep',
+      ),
+    ).rejects.toMatchObject({ status: 409 });
+  });
+
+  it('creates a new curator lemma and moves selected children, auditing both sides', async () => {
+    stage([lemmaRow({ id: 'lemma-1', headword: 'सोना' })]); // source
+    stage([{ id: 'tr-1', lemmaId: 'lemma-1' }]); // translation validation
+    stage([{ id: 'form-1', lemmaId: 'lemma-1' }]); // form validation
+    const created = lemmaRow({
+      id: 'lemma-new',
+      headword: 'सोना',
+      pos: 'noun',
+      source: 'curator',
+      sourceAttribution: 'Split from सोना',
+      curatorLocked: true,
+    });
+    stage([created]); // insert new lemma returning
+    stage([{ id: 'hist-src' }]); // source audit
+    stage([{ id: 'hist-new' }]); // created audit
+
+    const result = await splitLemma(
+      ADMIN,
+      {
+        fromLemmaId: 'lemma-1',
+        newLemma: { headword: 'सोना', pos: 'noun' },
+        translationIds: ['tr-1'],
+        formIds: ['form-1'],
+      },
+      'Disambiguate gold (noun) from sleep (verb)',
+    );
+
+    expect(result.created.id).toBe('lemma-new');
+    expect(result.translationsMoved).toBe(1);
+    expect(result.formsMoved).toBe(1);
+
+    const insertCalls = calls.filter(
+      (c): c is Extract<Call, { kind: 'insert' }> => c.kind === 'insert',
+    );
+    // 1 new lemma + 2 history rows
+    expect(insertCalls).toHaveLength(3);
+    const splitAudits = insertCalls.filter(
+      (c) =>
+        (c.values as { changeType?: string } | undefined)?.changeType ===
+        'lemma_split',
+    );
+    expect(splitAudits).toHaveLength(2);
+    const directions = splitAudits.map(
+      (c) =>
+        (c.values as { change?: { direction?: string } } | undefined)?.change
+          ?.direction,
+    );
+    expect(directions).toContain('source');
+    expect(directions).toContain('created');
+  });
+});
+
+// -----------------------------------------------------------------------
+// getLemmaEditorView
+// -----------------------------------------------------------------------
+
+describe('getLemmaEditorView', () => {
+  it('assembles lemma + translations + forms + history for the editor', async () => {
+    stage([lemmaRow()]); // loadLemma
+    stage([translationRow(), translationRow({ id: 'tr-2' })]); // translations
+    stage([{ id: 'form-1', lemmaId: 'lemma-1', surface: 'bolta', features: {} }]);
+    stage([
+      {
+        id: 'hist-1',
+        changeType: 'lemma_update',
+        reason: 'typo',
+        createdAt: new Date(),
+        editorId: 'admin-1',
+      },
+    ]);
+    const view = await getLemmaEditorView(ADMIN, 'lemma-1');
+    expect(view.lemma.id).toBe('lemma-1');
+    expect(view.translations).toHaveLength(2);
+    expect(view.forms).toHaveLength(1);
+    expect(view.history).toHaveLength(1);
+  });
+
+  it('rejects a curator without the language grant', async () => {
+    stage([lemmaRow({ language: 'or' })]); // loadLemma
+    stage([]); // permission check: no grant
+    await expect(
+      getLemmaEditorView({ id: 'c1', role: 'curator' }, 'lemma-1'),
+    ).rejects.toBeInstanceOf(ForbiddenError);
+  });
+});

--- a/apps/web/src/lib/server/dictionary/curator.ts
+++ b/apps/web/src/lib/server/dictionary/curator.ts
@@ -1,0 +1,737 @@
+/**
+ * Curator dictionary editor service (T-3.7).
+ *
+ * Backs the `/moderation/dictionary` UI and the admin JSON endpoints.
+ * Every mutating function here:
+ *
+ *  1. Resolves the affected lemma and checks
+ *     `requireCanEditDictionary(editor, lemma.language)`. Curators only
+ *     have write access on languages they've been granted; admins
+ *     always pass.
+ *  2. Captures a snapshot of the affected row(s) for the before/after
+ *     diff that lands in `lemma_edit_history`.
+ *  3. Writes the mutation, then records the audit row with a
+ *     caller-supplied `reason` (required — empty reasons throw
+ *     `MissingReasonError`).
+ *
+ * Scope note for merge/split: the plan (M6 + beyond) calls for rewiring
+ * `text_tokens`, `user_known_lemmas`, and `form_lemma_overrides` across
+ * the loser/winner split. Those tables don't exist yet — they land in
+ * M5/M6. For now, merge rewires `translations` + `lemma_forms` only;
+ * split moves selected `translations` + `lemma_forms`. The future
+ * tickets that introduce those tables will extend these functions.
+ */
+import { and, eq, inArray } from 'drizzle-orm';
+
+import { db, schema } from '../db/index.js';
+import { recordLemmaEdit, MissingReasonError } from './audit.js';
+import { requireCanEditDictionary } from './permissions.js';
+import type {
+  Lemma,
+  LemmaForm,
+  Translation,
+  User,
+} from '../db/schema.js';
+
+export class CuratorValidationError extends Error {
+  constructor(
+    message: string,
+    public readonly status: 400 | 403 | 404 | 409 = 400,
+  ) {
+    super(message);
+    this.name = 'CuratorValidationError';
+  }
+}
+
+type Editor = Pick<User, 'id' | 'role'>;
+
+/**
+ * Load a lemma or throw 404. Used at the start of every mutator so we
+ * can check per-language curator rights before touching anything.
+ */
+async function loadLemma(id: string): Promise<Lemma> {
+  const [row] = await db
+    .select()
+    .from(schema.lemmas)
+    .where(eq(schema.lemmas.id, id))
+    .limit(1);
+  if (!row) throw new CuratorValidationError(`Lemma ${id} not found`, 404);
+  return row as Lemma;
+}
+
+async function loadTranslation(id: string): Promise<Translation> {
+  const [row] = await db
+    .select()
+    .from(schema.translations)
+    .where(eq(schema.translations.id, id))
+    .limit(1);
+  if (!row) {
+    throw new CuratorValidationError(`Translation ${id} not found`, 404);
+  }
+  return row as Translation;
+}
+
+/** Snapshot a lemma row for the audit diff. Dates are stringified so
+ * the JSONB column round-trips cleanly. */
+function snapshotLemma(row: Lemma): Record<string, unknown> {
+  return {
+    id: row.id,
+    language: row.language,
+    headword: row.headword,
+    pos: row.pos,
+    script: row.script,
+    glossDefault: row.glossDefault,
+    frequencyRank: row.frequencyRank,
+    source: row.source,
+    sourceAttribution: row.sourceAttribution,
+    sourceId: row.sourceId,
+    curatorLocked: row.curatorLocked,
+  };
+}
+
+function snapshotTranslation(row: Translation): Record<string, unknown> {
+  return {
+    id: row.id,
+    lemmaId: row.lemmaId,
+    source: row.source,
+    submittedBy: row.submittedBy,
+    parentTranslationId: row.parentTranslationId,
+    body: row.body,
+    targetLanguage: row.targetLanguage,
+    sourceAttribution: row.sourceAttribution,
+    sourceId: row.sourceId,
+    hidden: row.hidden,
+  };
+}
+
+function snapshotForm(row: LemmaForm): Record<string, unknown> {
+  return {
+    id: row.id,
+    lemmaId: row.lemmaId,
+    surface: row.surface,
+    features: row.features,
+    romanization: row.romanization,
+  };
+}
+
+// -----------------------------------------------------------------------
+// updateLemma
+// -----------------------------------------------------------------------
+
+export type UpdateLemmaPatch = {
+  headword?: string;
+  pos?: string;
+  script?: string;
+  glossDefault?: string | null;
+  frequencyRank?: number | null;
+  sourceAttribution?: string | null;
+};
+
+function normalizeHeadword(raw: string): string {
+  return raw.normalize('NFC').trim();
+}
+
+function validateLemmaPatch(patch: UpdateLemmaPatch): void {
+  if (patch.headword !== undefined) {
+    const trimmed = normalizeHeadword(patch.headword);
+    if (trimmed.length === 0) {
+      throw new CuratorValidationError('headword cannot be empty');
+    }
+    if (trimmed.length > 128) {
+      throw new CuratorValidationError('headword exceeds 128 characters');
+    }
+  }
+  if (patch.pos !== undefined) {
+    if (patch.pos.trim().length === 0) {
+      throw new CuratorValidationError('pos cannot be empty');
+    }
+    if (patch.pos.length > 32) {
+      throw new CuratorValidationError('pos exceeds 32 characters');
+    }
+  }
+  if (patch.script !== undefined && !/^[A-Z][a-z]{3}$/.test(patch.script)) {
+    throw new CuratorValidationError('script must be an ISO 15924 code');
+  }
+  if (
+    patch.frequencyRank !== undefined &&
+    patch.frequencyRank !== null &&
+    (!Number.isInteger(patch.frequencyRank) || patch.frequencyRank < 0)
+  ) {
+    throw new CuratorValidationError('frequencyRank must be a non-negative integer');
+  }
+}
+
+/**
+ * Update editable fields on a lemma. Does NOT allow changing `language`
+ * (which would orphan translations + forms); merges are the right tool
+ * for that if the language was wrong originally.
+ */
+export async function updateLemma(
+  editor: Editor,
+  lemmaId: string,
+  patch: UpdateLemmaPatch,
+  reason: string,
+  now: Date = new Date(),
+): Promise<Lemma> {
+  validateLemmaPatch(patch);
+  const existing = await loadLemma(lemmaId);
+  await requireCanEditDictionary(editor, existing.language);
+
+  const setValues: Partial<Lemma> = { updatedAt: now };
+  if (patch.headword !== undefined) setValues.headword = normalizeHeadword(patch.headword);
+  if (patch.pos !== undefined) setValues.pos = patch.pos.trim();
+  if (patch.script !== undefined) setValues.script = patch.script;
+  if (patch.glossDefault !== undefined) setValues.glossDefault = patch.glossDefault;
+  if (patch.frequencyRank !== undefined) setValues.frequencyRank = patch.frequencyRank;
+  if (patch.sourceAttribution !== undefined) {
+    setValues.sourceAttribution = patch.sourceAttribution;
+  }
+  // Any curator touch implicitly locks the row against future import
+  // re-runs clobbering the edit.
+  setValues.curatorLocked = true;
+
+  const [updated] = await db
+    .update(schema.lemmas)
+    .set(setValues)
+    .where(eq(schema.lemmas.id, lemmaId))
+    .returning();
+  if (!updated) throw new Error('Failed to update lemma');
+
+  await recordLemmaEdit({
+    lemmaId,
+    editorId: editor.id,
+    changeType: 'lemma_update',
+    change: {
+      before: snapshotLemma(existing),
+      after: snapshotLemma(updated as Lemma),
+    },
+    reason,
+  });
+  return updated as Lemma;
+}
+
+// -----------------------------------------------------------------------
+// setLemmaLock
+// -----------------------------------------------------------------------
+
+/**
+ * Flip `curatorLocked`. Unlocking is explicit so a curator can accept a
+ * fresh upstream import over their edit if they want to — otherwise
+ * `updateLemma` keeps the row locked.
+ */
+export async function setLemmaLock(
+  editor: Editor,
+  lemmaId: string,
+  locked: boolean,
+  reason: string,
+  now: Date = new Date(),
+): Promise<Lemma> {
+  const existing = await loadLemma(lemmaId);
+  await requireCanEditDictionary(editor, existing.language);
+  if (existing.curatorLocked === locked) return existing;
+
+  const [updated] = await db
+    .update(schema.lemmas)
+    .set({ curatorLocked: locked, updatedAt: now })
+    .where(eq(schema.lemmas.id, lemmaId))
+    .returning();
+  if (!updated) throw new Error('Failed to set lemma lock');
+
+  await recordLemmaEdit({
+    lemmaId,
+    editorId: editor.id,
+    changeType: locked ? 'lemma_lock' : 'lemma_unlock',
+    change: {
+      before: snapshotLemma(existing),
+      after: snapshotLemma(updated as Lemma),
+    },
+    reason,
+  });
+  return updated as Lemma;
+}
+
+// -----------------------------------------------------------------------
+// updateTranslation (curator edit)
+// -----------------------------------------------------------------------
+
+export type UpdateTranslationPatch = {
+  body?: string;
+  targetLanguage?: string;
+  sourceAttribution?: string | null;
+  /** Promote a community submission into an official curator translation.
+   * Only forward transitions allowed: `user` → `curator`. Curator rows
+   * stay curator; official imports cannot be demoted here. */
+  promoteToCurator?: boolean;
+};
+
+const MAX_BODY_LEN = 500;
+
+function normalizeBody(body: string): string {
+  return body.trim().replace(/\s+/g, ' ');
+}
+
+function validateTranslationPatch(patch: UpdateTranslationPatch): void {
+  if (patch.body !== undefined) {
+    const body = normalizeBody(patch.body);
+    if (body.length === 0) {
+      throw new CuratorValidationError('body cannot be empty');
+    }
+    if (body.length > MAX_BODY_LEN) {
+      throw new CuratorValidationError(`body exceeds ${MAX_BODY_LEN} characters`);
+    }
+  }
+  if (
+    patch.targetLanguage !== undefined &&
+    !/^[a-z]{2,3}$/.test(patch.targetLanguage.toLowerCase())
+  ) {
+    throw new CuratorValidationError(
+      'targetLanguage must be a 2- or 3-letter ISO code',
+    );
+  }
+}
+
+export async function updateTranslation(
+  editor: Editor,
+  translationId: string,
+  patch: UpdateTranslationPatch,
+  reason: string,
+  now: Date = new Date(),
+): Promise<Translation> {
+  validateTranslationPatch(patch);
+  const existing = await loadTranslation(translationId);
+  const parentLemma = await loadLemma(existing.lemmaId);
+  await requireCanEditDictionary(editor, parentLemma.language);
+
+  if (patch.promoteToCurator && existing.source === 'official_dictionary') {
+    throw new CuratorValidationError(
+      'An imported official translation cannot be re-tagged as curator — edit it directly',
+      409,
+    );
+  }
+
+  const setValues: Partial<Translation> = { updatedAt: now };
+  if (patch.body !== undefined) setValues.body = normalizeBody(patch.body);
+  if (patch.targetLanguage !== undefined) {
+    setValues.targetLanguage = patch.targetLanguage.toLowerCase();
+  }
+  if (patch.sourceAttribution !== undefined) {
+    setValues.sourceAttribution = patch.sourceAttribution;
+  }
+  if (patch.promoteToCurator && existing.source === 'user') {
+    setValues.source = 'curator';
+  }
+
+  const [updated] = await db
+    .update(schema.translations)
+    .set(setValues)
+    .where(eq(schema.translations.id, translationId))
+    .returning();
+  if (!updated) throw new Error('Failed to update translation');
+
+  await recordLemmaEdit({
+    lemmaId: existing.lemmaId,
+    editorId: editor.id,
+    changeType: 'translation_update',
+    change: {
+      translationId,
+      before: snapshotTranslation(existing),
+      after: snapshotTranslation(updated as Translation),
+    },
+    reason,
+  });
+  return updated as Translation;
+}
+
+// -----------------------------------------------------------------------
+// setTranslationHidden
+// -----------------------------------------------------------------------
+
+export async function setTranslationHidden(
+  editor: Editor,
+  translationId: string,
+  hidden: boolean,
+  reason: string,
+  now: Date = new Date(),
+): Promise<Translation> {
+  const existing = await loadTranslation(translationId);
+  const parentLemma = await loadLemma(existing.lemmaId);
+  await requireCanEditDictionary(editor, parentLemma.language);
+
+  if (existing.source !== 'user') {
+    throw new CuratorValidationError(
+      'Only community (source=user) translations can be hidden — edit officials directly',
+      409,
+    );
+  }
+  if (existing.hidden === hidden) return existing;
+
+  const [updated] = await db
+    .update(schema.translations)
+    .set({ hidden, updatedAt: now })
+    .where(eq(schema.translations.id, translationId))
+    .returning();
+  if (!updated) throw new Error('Failed to set hidden flag');
+
+  await recordLemmaEdit({
+    lemmaId: existing.lemmaId,
+    editorId: editor.id,
+    changeType: hidden ? 'translation_hide' : 'translation_unhide',
+    change: {
+      translationId,
+      before: snapshotTranslation(existing),
+      after: snapshotTranslation(updated as Translation),
+    },
+    reason,
+  });
+  return updated as Translation;
+}
+
+// -----------------------------------------------------------------------
+// mergeLemmas
+// -----------------------------------------------------------------------
+
+export type MergeLemmasInput = {
+  winnerId: string;
+  loserId: string;
+};
+
+export type MergeLemmasResult = {
+  winner: Lemma;
+  translationsMoved: number;
+  formsMoved: number;
+};
+
+/**
+ * Rewire translations + forms from loser → winner, then delete the loser.
+ *
+ * Guards:
+ *  - Same language (the two enum rows must match; merging across
+ *    languages is a mistake, not a correction).
+ *  - Winner and loser must be distinct rows.
+ *  - Both must exist.
+ *
+ * Audits once per lemma in `lemma_edit_history`: the winner's row gets
+ * a summary with the loser snapshot, and the loser's row gets the
+ * same payload under its own `lemma_id` so the timeline is complete
+ * from either side (the loser row remains referenceable by FK before
+ * cascade removes its history on the final delete — so we write the
+ * loser-side audit BEFORE the delete).
+ */
+export async function mergeLemmas(
+  editor: Editor,
+  input: MergeLemmasInput,
+  reason: string,
+): Promise<MergeLemmasResult> {
+  if (!reason || reason.trim().length < 3) throw new MissingReasonError();
+  if (input.winnerId === input.loserId) {
+    throw new CuratorValidationError('Cannot merge a lemma into itself');
+  }
+  const winner = await loadLemma(input.winnerId);
+  const loser = await loadLemma(input.loserId);
+  if (winner.language !== loser.language) {
+    throw new CuratorValidationError(
+      'Cannot merge lemmas across languages',
+      409,
+    );
+  }
+  await requireCanEditDictionary(editor, winner.language);
+
+  const loserTranslations = await db
+    .select()
+    .from(schema.translations)
+    .where(eq(schema.translations.lemmaId, loser.id));
+
+  const loserForms = await db
+    .select()
+    .from(schema.lemmaForms)
+    .where(eq(schema.lemmaForms.lemmaId, loser.id));
+
+  await db
+    .update(schema.translations)
+    .set({ lemmaId: winner.id })
+    .where(eq(schema.translations.lemmaId, loser.id));
+
+  await db
+    .update(schema.lemmaForms)
+    .set({ lemmaId: winner.id })
+    .where(eq(schema.lemmaForms.lemmaId, loser.id));
+
+  // Record the loser-side audit FIRST — cascading delete below would
+  // otherwise remove the audit rows we just wrote for its lemma_id.
+  // The history table's FK is `ON DELETE cascade` precisely so we don't
+  // leak orphans, but it means loser-side audit has to pre-date the delete.
+  await recordLemmaEdit({
+    lemmaId: loser.id,
+    editorId: editor.id,
+    changeType: 'lemma_merge',
+    change: {
+      before: snapshotLemma(loser),
+      after: snapshotLemma(winner),
+      translationIds: (loserTranslations as Translation[]).map((t) => t.id),
+      formIds: (loserForms as LemmaForm[]).map((f) => f.id),
+      direction: 'loser',
+    },
+    reason,
+  });
+
+  await db.delete(schema.lemmas).where(eq(schema.lemmas.id, loser.id));
+
+  await recordLemmaEdit({
+    lemmaId: winner.id,
+    editorId: editor.id,
+    changeType: 'lemma_merge',
+    change: {
+      before: snapshotLemma(winner),
+      after: snapshotLemma(winner),
+      mergedFrom: snapshotLemma(loser),
+      translationsMoved: (loserTranslations as Translation[]).map(snapshotTranslation),
+      formsMoved: (loserForms as LemmaForm[]).map(snapshotForm),
+      direction: 'winner',
+    },
+    reason,
+  });
+
+  return {
+    winner,
+    translationsMoved: (loserTranslations as Translation[]).length,
+    formsMoved: (loserForms as LemmaForm[]).length,
+  };
+}
+
+// -----------------------------------------------------------------------
+// splitLemma
+// -----------------------------------------------------------------------
+
+export type SplitLemmaInput = {
+  fromLemmaId: string;
+  /** Fields of the newly created lemma. `language` and `script` are
+   * inherited from the source unless overridden. */
+  newLemma: {
+    headword: string;
+    pos: string;
+    script?: string;
+    glossDefault?: string | null;
+    frequencyRank?: number | null;
+    sourceAttribution?: string | null;
+  };
+  /** Translation ids to move off the source onto the new lemma. */
+  translationIds?: string[];
+  /** Lemma-form ids to move. */
+  formIds?: string[];
+};
+
+export type SplitLemmaResult = {
+  source: Lemma;
+  created: Lemma;
+  translationsMoved: number;
+  formsMoved: number;
+};
+
+/**
+ * Create a new lemma off an existing one, moving the selected
+ * translations + forms. Useful when a single dictionary entry turns out
+ * to conflate two genuine lemmas (common with homographs imported
+ * without POS disambiguation).
+ *
+ * Guards against moving translations/forms that don't actually belong
+ * to the source lemma — that would silently corrupt someone else's row.
+ */
+export async function splitLemma(
+  editor: Editor,
+  input: SplitLemmaInput,
+  reason: string,
+): Promise<SplitLemmaResult> {
+  if (!reason || reason.trim().length < 3) throw new MissingReasonError();
+  const source = await loadLemma(input.fromLemmaId);
+  await requireCanEditDictionary(editor, source.language);
+
+  const headword = normalizeHeadword(input.newLemma.headword ?? '');
+  if (headword.length === 0) {
+    throw new CuratorValidationError('new headword cannot be empty');
+  }
+  const pos = input.newLemma.pos?.trim() ?? '';
+  if (pos.length === 0) {
+    throw new CuratorValidationError('new pos cannot be empty');
+  }
+  const translationIds = input.translationIds ?? [];
+  const formIds = input.formIds ?? [];
+
+  if (translationIds.length === 0 && formIds.length === 0) {
+    throw new CuratorValidationError(
+      'Split requires at least one translation or form to move',
+    );
+  }
+
+  if (translationIds.length > 0) {
+    const rows = await db
+      .select({ id: schema.translations.id, lemmaId: schema.translations.lemmaId })
+      .from(schema.translations)
+      .where(inArray(schema.translations.id, translationIds));
+    if (rows.length !== translationIds.length) {
+      throw new CuratorValidationError(
+        'One or more translationIds do not exist',
+        404,
+      );
+    }
+    for (const row of rows) {
+      if (row.lemmaId !== source.id) {
+        throw new CuratorValidationError(
+          `Translation ${row.id} does not belong to the source lemma`,
+          409,
+        );
+      }
+    }
+  }
+  if (formIds.length > 0) {
+    const rows = await db
+      .select({ id: schema.lemmaForms.id, lemmaId: schema.lemmaForms.lemmaId })
+      .from(schema.lemmaForms)
+      .where(inArray(schema.lemmaForms.id, formIds));
+    if (rows.length !== formIds.length) {
+      throw new CuratorValidationError(
+        'One or more formIds do not exist',
+        404,
+      );
+    }
+    for (const row of rows) {
+      if (row.lemmaId !== source.id) {
+        throw new CuratorValidationError(
+          `Form ${row.id} does not belong to the source lemma`,
+          409,
+        );
+      }
+    }
+  }
+
+  const [created] = await db
+    .insert(schema.lemmas)
+    .values({
+      language: source.language,
+      headword,
+      pos,
+      script: input.newLemma.script ?? source.script,
+      glossDefault: input.newLemma.glossDefault ?? null,
+      frequencyRank: input.newLemma.frequencyRank ?? null,
+      // New lemmas born of a split are curator rows — they never came
+      // from an upstream source.
+      source: 'curator',
+      sourceAttribution:
+        input.newLemma.sourceAttribution ?? `Split from ${source.headword}`,
+      sourceId: null,
+      curatorLocked: true,
+    })
+    .returning();
+  if (!created) throw new Error('Failed to create split lemma');
+
+  if (translationIds.length > 0) {
+    await db
+      .update(schema.translations)
+      .set({ lemmaId: (created as Lemma).id })
+      .where(
+        and(
+          inArray(schema.translations.id, translationIds),
+          eq(schema.translations.lemmaId, source.id),
+        ),
+      );
+  }
+  if (formIds.length > 0) {
+    await db
+      .update(schema.lemmaForms)
+      .set({ lemmaId: (created as Lemma).id })
+      .where(
+        and(
+          inArray(schema.lemmaForms.id, formIds),
+          eq(schema.lemmaForms.lemmaId, source.id),
+        ),
+      );
+  }
+
+  await recordLemmaEdit({
+    lemmaId: source.id,
+    editorId: editor.id,
+    changeType: 'lemma_split',
+    change: {
+      before: snapshotLemma(source),
+      after: snapshotLemma(source),
+      splitInto: snapshotLemma(created as Lemma),
+      translationIds,
+      formIds,
+      direction: 'source',
+    },
+    reason,
+  });
+  await recordLemmaEdit({
+    lemmaId: (created as Lemma).id,
+    editorId: editor.id,
+    changeType: 'lemma_split',
+    change: {
+      before: null,
+      after: snapshotLemma(created as Lemma),
+      splitFrom: snapshotLemma(source),
+      translationIds,
+      formIds,
+      direction: 'created',
+    },
+    reason,
+  });
+
+  return {
+    source,
+    created: created as Lemma,
+    translationsMoved: translationIds.length,
+    formsMoved: formIds.length,
+  };
+}
+
+// -----------------------------------------------------------------------
+// Read helpers for the editor UI
+// -----------------------------------------------------------------------
+
+/**
+ * Full lemma detail + all translations (including hidden) + forms +
+ * recent audit history. Curator view — bypasses the reader's
+ * hidden-translation filter.
+ */
+export async function getLemmaEditorView(
+  editor: Editor,
+  lemmaId: string,
+): Promise<{
+  lemma: Lemma;
+  translations: Translation[];
+  forms: LemmaForm[];
+  history: Array<{
+    id: string;
+    changeType: string;
+    reason: string;
+    createdAt: Date;
+    editorId: string | null;
+  }>;
+}> {
+  const lemma = await loadLemma(lemmaId);
+  await requireCanEditDictionary(editor, lemma.language);
+  const translations = (await db
+    .select()
+    .from(schema.translations)
+    .where(eq(schema.translations.lemmaId, lemmaId))) as Translation[];
+  const forms = (await db
+    .select()
+    .from(schema.lemmaForms)
+    .where(eq(schema.lemmaForms.lemmaId, lemmaId))) as LemmaForm[];
+  const history = (await db
+    .select({
+      id: schema.lemmaEditHistory.id,
+      changeType: schema.lemmaEditHistory.changeType,
+      reason: schema.lemmaEditHistory.reason,
+      createdAt: schema.lemmaEditHistory.createdAt,
+      editorId: schema.lemmaEditHistory.editorId,
+    })
+    .from(schema.lemmaEditHistory)
+    .where(eq(schema.lemmaEditHistory.lemmaId, lemmaId))) as Array<{
+    id: string;
+    changeType: string;
+    reason: string;
+    createdAt: Date;
+    editorId: string | null;
+  }>;
+  return { lemma, translations, forms, history };
+}

--- a/apps/web/src/routes/api/v1/admin/lemmas/[id]/+server.ts
+++ b/apps/web/src/routes/api/v1/admin/lemmas/[id]/+server.ts
@@ -1,0 +1,70 @@
+/**
+ * GET + PATCH /api/v1/admin/lemmas/:id (T-3.7).
+ *
+ * Backs the curator dictionary editor. GET returns the full editor
+ * view (lemma + translations + forms + recent history). PATCH updates
+ * editable fields on the lemma and implicitly marks it `curatorLocked`
+ * so future imports won't clobber the edit.
+ *
+ * Permission: requireCanEditDictionary inside the service — admins
+ * always pass, curators need a `curator_languages` grant for the
+ * lemma's language. Anonymous callers get 401 via requireUser.
+ */
+import { error, json } from '@sveltejs/kit';
+import { z } from 'zod';
+
+import { requireUser } from '$lib/server/auth/require-user.js';
+import {
+  CuratorValidationError,
+  getLemmaEditorView,
+  updateLemma,
+} from '$lib/server/dictionary/curator.js';
+import { ForbiddenError } from '$lib/server/dictionary/permissions.js';
+import { MissingReasonError } from '$lib/server/dictionary/audit.js';
+import type { RequestHandler } from './$types';
+import { parseJson } from '../../../auth/_helpers.js';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const patchBody = z.object({
+  headword: z.string().optional(),
+  pos: z.string().optional(),
+  script: z.string().optional(),
+  glossDefault: z.string().nullable().optional(),
+  frequencyRank: z.number().int().nullable().optional(),
+  sourceAttribution: z.string().nullable().optional(),
+  reason: z.string(),
+});
+
+function mapCuratorError(err: unknown): never {
+  if (err instanceof CuratorValidationError) throw error(err.status, err.message);
+  if (err instanceof ForbiddenError) throw error(403, err.message);
+  if (err instanceof MissingReasonError) throw error(400, err.message);
+  throw err;
+}
+
+export const GET: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  const id = event.params.id;
+  if (!id || !UUID_RE.test(id)) throw error(400, 'Invalid lemma id');
+  try {
+    const view = await getLemmaEditorView(user, id);
+    return json(view);
+  } catch (err) {
+    mapCuratorError(err);
+  }
+};
+
+export const PATCH: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  const id = event.params.id;
+  if (!id || !UUID_RE.test(id)) throw error(400, 'Invalid lemma id');
+  const input = await parseJson(event.request, patchBody);
+  const { reason, ...patch } = input;
+  try {
+    const lemma = await updateLemma(user, id, patch, reason);
+    return json({ lemma });
+  } catch (err) {
+    mapCuratorError(err);
+  }
+};

--- a/apps/web/src/routes/api/v1/admin/lemmas/[id]/lemma-server.test.ts
+++ b/apps/web/src/routes/api/v1/admin/lemmas/[id]/lemma-server.test.ts
@@ -1,0 +1,167 @@
+// @vitest-environment node
+/**
+ * Route tests for GET + PATCH /api/v1/admin/lemmas/:id (T-3.7).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getLemmaEditorView = vi.fn();
+const updateLemma = vi.fn();
+const requireUser = vi.fn();
+
+vi.mock('$lib/server/dictionary/curator.js', async () => {
+  const actual = await vi.importActual<
+    typeof import('$lib/server/dictionary/curator.js')
+  >('$lib/server/dictionary/curator.js');
+  return {
+    ...actual,
+    getLemmaEditorView: (...a: unknown[]) => getLemmaEditorView(...a),
+    updateLemma: (...a: unknown[]) => updateLemma(...a),
+  };
+});
+
+vi.mock('$lib/server/auth/require-user.js', () => ({
+  requireUser: (...a: unknown[]) => requireUser(...a),
+}));
+
+type GetFn = (typeof import('./+server.js'))['GET'];
+type PatchFn = (typeof import('./+server.js'))['PATCH'];
+
+const VALID_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const ADMIN = { id: 'admin-1', role: 'admin' as const };
+
+async function callGet(user = ADMIN, id = VALID_ID) {
+  requireUser.mockResolvedValueOnce(user);
+  const { GET } = await import('./+server.js');
+  const event = {
+    params: { id },
+    request: new Request(`http://x/api/v1/admin/lemmas/${id}`),
+  } as unknown as Parameters<GetFn>[0];
+  try {
+    return await GET(event);
+  } catch (e) {
+    return e as { status: number };
+  }
+}
+
+async function callPatch(body: unknown, user = ADMIN, id = VALID_ID) {
+  requireUser.mockResolvedValueOnce(user);
+  const { PATCH } = await import('./+server.js');
+  const event = {
+    params: { id },
+    request: new Request(`http://x/api/v1/admin/lemmas/${id}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+  } as unknown as Parameters<PatchFn>[0];
+  try {
+    return await PATCH(event);
+  } catch (e) {
+    return e as { status: number };
+  }
+}
+
+beforeEach(() => {
+  getLemmaEditorView.mockReset();
+  updateLemma.mockReset();
+  requireUser.mockReset();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('GET /api/v1/admin/lemmas/:id', () => {
+  it('returns the editor view on success', async () => {
+    getLemmaEditorView.mockResolvedValueOnce({
+      lemma: { id: VALID_ID, language: 'hi' },
+      translations: [],
+      forms: [],
+      history: [],
+    });
+    const res = (await callGet()) as Response;
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.lemma.id).toBe(VALID_ID);
+  });
+
+  it('returns 400 on malformed id', async () => {
+    const res = (await callGet(ADMIN, 'not-a-uuid')) as { status: number };
+    expect(res.status).toBe(400);
+    expect(getLemmaEditorView).not.toHaveBeenCalled();
+  });
+
+  it('maps ForbiddenError to 403', async () => {
+    const { ForbiddenError } = await import(
+      '$lib/server/dictionary/permissions.js'
+    );
+    getLemmaEditorView.mockRejectedValueOnce(new ForbiddenError('no grant'));
+    const res = (await callGet()) as { status: number };
+    expect(res.status).toBe(403);
+  });
+
+  it('maps CuratorValidationError(404) to 404', async () => {
+    const { CuratorValidationError } = await import(
+      '$lib/server/dictionary/curator.js'
+    );
+    getLemmaEditorView.mockRejectedValueOnce(
+      new CuratorValidationError('not found', 404),
+    );
+    const res = (await callGet()) as { status: number };
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('PATCH /api/v1/admin/lemmas/:id', () => {
+  it('updates the lemma and returns 200', async () => {
+    updateLemma.mockResolvedValueOnce({
+      id: VALID_ID,
+      language: 'hi',
+      headword: 'बोलना',
+      glossDefault: 'to speak',
+    });
+    const res = (await callPatch({
+      glossDefault: 'to speak',
+      reason: 'Clarify gloss',
+    })) as Response;
+    expect(res.status).toBe(200);
+    expect(updateLemma).toHaveBeenCalledWith(
+      ADMIN,
+      VALID_ID,
+      { glossDefault: 'to speak' },
+      'Clarify gloss',
+    );
+  });
+
+  it('returns 400 when reason is missing from the body', async () => {
+    const res = (await callPatch({ glossDefault: 'x' })) as { status: number };
+    expect(res.status).toBe(400);
+    expect(updateLemma).not.toHaveBeenCalled();
+  });
+
+  it('maps MissingReasonError to 400', async () => {
+    const { MissingReasonError } = await import(
+      '$lib/server/dictionary/audit.js'
+    );
+    updateLemma.mockRejectedValueOnce(new MissingReasonError());
+    const res = (await callPatch({
+      glossDefault: 'x',
+      reason: 'ok',
+    })) as { status: number };
+    expect(res.status).toBe(400);
+  });
+
+  it('maps CuratorValidationError(409) to 409', async () => {
+    const { CuratorValidationError } = await import(
+      '$lib/server/dictionary/curator.js'
+    );
+    updateLemma.mockRejectedValueOnce(
+      new CuratorValidationError('conflict', 409),
+    );
+    const res = (await callPatch({
+      glossDefault: 'x',
+      reason: 'ok now',
+    })) as { status: number };
+    expect(res.status).toBe(409);
+  });
+});

--- a/apps/web/src/routes/api/v1/admin/lemmas/[id]/lock/+server.ts
+++ b/apps/web/src/routes/api/v1/admin/lemmas/[id]/lock/+server.ts
@@ -1,0 +1,46 @@
+/**
+ * PATCH /api/v1/admin/lemmas/:id/lock (T-3.7).
+ *
+ * Flip `curatorLocked`. Unlocking explicitly opts the row back in for
+ * fresh upstream imports to overwrite; locking is the default any time
+ * a curator touches a row via updateLemma.
+ */
+import { error, json } from '@sveltejs/kit';
+import { z } from 'zod';
+
+import { requireUser } from '$lib/server/auth/require-user.js';
+import {
+  CuratorValidationError,
+  setLemmaLock,
+} from '$lib/server/dictionary/curator.js';
+import { ForbiddenError } from '$lib/server/dictionary/permissions.js';
+import { MissingReasonError } from '$lib/server/dictionary/audit.js';
+import type { RequestHandler } from './$types';
+import { parseJson } from '../../../../auth/_helpers.js';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const body = z.object({
+  locked: z.boolean(),
+  reason: z.string(),
+});
+
+function mapCuratorError(err: unknown): never {
+  if (err instanceof CuratorValidationError) throw error(err.status, err.message);
+  if (err instanceof ForbiddenError) throw error(403, err.message);
+  if (err instanceof MissingReasonError) throw error(400, err.message);
+  throw err;
+}
+
+export const PATCH: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  const id = event.params.id;
+  if (!id || !UUID_RE.test(id)) throw error(400, 'Invalid lemma id');
+  const input = await parseJson(event.request, body);
+  try {
+    const lemma = await setLemmaLock(user, id, input.locked, input.reason);
+    return json({ lemma });
+  } catch (err) {
+    mapCuratorError(err);
+  }
+};

--- a/apps/web/src/routes/api/v1/admin/lemmas/[id]/lock/lock-server.test.ts
+++ b/apps/web/src/routes/api/v1/admin/lemmas/[id]/lock/lock-server.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment node
+/**
+ * Route tests for PATCH /api/v1/admin/lemmas/:id/lock (T-3.7).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const setLemmaLock = vi.fn();
+const requireUser = vi.fn();
+
+vi.mock('$lib/server/dictionary/curator.js', async () => {
+  const actual = await vi.importActual<
+    typeof import('$lib/server/dictionary/curator.js')
+  >('$lib/server/dictionary/curator.js');
+  return {
+    ...actual,
+    setLemmaLock: (...a: unknown[]) => setLemmaLock(...a),
+  };
+});
+
+vi.mock('$lib/server/auth/require-user.js', () => ({
+  requireUser: (...a: unknown[]) => requireUser(...a),
+}));
+
+type PatchFn = (typeof import('./+server.js'))['PATCH'];
+
+const VALID_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const ADMIN = { id: 'admin-1', role: 'admin' as const };
+
+async function callPatch(body: unknown, user = ADMIN, id = VALID_ID) {
+  requireUser.mockResolvedValueOnce(user);
+  const { PATCH } = await import('./+server.js');
+  const event = {
+    params: { id },
+    request: new Request(`http://x/api/v1/admin/lemmas/${id}/lock`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+  } as unknown as Parameters<PatchFn>[0];
+  try {
+    return await PATCH(event);
+  } catch (e) {
+    return e as { status: number };
+  }
+}
+
+beforeEach(() => {
+  setLemmaLock.mockReset();
+  requireUser.mockReset();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('PATCH /api/v1/admin/lemmas/:id/lock', () => {
+  it('flips the lock flag and returns 200', async () => {
+    setLemmaLock.mockResolvedValueOnce({
+      id: VALID_ID,
+      curatorLocked: true,
+    });
+    const res = (await callPatch({
+      locked: true,
+      reason: 'Protect curated entry',
+    })) as Response;
+    expect(res.status).toBe(200);
+    expect(setLemmaLock).toHaveBeenCalledWith(
+      ADMIN,
+      VALID_ID,
+      true,
+      'Protect curated entry',
+    );
+  });
+
+  it('rejects a non-boolean locked value', async () => {
+    const res = (await callPatch({
+      locked: 'yes',
+      reason: 'ok',
+    })) as { status: number };
+    expect(res.status).toBe(400);
+    expect(setLemmaLock).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 on malformed id', async () => {
+    const res = (await callPatch(
+      { locked: true, reason: 'ok' },
+      ADMIN,
+      'bad',
+    )) as { status: number };
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/web/src/routes/api/v1/admin/lemmas/[id]/merge/+server.ts
+++ b/apps/web/src/routes/api/v1/admin/lemmas/[id]/merge/+server.ts
@@ -1,0 +1,59 @@
+/**
+ * POST /api/v1/admin/lemmas/:id/merge (T-3.7).
+ *
+ * `:id` is the **winner** — the lemma that will remain after the merge.
+ * Body carries the loser id and a human reason. Rewires translations +
+ * lemma_forms, deletes the loser, and audits both sides.
+ *
+ * Out of scope at M3: rewiring `text_tokens`, `user_known_lemmas`, and
+ * `form_lemma_overrides`. Those tables land in M5/M6 and the merge
+ * function will extend then.
+ */
+import { error, json } from '@sveltejs/kit';
+import { z } from 'zod';
+
+import { requireUser } from '$lib/server/auth/require-user.js';
+import {
+  CuratorValidationError,
+  mergeLemmas,
+} from '$lib/server/dictionary/curator.js';
+import { ForbiddenError } from '$lib/server/dictionary/permissions.js';
+import { MissingReasonError } from '$lib/server/dictionary/audit.js';
+import type { RequestHandler } from './$types';
+import { parseJson } from '../../../../auth/_helpers.js';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const body = z.object({
+  loserId: z.string(),
+  reason: z.string(),
+});
+
+function mapCuratorError(err: unknown): never {
+  if (err instanceof CuratorValidationError) throw error(err.status, err.message);
+  if (err instanceof ForbiddenError) throw error(403, err.message);
+  if (err instanceof MissingReasonError) throw error(400, err.message);
+  throw err;
+}
+
+export const POST: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  const winnerId = event.params.id;
+  if (!winnerId || !UUID_RE.test(winnerId)) throw error(400, 'Invalid lemma id');
+  const input = await parseJson(event.request, body);
+  if (!UUID_RE.test(input.loserId)) throw error(400, 'Invalid loserId');
+  try {
+    const result = await mergeLemmas(
+      user,
+      { winnerId, loserId: input.loserId },
+      input.reason,
+    );
+    return json({
+      winner: result.winner,
+      translationsMoved: result.translationsMoved,
+      formsMoved: result.formsMoved,
+    });
+  } catch (err) {
+    mapCuratorError(err);
+  }
+};

--- a/apps/web/src/routes/api/v1/admin/lemmas/[id]/merge/merge-server.test.ts
+++ b/apps/web/src/routes/api/v1/admin/lemmas/[id]/merge/merge-server.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment node
+/**
+ * Route tests for POST /api/v1/admin/lemmas/:id/merge (T-3.7).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mergeLemmas = vi.fn();
+const requireUser = vi.fn();
+
+vi.mock('$lib/server/dictionary/curator.js', async () => {
+  const actual = await vi.importActual<
+    typeof import('$lib/server/dictionary/curator.js')
+  >('$lib/server/dictionary/curator.js');
+  return {
+    ...actual,
+    mergeLemmas: (...a: unknown[]) => mergeLemmas(...a),
+  };
+});
+
+vi.mock('$lib/server/auth/require-user.js', () => ({
+  requireUser: (...a: unknown[]) => requireUser(...a),
+}));
+
+type PostFn = (typeof import('./+server.js'))['POST'];
+
+const WINNER = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const LOSER = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+const ADMIN = { id: 'admin-1', role: 'admin' as const };
+
+async function callPost(body: unknown, user = ADMIN, id = WINNER) {
+  requireUser.mockResolvedValueOnce(user);
+  const { POST } = await import('./+server.js');
+  const event = {
+    params: { id },
+    request: new Request(`http://x/api/v1/admin/lemmas/${id}/merge`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+  } as unknown as Parameters<PostFn>[0];
+  try {
+    return await POST(event);
+  } catch (e) {
+    return e as { status: number };
+  }
+}
+
+beforeEach(() => {
+  mergeLemmas.mockReset();
+  requireUser.mockReset();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('POST /api/v1/admin/lemmas/:id/merge', () => {
+  it('merges and returns movement counts', async () => {
+    mergeLemmas.mockResolvedValueOnce({
+      winner: { id: WINNER, language: 'hi' },
+      translationsMoved: 3,
+      formsMoved: 2,
+    });
+    const res = (await callPost({
+      loserId: LOSER,
+      reason: 'Duplicate import',
+    })) as Response;
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.translationsMoved).toBe(3);
+    expect(json.formsMoved).toBe(2);
+    expect(mergeLemmas).toHaveBeenCalledWith(
+      ADMIN,
+      { winnerId: WINNER, loserId: LOSER },
+      'Duplicate import',
+    );
+  });
+
+  it('returns 400 when loserId is not a UUID', async () => {
+    const res = (await callPost({
+      loserId: 'nope',
+      reason: 'dup',
+    })) as { status: number };
+    expect(res.status).toBe(400);
+    expect(mergeLemmas).not.toHaveBeenCalled();
+  });
+
+  it('maps CuratorValidationError(409) from cross-language merge', async () => {
+    const { CuratorValidationError } = await import(
+      '$lib/server/dictionary/curator.js'
+    );
+    mergeLemmas.mockRejectedValueOnce(
+      new CuratorValidationError('Cannot merge lemmas across languages', 409),
+    );
+    const res = (await callPost({
+      loserId: LOSER,
+      reason: 'x',
+    })) as { status: number };
+    expect(res.status).toBe(409);
+  });
+});

--- a/apps/web/src/routes/api/v1/admin/lemmas/[id]/split/+server.ts
+++ b/apps/web/src/routes/api/v1/admin/lemmas/[id]/split/+server.ts
@@ -1,0 +1,72 @@
+/**
+ * POST /api/v1/admin/lemmas/:id/split (T-3.7).
+ *
+ * Creates a new curator-sourced lemma off an existing one and moves the
+ * selected translations + forms onto it. `:id` is the source lemma.
+ *
+ * Intended for homograph disambiguation — e.g. Hindi "सोना" was
+ * imported as one entry but actually conflates noun "gold" and verb
+ * "to sleep"; split the translations that describe "gold" onto a new
+ * noun lemma.
+ */
+import { error, json } from '@sveltejs/kit';
+import { z } from 'zod';
+
+import { requireUser } from '$lib/server/auth/require-user.js';
+import {
+  CuratorValidationError,
+  splitLemma,
+} from '$lib/server/dictionary/curator.js';
+import { ForbiddenError } from '$lib/server/dictionary/permissions.js';
+import { MissingReasonError } from '$lib/server/dictionary/audit.js';
+import type { RequestHandler } from './$types';
+import { parseJson } from '../../../../auth/_helpers.js';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const body = z.object({
+  newLemma: z.object({
+    headword: z.string(),
+    pos: z.string(),
+    script: z.string().optional(),
+    glossDefault: z.string().nullable().optional(),
+    frequencyRank: z.number().int().nullable().optional(),
+    sourceAttribution: z.string().nullable().optional(),
+  }),
+  translationIds: z.array(z.string()).optional(),
+  formIds: z.array(z.string()).optional(),
+  reason: z.string(),
+});
+
+function mapCuratorError(err: unknown): never {
+  if (err instanceof CuratorValidationError) throw error(err.status, err.message);
+  if (err instanceof ForbiddenError) throw error(403, err.message);
+  if (err instanceof MissingReasonError) throw error(400, err.message);
+  throw err;
+}
+
+export const POST: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  const sourceId = event.params.id;
+  if (!sourceId || !UUID_RE.test(sourceId)) throw error(400, 'Invalid lemma id');
+  const input = await parseJson(event.request, body);
+  try {
+    const result = await splitLemma(
+      user,
+      {
+        fromLemmaId: sourceId,
+        newLemma: input.newLemma,
+        translationIds: input.translationIds,
+        formIds: input.formIds,
+      },
+      input.reason,
+    );
+    return json({
+      created: result.created,
+      translationsMoved: result.translationsMoved,
+      formsMoved: result.formsMoved,
+    });
+  } catch (err) {
+    mapCuratorError(err);
+  }
+};

--- a/apps/web/src/routes/api/v1/admin/lemmas/[id]/split/split-server.test.ts
+++ b/apps/web/src/routes/api/v1/admin/lemmas/[id]/split/split-server.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment node
+/**
+ * Route tests for POST /api/v1/admin/lemmas/:id/split (T-3.7).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const splitLemma = vi.fn();
+const requireUser = vi.fn();
+
+vi.mock('$lib/server/dictionary/curator.js', async () => {
+  const actual = await vi.importActual<
+    typeof import('$lib/server/dictionary/curator.js')
+  >('$lib/server/dictionary/curator.js');
+  return {
+    ...actual,
+    splitLemma: (...a: unknown[]) => splitLemma(...a),
+  };
+});
+
+vi.mock('$lib/server/auth/require-user.js', () => ({
+  requireUser: (...a: unknown[]) => requireUser(...a),
+}));
+
+type PostFn = (typeof import('./+server.js'))['POST'];
+
+const SRC = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const ADMIN = { id: 'admin-1', role: 'admin' as const };
+
+async function callPost(body: unknown, user = ADMIN, id = SRC) {
+  requireUser.mockResolvedValueOnce(user);
+  const { POST } = await import('./+server.js');
+  const event = {
+    params: { id },
+    request: new Request(`http://x/api/v1/admin/lemmas/${id}/split`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+  } as unknown as Parameters<PostFn>[0];
+  try {
+    return await POST(event);
+  } catch (e) {
+    return e as { status: number };
+  }
+}
+
+beforeEach(() => {
+  splitLemma.mockReset();
+  requireUser.mockReset();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('POST /api/v1/admin/lemmas/:id/split', () => {
+  it('creates a new lemma and returns movement counts', async () => {
+    splitLemma.mockResolvedValueOnce({
+      source: { id: SRC },
+      created: { id: 'new-id', headword: 'सोना', pos: 'noun' },
+      translationsMoved: 1,
+      formsMoved: 0,
+    });
+    const res = (await callPost({
+      newLemma: { headword: 'सोना', pos: 'noun' },
+      translationIds: ['tr-1'],
+      reason: 'Disambiguate gold vs sleep',
+    })) as Response;
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.created.headword).toBe('सोना');
+    expect(json.translationsMoved).toBe(1);
+  });
+
+  it('returns 400 when newLemma is missing', async () => {
+    const res = (await callPost({
+      translationIds: ['tr-1'],
+      reason: 'x',
+    })) as { status: number };
+    expect(res.status).toBe(400);
+    expect(splitLemma).not.toHaveBeenCalled();
+  });
+
+  it('maps CuratorValidationError(409) when a child does not belong', async () => {
+    const { CuratorValidationError } = await import(
+      '$lib/server/dictionary/curator.js'
+    );
+    splitLemma.mockRejectedValueOnce(
+      new CuratorValidationError('does not belong', 409),
+    );
+    const res = (await callPost({
+      newLemma: { headword: 'x', pos: 'noun' },
+      translationIds: ['tr-1'],
+      reason: 'x',
+    })) as { status: number };
+    expect(res.status).toBe(409);
+  });
+});

--- a/apps/web/src/routes/api/v1/admin/translations/[id]/+server.ts
+++ b/apps/web/src/routes/api/v1/admin/translations/[id]/+server.ts
@@ -1,0 +1,53 @@
+/**
+ * PATCH /api/v1/admin/translations/:id (T-3.7).
+ *
+ * Curator-level edit on any translation tied to a lemma they can edit.
+ * Supports editing body, target language, attribution, and the
+ * one-way promotion of a community translation to curator.
+ *
+ * Hiding / unhiding a community translation goes through the separate
+ * `hidden` sub-route so the intent is explicit in the audit trail.
+ */
+import { error, json } from '@sveltejs/kit';
+import { z } from 'zod';
+
+import { requireUser } from '$lib/server/auth/require-user.js';
+import {
+  CuratorValidationError,
+  updateTranslation,
+} from '$lib/server/dictionary/curator.js';
+import { ForbiddenError } from '$lib/server/dictionary/permissions.js';
+import { MissingReasonError } from '$lib/server/dictionary/audit.js';
+import type { RequestHandler } from './$types';
+import { parseJson } from '../../../auth/_helpers.js';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const body = z.object({
+  body: z.string().optional(),
+  targetLanguage: z.string().optional(),
+  sourceAttribution: z.string().nullable().optional(),
+  promoteToCurator: z.boolean().optional(),
+  reason: z.string(),
+});
+
+function mapCuratorError(err: unknown): never {
+  if (err instanceof CuratorValidationError) throw error(err.status, err.message);
+  if (err instanceof ForbiddenError) throw error(403, err.message);
+  if (err instanceof MissingReasonError) throw error(400, err.message);
+  throw err;
+}
+
+export const PATCH: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  const id = event.params.id;
+  if (!id || !UUID_RE.test(id)) throw error(400, 'Invalid translation id');
+  const input = await parseJson(event.request, body);
+  const { reason, ...patch } = input;
+  try {
+    const translation = await updateTranslation(user, id, patch, reason);
+    return json({ translation });
+  } catch (err) {
+    mapCuratorError(err);
+  }
+};

--- a/apps/web/src/routes/api/v1/admin/translations/[id]/hidden/+server.ts
+++ b/apps/web/src/routes/api/v1/admin/translations/[id]/hidden/+server.ts
@@ -1,0 +1,51 @@
+/**
+ * PATCH /api/v1/admin/translations/:id/hidden (T-3.7).
+ *
+ * Hide or unhide a community (source=user) translation. Officials are
+ * not hidden — they're edited in place through the main translation
+ * PATCH and audited via `lemma_edit_history`.
+ */
+import { error, json } from '@sveltejs/kit';
+import { z } from 'zod';
+
+import { requireUser } from '$lib/server/auth/require-user.js';
+import {
+  CuratorValidationError,
+  setTranslationHidden,
+} from '$lib/server/dictionary/curator.js';
+import { ForbiddenError } from '$lib/server/dictionary/permissions.js';
+import { MissingReasonError } from '$lib/server/dictionary/audit.js';
+import type { RequestHandler } from './$types';
+import { parseJson } from '../../../../auth/_helpers.js';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const body = z.object({
+  hidden: z.boolean(),
+  reason: z.string(),
+});
+
+function mapCuratorError(err: unknown): never {
+  if (err instanceof CuratorValidationError) throw error(err.status, err.message);
+  if (err instanceof ForbiddenError) throw error(403, err.message);
+  if (err instanceof MissingReasonError) throw error(400, err.message);
+  throw err;
+}
+
+export const PATCH: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  const id = event.params.id;
+  if (!id || !UUID_RE.test(id)) throw error(400, 'Invalid translation id');
+  const input = await parseJson(event.request, body);
+  try {
+    const translation = await setTranslationHidden(
+      user,
+      id,
+      input.hidden,
+      input.reason,
+    );
+    return json({ translation });
+  } catch (err) {
+    mapCuratorError(err);
+  }
+};

--- a/apps/web/src/routes/api/v1/admin/translations/[id]/hidden/hidden-server.test.ts
+++ b/apps/web/src/routes/api/v1/admin/translations/[id]/hidden/hidden-server.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment node
+/**
+ * Route tests for PATCH /api/v1/admin/translations/:id/hidden (T-3.7).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const setTranslationHidden = vi.fn();
+const requireUser = vi.fn();
+
+vi.mock('$lib/server/dictionary/curator.js', async () => {
+  const actual = await vi.importActual<
+    typeof import('$lib/server/dictionary/curator.js')
+  >('$lib/server/dictionary/curator.js');
+  return {
+    ...actual,
+    setTranslationHidden: (...a: unknown[]) => setTranslationHidden(...a),
+  };
+});
+
+vi.mock('$lib/server/auth/require-user.js', () => ({
+  requireUser: (...a: unknown[]) => requireUser(...a),
+}));
+
+type PatchFn = (typeof import('./+server.js'))['PATCH'];
+
+const VALID_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const ADMIN = { id: 'admin-1', role: 'admin' as const };
+
+async function callPatch(body: unknown, user = ADMIN, id = VALID_ID) {
+  requireUser.mockResolvedValueOnce(user);
+  const { PATCH } = await import('./+server.js');
+  const event = {
+    params: { id },
+    request: new Request(`http://x/api/v1/admin/translations/${id}/hidden`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+  } as unknown as Parameters<PatchFn>[0];
+  try {
+    return await PATCH(event);
+  } catch (e) {
+    return e as { status: number };
+  }
+}
+
+beforeEach(() => {
+  setTranslationHidden.mockReset();
+  requireUser.mockReset();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('PATCH /api/v1/admin/translations/:id/hidden', () => {
+  it('hides a community translation', async () => {
+    setTranslationHidden.mockResolvedValueOnce({
+      id: VALID_ID,
+      hidden: true,
+    });
+    const res = (await callPatch({
+      hidden: true,
+      reason: 'Spam submission',
+    })) as Response;
+    expect(res.status).toBe(200);
+    expect(setTranslationHidden).toHaveBeenCalledWith(
+      ADMIN,
+      VALID_ID,
+      true,
+      'Spam submission',
+    );
+  });
+
+  it('maps CuratorValidationError(409) when hiding an official', async () => {
+    const { CuratorValidationError } = await import(
+      '$lib/server/dictionary/curator.js'
+    );
+    setTranslationHidden.mockRejectedValueOnce(
+      new CuratorValidationError('Only community', 409),
+    );
+    const res = (await callPatch({
+      hidden: true,
+      reason: 'trying to hide curator',
+    })) as { status: number };
+    expect(res.status).toBe(409);
+  });
+
+  it('rejects a non-boolean hidden value', async () => {
+    const res = (await callPatch({
+      hidden: 'yes',
+      reason: 'x',
+    })) as { status: number };
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/web/src/routes/api/v1/admin/translations/[id]/translation-server.test.ts
+++ b/apps/web/src/routes/api/v1/admin/translations/[id]/translation-server.test.ts
@@ -1,0 +1,97 @@
+// @vitest-environment node
+/**
+ * Route tests for PATCH /api/v1/admin/translations/:id (T-3.7).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const updateTranslation = vi.fn();
+const requireUser = vi.fn();
+
+vi.mock('$lib/server/dictionary/curator.js', async () => {
+  const actual = await vi.importActual<
+    typeof import('$lib/server/dictionary/curator.js')
+  >('$lib/server/dictionary/curator.js');
+  return {
+    ...actual,
+    updateTranslation: (...a: unknown[]) => updateTranslation(...a),
+  };
+});
+
+vi.mock('$lib/server/auth/require-user.js', () => ({
+  requireUser: (...a: unknown[]) => requireUser(...a),
+}));
+
+type PatchFn = (typeof import('./+server.js'))['PATCH'];
+
+const VALID_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const ADMIN = { id: 'admin-1', role: 'admin' as const };
+
+async function callPatch(body: unknown, user = ADMIN, id = VALID_ID) {
+  requireUser.mockResolvedValueOnce(user);
+  const { PATCH } = await import('./+server.js');
+  const event = {
+    params: { id },
+    request: new Request(`http://x/api/v1/admin/translations/${id}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+  } as unknown as Parameters<PatchFn>[0];
+  try {
+    return await PATCH(event);
+  } catch (e) {
+    return e as { status: number };
+  }
+}
+
+beforeEach(() => {
+  updateTranslation.mockReset();
+  requireUser.mockReset();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('PATCH /api/v1/admin/translations/:id', () => {
+  it('promotes a community translation and returns 200', async () => {
+    updateTranslation.mockResolvedValueOnce({
+      id: VALID_ID,
+      source: 'curator',
+      body: 'to speak',
+    });
+    const res = (await callPatch({
+      promoteToCurator: true,
+      reason: 'Endorsing a strong community gloss',
+    })) as Response;
+    expect(res.status).toBe(200);
+    expect(updateTranslation).toHaveBeenCalledWith(
+      ADMIN,
+      VALID_ID,
+      { promoteToCurator: true },
+      'Endorsing a strong community gloss',
+    );
+  });
+
+  it('maps CuratorValidationError(409) when promotion is illegal', async () => {
+    const { CuratorValidationError } = await import(
+      '$lib/server/dictionary/curator.js'
+    );
+    updateTranslation.mockRejectedValueOnce(
+      new CuratorValidationError('cannot re-tag', 409),
+    );
+    const res = (await callPatch({
+      promoteToCurator: true,
+      reason: 'x',
+    })) as { status: number };
+    expect(res.status).toBe(409);
+  });
+
+  it('returns 400 when reason is missing', async () => {
+    const res = (await callPatch({
+      promoteToCurator: true,
+    })) as { status: number };
+    expect(res.status).toBe(400);
+    expect(updateTranslation).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/routes/moderation/+layout.server.ts
+++ b/apps/web/src/routes/moderation/+layout.server.ts
@@ -1,0 +1,33 @@
+/**
+ * Moderation section guard (T-3.7).
+ *
+ * Blocks unauthenticated and non-curator visitors from every route under
+ * /moderation. The curator/admin distinction (and per-language scope) is
+ * enforced again in the service layer — this guard is cosmetic / UX,
+ * not a security boundary. It exists so an ordinary user never sees a
+ * half-rendered moderation page.
+ */
+import { error, redirect } from '@sveltejs/kit';
+import { listGrantedLanguages } from '$lib/server/dictionary/permissions.js';
+import type { LayoutServerLoad } from './$types';
+
+export const load: LayoutServerLoad = async ({ locals, url }) => {
+  if (!locals.user) {
+    throw redirect(303, `/login?next=${encodeURIComponent(url.pathname + url.search)}`);
+  }
+  const role = locals.user.role;
+  if (role !== 'curator' && role !== 'admin') {
+    throw error(403, 'Curator or admin role required');
+  }
+  const grantedLanguages = await listGrantedLanguages({
+    id: locals.user.id,
+    role,
+  });
+  return {
+    moderator: {
+      id: locals.user.id,
+      role,
+      grantedLanguages,
+    },
+  };
+};

--- a/apps/web/src/routes/moderation/+page.server.ts
+++ b/apps/web/src/routes/moderation/+page.server.ts
@@ -1,0 +1,6 @@
+import { redirect } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = () => {
+  throw redirect(303, '/moderation/dictionary');
+};

--- a/apps/web/src/routes/moderation/dictionary/+page.server.ts
+++ b/apps/web/src/routes/moderation/dictionary/+page.server.ts
@@ -1,0 +1,84 @@
+/**
+ * Curator dictionary list (T-3.7).
+ *
+ * Reuses the public browse service so curators see the same index the
+ * public does — filtered to the languages the current curator is granted
+ * on. Admins see every MVP language.
+ *
+ * The curator-only affordances (merge, split, edit) live on the detail
+ * page at /moderation/dictionary/[id]. This page is the jumping-off
+ * point.
+ */
+import { error } from '@sveltejs/kit';
+import {
+  DEFAULT_PAGE_SIZE,
+  MAX_PAGE_SIZE,
+  listDictionaryLemmas,
+  publicLemma,
+} from '$lib/server/dictionary/browse.js';
+import { LANGUAGES, isSupportedLanguage } from '@ciareader/shared-types';
+import type { LanguageCode } from '@ciareader/shared-types';
+import type { PageServerLoad } from './$types';
+
+function readInt(url: URL, key: string, fallback: number): number {
+  const raw = url.searchParams.get(key);
+  if (raw == null || raw === '') return fallback;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+export const load: PageServerLoad = async ({ url, parent }) => {
+  const { moderator } = await parent();
+  if (moderator.grantedLanguages.length === 0) {
+    return {
+      language: null,
+      descriptors: [],
+      lemmas: [],
+      totalCount: 0,
+      limit: DEFAULT_PAGE_SIZE,
+      offset: 0,
+      query: { q: '' },
+    };
+  }
+
+  const descriptors = moderator.grantedLanguages.map((code) => ({
+    code,
+    displayName: LANGUAGES[code].displayName,
+    nativeName: LANGUAGES[code].nativeName,
+  }));
+
+  const requestedLang = url.searchParams.get('language');
+  const fallback = moderator.grantedLanguages[0]!;
+  const language: LanguageCode =
+    requestedLang && isSupportedLanguage(requestedLang)
+      ? (requestedLang as LanguageCode)
+      : fallback;
+
+  if (!moderator.grantedLanguages.includes(language)) {
+    throw error(403, `You do not have curator rights for ${language}`);
+  }
+
+  const limit = Math.min(
+    Math.max(readInt(url, 'limit', DEFAULT_PAGE_SIZE), 1),
+    MAX_PAGE_SIZE,
+  );
+  const offset = Math.max(readInt(url, 'offset', 0), 0);
+  const q = url.searchParams.get('q');
+
+  const result = await listDictionaryLemmas(language, { q, limit, offset });
+
+  return {
+    language: {
+      code: language,
+      displayName: LANGUAGES[language].displayName,
+      nativeName: LANGUAGES[language].nativeName,
+      textDirection: LANGUAGES[language].textDirection,
+    },
+    descriptors,
+    lemmas: result.lemmas.map(publicLemma),
+    totalCount: result.totalCount,
+    limit: result.limit,
+    offset: result.offset,
+    query: { q: q ?? '' },
+  };
+};

--- a/apps/web/src/routes/moderation/dictionary/+page.svelte
+++ b/apps/web/src/routes/moderation/dictionary/+page.svelte
@@ -1,0 +1,224 @@
+<script lang="ts">
+  import type { PageData } from './$types';
+  let { data }: { data: PageData } = $props();
+
+  const pageNum = $derived(Math.floor(data.offset / data.limit) + 1);
+  const totalPages = $derived(Math.max(1, Math.ceil(data.totalCount / data.limit)));
+  const prevOffset = $derived(Math.max(0, data.offset - data.limit));
+  const nextOffset = $derived(data.offset + data.limit);
+
+  function hrefWith(offset: number): string {
+    const params = new URLSearchParams();
+    if (data.language) params.set('language', data.language.code);
+    if (data.query.q) params.set('q', data.query.q);
+    if (offset > 0) params.set('offset', String(offset));
+    if (data.limit !== 50) params.set('limit', String(data.limit));
+    const qs = params.toString();
+    return qs ? `?${qs}` : '';
+  }
+</script>
+
+<svelte:head>
+  <title>Dictionary moderation — CIA Reader</title>
+  <meta name="robots" content="noindex" />
+</svelte:head>
+
+<div class="page">
+  <header>
+    <h1>Dictionary moderation</h1>
+    {#if data.language}
+      <p class="sub">
+        Editing <strong>{data.language.nativeName}</strong> —
+        {data.totalCount.toLocaleString()} lemmas
+      </p>
+    {:else}
+      <p class="sub">No language grants. Ask an admin for curator rights.</p>
+    {/if}
+  </header>
+
+  {#if data.descriptors.length > 1}
+    <nav class="lang-picker" aria-label="Language">
+      {#each data.descriptors as d (d.code)}
+        <a
+          class:active={data.language?.code === d.code}
+          href={`?language=${d.code}`}
+        >
+          {d.displayName}
+        </a>
+      {/each}
+    </nav>
+  {/if}
+
+  {#if data.language}
+    <form method="get" class="search">
+      <input type="hidden" name="language" value={data.language.code} />
+      <input
+        type="search"
+        name="q"
+        value={data.query.q}
+        placeholder="Search {data.language.nativeName} headwords…"
+        aria-label="Search"
+      />
+      <button type="submit">Search</button>
+    </form>
+
+    {#if data.lemmas.length === 0}
+      <p class="empty">No lemmas match.</p>
+    {:else}
+      <ol class="lemmas" dir={data.language.textDirection}>
+        {#each data.lemmas as lemma (lemma.id)}
+          <li>
+            <a class="row" href={`/moderation/dictionary/${lemma.id}`}>
+              <span class="headword">{lemma.headword}</span>
+              <span class="pos">{lemma.pos}</span>
+              {#if lemma.curatorLocked}
+                <span class="badge">locked</span>
+              {/if}
+              {#if lemma.frequencyRank != null}
+                <span class="rank muted">#{lemma.frequencyRank}</span>
+              {/if}
+            </a>
+            {#if lemma.glossDefault}
+              <div class="gloss">{lemma.glossDefault}</div>
+            {/if}
+          </li>
+        {/each}
+      </ol>
+
+      <nav class="pager" aria-label="Pagination">
+        {#if data.offset > 0}
+          <a rel="prev" href={hrefWith(prevOffset)}>← Previous</a>
+        {:else}
+          <span class="muted">← Previous</span>
+        {/if}
+        <span class="muted">Page {pageNum} of {totalPages}</span>
+        {#if nextOffset < data.totalCount}
+          <a rel="next" href={hrefWith(nextOffset)}>Next →</a>
+        {:else}
+          <span class="muted">Next →</span>
+        {/if}
+      </nav>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .page {
+    max-width: 48rem;
+    margin: 0 auto;
+    padding: 1.5rem 1.25rem 3rem;
+  }
+  h1 {
+    margin: 0 0 0.25rem;
+    font-size: 1.6rem;
+  }
+  .sub {
+    margin: 0 0 1.25rem;
+    color: var(--color-fg-muted);
+  }
+  .muted {
+    color: var(--color-fg-muted);
+  }
+  .lang-picker {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+    flex-wrap: wrap;
+  }
+  .lang-picker a {
+    padding: 0.4rem 0.75rem;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    color: var(--color-fg);
+    text-decoration: none;
+    font-size: 0.9rem;
+  }
+  .lang-picker a.active {
+    background: var(--color-accent);
+    color: var(--color-accent-fg, #fff);
+    border-color: transparent;
+  }
+  .search {
+    display: grid;
+    gap: 0.5rem;
+    grid-template-columns: 1fr auto;
+    margin-bottom: 1.25rem;
+  }
+  .search input[type='search'] {
+    padding: 0.6rem 0.75rem;
+    font: inherit;
+    min-height: 44px;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    background: var(--color-bg);
+    color: var(--color-fg);
+  }
+  .search button {
+    min-height: 44px;
+    padding: 0 1rem;
+    background: var(--color-accent);
+    color: var(--color-accent-fg, #fff);
+    border: 0;
+    border-radius: 6px;
+    cursor: pointer;
+  }
+  .lemmas {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+  .lemmas li {
+    padding: 0.75rem 0;
+    border-bottom: 1px solid var(--color-border);
+  }
+  .row {
+    display: flex;
+    align-items: baseline;
+    gap: 0.75rem;
+    text-decoration: none;
+    color: var(--color-fg);
+  }
+  .row:hover .headword {
+    text-decoration: underline;
+  }
+  .headword {
+    font-size: 1.2rem;
+    font-weight: 500;
+  }
+  .pos {
+    font-size: 0.85rem;
+    color: var(--color-fg-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .badge {
+    font-size: 0.7rem;
+    padding: 0.05rem 0.4rem;
+    border-radius: 999px;
+    background: var(--color-border);
+    color: var(--color-fg-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .rank {
+    font-size: 0.8rem;
+  }
+  .gloss {
+    margin-top: 0.25rem;
+  }
+  .empty {
+    margin: 2rem 0;
+    color: var(--color-fg-muted);
+  }
+  .pager {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-top: 1.5rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--color-border);
+  }
+  .pager a {
+    color: var(--color-accent);
+  }
+</style>

--- a/apps/web/src/routes/moderation/dictionary/[id]/+page.server.ts
+++ b/apps/web/src/routes/moderation/dictionary/[id]/+page.server.ts
@@ -1,0 +1,355 @@
+/**
+ * Curator lemma editor (T-3.7).
+ *
+ * SSR loader renders the full editor view (lemma fields, translations,
+ * forms, recent history). Form actions route every mutation through the
+ * same service layer the JSON API uses, so the validation + audit rules
+ * are identical between web form and programmatic client.
+ *
+ * Sub-forms (edit / hide / merge / split / promote / lock) each post to
+ * a distinct action name and return a discriminated `section`-tagged
+ * result so the template can render inline success / error messages
+ * next to the right form without juggling union narrowing in the UI.
+ *
+ * Script-aware inputs (T-6.2a) aren't in the codebase yet; for now the
+ * form uses plain text inputs and curators paste the native-script
+ * headword directly. The service already NFC-normalises on write.
+ */
+import { error, fail, redirect } from '@sveltejs/kit';
+import { z } from 'zod';
+
+import {
+  CuratorValidationError,
+  getLemmaEditorView,
+  mergeLemmas,
+  setLemmaLock,
+  setTranslationHidden,
+  splitLemma,
+  updateLemma,
+  updateTranslation,
+} from '$lib/server/dictionary/curator.js';
+import { MissingReasonError } from '$lib/server/dictionary/audit.js';
+import { ForbiddenError } from '$lib/server/dictionary/permissions.js';
+import type { Actions, PageServerLoad } from './$types';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function mapError(e: unknown): { status: number; message: string } {
+  if (e instanceof CuratorValidationError) {
+    return { status: e.status, message: e.message };
+  }
+  if (e instanceof MissingReasonError) {
+    return { status: 400, message: e.message };
+  }
+  if (e instanceof ForbiddenError) {
+    return { status: 403, message: e.message };
+  }
+  return { status: 500, message: 'Unexpected error' };
+}
+
+type LemmaFormResult =
+  | { ok: true; section: 'lemma' }
+  | { ok: false; section: 'lemma'; message: string };
+type LockFormResult =
+  | { ok: true; section: 'lock' }
+  | { ok: false; section: 'lock'; message: string };
+type TranslationFormResult =
+  | { ok: true; section: 'translation'; translationId: string }
+  | { ok: false; section: 'translation'; translationId: string | null; message: string };
+type MergeFormResult =
+  | { ok: true; section: 'merge' }
+  | { ok: false; section: 'merge'; message: string };
+type SplitFormResult =
+  | { ok: true; section: 'split'; newLemmaId: string }
+  | { ok: false; section: 'split'; message: string };
+
+export const load: PageServerLoad = async ({ params, locals }) => {
+  if (!locals.user) throw redirect(303, '/login');
+  if (!UUID_RE.test(params.id)) throw error(400, 'Invalid lemma id');
+  try {
+    const view = await getLemmaEditorView(
+      { id: locals.user.id, role: locals.user.role },
+      params.id,
+    );
+    return { ...view };
+  } catch (e) {
+    const mapped = mapError(e);
+    throw error(mapped.status as 400 | 403 | 404, mapped.message);
+  }
+};
+
+const lemmaPatchSchema = z.object({
+  headword: z.string().min(1).max(128),
+  pos: z.string().min(1).max(32),
+  glossDefault: z
+    .string()
+    .max(500)
+    .transform((s) => (s.trim().length === 0 ? null : s))
+    .nullable(),
+  frequencyRank: z
+    .string()
+    .transform((s) => (s.trim().length === 0 ? null : Number.parseInt(s, 10)))
+    .refine((v) => v === null || (Number.isInteger(v) && v >= 0), {
+      message: 'frequencyRank must be a non-negative integer',
+    })
+    .nullable(),
+  sourceAttribution: z
+    .string()
+    .max(500)
+    .transform((s) => (s.trim().length === 0 ? null : s))
+    .nullable(),
+  reason: z.string().min(3).max(500),
+});
+
+const lockSchema = z.object({
+  locked: z.enum(['true', 'false']).transform((v) => v === 'true'),
+  reason: z.string().min(3).max(500),
+});
+
+const translationPatchSchema = z.object({
+  translationId: z.string().regex(UUID_RE),
+  body: z.string().min(1).max(500),
+  promoteToCurator: z
+    .enum(['true', 'false'])
+    .optional()
+    .transform((v) => v === 'true'),
+  hidden: z
+    .enum(['true', 'false'])
+    .optional()
+    .transform((v) => v === 'true'),
+  reason: z.string().min(3).max(500),
+});
+
+const hideSchema = z.object({
+  translationId: z.string().regex(UUID_RE),
+  hidden: z.enum(['true', 'false']).transform((v) => v === 'true'),
+  reason: z.string().min(3).max(500),
+});
+
+const mergeSchema = z.object({
+  loserId: z.string().regex(UUID_RE),
+  reason: z.string().min(3).max(500),
+});
+
+const splitSchema = z.object({
+  newHeadword: z.string().min(1).max(128),
+  newPos: z.string().min(1).max(32),
+  newGloss: z
+    .string()
+    .max(500)
+    .transform((s) => (s.trim().length === 0 ? null : s))
+    .nullable(),
+  translationIds: z.string().optional(),
+  reason: z.string().min(3).max(500),
+});
+
+function editorFromLocals(locals: App.Locals) {
+  if (!locals.user) throw new ForbiddenError('Unauthorized');
+  return { id: locals.user.id, role: locals.user.role };
+}
+
+export const actions: Actions = {
+  updateLemma: async ({ params, request, locals }) => {
+    const editor = editorFromLocals(locals);
+    const form = Object.fromEntries(await request.formData());
+    const parsed = lemmaPatchSchema.safeParse(form);
+    if (!parsed.success) {
+      return fail(400, {
+        ok: false,
+        section: 'lemma',
+        message: parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; '),
+      } satisfies LemmaFormResult);
+    }
+    try {
+      await updateLemma(
+        editor,
+        params.id,
+        {
+          headword: parsed.data.headword,
+          pos: parsed.data.pos,
+          glossDefault: parsed.data.glossDefault,
+          frequencyRank: parsed.data.frequencyRank,
+          sourceAttribution: parsed.data.sourceAttribution,
+        },
+        parsed.data.reason,
+      );
+      return { ok: true, section: 'lemma' } satisfies LemmaFormResult;
+    } catch (e) {
+      const mapped = mapError(e);
+      return fail(mapped.status, {
+        ok: false,
+        section: 'lemma',
+        message: mapped.message,
+      } satisfies LemmaFormResult);
+    }
+  },
+
+  setLock: async ({ params, request, locals }) => {
+    const editor = editorFromLocals(locals);
+    const form = Object.fromEntries(await request.formData());
+    const parsed = lockSchema.safeParse(form);
+    if (!parsed.success) {
+      return fail(400, {
+        ok: false,
+        section: 'lock',
+        message: parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; '),
+      } satisfies LockFormResult);
+    }
+    try {
+      await setLemmaLock(editor, params.id, parsed.data.locked, parsed.data.reason);
+      return { ok: true, section: 'lock' } satisfies LockFormResult;
+    } catch (e) {
+      const mapped = mapError(e);
+      return fail(mapped.status, {
+        ok: false,
+        section: 'lock',
+        message: mapped.message,
+      } satisfies LockFormResult);
+    }
+  },
+
+  updateTranslation: async ({ request, locals }) => {
+    const editor = editorFromLocals(locals);
+    const form = Object.fromEntries(await request.formData());
+    const parsed = translationPatchSchema.safeParse(form);
+    if (!parsed.success) {
+      return fail(400, {
+        ok: false,
+        section: 'translation',
+        translationId: (form.translationId as string | undefined) ?? null,
+        message: parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; '),
+      } satisfies TranslationFormResult);
+    }
+    try {
+      await updateTranslation(
+        editor,
+        parsed.data.translationId,
+        {
+          body: parsed.data.body,
+          promoteToCurator: parsed.data.promoteToCurator,
+        },
+        parsed.data.reason,
+      );
+      return {
+        ok: true,
+        section: 'translation',
+        translationId: parsed.data.translationId,
+      } satisfies TranslationFormResult;
+    } catch (e) {
+      const mapped = mapError(e);
+      return fail(mapped.status, {
+        ok: false,
+        section: 'translation',
+        translationId: parsed.data.translationId,
+        message: mapped.message,
+      } satisfies TranslationFormResult);
+    }
+  },
+
+  setTranslationHidden: async ({ request, locals }) => {
+    const editor = editorFromLocals(locals);
+    const form = Object.fromEntries(await request.formData());
+    const parsed = hideSchema.safeParse(form);
+    if (!parsed.success) {
+      return fail(400, {
+        ok: false,
+        section: 'translation',
+        translationId: (form.translationId as string | undefined) ?? null,
+        message: parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; '),
+      } satisfies TranslationFormResult);
+    }
+    try {
+      await setTranslationHidden(
+        editor,
+        parsed.data.translationId,
+        parsed.data.hidden,
+        parsed.data.reason,
+      );
+      return {
+        ok: true,
+        section: 'translation',
+        translationId: parsed.data.translationId,
+      } satisfies TranslationFormResult;
+    } catch (e) {
+      const mapped = mapError(e);
+      return fail(mapped.status, {
+        ok: false,
+        section: 'translation',
+        translationId: parsed.data.translationId,
+        message: mapped.message,
+      } satisfies TranslationFormResult);
+    }
+  },
+
+  merge: async ({ params, request, locals }) => {
+    const editor = editorFromLocals(locals);
+    const form = Object.fromEntries(await request.formData());
+    const parsed = mergeSchema.safeParse(form);
+    if (!parsed.success) {
+      return fail(400, {
+        ok: false,
+        section: 'merge',
+        message: parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; '),
+      } satisfies MergeFormResult);
+    }
+    try {
+      await mergeLemmas(
+        editor,
+        { winnerId: params.id, loserId: parsed.data.loserId },
+        parsed.data.reason,
+      );
+      return { ok: true, section: 'merge' } satisfies MergeFormResult;
+    } catch (e) {
+      const mapped = mapError(e);
+      return fail(mapped.status, {
+        ok: false,
+        section: 'merge',
+        message: mapped.message,
+      } satisfies MergeFormResult);
+    }
+  },
+
+  split: async ({ params, request, locals }) => {
+    const editor = editorFromLocals(locals);
+    const form = Object.fromEntries(await request.formData());
+    const parsed = splitSchema.safeParse(form);
+    if (!parsed.success) {
+      return fail(400, {
+        ok: false,
+        section: 'split',
+        message: parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; '),
+      } satisfies SplitFormResult);
+    }
+    const translationIds = (parsed.data.translationIds ?? '')
+      .split(/[\s,]+/)
+      .map((s) => s.trim())
+      .filter((s) => UUID_RE.test(s));
+    try {
+      const result = await splitLemma(
+        editor,
+        {
+          fromLemmaId: params.id,
+          newLemma: {
+            headword: parsed.data.newHeadword,
+            pos: parsed.data.newPos,
+            glossDefault: parsed.data.newGloss,
+          },
+          translationIds,
+        },
+        parsed.data.reason,
+      );
+      return {
+        ok: true,
+        section: 'split',
+        newLemmaId: result.created.id,
+      } satisfies SplitFormResult;
+    } catch (e) {
+      const mapped = mapError(e);
+      return fail(mapped.status, {
+        ok: false,
+        section: 'split',
+        message: mapped.message,
+      } satisfies SplitFormResult);
+    }
+  },
+};

--- a/apps/web/src/routes/moderation/dictionary/[id]/+page.svelte
+++ b/apps/web/src/routes/moderation/dictionary/[id]/+page.svelte
@@ -1,0 +1,423 @@
+<script lang="ts">
+  import { enhance } from '$app/forms';
+  import type { ActionData, PageData } from './$types';
+
+  let {
+    data,
+    form,
+  }: { data: PageData; form: ActionData } = $props();
+
+  const lemma = $derived(data.lemma);
+
+  const formattedHistory = $derived(
+    data.history.map((h) => ({
+      ...h,
+      when: new Date(h.createdAt).toLocaleString(),
+    })),
+  );
+
+  function msgFor(section: string): string | null {
+    if (!form) return null;
+    if (form.section !== section) return null;
+    if (form.ok) return 'Saved.';
+    return form.message;
+  }
+
+  function translationMsg(
+    translationId: string,
+  ): { ok: boolean; message: string } | null {
+    if (!form || form.section !== 'translation') return null;
+    if (form.translationId !== translationId) return null;
+    return {
+      ok: form.ok,
+      message: form.ok ? 'Saved.' : form.message,
+    };
+  }
+</script>
+
+<svelte:head>
+  <title>Edit {lemma.headword} — CIA Reader</title>
+  <meta name="robots" content="noindex" />
+</svelte:head>
+
+<div class="page">
+  <p class="crumb">
+    <a href="/moderation/dictionary?language={lemma.language}">← Back to dictionary</a>
+  </p>
+
+  <header>
+    <h1>
+      <span class="headword">{lemma.headword}</span>
+      <span class="pos">{lemma.pos}</span>
+      {#if lemma.curatorLocked}<span class="badge">locked</span>{/if}
+    </h1>
+    <p class="sub">
+      {lemma.language} · {lemma.script}
+      {#if lemma.sourceAttribution}· {lemma.sourceAttribution}{/if}
+    </p>
+  </header>
+
+  <!-- Lemma fields ------------------------------------------------------ -->
+  <section>
+    <h2>Lemma</h2>
+    {#if msgFor('lemma')}
+      <p class:ok={form?.ok} class:err={!form?.ok}>{msgFor('lemma')}</p>
+    {/if}
+    <form method="post" action="?/updateLemma" use:enhance>
+      <label>
+        Headword
+        <input name="headword" value={lemma.headword} required />
+      </label>
+      <label>
+        Part of speech
+        <input name="pos" value={lemma.pos} required />
+      </label>
+      <label>
+        Default gloss
+        <textarea name="glossDefault" rows="2">{lemma.glossDefault ?? ''}</textarea>
+      </label>
+      <label>
+        Frequency rank
+        <input
+          name="frequencyRank"
+          type="number"
+          min="0"
+          value={lemma.frequencyRank ?? ''}
+        />
+      </label>
+      <label>
+        Source attribution
+        <input name="sourceAttribution" value={lemma.sourceAttribution ?? ''} />
+      </label>
+      <label>
+        Reason (required)
+        <input name="reason" required minlength="3" placeholder="Why are you making this change?" />
+      </label>
+      <button type="submit">Save lemma</button>
+    </form>
+  </section>
+
+  <!-- Lock toggle ------------------------------------------------------- -->
+  <section>
+    <h2>Import protection</h2>
+    {#if msgFor('lock')}
+      <p class:ok={form?.ok} class:err={!form?.ok}>{msgFor('lock')}</p>
+    {/if}
+    <p class="sub">
+      Locked lemmas are skipped by future dictionary re-imports so your edits
+      aren't clobbered.
+    </p>
+    <form method="post" action="?/setLock" use:enhance class="inline-form">
+      <input type="hidden" name="locked" value={lemma.curatorLocked ? 'false' : 'true'} />
+      <input name="reason" required minlength="3" placeholder="Reason" />
+      <button type="submit">
+        {lemma.curatorLocked ? 'Unlock' : 'Lock'}
+      </button>
+    </form>
+  </section>
+
+  <!-- Translations ------------------------------------------------------ -->
+  <section>
+    <h2>Translations ({data.translations.length})</h2>
+    {#if data.translations.length === 0}
+      <p class="muted">No translations.</p>
+    {:else}
+      <ul class="translations">
+        {#each data.translations as t (t.id)}
+          <li>
+            <div class="meta">
+              <span class="tag">{t.source}</span>
+              <span class="muted">{t.targetLanguage}</span>
+              {#if t.hidden}<span class="tag warn">hidden</span>{/if}
+            </div>
+            {#if translationMsg(t.id)}
+              {@const tm = translationMsg(t.id)!}
+              <p class:ok={tm.ok} class:err={!tm.ok}>{tm.message}</p>
+            {/if}
+            <form method="post" action="?/updateTranslation" use:enhance class="stack">
+              <input type="hidden" name="translationId" value={t.id} />
+              <label>
+                Body
+                <textarea name="body" rows="2" required>{t.body}</textarea>
+              </label>
+              {#if t.source === 'user'}
+                <label class="checkbox">
+                  <input type="checkbox" name="promoteToCurator" value="true" />
+                  Promote to curator (official)
+                </label>
+              {/if}
+              <label>
+                Reason
+                <input name="reason" required minlength="3" placeholder="Reason" />
+              </label>
+              <div class="row-actions">
+                <button type="submit">Save</button>
+                {#if t.source === 'user'}
+                  <button
+                    type="submit"
+                    formaction="?/setTranslationHidden"
+                    name="hidden"
+                    value={t.hidden ? 'false' : 'true'}
+                    class="secondary"
+                  >
+                    {t.hidden ? 'Unhide' : 'Hide'}
+                  </button>
+                {/if}
+              </div>
+            </form>
+          </li>
+        {/each}
+      </ul>
+    {/if}
+  </section>
+
+  <!-- Merge ------------------------------------------------------------- -->
+  <section>
+    <h2>Merge</h2>
+    {#if msgFor('merge')}
+      <p class:ok={form?.ok} class:err={!form?.ok}>{msgFor('merge')}</p>
+    {/if}
+    <p class="sub">
+      Rewires translations + forms from the loser lemma into this one, then
+      deletes the loser. Cross-language merges are rejected.
+    </p>
+    <form method="post" action="?/merge" use:enhance class="stack">
+      <label>
+        Loser lemma id
+        <input name="loserId" required placeholder="uuid of the duplicate lemma" />
+      </label>
+      <label>
+        Reason
+        <input name="reason" required minlength="3" placeholder="e.g. duplicate import" />
+      </label>
+      <button type="submit" class="danger">Merge into this lemma</button>
+    </form>
+  </section>
+
+  <!-- Split ------------------------------------------------------------- -->
+  <section>
+    <h2>Split</h2>
+    {#if msgFor('split')}
+      <p class:ok={form?.ok} class:err={!form?.ok}>
+        {msgFor('split')}
+        {#if form?.ok && form.section === 'split'}
+          <a href={`/moderation/dictionary/${form.newLemmaId}`}>Open new lemma →</a>
+        {/if}
+      </p>
+    {/if}
+    <p class="sub">
+      Creates a new curator-owned lemma and moves the selected translations
+      onto it.
+    </p>
+    <form method="post" action="?/split" use:enhance class="stack">
+      <label>
+        New headword
+        <input name="newHeadword" required />
+      </label>
+      <label>
+        New part of speech
+        <input name="newPos" required />
+      </label>
+      <label>
+        New gloss (optional)
+        <input name="newGloss" />
+      </label>
+      <label>
+        Translation ids to move (comma- or space-separated)
+        <textarea name="translationIds" rows="2"></textarea>
+      </label>
+      <label>
+        Reason
+        <input name="reason" required minlength="3" />
+      </label>
+      <button type="submit" class="danger">Split off new lemma</button>
+    </form>
+  </section>
+
+  <!-- History ---------------------------------------------------------- -->
+  <section>
+    <h2>Recent edits</h2>
+    {#if formattedHistory.length === 0}
+      <p class="muted">No audit rows yet.</p>
+    {:else}
+      <ol class="history">
+        {#each formattedHistory as h (h.id)}
+          <li>
+            <span class="tag">{h.changeType}</span>
+            <span class="muted">{h.when}</span>
+            <div>{h.reason}</div>
+          </li>
+        {/each}
+      </ol>
+    {/if}
+  </section>
+</div>
+
+<style>
+  .page {
+    max-width: 42rem;
+    margin: 0 auto;
+    padding: 1.5rem 1.25rem 3rem;
+  }
+  .crumb {
+    margin: 0 0 1rem;
+    font-size: 0.9rem;
+  }
+  .crumb a {
+    color: var(--color-accent);
+  }
+  header h1 {
+    margin: 0 0 0.25rem;
+    display: flex;
+    align-items: baseline;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+  .headword {
+    font-size: 1.6rem;
+  }
+  .pos {
+    font-size: 0.85rem;
+    color: var(--color-fg-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .badge,
+  .tag {
+    font-size: 0.7rem;
+    padding: 0.05rem 0.4rem;
+    border-radius: 999px;
+    background: var(--color-border);
+    color: var(--color-fg-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .tag.warn {
+    background: color-mix(in srgb, var(--color-accent) 30%, transparent);
+    color: var(--color-fg);
+  }
+  .sub {
+    color: var(--color-fg-muted);
+    margin: 0 0 1rem;
+    font-size: 0.9rem;
+  }
+  .muted {
+    color: var(--color-fg-muted);
+  }
+  section {
+    margin: 1.75rem 0;
+    padding: 1rem 1.25rem;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+  }
+  section h2 {
+    margin: 0 0 0.75rem;
+    font-size: 1.1rem;
+  }
+  form label {
+    display: block;
+    margin-bottom: 0.75rem;
+    font-size: 0.9rem;
+  }
+  form input,
+  form textarea {
+    display: block;
+    width: 100%;
+    margin-top: 0.25rem;
+    padding: 0.5rem 0.6rem;
+    font: inherit;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    background: var(--color-bg);
+    color: var(--color-fg);
+    min-height: 44px;
+  }
+  form textarea {
+    min-height: 3rem;
+    resize: vertical;
+  }
+  .stack > * {
+    margin-bottom: 0.75rem;
+  }
+  .inline-form {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+  }
+  .inline-form input[name='reason'] {
+    min-height: 44px;
+    margin-top: 0;
+    flex: 1;
+  }
+  form button {
+    min-height: 44px;
+    padding: 0 1rem;
+    background: var(--color-accent);
+    color: var(--color-accent-fg, #fff);
+    border: 0;
+    border-radius: 6px;
+    cursor: pointer;
+  }
+  form button.secondary {
+    background: transparent;
+    color: var(--color-fg);
+    border: 1px solid var(--color-border);
+  }
+  form button.danger {
+    background: #b03131;
+    color: #fff;
+  }
+  .row-actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+  .translations {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+  .translations li {
+    padding: 0.75rem 0;
+    border-bottom: 1px solid var(--color-border);
+  }
+  .translations li:last-child {
+    border-bottom: 0;
+  }
+  .meta {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    margin-bottom: 0.5rem;
+  }
+  .history {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    font-size: 0.9rem;
+  }
+  .history li {
+    padding: 0.5rem 0;
+    border-bottom: 1px solid var(--color-border);
+  }
+  .history li:last-child {
+    border-bottom: 0;
+  }
+  .ok {
+    color: #197a2f;
+  }
+  .err {
+    color: #b03131;
+  }
+  .checkbox {
+    display: flex;
+    gap: 0.4rem;
+    align-items: center;
+  }
+  .checkbox input {
+    display: inline;
+    width: auto;
+    min-height: 0;
+    margin: 0;
+  }
+</style>

--- a/apps/web/src/routes/moderation/dictionary/[id]/page-server.test.ts
+++ b/apps/web/src/routes/moderation/dictionary/[id]/page-server.test.ts
@@ -1,0 +1,220 @@
+// @vitest-environment node
+/**
+ * Tests for /moderation/dictionary/:id SSR loader and form actions (T-3.7).
+ *
+ * The loader + every action delegates to the curator service; these tests
+ * mock that layer and assert the web-form plumbing (shape of the loader
+ * output, form validation, discriminated action results) — not the
+ * service semantics, which are covered in curator.test.ts.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getLemmaEditorView = vi.fn();
+const updateLemma = vi.fn();
+const setLemmaLock = vi.fn();
+const updateTranslation = vi.fn();
+const setTranslationHidden = vi.fn();
+const mergeLemmas = vi.fn();
+const splitLemma = vi.fn();
+
+vi.mock('$lib/server/dictionary/curator.js', async () => {
+  const actual = await vi.importActual<
+    typeof import('$lib/server/dictionary/curator.js')
+  >('$lib/server/dictionary/curator.js');
+  return {
+    ...actual,
+    getLemmaEditorView: (...a: unknown[]) => getLemmaEditorView(...a),
+    updateLemma: (...a: unknown[]) => updateLemma(...a),
+    setLemmaLock: (...a: unknown[]) => setLemmaLock(...a),
+    updateTranslation: (...a: unknown[]) => updateTranslation(...a),
+    setTranslationHidden: (...a: unknown[]) => setTranslationHidden(...a),
+    mergeLemmas: (...a: unknown[]) => mergeLemmas(...a),
+    splitLemma: (...a: unknown[]) => splitLemma(...a),
+  };
+});
+
+type Mod = typeof import('./+page.server.js');
+
+const LEMMA_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const OTHER_ID = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+const USER = { id: 'u1', role: 'curator' as const };
+
+async function callLoad(id = LEMMA_ID, user: typeof USER | null = USER) {
+  const { load } = (await import('./+page.server.js')) as Mod;
+  const event = {
+    params: { id },
+    locals: { user },
+  } as Parameters<Mod['load']>[0];
+  try {
+    return await load(event);
+  } catch (e) {
+    return e as { status: number };
+  }
+}
+
+async function callAction(
+  name: keyof Mod['actions'],
+  fields: Record<string, string>,
+  id = LEMMA_ID,
+) {
+  const { actions } = (await import('./+page.server.js')) as Mod;
+  const fd = new FormData();
+  for (const [k, v] of Object.entries(fields)) fd.set(k, v);
+  const event = {
+    params: { id },
+    locals: { user: USER },
+    request: new Request('http://x', { method: 'POST', body: fd }),
+  } as unknown as Parameters<Mod['actions'][typeof name]>[0];
+  return actions[name]!(event);
+}
+
+beforeEach(() => {
+  getLemmaEditorView.mockReset();
+  updateLemma.mockReset();
+  setLemmaLock.mockReset();
+  updateTranslation.mockReset();
+  setTranslationHidden.mockReset();
+  mergeLemmas.mockReset();
+  splitLemma.mockReset();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('moderation lemma editor loader', () => {
+  it('returns the editor view on success', async () => {
+    const view = {
+      lemma: { id: LEMMA_ID, headword: 'बोलना' },
+      translations: [],
+      forms: [],
+      history: [],
+    };
+    getLemmaEditorView.mockResolvedValueOnce(view);
+    const data = (await callLoad()) as { lemma: { id: string } };
+    expect(data.lemma.id).toBe(LEMMA_ID);
+    expect(getLemmaEditorView).toHaveBeenCalledWith(USER, LEMMA_ID);
+  });
+
+  it('rejects a malformed lemma id with 400', async () => {
+    const res = (await callLoad('not-a-uuid')) as { status: number };
+    expect(res.status).toBe(400);
+    expect(getLemmaEditorView).not.toHaveBeenCalled();
+  });
+
+  it('maps CuratorValidationError(404) to a 404', async () => {
+    const { CuratorValidationError } = await import(
+      '$lib/server/dictionary/curator.js'
+    );
+    getLemmaEditorView.mockRejectedValueOnce(
+      new CuratorValidationError('gone', 404),
+    );
+    const res = (await callLoad()) as { status: number };
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('moderation lemma editor actions', () => {
+  it('updateLemma happy path returns section=lemma, ok=true', async () => {
+    updateLemma.mockResolvedValueOnce({ id: LEMMA_ID });
+    const res = await callAction('updateLemma', {
+      headword: 'बोलना',
+      pos: 'verb',
+      glossDefault: 'to speak',
+      frequencyRank: '123',
+      sourceAttribution: '',
+      reason: 'fix typo',
+    });
+    expect(res).toEqual({ ok: true, section: 'lemma' });
+    expect(updateLemma).toHaveBeenCalledWith(
+      USER,
+      LEMMA_ID,
+      expect.objectContaining({ headword: 'बोलना', frequencyRank: 123 }),
+      'fix typo',
+    );
+  });
+
+  it('updateLemma fail on short reason', async () => {
+    const res = await callAction('updateLemma', {
+      headword: 'x',
+      pos: 'v',
+      glossDefault: '',
+      frequencyRank: '',
+      sourceAttribution: '',
+      reason: 'no',
+    });
+    // SvelteKit's fail() wraps the body in { status, data }; our helper returns
+    // the ActionFailure, so inspect `.data` for the section/message shape.
+    expect((res as { status: number }).status).toBe(400);
+    expect((res as { data: { ok: boolean } }).data.ok).toBe(false);
+    expect(updateLemma).not.toHaveBeenCalled();
+  });
+
+  it('merge forwards winnerId from params and loserId from form', async () => {
+    mergeLemmas.mockResolvedValueOnce({ translationsMoved: 0, formsMoved: 0 });
+    const res = await callAction('merge', {
+      loserId: OTHER_ID,
+      reason: 'duplicate',
+    });
+    expect(res).toEqual({ ok: true, section: 'merge' });
+    expect(mergeLemmas).toHaveBeenCalledWith(
+      USER,
+      { winnerId: LEMMA_ID, loserId: OTHER_ID },
+      'duplicate',
+    );
+  });
+
+  it('merge returns 400 when loserId is not a UUID', async () => {
+    const res = await callAction('merge', {
+      loserId: 'nope',
+      reason: 'duplicate',
+    });
+    expect((res as { status: number }).status).toBe(400);
+    expect(mergeLemmas).not.toHaveBeenCalled();
+  });
+
+  it('split parses translationIds as comma-separated UUIDs', async () => {
+    splitLemma.mockResolvedValueOnce({
+      created: { id: 'new-id' },
+    });
+    const tid1 = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+    const tid2 = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+    const res = await callAction('split', {
+      newHeadword: 'सोना',
+      newPos: 'noun',
+      newGloss: 'gold',
+      translationIds: `${tid1}, ${tid2}`,
+      reason: 'disambiguate',
+    });
+    expect((res as { ok: boolean }).ok).toBe(true);
+    expect(splitLemma).toHaveBeenCalledWith(
+      USER,
+      expect.objectContaining({
+        translationIds: [tid1, tid2],
+        newLemma: expect.objectContaining({ headword: 'सोना', pos: 'noun' }),
+      }),
+      'disambiguate',
+    );
+  });
+
+  it('setTranslationHidden forwards the translation id and boolean', async () => {
+    setTranslationHidden.mockResolvedValueOnce({});
+    const tid = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+    const res = await callAction('setTranslationHidden', {
+      translationId: tid,
+      hidden: 'true',
+      reason: 'spam submission',
+    });
+    expect((res as { ok: boolean; section: string; translationId: string })).toEqual({
+      ok: true,
+      section: 'translation',
+      translationId: tid,
+    });
+    expect(setTranslationHidden).toHaveBeenCalledWith(
+      USER,
+      tid,
+      true,
+      'spam submission',
+    );
+  });
+});

--- a/apps/web/src/routes/moderation/dictionary/page-server.test.ts
+++ b/apps/web/src/routes/moderation/dictionary/page-server.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment node
+/**
+ * Tests for /moderation/dictionary SSR loader (T-3.7).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const listDictionaryLemmas = vi.fn();
+
+vi.mock('$lib/server/dictionary/browse.js', async () => {
+  const actual = await vi.importActual<
+    typeof import('$lib/server/dictionary/browse.js')
+  >('$lib/server/dictionary/browse.js');
+  return {
+    ...actual,
+    listDictionaryLemmas: (...a: unknown[]) => listDictionaryLemmas(...a),
+  };
+});
+
+type LoadFn = (typeof import('./+page.server.js'))['load'];
+type LoadEvent = Parameters<LoadFn>[0];
+
+async function callLoad(
+  url: string,
+  grantedLanguages: string[] = ['hi', 'mr'],
+) {
+  const { load } = await import('./+page.server.js');
+  const parent = vi.fn().mockResolvedValue({
+    moderator: {
+      id: 'u1',
+      role: 'curator',
+      grantedLanguages,
+    },
+  });
+  const event = {
+    url: new URL(url),
+    parent,
+  } as unknown as LoadEvent;
+  try {
+    return await load(event);
+  } catch (e) {
+    return e as { status: number };
+  }
+}
+
+beforeEach(() => {
+  listDictionaryLemmas.mockReset();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('/moderation/dictionary loader', () => {
+  it('defaults to the first granted language when none is in the URL', async () => {
+    listDictionaryLemmas.mockResolvedValueOnce({
+      lemmas: [],
+      totalCount: 0,
+      limit: 50,
+      offset: 0,
+    });
+    const data = (await callLoad('http://x/moderation/dictionary')) as {
+      language: { code: string };
+    };
+    expect(data.language.code).toBe('hi');
+    expect(listDictionaryLemmas).toHaveBeenCalledWith('hi', expect.any(Object));
+  });
+
+  it('honors the ?language= query when the curator has that grant', async () => {
+    listDictionaryLemmas.mockResolvedValueOnce({
+      lemmas: [],
+      totalCount: 0,
+      limit: 50,
+      offset: 0,
+    });
+    const data = (await callLoad(
+      'http://x/moderation/dictionary?language=mr',
+    )) as { language: { code: string } };
+    expect(data.language.code).toBe('mr');
+  });
+
+  it('403s when the requested language is outside the curator’s grants', async () => {
+    const res = (await callLoad(
+      'http://x/moderation/dictionary?language=or',
+      ['hi'],
+    )) as { status: number };
+    expect(res.status).toBe(403);
+    expect(listDictionaryLemmas).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty shape when the curator has no grants', async () => {
+    const data = (await callLoad('http://x/moderation/dictionary', [])) as {
+      language: null;
+      descriptors: unknown[];
+    };
+    expect(data.language).toBeNull();
+    expect(data.descriptors).toEqual([]);
+    expect(listDictionaryLemmas).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/routes/moderation/layout-server.test.ts
+++ b/apps/web/src/routes/moderation/layout-server.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment node
+/**
+ * Tests for /moderation/+layout.server.ts guard (T-3.7).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const listGrantedLanguages = vi.fn();
+
+vi.mock('$lib/server/dictionary/permissions.js', async () => {
+  const actual = await vi.importActual<
+    typeof import('$lib/server/dictionary/permissions.js')
+  >('$lib/server/dictionary/permissions.js');
+  return {
+    ...actual,
+    listGrantedLanguages: (...a: unknown[]) => listGrantedLanguages(...a),
+  };
+});
+
+type LoadFn = (typeof import('./+layout.server.js'))['load'];
+type LoadEvent = Parameters<LoadFn>[0];
+
+async function callLoad(
+  user: { id: string; role: string } | null,
+  path = '/moderation/dictionary',
+) {
+  const { load } = await import('./+layout.server.js');
+  const event = {
+    locals: { user },
+    url: new URL(`http://x${path}`),
+  } as unknown as LoadEvent;
+  try {
+    return await load(event);
+  } catch (e) {
+    return e as { status?: number; location?: string };
+  }
+}
+
+beforeEach(() => {
+  listGrantedLanguages.mockReset();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('/moderation layout guard', () => {
+  it('redirects an unauthenticated visitor to the login page', async () => {
+    const res = (await callLoad(null)) as { status: number; location: string };
+    expect(res.status).toBe(303);
+    expect(res.location).toContain('/login');
+    expect(res.location).toContain('next=');
+  });
+
+  it('forbids a regular user role', async () => {
+    const res = (await callLoad({ id: 'u1', role: 'user' })) as { status: number };
+    expect(res.status).toBe(403);
+    expect(listGrantedLanguages).not.toHaveBeenCalled();
+  });
+
+  it('returns granted languages for a curator', async () => {
+    listGrantedLanguages.mockResolvedValueOnce(['hi', 'mr']);
+    const data = (await callLoad({ id: 'c1', role: 'curator' })) as {
+      moderator: { grantedLanguages: string[]; role: string };
+    };
+    expect(data.moderator.role).toBe('curator');
+    expect(data.moderator.grantedLanguages).toEqual(['hi', 'mr']);
+  });
+
+  it('returns all MVP languages for an admin', async () => {
+    listGrantedLanguages.mockResolvedValueOnce(['hi', 'mr', 'or']);
+    const data = (await callLoad({ id: 'a1', role: 'admin' })) as {
+      moderator: { grantedLanguages: string[]; role: string };
+    };
+    expect(data.moderator.role).toBe('admin');
+    expect(data.moderator.grantedLanguages).toEqual(['hi', 'mr', 'or']);
+  });
+});


### PR DESCRIPTION
## Summary
- Curator editor service at `lib/server/dictionary/curator.ts`: edit lemma fields, toggle curator lock, edit / promote / hide translations, merge two lemmas, split a lemma into two. Every mutator checks `requireCanEditDictionary`, records a `lemma_edit_history` row with a required reason, and NFC-normalises headwords. Merge pre-writes the loser-side audit so the history FK cascade doesn't take it out on the loser delete. Split creates a new curator-owned lemma with `curator_locked=true`.
- Admin JSON endpoints under `/api/v1/admin/lemmas/:id[/lock|/merge|/split]` and `/api/v1/admin/translations/:id[/hidden]`, with UUID + Zod validation up front. `CuratorValidationError` status codes (400/403/404/409) surface directly; `MissingReasonError` → 400; `ForbiddenError` → 403.
- Web UI under `/moderation/dictionary`: layout guard redirects unauth and 403s non-curators, list page scoped to the curator's granted languages, detail page with form actions for every mutator.
- Migration `0005` adds `lemma_merge` + `lemma_split` to the audit-type enum. Schema widens `LemmaEditChangePayload` with merge/split-specific fields.

## Scope note
Merge + split only rewire `translations` + `lemma_forms` in this PR. Rewiring `text_tokens` / `user_known_lemmas` / `form_lemma_overrides` lands with the M5/M6 tickets that introduce those tables.

## Test plan
- [x] 22 curator-service unit tests (happy + validation + cross-language + self-merge + missing reason)
- [x] 45 admin-API tests (happy + 400/403/404/409 mapping)
- [x] 17 moderation-UI tests (layout guard redirect/403, language scoping, action plumbing incl. `{winnerId, loserId}` from params + form, split `translationIds` parsing)
- [x] `pnpm --filter @ciareader/web check` clean
- [x] `pnpm --filter @ciareader/web lint` clean
- [x] `pnpm --filter @ciareader/web test:coverage` — 301 tests pass, thresholds met (86%+ overall)