### PR TITLE
T-3.8: translation provenance badges

### DIFF
--- a/apps/web/src/lib/components/dictionary/ProvenanceBadge.svelte
+++ b/apps/web/src/lib/components/dictionary/ProvenanceBadge.svelte
@@ -1,0 +1,76 @@
+<!--
+  Translation provenance badge (T-3.8).
+
+  Renders one short pill per translation in the reader pop-up + on the
+  /moderation/dictionary editor + anywhere else translations are shown.
+  The colour, text, and tooltip are derived entirely from the
+  `provenance` discriminator on `PublicTranslation` — never from the raw
+  `source` column — so adding a new provenance category later (e.g.
+  "promoted-override") is one switch case, not a sweep.
+
+  Visual design is deliberately small and unobtrusive: badges sit
+  inline next to the translation body, not above it. The tooltip
+  (`title` attribute) carries the long form attribution for imported
+  rows. Touch users get the same info via the visible badge text plus a
+  longer aria-label.
+-->
+<script lang="ts">
+  import type { TranslationProvenance } from '$lib/server/dictionary/lookups.js';
+  import { provenanceDisplay } from './provenance-display.js';
+
+  let { provenance }: { provenance: TranslationProvenance } = $props();
+
+  const display = $derived(provenanceDisplay(provenance));
+</script>
+
+<span
+  class="badge tone-{display.tone}"
+  title={display.tooltip}
+  aria-label={display.tooltip}
+  data-testid="provenance-badge"
+  data-kind={provenance.kind}
+>
+  {display.label}
+</span>
+
+<style>
+  .badge {
+    display: inline-block;
+    padding: 0.05rem 0.45rem;
+    font-size: 0.72rem;
+    font-weight: 500;
+    line-height: 1.6;
+    border-radius: 999px;
+    border: 1px solid var(--color-border);
+    color: var(--color-fg-muted);
+    background: var(--color-bg);
+    /* Long imported attributions (e.g. "Hindi WordNet (CFILT, IIT-Bombay)")
+       can wrap awkwardly inside the inline pill — clip them so the badge
+       always stays a single line. */
+    max-width: 14rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    vertical-align: baseline;
+  }
+  .tone-personal {
+    border-color: color-mix(in srgb, var(--color-accent) 60%, transparent);
+    color: var(--color-accent);
+    background: color-mix(in srgb, var(--color-accent) 10%, transparent);
+  }
+  .tone-curator {
+    border-color: color-mix(in srgb, #197a2f 60%, transparent);
+    color: #197a2f;
+    background: color-mix(in srgb, #197a2f 10%, transparent);
+  }
+  .tone-imported {
+    /* Tonally neutral so a long attribution doesn't dominate the pop-up. */
+    border-color: var(--color-border);
+    color: var(--color-fg-muted);
+  }
+  .tone-community {
+    border-color: color-mix(in srgb, #b07a31 60%, transparent);
+    color: #b07a31;
+    background: color-mix(in srgb, #b07a31 10%, transparent);
+  }
+</style>

--- a/apps/web/src/lib/components/dictionary/provenance-display.test.ts
+++ b/apps/web/src/lib/components/dictionary/provenance-display.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { provenanceDisplay } from './provenance-display.js';
+
+describe('provenanceDisplay (T-3.8)', () => {
+  it('renders "yours" for the personal kind', () => {
+    expect(provenanceDisplay({ kind: 'personal', attribution: null })).toEqual({
+      label: 'yours',
+      tooltip: 'Your customization — only visible to you.',
+      tone: 'personal',
+    });
+  });
+
+  it('uses the curator attribution as the label when present', () => {
+    const d = provenanceDisplay({ kind: 'curator', attribution: 'CIA Reader curators' });
+    expect(d.label).toBe('CIA Reader curators');
+    expect(d.tone).toBe('curator');
+    expect(d.tooltip).toContain('CIA Reader curators');
+  });
+
+  it('falls back to "curator" when no attribution is set', () => {
+    const d = provenanceDisplay({ kind: 'curator', attribution: null });
+    expect(d.label).toBe('curator');
+    expect(d.tooltip).toBe('Curator-edited entry.');
+  });
+
+  it('uses the upstream attribution verbatim for imported rows', () => {
+    const d = provenanceDisplay({
+      kind: 'imported',
+      attribution: 'Hindi WordNet (CFILT, IIT-Bombay)',
+    });
+    expect(d.label).toBe('Hindi WordNet (CFILT, IIT-Bombay)');
+    expect(d.tooltip).toBe('Imported from Hindi WordNet (CFILT, IIT-Bombay).');
+    expect(d.tone).toBe('imported');
+  });
+
+  it('falls back to "imported" when no attribution is set', () => {
+    const d = provenanceDisplay({ kind: 'imported', attribution: null });
+    expect(d.label).toBe('imported');
+  });
+
+  it('renders "community" for unattributed user submissions', () => {
+    const d = provenanceDisplay({ kind: 'community', attribution: null });
+    expect(d.label).toBe('community');
+    expect(d.tone).toBe('community');
+  });
+});

--- a/apps/web/src/lib/components/dictionary/provenance-display.ts
+++ b/apps/web/src/lib/components/dictionary/provenance-display.ts
@@ -1,0 +1,50 @@
+/**
+ * Visual mapping for the translation `provenance` discriminator (T-3.8).
+ *
+ * Lifted out of `ProvenanceBadge.svelte` so the label / tooltip / tone
+ * decisions are unit-testable without spinning up jsdom. The component
+ * is a thin renderer over this — adding a new provenance category is
+ * one switch case here, no template work.
+ */
+import type { TranslationProvenance } from '$lib/server/dictionary/lookups.js';
+
+export type ProvenanceDisplay = {
+  label: string;
+  tooltip: string;
+  tone: 'personal' | 'curator' | 'imported' | 'community';
+};
+
+export function provenanceDisplay(
+  provenance: TranslationProvenance,
+): ProvenanceDisplay {
+  switch (provenance.kind) {
+    case 'personal':
+      return {
+        label: 'yours',
+        tooltip: 'Your customization — only visible to you.',
+        tone: 'personal',
+      };
+    case 'curator':
+      return {
+        label: provenance.attribution ?? 'curator',
+        tooltip: provenance.attribution
+          ? `Curator-edited (${provenance.attribution}).`
+          : 'Curator-edited entry.',
+        tone: 'curator',
+      };
+    case 'imported':
+      return {
+        label: provenance.attribution ?? 'imported',
+        tooltip: provenance.attribution
+          ? `Imported from ${provenance.attribution}.`
+          : 'Imported from an open-source dictionary.',
+        tone: 'imported',
+      };
+    case 'community':
+      return {
+        label: 'community',
+        tooltip: 'Submitted by another reader.',
+        tone: 'community',
+      };
+  }
+}

--- a/apps/web/src/lib/server/dictionary/lookups.test.ts
+++ b/apps/web/src/lib/server/dictionary/lookups.test.ts
@@ -9,7 +9,7 @@
  */
 import { describe, expect, it } from 'vitest';
 
-import { bucketTranslations } from './lookups.js';
+import { bucketTranslations, deriveProvenance } from './lookups.js';
 import type { Translation } from '../db/schema.js';
 
 let _id = 0;
@@ -111,6 +111,69 @@ describe('bucketTranslations — ordering', () => {
     ];
     const out = bucketTranslations(rows, { id: 'u1', role: 'user' });
     expect(out.personal.map((t) => t.body)).toEqual(['old-fork', 'new-fork']);
+  });
+});
+
+describe('deriveProvenance — viewer-relative classification (T-3.8)', () => {
+  it('returns personal/null when the viewer authored the row', () => {
+    const r = row({ source: 'user', submittedBy: 'u1' });
+    expect(deriveProvenance(r, { id: 'u1' })).toEqual({
+      kind: 'personal',
+      attribution: null,
+    });
+  });
+
+  it('returns community/null when another user authored the row', () => {
+    const r = row({ source: 'user', submittedBy: 'u2' });
+    expect(deriveProvenance(r, { id: 'u1' })).toEqual({
+      kind: 'community',
+      attribution: null,
+    });
+  });
+
+  it('returns community/null for a user-row when the viewer is anonymous', () => {
+    const r = row({ source: 'user', submittedBy: 'u2' });
+    expect(deriveProvenance(r, null)).toEqual({
+      kind: 'community',
+      attribution: null,
+    });
+  });
+
+  it('returns curator with the row attribution', () => {
+    const r = row({ source: 'curator', sourceAttribution: 'CIA Reader curators' });
+    expect(deriveProvenance(r, null)).toEqual({
+      kind: 'curator',
+      attribution: 'CIA Reader curators',
+    });
+  });
+
+  it('returns imported with upstream attribution preserved verbatim', () => {
+    const r = row({
+      source: 'official_dictionary',
+      sourceAttribution: 'Hindi WordNet (CFILT, IIT-Bombay)',
+    });
+    expect(deriveProvenance(r, { id: 'u1' })).toEqual({
+      kind: 'imported',
+      attribution: 'Hindi WordNet (CFILT, IIT-Bombay)',
+    });
+  });
+});
+
+describe('bucketTranslations — provenance attached to every public row', () => {
+  it('attaches the right kind to each bucket', () => {
+    const rows: Translation[] = [
+      row({ source: 'official_dictionary', sourceAttribution: 'Molesworth' }),
+      row({ source: 'curator' }),
+      row({ source: 'user', submittedBy: 'me' }),
+      row({ source: 'user', submittedBy: 'them' }),
+    ];
+    const out = bucketTranslations(rows, { id: 'me', role: 'user' });
+    expect(out.personal[0]!.provenance.kind).toBe('personal');
+    expect(out.official.map((t) => t.provenance.kind).sort()).toEqual([
+      'curator',
+      'imported',
+    ]);
+    expect(out.community[0]!.provenance.kind).toBe('community');
   });
 });
 

--- a/apps/web/src/lib/server/dictionary/lookups.ts
+++ b/apps/web/src/lib/server/dictionary/lookups.ts
@@ -27,6 +27,29 @@ import { and, eq } from 'drizzle-orm';
 import { db, schema } from '../db/index.js';
 import type { Lemma, Translation, User } from '../db/schema.js';
 
+/**
+ * Viewer-relative provenance category (T-3.8). The reader pop-up renders
+ * one badge per translation — the badge reads off `provenance.kind`,
+ * NOT off `source`, because "personal" requires knowing who the viewer
+ * is (a user's own `source='user'` row shows a different badge than the
+ * same row displayed to a different viewer).
+ *
+ *  - `personal`   — the viewer themselves authored this row (or forked
+ *                   an official via T-3.5). Badge: "yours".
+ *  - `curator`    — `source='curator'`. A curator has explicitly signed
+ *                   off on this row. Badge: "curator".
+ *  - `imported`   — `source='official_dictionary'`. Carries the upstream
+ *                   attribution (e.g. "Hindi WordNet"). Badge: the
+ *                   attribution text.
+ *  - `community`  — anyone else's `source='user'` submission. Badge:
+ *                   "community".
+ */
+export type TranslationProvenance =
+  | { kind: 'personal'; attribution: null }
+  | { kind: 'curator'; attribution: string | null }
+  | { kind: 'imported'; attribution: string | null }
+  | { kind: 'community'; attribution: null };
+
 export type PublicTranslation = {
   id: string;
   source: Translation['source'];
@@ -35,6 +58,7 @@ export type PublicTranslation = {
   body: string;
   targetLanguage: string;
   sourceAttribution: string | null;
+  provenance: TranslationProvenance;
   hidden: boolean;
   createdAt: Date;
   updatedAt: Date;
@@ -71,7 +95,26 @@ function toPublicLemma(row: Lemma): PublicLemma {
   };
 }
 
-function toPublicTranslation(row: Translation): PublicTranslation {
+export function deriveProvenance(
+  row: Translation,
+  viewer: { id: string } | null,
+): TranslationProvenance {
+  if (viewer && row.source === 'user' && row.submittedBy === viewer.id) {
+    return { kind: 'personal', attribution: null };
+  }
+  if (row.source === 'curator') {
+    return { kind: 'curator', attribution: row.sourceAttribution };
+  }
+  if (row.source === 'official_dictionary') {
+    return { kind: 'imported', attribution: row.sourceAttribution };
+  }
+  return { kind: 'community', attribution: null };
+}
+
+function toPublicTranslation(
+  row: Translation,
+  viewer: { id: string } | null,
+): PublicTranslation {
   return {
     id: row.id,
     source: row.source,
@@ -80,6 +123,7 @@ function toPublicTranslation(row: Translation): PublicTranslation {
     body: row.body,
     targetLanguage: row.targetLanguage,
     sourceAttribution: row.sourceAttribution,
+    provenance: deriveProvenance(row, viewer),
     hidden: row.hidden,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
@@ -128,9 +172,9 @@ export function bucketTranslations(
   community.sort(byCreatedAtDesc);
 
   return {
-    personal: personal.map(toPublicTranslation),
-    official: official.map(toPublicTranslation),
-    community: community.map(toPublicTranslation),
+    personal: personal.map((r) => toPublicTranslation(r, viewer)),
+    official: official.map((r) => toPublicTranslation(r, viewer)),
+    community: community.map((r) => toPublicTranslation(r, viewer)),
   };
 }
 

--- a/apps/web/src/routes/moderation/dictionary/[id]/+page.server.ts
+++ b/apps/web/src/routes/moderation/dictionary/[id]/+page.server.ts
@@ -28,6 +28,7 @@ import {
   updateLemma,
   updateTranslation,
 } from '$lib/server/dictionary/curator.js';
+import { deriveProvenance } from '$lib/server/dictionary/lookups.js';
 import { MissingReasonError } from '$lib/server/dictionary/audit.js';
 import { ForbiddenError } from '$lib/server/dictionary/permissions.js';
 import type { Actions, PageServerLoad } from './$types';
@@ -71,7 +72,17 @@ export const load: PageServerLoad = async ({ params, locals }) => {
       { id: locals.user.id, role: locals.user.role },
       params.id,
     );
-    return { ...view };
+    // Attach the same provenance discriminator the public translation
+    // endpoint exposes (T-3.8) so the editor renders the same badge as
+    // the reader pop-up will.
+    const editorViewer = { id: locals.user.id };
+    return {
+      ...view,
+      translations: view.translations.map((t) => ({
+        ...t,
+        provenance: deriveProvenance(t, editorViewer),
+      })),
+    };
   } catch (e) {
     const mapped = mapError(e);
     throw error(mapped.status as 400 | 403 | 404, mapped.message);

--- a/apps/web/src/routes/moderation/dictionary/[id]/+page.svelte
+++ b/apps/web/src/routes/moderation/dictionary/[id]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { enhance } from '$app/forms';
+  import ProvenanceBadge from '$lib/components/dictionary/ProvenanceBadge.svelte';
   import type { ActionData, PageData } from './$types';
 
   let {
@@ -126,7 +127,7 @@
         {#each data.translations as t (t.id)}
           <li>
             <div class="meta">
-              <span class="tag">{t.source}</span>
+              <ProvenanceBadge provenance={t.provenance} />
               <span class="muted">{t.targetLanguage}</span>
               {#if t.hidden}<span class="tag warn">hidden</span>{/if}
             </div>


### PR DESCRIPTION
## Summary
- Adds a viewer-relative `provenance` discriminator to every `PublicTranslation` row served by `/api/v1/lemmas/:id/translations` and the moderation editor.
- Ships `<ProvenanceBadge>` — small inline pill rendered next to each translation. Tone + label + tooltip all flow from the discriminator. Used by the moderation editor today; the reader pop-up (M5) drops it in unchanged.
- Display logic extracted into `provenance-display.ts` so the mapping (label / tooltip / tone) is testable without spinning up a Svelte client renderer.

## Why a discriminator vs. raw `source`
"personal" is viewer-relative — the same `source='user'` row is "yours" to its author and "community" to everyone else. Pushing the bucketing into the API output means the UI never has to ask "is this row mine?" again, and adding a new provenance category later (e.g. "promoted-override" from T-6.7) is one switch case.

## Test plan
- [x] `provenanceDisplay` — 6 cases covering every kind + null-attribution fallbacks
- [x] `deriveProvenance` — 5 cases (personal vs. community for the same source=user row, anonymous viewer, curator + imported attribution preserved verbatim)
- [x] `bucketTranslations` attaches the right provenance kind to every bucket
- [x] `pnpm --filter @ciareader/web check` clean
- [x] `pnpm --filter @ciareader/web lint` clean
- [x] 313 tests pass