### PR TITLE
T-3.9: bulk curator tools (CSV import / bulk promote / attribution rewrite)

### DIFF
--- a/apps/web/src/lib/server/db/schema.ts
+++ b/apps/web/src/lib/server/db/schema.ts
@@ -444,6 +444,13 @@ export type LemmaEditChangePayload = {
   splitInto?: Record<string, unknown>;
   splitFrom?: Record<string, unknown>;
   direction?: 'winner' | 'loser' | 'source' | 'created';
+  // T-3.9 bulk-tool discriminators. The history viewer uses these to
+  // group "ran one CSV" / "promoted N rows" / "rebranded an attribution"
+  // into a single visible action even though each touched row writes
+  // its own audit entry.
+  bulkImportRow?: number;
+  bulkPromote?: boolean;
+  bulkAttribution?: boolean;
 };
 
 export type User = InferSelectModel<typeof users>;

--- a/apps/web/src/lib/server/dictionary/bulk.test.ts
+++ b/apps/web/src/lib/server/dictionary/bulk.test.ts
@@ -1,0 +1,656 @@
+// @vitest-environment node
+/**
+ * Unit tests for the bulk curator tools (T-3.9).
+ *
+ * Mirrors the staged-mock pattern from `curator.test.ts`:
+ *   - Each DB call (`select`, `update`, `insert`, `delete`) returns a
+ *     thenable chain that resolves the next staged result.
+ *   - Tests `stage(rows)` the rows each SELECT/UPDATE/INSERT will see,
+ *     in call order, then assert via the recorded `calls` log.
+ *
+ * Permission model is simple: every function is admin-only. We test
+ * (a) that admin happy paths succeed, (b) that curator/user editors are
+ * rejected up-front (no DB calls), (c) that empty / over-cap inputs
+ * raise CuratorValidationError, (d) that per-row skips are reported in
+ * the result, and (e) that every successful row writes one
+ * `lemma_edit_history` audit row tagged with the bulk discriminator.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Call =
+  | { kind: 'select' }
+  | { kind: 'update'; set?: unknown; where?: unknown }
+  | { kind: 'insert'; values?: unknown }
+  | { kind: 'delete' };
+const calls: Call[] = [];
+
+const staged: Array<unknown[]> = [];
+function stage(rows: unknown[]) {
+  staged.push(rows);
+}
+function nextStaged(): unknown[] {
+  const v = staged.shift();
+  if (!v) throw new Error('Test bug: no staged result available');
+  return v;
+}
+
+function makeSelectChain() {
+  const chain: Record<string, unknown> = {};
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.limit = vi.fn(() => chain);
+  chain.orderBy = vi.fn(() => chain);
+  chain.then = (resolve: (v: unknown) => unknown) => resolve(nextStaged());
+  return chain;
+}
+
+function makeUpdateChain() {
+  const entry: Call = { kind: 'update' };
+  calls.push(entry);
+  const chain: Record<string, unknown> = {};
+  chain.set = vi.fn((v: unknown) => {
+    entry.set = v;
+    return chain;
+  });
+  chain.where = vi.fn((w: unknown) => {
+    entry.where = w;
+    return chain;
+  });
+  chain.returning = vi.fn(() => nextStaged());
+  // Bulk attribution update doesn't call .returning() — resolve to undefined.
+  chain.then = (resolve: (v: unknown) => unknown) => resolve(undefined);
+  return chain;
+}
+
+function makeInsertChain() {
+  const entry: Call = { kind: 'insert' };
+  calls.push(entry);
+  const chain: Record<string, unknown> = {};
+  chain.values = vi.fn((v: unknown) => {
+    entry.values = v;
+    return chain;
+  });
+  chain.returning = vi.fn(() => nextStaged());
+  chain.then = (resolve: (v: unknown) => unknown) => resolve(undefined);
+  return chain;
+}
+
+function makeDeleteChain() {
+  calls.push({ kind: 'delete' });
+  const chain: Record<string, unknown> = {};
+  chain.where = vi.fn(() => chain);
+  chain.then = (resolve: (v: unknown) => unknown) => resolve(undefined);
+  return chain;
+}
+
+const selectFn = vi.fn(() => {
+  calls.push({ kind: 'select' });
+  return makeSelectChain();
+});
+const updateFn = vi.fn(() => makeUpdateChain());
+const insertFn = vi.fn(() => makeInsertChain());
+const deleteFn = vi.fn(() => makeDeleteChain());
+
+vi.mock('../db/index.js', () => ({
+  db: {
+    select: () => selectFn(),
+    update: () => updateFn(),
+    insert: () => insertFn(),
+    delete: () => deleteFn(),
+  },
+  schema: {
+    lemmas: {
+      id: 'lemmas.id',
+      language: 'lemmas.language',
+      headword: 'lemmas.headword',
+      pos: 'lemmas.pos',
+    },
+    translations: {
+      id: 'translations.id',
+      lemmaId: 'translations.lemma_id',
+      source: 'translations.source',
+      sourceAttribution: 'translations.source_attribution',
+    },
+    lemmaEditHistory: {
+      id: 'lemma_edit_history.id',
+      lemmaId: 'lemma_edit_history.lemma_id',
+    },
+  },
+}));
+
+const {
+  bulkImportTranslations,
+  bulkPromoteTranslations,
+  bulkUpdateAttribution,
+  BULK_LIMIT,
+} = await import('./bulk.js');
+const { CuratorValidationError } = await import('./curator.js');
+const { ForbiddenError } = await import('./permissions.js');
+
+const ADMIN = { id: 'admin-1', role: 'admin' as const };
+const CURATOR = { id: 'cur-1', role: 'curator' as const };
+const USER = { id: 'usr-1', role: 'user' as const };
+
+function lemmaRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'lemma-1',
+    language: 'hi',
+    headword: 'बोलना',
+    pos: 'verb',
+    script: 'Deva',
+    glossDefault: 'to speak',
+    frequencyRank: 42,
+    source: 'official_dictionary',
+    sourceAttribution: 'Hindi WordNet',
+    sourceId: null,
+    curatorLocked: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function translationRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'tr-1',
+    lemmaId: 'lemma-1',
+    source: 'user',
+    submittedBy: 'user-42',
+    parentTranslationId: null,
+    body: 'to speak',
+    targetLanguage: 'en',
+    sourceAttribution: null,
+    sourceId: null,
+    hidden: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  calls.length = 0;
+  staged.length = 0;
+  selectFn.mockClear();
+  updateFn.mockClear();
+  insertFn.mockClear();
+  deleteFn.mockClear();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// -----------------------------------------------------------------------
+// bulkImportTranslations
+// -----------------------------------------------------------------------
+
+describe('bulkImportTranslations', () => {
+  it('rejects non-admins before touching the DB', async () => {
+    await expect(
+      bulkImportTranslations(
+        CURATOR,
+        [{ language: 'hi', headword: 'बोलना', pos: 'verb', body: 'to speak' }],
+        'curator import attempt',
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenError);
+    await expect(
+      bulkImportTranslations(
+        USER,
+        [{ language: 'hi', headword: 'बोलना', pos: 'verb', body: 'to speak' }],
+        'user import attempt',
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenError);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('rejects an empty rows[] with a validation error', async () => {
+    await expect(
+      bulkImportTranslations(ADMIN, [], 'no rows'),
+    ).rejects.toBeInstanceOf(CuratorValidationError);
+  });
+
+  it('rejects a missing reason', async () => {
+    await expect(
+      bulkImportTranslations(
+        ADMIN,
+        [{ language: 'hi', headword: 'बोलना', pos: 'verb', body: 'to speak' }],
+        '  ',
+      ),
+    ).rejects.toBeInstanceOf(CuratorValidationError);
+  });
+
+  it('rejects more than BULK_LIMIT rows', async () => {
+    const rows = Array.from({ length: BULK_LIMIT + 1 }, () => ({
+      language: 'hi',
+      headword: 'बोलना',
+      pos: 'verb',
+      body: 'to speak',
+    }));
+    await expect(
+      bulkImportTranslations(ADMIN, rows, 'too many'),
+    ).rejects.toBeInstanceOf(CuratorValidationError);
+  });
+
+  it('inserts a happy-path row and writes one audit', async () => {
+    stage([lemmaRow()]); // lemma lookup
+    const created = translationRow({
+      id: 'tr-new',
+      source: 'curator',
+      submittedBy: ADMIN.id,
+      body: 'to speak',
+      sourceAttribution: 'Custom CSV 2026',
+    });
+    stage([created]); // insert .returning
+    stage([{ id: 'hist-1' }]); // audit insert .returning
+
+    const result = await bulkImportTranslations(
+      ADMIN,
+      [
+        {
+          language: 'hi',
+          headword: 'बोलना',
+          pos: 'verb',
+          body: 'to speak',
+          sourceAttribution: 'Custom CSV 2026',
+        },
+      ],
+      'Importing curator gloss CSV',
+    );
+
+    expect(result.inserted).toBe(1);
+    expect(result.skipped).toEqual([]);
+    const insertCalls = calls.filter(
+      (c): c is Extract<Call, { kind: 'insert' }> => c.kind === 'insert',
+    );
+    // 1 translation insert + 1 audit insert.
+    expect(insertCalls).toHaveLength(2);
+    const trInsert = insertCalls[0]!;
+    expect(trInsert.values).toMatchObject({
+      lemmaId: 'lemma-1',
+      source: 'curator',
+      submittedBy: ADMIN.id,
+      body: 'to speak',
+      targetLanguage: 'en',
+      sourceAttribution: 'Custom CSV 2026',
+    });
+    const auditInsert = insertCalls[1]!;
+    expect(auditInsert.values).toMatchObject({
+      lemmaId: 'lemma-1',
+      editorId: ADMIN.id,
+      changeType: 'translation_insert',
+    });
+    const change = (auditInsert.values as { change: Record<string, unknown> }).change;
+    expect(change).toMatchObject({
+      translationId: 'tr-new',
+      bulkImportRow: 1,
+      before: null,
+    });
+  });
+
+  it('falls back to the per-call default attribution when a row omits it', async () => {
+    stage([lemmaRow()]);
+    stage([translationRow({ id: 'tr-x', sourceAttribution: 'Dflt 2026' })]);
+    stage([{ id: 'hist-1' }]);
+
+    const result = await bulkImportTranslations(
+      ADMIN,
+      [{ language: 'hi', headword: 'बोलना', pos: 'verb', body: 'to speak' }],
+      'use default attribution',
+      { sourceAttribution: 'Dflt 2026' },
+    );
+    expect(result.inserted).toBe(1);
+    const trInsert = calls.find(
+      (c): c is Extract<Call, { kind: 'insert' }> => c.kind === 'insert',
+    )!;
+    expect(
+      (trInsert.values as { sourceAttribution: string | null }).sourceAttribution,
+    ).toBe('Dflt 2026');
+  });
+
+  it('skips rows with unsupported languages, empty fields, oversize bodies, bad targetLanguage, and missing lemmas', async () => {
+    // Row 1: unsupported language → skip (no DB call).
+    // Row 2: empty headword → skip.
+    // Row 3: empty pos → skip.
+    // Row 4: empty body → skip.
+    // Row 5: body over MAX_BODY_LEN → skip.
+    // Row 6: invalid targetLanguage → skip.
+    // Row 7: lemma not found (SELECT returns []) → skip.
+    // Row 8: happy path.
+    stage([]); // row 7 lookup → not found
+    stage([lemmaRow()]); // row 8 lookup
+    stage([translationRow({ id: 'tr-ok' })]); // row 8 insert
+    stage([{ id: 'hist-1' }]); // row 8 audit
+
+    const result = await bulkImportTranslations(
+      ADMIN,
+      [
+        { language: 'xx', headword: 'x', pos: 'verb', body: 'x' },
+        { language: 'hi', headword: '   ', pos: 'verb', body: 'x' },
+        { language: 'hi', headword: 'बोलना', pos: '', body: 'x' },
+        { language: 'hi', headword: 'बोलना', pos: 'verb', body: '' },
+        {
+          language: 'hi',
+          headword: 'बोलना',
+          pos: 'verb',
+          body: 'a'.repeat(501),
+        },
+        {
+          language: 'hi',
+          headword: 'बोलना',
+          pos: 'verb',
+          body: 'ok',
+          targetLanguage: 'english',
+        },
+        { language: 'hi', headword: 'unknown', pos: 'verb', body: 'mystery' },
+        { language: 'hi', headword: 'बोलना', pos: 'verb', body: 'to speak' },
+      ],
+      'mixed CSV',
+    );
+
+    expect(result.inserted).toBe(1);
+    expect(result.skipped).toHaveLength(7);
+    const reasons = result.skipped.map((s) => `row ${s.row}: ${s.reason}`);
+    expect(reasons[0]).toMatch(/unsupported language/);
+    expect(reasons[1]).toMatch(/empty headword/);
+    expect(reasons[2]).toMatch(/empty pos/);
+    expect(reasons[3]).toMatch(/empty body/);
+    expect(reasons[4]).toMatch(/exceeds 500/);
+    expect(reasons[5]).toMatch(/invalid targetLanguage/);
+    expect(reasons[6]).toMatch(/lemma not found/);
+    // Only one translation insert + one audit insert (row 8).
+    const trInserts = calls.filter(
+      (c) => c.kind === 'insert' && (c.values as { source?: unknown }).source === 'curator',
+    );
+    expect(trInserts).toHaveLength(1);
+  });
+
+  it('trims and NFC-normalises the headword before the lemma lookup', async () => {
+    stage([lemmaRow({ headword: 'बोलना' })]);
+    stage([translationRow({ id: 'tr-x' })]);
+    stage([{ id: 'hist-1' }]);
+
+    // Padded with whitespace and given as a non-NFC string; normalize +
+    // trim should still find the canonical lemma.
+    const headword = '  बोलना  '.normalize('NFD');
+
+    const result = await bulkImportTranslations(
+      ADMIN,
+      [
+        {
+          language: 'hi',
+          headword,
+          pos: 'verb',
+          body: 'to speak',
+        },
+      ],
+      'NFC test',
+    );
+    expect(result.inserted).toBe(1);
+  });
+});
+
+// -----------------------------------------------------------------------
+// bulkPromoteTranslations
+// -----------------------------------------------------------------------
+
+describe('bulkPromoteTranslations', () => {
+  it('rejects non-admins', async () => {
+    await expect(
+      bulkPromoteTranslations(CURATOR, ['tr-1'], 'promote'),
+    ).rejects.toBeInstanceOf(ForbiddenError);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('rejects an empty list', async () => {
+    await expect(
+      bulkPromoteTranslations(ADMIN, [], 'nothing'),
+    ).rejects.toBeInstanceOf(CuratorValidationError);
+  });
+
+  it('rejects a missing reason', async () => {
+    await expect(
+      bulkPromoteTranslations(ADMIN, ['tr-1'], '  '),
+    ).rejects.toBeInstanceOf(CuratorValidationError);
+  });
+
+  it('rejects more than BULK_LIMIT ids', async () => {
+    const ids = Array.from({ length: BULK_LIMIT + 1 }, (_, i) => `tr-${i}`);
+    await expect(
+      bulkPromoteTranslations(ADMIN, ids, 'too many'),
+    ).rejects.toBeInstanceOf(CuratorValidationError);
+  });
+
+  it('promotes a community row, skips already-curator + imported + missing', async () => {
+    stage([
+      translationRow({ id: 'tr-1', source: 'user' }),
+      translationRow({ id: 'tr-2', source: 'curator' }),
+      translationRow({ id: 'tr-3', source: 'official_dictionary' }),
+      // tr-4 missing → not in result set
+    ]);
+    // tr-1 update + audit
+    stage([translationRow({ id: 'tr-1', source: 'curator' })]);
+    stage([{ id: 'hist-1' }]);
+
+    const result = await bulkPromoteTranslations(
+      ADMIN,
+      ['tr-1', 'tr-2', 'tr-3', 'tr-4', 'tr-1'], // tr-1 duplicated → dedup
+      'Endorsing strong community submissions',
+    );
+    expect(result.promoted).toBe(1);
+    expect(result.skipped).toHaveLength(3);
+    const reasonsById = Object.fromEntries(result.skipped.map((s) => [s.id, s.reason]));
+    expect(reasonsById['tr-2']).toMatch(/already curator/);
+    expect(reasonsById['tr-3']).toMatch(/imported officials/);
+    expect(reasonsById['tr-4']).toMatch(/not found/);
+
+    const updCall = calls.find(
+      (c): c is Extract<Call, { kind: 'update' }> => c.kind === 'update',
+    );
+    expect(updCall?.set).toMatchObject({ source: 'curator' });
+    const auditInsert = calls.find(
+      (c): c is Extract<Call, { kind: 'insert' }> =>
+        c.kind === 'insert' &&
+        (c.values as { changeType?: string } | undefined)?.changeType ===
+          'translation_update',
+    );
+    expect(auditInsert).toBeDefined();
+    expect(
+      (auditInsert!.values as { change: Record<string, unknown> }).change,
+    ).toMatchObject({
+      translationId: 'tr-1',
+      bulkPromote: true,
+      before: { source: 'user' },
+      after: { source: 'curator' },
+    });
+  });
+});
+
+// -----------------------------------------------------------------------
+// bulkUpdateAttribution
+// -----------------------------------------------------------------------
+
+describe('bulkUpdateAttribution', () => {
+  it('rejects non-admins', async () => {
+    await expect(
+      bulkUpdateAttribution(
+        CURATOR,
+        {
+          source: 'official_dictionary',
+          oldAttribution: 'Old',
+          newAttribution: 'New',
+        },
+        'rebrand',
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenError);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('rejects a missing reason', async () => {
+    await expect(
+      bulkUpdateAttribution(
+        ADMIN,
+        {
+          source: 'official_dictionary',
+          oldAttribution: 'Old',
+          newAttribution: 'New',
+        },
+        '',
+      ),
+    ).rejects.toBeInstanceOf(CuratorValidationError);
+  });
+
+  it('refuses to sweep without an oldAttribution', async () => {
+    await expect(
+      bulkUpdateAttribution(
+        ADMIN,
+        {
+          source: 'official_dictionary',
+          oldAttribution: '   ',
+          newAttribution: 'New',
+        },
+        'guard',
+      ),
+    ).rejects.toBeInstanceOf(CuratorValidationError);
+  });
+
+  it('returns 0 updates when no rows match (no scope)', async () => {
+    stage([]); // before snapshot → nothing
+    const result = await bulkUpdateAttribution(
+      ADMIN,
+      {
+        source: 'official_dictionary',
+        oldAttribution: 'Old',
+        newAttribution: 'New',
+      },
+      'rebrand to New',
+    );
+    expect(result.updated).toBe(0);
+    // No update statement, no audit inserts.
+    expect(calls.find((c) => c.kind === 'update')).toBeUndefined();
+    expect(calls.find((c) => c.kind === 'insert')).toBeUndefined();
+  });
+
+  it('returns 0 updates when language scope finds no lemmas', async () => {
+    stage([]); // language-scoped lemma id query → []
+    const result = await bulkUpdateAttribution(
+      ADMIN,
+      {
+        source: 'official_dictionary',
+        oldAttribution: 'Old',
+        newAttribution: 'New',
+        language: 'or',
+      },
+      'rebrand Odia',
+    );
+    expect(result.updated).toBe(0);
+  });
+
+  it('rewrites attribution and writes one audit per affected row', async () => {
+    const rows = [
+      translationRow({
+        id: 'tr-1',
+        source: 'official_dictionary',
+        sourceAttribution: 'Old',
+      }),
+      translationRow({
+        id: 'tr-2',
+        lemmaId: 'lemma-2',
+        source: 'official_dictionary',
+        sourceAttribution: 'Old',
+      }),
+    ];
+    stage(rows); // before snapshot
+    stage([{ id: 'hist-1' }]); // tr-1 audit
+    stage([{ id: 'hist-2' }]); // tr-2 audit
+
+    const result = await bulkUpdateAttribution(
+      ADMIN,
+      {
+        source: 'official_dictionary',
+        oldAttribution: 'Old',
+        newAttribution: 'New',
+      },
+      'Rebrand 2026',
+    );
+    expect(result.updated).toBe(2);
+    const updCall = calls.find(
+      (c): c is Extract<Call, { kind: 'update' }> => c.kind === 'update',
+    );
+    expect(updCall?.set).toMatchObject({ sourceAttribution: 'New' });
+    const auditInserts = calls.filter(
+      (c): c is Extract<Call, { kind: 'insert' }> =>
+        c.kind === 'insert' &&
+        (c.values as { changeType?: string } | undefined)?.changeType ===
+          'translation_update',
+    );
+    expect(auditInserts).toHaveLength(2);
+    const ids = auditInserts.map(
+      (c) =>
+        (c.values as { change: { translationId: string } }).change.translationId,
+    );
+    expect(ids).toEqual(['tr-1', 'tr-2']);
+    for (const ai of auditInserts) {
+      expect(
+        (ai.values as { change: Record<string, unknown> }).change,
+      ).toMatchObject({
+        bulkAttribution: true,
+        before: { sourceAttribution: 'Old' },
+        after: { sourceAttribution: 'New' },
+      });
+    }
+  });
+
+  it('rejects an update that would touch more than BULK_LIMIT rows', async () => {
+    const tooMany = Array.from({ length: BULK_LIMIT + 1 }, (_, i) =>
+      translationRow({
+        id: `tr-${i}`,
+        source: 'official_dictionary',
+        sourceAttribution: 'Old',
+      }),
+    );
+    stage(tooMany); // before snapshot
+    await expect(
+      bulkUpdateAttribution(
+        ADMIN,
+        {
+          source: 'official_dictionary',
+          oldAttribution: 'Old',
+          newAttribution: 'New',
+        },
+        'too broad',
+      ),
+    ).rejects.toBeInstanceOf(CuratorValidationError);
+  });
+
+  it('honors a language scope by pre-filtering through lemmas', async () => {
+    // language-scoped lemma id query → 2 lemmas
+    stage([{ id: 'lemma-1' }, { id: 'lemma-2' }]);
+    // scoped translation id query → 1 hit
+    stage([{ id: 'tr-1', lemmaId: 'lemma-1' }]);
+    // before snapshot of those rows
+    stage([
+      translationRow({
+        id: 'tr-1',
+        source: 'official_dictionary',
+        sourceAttribution: 'Old',
+      }),
+    ]);
+    // audit insert for tr-1
+    stage([{ id: 'hist-1' }]);
+
+    const result = await bulkUpdateAttribution(
+      ADMIN,
+      {
+        source: 'official_dictionary',
+        oldAttribution: 'Old',
+        newAttribution: 'New',
+        language: 'hi',
+      },
+      'Rebrand Hindi rows',
+    );
+    expect(result.updated).toBe(1);
+    // Three SELECTs: lemma id list, scoped id list, before snapshot.
+    expect(calls.filter((c) => c.kind === 'select')).toHaveLength(3);
+  });
+});

--- a/apps/web/src/lib/server/dictionary/bulk.ts
+++ b/apps/web/src/lib/server/dictionary/bulk.ts
@@ -1,0 +1,423 @@
+/**
+ * Bulk curator tools (T-3.9).
+ *
+ * Three operations the curator dashboard offers when one-row-at-a-time
+ * editing isn't enough:
+ *
+ *  - `bulkImportTranslations`: a CSV-shaped feed of curator-written
+ *     glosses. Each row resolves to an existing lemma by
+ *     `(language, headword, pos)` (the unique constraint columns) and
+ *     inserts a new `source='curator'` translation. Rows that don't
+ *     resolve are skipped and reported back so the curator can fix
+ *     their CSV instead of the import silently dropping data.
+ *
+ *  - `bulkPromoteTranslations`: take a list of `source='user'` rows
+ *     and re-tag them as `source='curator'` in one pass. Same one-way
+ *     transition guard as `updateTranslation` (rejects officials).
+ *
+ *  - `bulkUpdateAttribution`: rewrite `sourceAttribution` on every
+ *     translation matching `(source, oldAttribution, language?)`. Used
+ *     when an upstream source renames or rebrands and we want every
+ *     imported row's badge to refresh in one shot.
+ *
+ * Every operation requires a single reason and writes one
+ * `lemma_edit_history` row PER affected translation, so the audit log
+ * still answers "what changed and why" at the row granularity.
+ *
+ * Permission model: bulk operations are admin-only. A per-language
+ * curator wouldn't have rights on every row a bulk update could touch
+ * (e.g. a CSV that mixes Hindi and Marathi rows would partially fail
+ * for them in surprising ways). Restricting to admin sidesteps the
+ * sharp edges; we can relax later if curators ask for it.
+ */
+import { and, eq, inArray } from 'drizzle-orm';
+
+import { db, schema } from '../db/index.js';
+import { recordLemmaEdit } from './audit.js';
+import { ForbiddenError, isAdmin } from './permissions.js';
+import { CuratorValidationError } from './curator.js';
+import type { LanguageCode } from '@ciareader/shared-types';
+import type { Lemma, Translation, User } from '../db/schema.js';
+
+type Editor = Pick<User, 'id' | 'role'>;
+
+/**
+ * Common bulk-input cap. A single bulk request must not be a denial-of-
+ * service vector for the curator tooling — 1000 rows is enough for any
+ * realistic dictionary import in one go and small enough to fit
+ * comfortably in a single Postgres transaction's lock budget.
+ */
+export const BULK_LIMIT = 1000;
+
+const MIN_REASON_LEN = 3;
+
+function requireAdminEditor(editor: Editor): void {
+  if (!isAdmin(editor)) {
+    throw new ForbiddenError('Bulk operations require admin role');
+  }
+}
+
+function requireReason(reason: string): string {
+  const trimmed = reason?.trim() ?? '';
+  if (trimmed.length < MIN_REASON_LEN) {
+    throw new CuratorValidationError('reason is required (≥3 chars)');
+  }
+  return trimmed;
+}
+
+// -----------------------------------------------------------------------
+// CSV import
+// -----------------------------------------------------------------------
+
+export type BulkImportRow = {
+  language: string;
+  headword: string;
+  pos: string;
+  body: string;
+  /** ISO 2- or 3-letter code; defaults to 'en'. */
+  targetLanguage?: string;
+  /** Optional human-readable attribution. Falls back to the import
+   *  attribution at the call site if omitted. */
+  sourceAttribution?: string | null;
+};
+
+export type BulkImportResult = {
+  inserted: number;
+  /** 1-based row number → reason. The curator sees this and re-uploads
+   *  a fixed CSV; we do NOT auto-create lemmas here (use the dictionary
+   *  editor or the proposal flow for that). */
+  skipped: Array<{ row: number; reason: string }>;
+};
+
+/** Maximum length of a single CSV-imported gloss. Mirrors the per-row
+ *  cap in `translations.ts`. */
+const MAX_BODY_LEN = 500;
+
+function normalizeBody(body: string): string {
+  return body.trim().replace(/\s+/g, ' ');
+}
+
+function normalizeHeadword(raw: string): string {
+  return raw.normalize('NFC').trim();
+}
+
+function isLanguageCode(s: string): s is LanguageCode {
+  return s === 'hi' || s === 'mr' || s === 'or';
+}
+
+export async function bulkImportTranslations(
+  editor: Editor,
+  rows: BulkImportRow[],
+  reason: string,
+  defaults: { sourceAttribution?: string | null } = {},
+  now: Date = new Date(),
+): Promise<BulkImportResult> {
+  requireAdminEditor(editor);
+  const trimmedReason = requireReason(reason);
+  if (rows.length === 0) {
+    throw new CuratorValidationError('rows is empty');
+  }
+  if (rows.length > BULK_LIMIT) {
+    throw new CuratorValidationError(
+      `bulk import is capped at ${BULK_LIMIT} rows (got ${rows.length})`,
+    );
+  }
+
+  const skipped: BulkImportResult['skipped'] = [];
+  let inserted = 0;
+
+  for (let i = 0; i < rows.length; i += 1) {
+    const row = rows[i]!;
+    const rowNumber = i + 1;
+
+    const language = row.language?.toLowerCase().trim();
+    if (!language || !isLanguageCode(language)) {
+      skipped.push({ row: rowNumber, reason: `unsupported language '${row.language}'` });
+      continue;
+    }
+    const headword = normalizeHeadword(row.headword ?? '');
+    if (headword.length === 0) {
+      skipped.push({ row: rowNumber, reason: 'empty headword' });
+      continue;
+    }
+    const pos = (row.pos ?? '').trim();
+    if (pos.length === 0) {
+      skipped.push({ row: rowNumber, reason: 'empty pos' });
+      continue;
+    }
+    const body = normalizeBody(row.body ?? '');
+    if (body.length === 0) {
+      skipped.push({ row: rowNumber, reason: 'empty body' });
+      continue;
+    }
+    if (body.length > MAX_BODY_LEN) {
+      skipped.push({
+        row: rowNumber,
+        reason: `body exceeds ${MAX_BODY_LEN} chars`,
+      });
+      continue;
+    }
+    const targetLanguage = (row.targetLanguage ?? 'en').toLowerCase().trim();
+    if (!/^[a-z]{2,3}$/.test(targetLanguage)) {
+      skipped.push({
+        row: rowNumber,
+        reason: `invalid targetLanguage '${row.targetLanguage}'`,
+      });
+      continue;
+    }
+
+    const [lemma] = (await db
+      .select()
+      .from(schema.lemmas)
+      .where(
+        and(
+          eq(schema.lemmas.language, language),
+          eq(schema.lemmas.headword, headword),
+          eq(schema.lemmas.pos, pos),
+        ),
+      )
+      .limit(1)) as Lemma[];
+    if (!lemma) {
+      skipped.push({
+        row: rowNumber,
+        reason: `lemma not found: (${language}, ${headword}, ${pos})`,
+      });
+      continue;
+    }
+
+    const [created] = (await db
+      .insert(schema.translations)
+      .values({
+        lemmaId: lemma.id,
+        source: 'curator',
+        submittedBy: editor.id,
+        body,
+        targetLanguage,
+        sourceAttribution:
+          row.sourceAttribution !== undefined
+            ? row.sourceAttribution
+            : (defaults.sourceAttribution ?? null),
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning()) as Translation[];
+    if (!created) {
+      skipped.push({ row: rowNumber, reason: 'insert failed' });
+      continue;
+    }
+
+    await recordLemmaEdit({
+      lemmaId: lemma.id,
+      editorId: editor.id,
+      changeType: 'translation_insert',
+      change: {
+        translationId: created.id,
+        bulkImportRow: rowNumber,
+        before: null,
+        after: {
+          source: 'curator',
+          body,
+          targetLanguage,
+          sourceAttribution: created.sourceAttribution,
+        },
+      },
+      reason: trimmedReason,
+    });
+    inserted += 1;
+  }
+
+  return { inserted, skipped };
+}
+
+// -----------------------------------------------------------------------
+// Bulk promote
+// -----------------------------------------------------------------------
+
+export type BulkPromoteResult = {
+  promoted: number;
+  skipped: Array<{ id: string; reason: string }>;
+};
+
+export async function bulkPromoteTranslations(
+  editor: Editor,
+  translationIds: string[],
+  reason: string,
+  now: Date = new Date(),
+): Promise<BulkPromoteResult> {
+  requireAdminEditor(editor);
+  const trimmedReason = requireReason(reason);
+  if (translationIds.length === 0) {
+    throw new CuratorValidationError('translationIds is empty');
+  }
+  if (translationIds.length > BULK_LIMIT) {
+    throw new CuratorValidationError(
+      `bulk promote is capped at ${BULK_LIMIT} ids (got ${translationIds.length})`,
+    );
+  }
+  const dedup = Array.from(new Set(translationIds));
+
+  const found = (await db
+    .select()
+    .from(schema.translations)
+    .where(inArray(schema.translations.id, dedup))) as Translation[];
+  const byId = new Map(found.map((t) => [t.id, t]));
+
+  const skipped: BulkPromoteResult['skipped'] = [];
+  let promoted = 0;
+
+  for (const id of dedup) {
+    const row = byId.get(id);
+    if (!row) {
+      skipped.push({ id, reason: 'not found' });
+      continue;
+    }
+    if (row.source === 'curator') {
+      skipped.push({ id, reason: 'already curator' });
+      continue;
+    }
+    if (row.source === 'official_dictionary') {
+      // Same one-way guard as updateTranslation: imported rows must be
+      // edited directly, not re-tagged.
+      skipped.push({ id, reason: 'imported officials cannot be re-tagged' });
+      continue;
+    }
+
+    const [updated] = (await db
+      .update(schema.translations)
+      .set({ source: 'curator', updatedAt: now })
+      .where(eq(schema.translations.id, id))
+      .returning()) as Translation[];
+    if (!updated) {
+      skipped.push({ id, reason: 'update failed' });
+      continue;
+    }
+    await recordLemmaEdit({
+      lemmaId: row.lemmaId,
+      editorId: editor.id,
+      changeType: 'translation_update',
+      change: {
+        translationId: id,
+        bulkPromote: true,
+        before: { source: row.source },
+        after: { source: 'curator' },
+      },
+      reason: trimmedReason,
+    });
+    promoted += 1;
+  }
+
+  return { promoted, skipped };
+}
+
+// -----------------------------------------------------------------------
+// Bulk attribution update
+// -----------------------------------------------------------------------
+
+export type BulkAttributionInput = {
+  /** Which translation source class to target. */
+  source: 'official_dictionary' | 'curator';
+  /** The current attribution string to find and replace. Required —
+   *  matching every NULL row here would be too easy to do by accident. */
+  oldAttribution: string;
+  /** The new attribution string. `null` clears the field. */
+  newAttribution: string | null;
+  /** Optional language scope. Omit to update across every language. */
+  language?: LanguageCode;
+};
+
+export type BulkAttributionResult = {
+  updated: number;
+};
+
+export async function bulkUpdateAttribution(
+  editor: Editor,
+  input: BulkAttributionInput,
+  reason: string,
+  now: Date = new Date(),
+): Promise<BulkAttributionResult> {
+  requireAdminEditor(editor);
+  const trimmedReason = requireReason(reason);
+  if (!input.oldAttribution || input.oldAttribution.trim().length === 0) {
+    throw new CuratorValidationError('oldAttribution is required');
+  }
+
+  const conditions = [
+    eq(schema.translations.source, input.source),
+    eq(schema.translations.sourceAttribution, input.oldAttribution),
+  ];
+
+  // Language scoping needs a join through lemmas; do it as a
+  // pre-filtered id list rather than a SQL JOIN to keep the update
+  // statement straightforward.
+  let scopedIds: string[] | null = null;
+  if (input.language) {
+    const lemmaRows = await db
+      .select({ id: schema.lemmas.id })
+      .from(schema.lemmas)
+      .where(eq(schema.lemmas.language, input.language));
+    const lemmaIds = lemmaRows.map((r) => r.id);
+    if (lemmaIds.length === 0) {
+      return { updated: 0 };
+    }
+    const scoped = (await db
+      .select({ id: schema.translations.id, lemmaId: schema.translations.lemmaId })
+      .from(schema.translations)
+      .where(
+        and(
+          eq(schema.translations.source, input.source),
+          eq(schema.translations.sourceAttribution, input.oldAttribution),
+          inArray(schema.translations.lemmaId, lemmaIds),
+        ),
+      )) as Array<{ id: string; lemmaId: string }>;
+    scopedIds = scoped.map((r) => r.id);
+    if (scopedIds.length === 0) {
+      return { updated: 0 };
+    }
+  }
+
+  // Snapshot the rows we're about to change so the audit-log diff
+  // captures the before-state per row.
+  const before = (await db
+    .select()
+    .from(schema.translations)
+    .where(
+      scopedIds
+        ? and(...conditions, inArray(schema.translations.id, scopedIds))
+        : and(...conditions),
+    )) as Translation[];
+
+  if (before.length === 0) {
+    return { updated: 0 };
+  }
+  if (before.length > BULK_LIMIT) {
+    throw new CuratorValidationError(
+      `bulk attribution would touch ${before.length} rows (cap ${BULK_LIMIT}); narrow the filter`,
+    );
+  }
+
+  await db
+    .update(schema.translations)
+    .set({ sourceAttribution: input.newAttribution, updatedAt: now })
+    .where(
+      scopedIds
+        ? and(...conditions, inArray(schema.translations.id, scopedIds))
+        : and(...conditions),
+    );
+
+  for (const row of before) {
+    await recordLemmaEdit({
+      lemmaId: row.lemmaId,
+      editorId: editor.id,
+      changeType: 'translation_update',
+      change: {
+        translationId: row.id,
+        bulkAttribution: true,
+        before: { sourceAttribution: row.sourceAttribution },
+        after: { sourceAttribution: input.newAttribution },
+      },
+      reason: trimmedReason,
+    });
+  }
+
+  return { updated: before.length };
+}

--- a/apps/web/src/routes/api/v1/admin/translations/bulk-attribution/+server.ts
+++ b/apps/web/src/routes/api/v1/admin/translations/bulk-attribution/+server.ts
@@ -1,0 +1,56 @@
+/**
+ * POST /api/v1/admin/translations/bulk-attribution (T-3.9).
+ *
+ * Admin-only. Rewrites `sourceAttribution` on every translation matching
+ * (source, oldAttribution, language?) in one pass. Used when an upstream
+ * source renames or rebrands. The query is bounded by BULK_LIMIT — if a
+ * filter would touch more rows the request is rejected and the caller
+ * is told to narrow.
+ *
+ * Response shape: { updated: number }.
+ */
+import { error, json } from '@sveltejs/kit';
+import { z } from 'zod';
+
+import { requireUser } from '$lib/server/auth/require-user.js';
+import { bulkUpdateAttribution } from '$lib/server/dictionary/bulk.js';
+import { CuratorValidationError } from '$lib/server/dictionary/curator.js';
+import { ForbiddenError } from '$lib/server/dictionary/permissions.js';
+import { MissingReasonError } from '$lib/server/dictionary/audit.js';
+import type { RequestHandler } from './$types';
+import { parseJson } from '../../../auth/_helpers.js';
+
+const body = z.object({
+  source: z.enum(['official_dictionary', 'curator']),
+  oldAttribution: z.string().min(1).max(500),
+  newAttribution: z.string().max(500).nullable(),
+  language: z.enum(['hi', 'mr', 'or']).optional(),
+  reason: z.string().min(3).max(500),
+});
+
+function mapErr(err: unknown): never {
+  if (err instanceof CuratorValidationError) throw error(err.status, err.message);
+  if (err instanceof ForbiddenError) throw error(403, err.message);
+  if (err instanceof MissingReasonError) throw error(400, err.message);
+  throw err;
+}
+
+export const POST: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  const input = await parseJson(event.request, body);
+  try {
+    const result = await bulkUpdateAttribution(
+      user,
+      {
+        source: input.source,
+        oldAttribution: input.oldAttribution,
+        newAttribution: input.newAttribution,
+        language: input.language,
+      },
+      input.reason,
+    );
+    return json(result);
+  } catch (err) {
+    mapErr(err);
+  }
+};

--- a/apps/web/src/routes/api/v1/admin/translations/bulk-attribution/bulk-attribution.test.ts
+++ b/apps/web/src/routes/api/v1/admin/translations/bulk-attribution/bulk-attribution.test.ts
@@ -1,0 +1,153 @@
+// @vitest-environment node
+/**
+ * Route tests for POST /api/v1/admin/translations/bulk-attribution (T-3.9).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const bulkUpdateAttribution = vi.fn();
+const requireUser = vi.fn();
+
+vi.mock('$lib/server/dictionary/bulk.js', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/dictionary/bulk.js')>(
+    '$lib/server/dictionary/bulk.js',
+  );
+  return {
+    ...actual,
+    bulkUpdateAttribution: (...a: unknown[]) => bulkUpdateAttribution(...a),
+  };
+});
+
+vi.mock('$lib/server/auth/require-user.js', () => ({
+  requireUser: (...a: unknown[]) => requireUser(...a),
+}));
+
+type PostFn = (typeof import('./+server.js'))['POST'];
+
+const ADMIN = { id: 'admin-1', role: 'admin' as const };
+
+async function callPost(body: unknown, user = ADMIN) {
+  requireUser.mockResolvedValueOnce(user);
+  const { POST } = await import('./+server.js');
+  const event = {
+    params: {},
+    request: new Request('http://x/api/v1/admin/translations/bulk-attribution', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+  } as unknown as Parameters<PostFn>[0];
+  try {
+    return await POST(event);
+  } catch (e) {
+    return e as { status: number };
+  }
+}
+
+beforeEach(() => {
+  bulkUpdateAttribution.mockReset();
+  requireUser.mockReset();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('POST /api/v1/admin/translations/bulk-attribution', () => {
+  it('updates attribution and returns the count', async () => {
+    bulkUpdateAttribution.mockResolvedValueOnce({ updated: 5 });
+    const res = (await callPost({
+      source: 'official_dictionary',
+      oldAttribution: 'Hindi WordNet',
+      newAttribution: 'Hindi WordNet (CFILT, IIT-Bombay)',
+      reason: 'Add full attribution to imported rows',
+    })) as Response;
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ updated: 5 });
+    expect(bulkUpdateAttribution).toHaveBeenCalledWith(
+      ADMIN,
+      {
+        source: 'official_dictionary',
+        oldAttribution: 'Hindi WordNet',
+        newAttribution: 'Hindi WordNet (CFILT, IIT-Bombay)',
+        language: undefined,
+      },
+      'Add full attribution to imported rows',
+    );
+  });
+
+  it('passes language scope when provided', async () => {
+    bulkUpdateAttribution.mockResolvedValueOnce({ updated: 3 });
+    await callPost({
+      source: 'official_dictionary',
+      oldAttribution: 'Old',
+      newAttribution: null,
+      language: 'or',
+      reason: 'Clear obsolete attribution on Odia rows',
+    });
+    expect(bulkUpdateAttribution).toHaveBeenCalledWith(
+      ADMIN,
+      expect.objectContaining({ language: 'or', newAttribution: null }),
+      'Clear obsolete attribution on Odia rows',
+    );
+  });
+
+  it('rejects an unsupported source with 400', async () => {
+    const res = (await callPost({
+      source: 'user',
+      oldAttribution: 'Old',
+      newAttribution: 'New',
+      reason: 'forced',
+    })) as { status: number };
+    expect(res.status).toBe(400);
+    expect(bulkUpdateAttribution).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty oldAttribution with 400 (zod min)', async () => {
+    const res = (await callPost({
+      source: 'official_dictionary',
+      oldAttribution: '',
+      newAttribution: 'New',
+      reason: 'forced',
+    })) as { status: number };
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects an unsupported language code', async () => {
+    const res = (await callPost({
+      source: 'official_dictionary',
+      oldAttribution: 'Old',
+      newAttribution: 'New',
+      language: 'xx',
+      reason: 'forced',
+    })) as { status: number };
+    expect(res.status).toBe(400);
+  });
+
+  it('maps ForbiddenError to 403', async () => {
+    const { ForbiddenError } = await import('$lib/server/dictionary/permissions.js');
+    bulkUpdateAttribution.mockRejectedValueOnce(new ForbiddenError('admin only'));
+    const res = (await callPost({
+      source: 'official_dictionary',
+      oldAttribution: 'Old',
+      newAttribution: 'New',
+      reason: 'attempt as curator',
+    })) as { status: number };
+    expect(res.status).toBe(403);
+  });
+
+  it('maps over-cap CuratorValidationError to 400', async () => {
+    const { CuratorValidationError } = await import(
+      '$lib/server/dictionary/curator.js'
+    );
+    bulkUpdateAttribution.mockRejectedValueOnce(
+      new CuratorValidationError('would touch too many', 400),
+    );
+    const res = (await callPost({
+      source: 'official_dictionary',
+      oldAttribution: 'Old',
+      newAttribution: 'New',
+      reason: 'too broad',
+    })) as { status: number };
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/web/src/routes/api/v1/admin/translations/bulk-import/+server.ts
+++ b/apps/web/src/routes/api/v1/admin/translations/bulk-import/+server.ts
@@ -1,0 +1,67 @@
+/**
+ * POST /api/v1/admin/translations/bulk-import (T-3.9).
+ *
+ * Admin-only. Accepts an array of curator-written gloss rows, each
+ * resolving an existing lemma by `(language, headword, pos)`. Rows that
+ * cannot be resolved are returned in `skipped` so the caller can fix
+ * the upload — we never auto-create lemmas here (use the dictionary
+ * editor / proposal queue for that).
+ *
+ * Response shape:
+ *   { inserted: number, skipped: Array<{ row: number, reason: string }> }
+ */
+import { error, json } from '@sveltejs/kit';
+import { z } from 'zod';
+
+import { requireUser } from '$lib/server/auth/require-user.js';
+import {
+  bulkImportTranslations,
+  BULK_LIMIT,
+} from '$lib/server/dictionary/bulk.js';
+import { CuratorValidationError } from '$lib/server/dictionary/curator.js';
+import { ForbiddenError } from '$lib/server/dictionary/permissions.js';
+import { MissingReasonError } from '$lib/server/dictionary/audit.js';
+import type { RequestHandler } from './$types';
+import { parseJson } from '../../../auth/_helpers.js';
+
+const rowSchema = z.object({
+  language: z.string().min(2).max(8),
+  headword: z.string().min(1).max(128),
+  pos: z.string().min(1).max(32),
+  body: z.string().min(1).max(500),
+  targetLanguage: z.string().min(2).max(8).optional(),
+  sourceAttribution: z.string().max(500).nullable().optional(),
+});
+
+const body = z.object({
+  rows: z.array(rowSchema).min(1).max(BULK_LIMIT),
+  reason: z.string().min(3).max(500),
+  defaults: z
+    .object({
+      sourceAttribution: z.string().max(500).nullable().optional(),
+    })
+    .optional(),
+});
+
+function mapErr(err: unknown): never {
+  if (err instanceof CuratorValidationError) throw error(err.status, err.message);
+  if (err instanceof ForbiddenError) throw error(403, err.message);
+  if (err instanceof MissingReasonError) throw error(400, err.message);
+  throw err;
+}
+
+export const POST: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  const input = await parseJson(event.request, body);
+  try {
+    const result = await bulkImportTranslations(
+      user,
+      input.rows,
+      input.reason,
+      input.defaults ?? {},
+    );
+    return json(result);
+  } catch (err) {
+    mapErr(err);
+  }
+};

--- a/apps/web/src/routes/api/v1/admin/translations/bulk-import/bulk-import.test.ts
+++ b/apps/web/src/routes/api/v1/admin/translations/bulk-import/bulk-import.test.ts
@@ -1,0 +1,155 @@
+// @vitest-environment node
+/**
+ * Route tests for POST /api/v1/admin/translations/bulk-import (T-3.9).
+ *
+ * The service is fully unit-tested in `bulk.test.ts`; this suite is just
+ * the request → service handoff: zod validation, error mapping, JSON
+ * shape, auth.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const bulkImportTranslations = vi.fn();
+const requireUser = vi.fn();
+
+vi.mock('$lib/server/dictionary/bulk.js', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/dictionary/bulk.js')>(
+    '$lib/server/dictionary/bulk.js',
+  );
+  return {
+    ...actual,
+    bulkImportTranslations: (...a: unknown[]) => bulkImportTranslations(...a),
+  };
+});
+
+vi.mock('$lib/server/auth/require-user.js', () => ({
+  requireUser: (...a: unknown[]) => requireUser(...a),
+}));
+
+type PostFn = (typeof import('./+server.js'))['POST'];
+
+const ADMIN = { id: 'admin-1', role: 'admin' as const };
+
+async function callPost(body: unknown, user = ADMIN) {
+  requireUser.mockResolvedValueOnce(user);
+  const { POST } = await import('./+server.js');
+  const event = {
+    params: {},
+    request: new Request('http://x/api/v1/admin/translations/bulk-import', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+  } as unknown as Parameters<PostFn>[0];
+  try {
+    return await POST(event);
+  } catch (e) {
+    return e as { status: number };
+  }
+}
+
+beforeEach(() => {
+  bulkImportTranslations.mockReset();
+  requireUser.mockReset();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('POST /api/v1/admin/translations/bulk-import', () => {
+  it('returns the service result on a happy path', async () => {
+    bulkImportTranslations.mockResolvedValueOnce({ inserted: 2, skipped: [] });
+    const res = (await callPost({
+      rows: [
+        { language: 'hi', headword: 'बोलना', pos: 'verb', body: 'to speak' },
+        { language: 'hi', headword: 'सोना', pos: 'noun', body: 'gold' },
+      ],
+      reason: 'Importing curator gloss CSV',
+    })) as Response;
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({ inserted: 2, skipped: [] });
+    expect(bulkImportTranslations).toHaveBeenCalledWith(
+      ADMIN,
+      [
+        { language: 'hi', headword: 'बोलना', pos: 'verb', body: 'to speak' },
+        { language: 'hi', headword: 'सोना', pos: 'noun', body: 'gold' },
+      ],
+      'Importing curator gloss CSV',
+      {},
+    );
+  });
+
+  it('forwards the optional `defaults` block to the service', async () => {
+    bulkImportTranslations.mockResolvedValueOnce({ inserted: 1, skipped: [] });
+    await callPost({
+      rows: [{ language: 'hi', headword: 'बोलना', pos: 'verb', body: 'to speak' }],
+      reason: 'CSV import',
+      defaults: { sourceAttribution: 'My CSV 2026' },
+    });
+    expect(bulkImportTranslations).toHaveBeenCalledWith(
+      ADMIN,
+      expect.any(Array),
+      'CSV import',
+      { sourceAttribution: 'My CSV 2026' },
+    );
+  });
+
+  it('rejects an empty rows[] with 400', async () => {
+    const res = (await callPost({ rows: [], reason: 'noop' })) as { status: number };
+    expect(res.status).toBe(400);
+    expect(bulkImportTranslations).not.toHaveBeenCalled();
+  });
+
+  it('rejects a too-short reason with 400', async () => {
+    const res = (await callPost({
+      rows: [{ language: 'hi', headword: 'बोलना', pos: 'verb', body: 'to speak' }],
+      reason: 'x',
+    })) as { status: number };
+    expect(res.status).toBe(400);
+  });
+
+  it('maps ForbiddenError to 403', async () => {
+    const { ForbiddenError } = await import('$lib/server/dictionary/permissions.js');
+    bulkImportTranslations.mockRejectedValueOnce(new ForbiddenError('admin only'));
+    const res = (await callPost({
+      rows: [{ language: 'hi', headword: 'बोलना', pos: 'verb', body: 'to speak' }],
+      reason: 'attempt as curator',
+    })) as { status: number };
+    expect(res.status).toBe(403);
+  });
+
+  it('maps CuratorValidationError to its status', async () => {
+    const { CuratorValidationError } = await import(
+      '$lib/server/dictionary/curator.js'
+    );
+    bulkImportTranslations.mockRejectedValueOnce(
+      new CuratorValidationError('rows is empty', 400),
+    );
+    const res = (await callPost({
+      rows: [{ language: 'hi', headword: 'बोलना', pos: 'verb', body: 'to speak' }],
+      reason: 'forced',
+    })) as { status: number };
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for invalid JSON', async () => {
+    requireUser.mockResolvedValueOnce(ADMIN);
+    const { POST } = await import('./+server.js');
+    const event = {
+      params: {},
+      request: new Request('http://x/api/v1/admin/translations/bulk-import', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: 'not json',
+      }),
+    } as unknown as Parameters<PostFn>[0];
+    let status = 0;
+    try {
+      await POST(event);
+    } catch (e) {
+      status = (e as { status: number }).status;
+    }
+    expect(status).toBe(400);
+  });
+});

--- a/apps/web/src/routes/api/v1/admin/translations/bulk-promote/+server.ts
+++ b/apps/web/src/routes/api/v1/admin/translations/bulk-promote/+server.ts
@@ -1,0 +1,55 @@
+/**
+ * POST /api/v1/admin/translations/bulk-promote (T-3.9).
+ *
+ * Admin-only. Re-tags a set of community (`source='user'`) translations
+ * as curator translations in one pass. Officials are explicitly skipped
+ * (same one-way guard as `updateTranslation`).
+ *
+ * Response shape:
+ *   { promoted: number, skipped: Array<{ id: string, reason: string }> }
+ */
+import { error, json } from '@sveltejs/kit';
+import { z } from 'zod';
+
+import { requireUser } from '$lib/server/auth/require-user.js';
+import {
+  bulkPromoteTranslations,
+  BULK_LIMIT,
+} from '$lib/server/dictionary/bulk.js';
+import { CuratorValidationError } from '$lib/server/dictionary/curator.js';
+import { ForbiddenError } from '$lib/server/dictionary/permissions.js';
+import { MissingReasonError } from '$lib/server/dictionary/audit.js';
+import type { RequestHandler } from './$types';
+import { parseJson } from '../../../auth/_helpers.js';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const body = z.object({
+  translationIds: z
+    .array(z.string().regex(UUID_RE, 'must be a UUID'))
+    .min(1)
+    .max(BULK_LIMIT),
+  reason: z.string().min(3).max(500),
+});
+
+function mapErr(err: unknown): never {
+  if (err instanceof CuratorValidationError) throw error(err.status, err.message);
+  if (err instanceof ForbiddenError) throw error(403, err.message);
+  if (err instanceof MissingReasonError) throw error(400, err.message);
+  throw err;
+}
+
+export const POST: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  const input = await parseJson(event.request, body);
+  try {
+    const result = await bulkPromoteTranslations(
+      user,
+      input.translationIds,
+      input.reason,
+    );
+    return json(result);
+  } catch (err) {
+    mapErr(err);
+  }
+};

--- a/apps/web/src/routes/api/v1/admin/translations/bulk-promote/bulk-promote.test.ts
+++ b/apps/web/src/routes/api/v1/admin/translations/bulk-promote/bulk-promote.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment node
+/**
+ * Route tests for POST /api/v1/admin/translations/bulk-promote (T-3.9).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const bulkPromoteTranslations = vi.fn();
+const requireUser = vi.fn();
+
+vi.mock('$lib/server/dictionary/bulk.js', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/dictionary/bulk.js')>(
+    '$lib/server/dictionary/bulk.js',
+  );
+  return {
+    ...actual,
+    bulkPromoteTranslations: (...a: unknown[]) => bulkPromoteTranslations(...a),
+  };
+});
+
+vi.mock('$lib/server/auth/require-user.js', () => ({
+  requireUser: (...a: unknown[]) => requireUser(...a),
+}));
+
+type PostFn = (typeof import('./+server.js'))['POST'];
+
+const ADMIN = { id: 'admin-1', role: 'admin' as const };
+const VALID_ID_1 = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const VALID_ID_2 = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+
+async function callPost(body: unknown, user = ADMIN) {
+  requireUser.mockResolvedValueOnce(user);
+  const { POST } = await import('./+server.js');
+  const event = {
+    params: {},
+    request: new Request('http://x/api/v1/admin/translations/bulk-promote', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+  } as unknown as Parameters<PostFn>[0];
+  try {
+    return await POST(event);
+  } catch (e) {
+    return e as { status: number };
+  }
+}
+
+beforeEach(() => {
+  bulkPromoteTranslations.mockReset();
+  requireUser.mockReset();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('POST /api/v1/admin/translations/bulk-promote', () => {
+  it('promotes a set of ids and returns the result envelope', async () => {
+    bulkPromoteTranslations.mockResolvedValueOnce({
+      promoted: 2,
+      skipped: [],
+    });
+    const res = (await callPost({
+      translationIds: [VALID_ID_1, VALID_ID_2],
+      reason: 'Endorsing strong community submissions',
+    })) as Response;
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ promoted: 2, skipped: [] });
+    expect(bulkPromoteTranslations).toHaveBeenCalledWith(
+      ADMIN,
+      [VALID_ID_1, VALID_ID_2],
+      'Endorsing strong community submissions',
+    );
+  });
+
+  it('rejects a non-uuid in the list with 400', async () => {
+    const res = (await callPost({
+      translationIds: ['not-a-uuid'],
+      reason: 'forced',
+    })) as { status: number };
+    expect(res.status).toBe(400);
+    expect(bulkPromoteTranslations).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty list with 400', async () => {
+    const res = (await callPost({ translationIds: [], reason: 'noop' })) as {
+      status: number;
+    };
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a too-short reason with 400', async () => {
+    const res = (await callPost({
+      translationIds: [VALID_ID_1],
+      reason: 'x',
+    })) as { status: number };
+    expect(res.status).toBe(400);
+  });
+
+  it('maps ForbiddenError to 403', async () => {
+    const { ForbiddenError } = await import('$lib/server/dictionary/permissions.js');
+    bulkPromoteTranslations.mockRejectedValueOnce(
+      new ForbiddenError('admin only'),
+    );
+    const res = (await callPost({
+      translationIds: [VALID_ID_1],
+      reason: 'attempt as curator',
+    })) as { status: number };
+    expect(res.status).toBe(403);
+  });
+});

--- a/apps/web/src/routes/moderation/dictionary/+page.server.ts
+++ b/apps/web/src/routes/moderation/dictionary/+page.server.ts
@@ -38,6 +38,7 @@ export const load: PageServerLoad = async ({ url, parent }) => {
       limit: DEFAULT_PAGE_SIZE,
       offset: 0,
       query: { q: '' },
+      isAdmin: moderator.role === 'admin',
     };
   }
 
@@ -80,5 +81,6 @@ export const load: PageServerLoad = async ({ url, parent }) => {
     limit: result.limit,
     offset: result.offset,
     query: { q: q ?? '' },
+    isAdmin: moderator.role === 'admin',
   };
 };

--- a/apps/web/src/routes/moderation/dictionary/+page.svelte
+++ b/apps/web/src/routes/moderation/dictionary/+page.svelte
@@ -34,6 +34,11 @@
     {:else}
       <p class="sub">No language grants. Ask an admin for curator rights.</p>
     {/if}
+    {#if data.isAdmin}
+      <p class="admin-tools">
+        <a href="/moderation/dictionary/bulk">Bulk tools →</a>
+      </p>
+    {/if}
   </header>
 
   {#if data.descriptors.length > 1}

--- a/apps/web/src/routes/moderation/dictionary/bulk/+page.server.ts
+++ b/apps/web/src/routes/moderation/dictionary/bulk/+page.server.ts
@@ -1,0 +1,284 @@
+/**
+ * Bulk curator tools page (T-3.9).
+ *
+ * Three forms in one page, each routed to a distinct action so we can
+ * narrow the result by `section` exactly the way the lemma editor does.
+ * All three operations are admin-only at the service layer; this loader
+ * additionally gates the page so a curator without admin role doesn't
+ * see a UI they can't use.
+ *
+ * The CSV-style import accepts a tab- or comma-separated paste in the
+ * textarea; it's parsed line by line on the server. Re-using the
+ * existing JSON service keeps every code path through one validator.
+ */
+import { error, fail, redirect } from '@sveltejs/kit';
+import { z } from 'zod';
+
+import {
+  bulkImportTranslations,
+  bulkPromoteTranslations,
+  bulkUpdateAttribution,
+  BULK_LIMIT,
+  type BulkImportRow,
+  type BulkImportResult,
+  type BulkPromoteResult,
+  type BulkAttributionResult,
+} from '$lib/server/dictionary/bulk.js';
+import { CuratorValidationError } from '$lib/server/dictionary/curator.js';
+import { ForbiddenError, isAdmin } from '$lib/server/dictionary/permissions.js';
+import { MissingReasonError } from '$lib/server/dictionary/audit.js';
+import type { Actions, PageServerLoad } from './$types';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function mapError(e: unknown): { status: number; message: string } {
+  if (e instanceof CuratorValidationError) return { status: e.status, message: e.message };
+  if (e instanceof MissingReasonError) return { status: 400, message: e.message };
+  if (e instanceof ForbiddenError) return { status: 403, message: e.message };
+  return { status: 500, message: 'Unexpected error' };
+}
+
+type ImportResult =
+  | ({ ok: true; section: 'import' } & BulkImportResult)
+  | { ok: false; section: 'import'; message: string };
+type PromoteResult =
+  | ({ ok: true; section: 'promote' } & BulkPromoteResult)
+  | { ok: false; section: 'promote'; message: string };
+type AttributionResult =
+  | ({ ok: true; section: 'attribution' } & BulkAttributionResult)
+  | { ok: false; section: 'attribution'; message: string };
+
+export const load: PageServerLoad = async ({ locals }) => {
+  if (!locals.user) throw redirect(303, '/login?next=/moderation/dictionary/bulk');
+  if (!isAdmin({ role: locals.user.role })) {
+    throw error(403, 'Bulk tools require admin role');
+  }
+  return { bulkLimit: BULK_LIMIT };
+};
+
+const importSchema = z.object({
+  csv: z.string().min(1, 'paste at least one row'),
+  reason: z.string().min(3).max(500),
+  defaultAttribution: z
+    .string()
+    .max(500)
+    .optional()
+    .transform((s) => (s && s.trim().length > 0 ? s.trim() : undefined)),
+});
+
+const promoteSchema = z.object({
+  ids: z.string().min(1, 'paste at least one id'),
+  reason: z.string().min(3).max(500),
+});
+
+const attributionSchema = z.object({
+  source: z.enum(['official_dictionary', 'curator']),
+  oldAttribution: z.string().min(1).max(500),
+  newAttribution: z
+    .string()
+    .max(500)
+    .transform((s) => (s.trim().length === 0 ? null : s)),
+  language: z
+    .string()
+    .optional()
+    .transform((s) => (s && s.length > 0 ? s : undefined)),
+  clearAttribution: z.string().optional().transform((s) => s === 'true'),
+  reason: z.string().min(3).max(500),
+});
+
+/**
+ * Parse a CSV-ish paste into structured rows. Splits each non-empty
+ * line on tabs first, then commas if there's no tab. We deliberately
+ * don't pull in a real CSV library — the tool is for curators pasting
+ * spreadsheet selections, not arbitrary CSV with quoted commas.
+ *
+ * Expected column order:
+ *   language, headword, pos, body[, targetLanguage, sourceAttribution]
+ */
+function parseCsv(text: string): BulkImportRow[] {
+  const rows: BulkImportRow[] = [];
+  const lines = text.split(/\r?\n/);
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (line.length === 0) continue;
+    if (line.startsWith('#')) continue;
+    const fields = line.includes('\t') ? line.split('\t') : line.split(',');
+    const [language, headword, pos, body, targetLanguage, sourceAttribution] = fields.map(
+      (f) => f.trim(),
+    );
+    rows.push({
+      language: language ?? '',
+      headword: headword ?? '',
+      pos: pos ?? '',
+      body: body ?? '',
+      ...(targetLanguage ? { targetLanguage } : {}),
+      ...(sourceAttribution !== undefined && sourceAttribution !== ''
+        ? { sourceAttribution }
+        : {}),
+    });
+  }
+  return rows;
+}
+
+function parseIds(text: string): string[] {
+  return text
+    .split(/[\s,]+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+export const actions: Actions = {
+  import: async ({ request, locals }) => {
+    if (!locals.user) throw error(401, 'Unauthorized');
+    const editor = { id: locals.user.id, role: locals.user.role };
+    const form = Object.fromEntries(await request.formData());
+    const parsed = importSchema.safeParse(form);
+    if (!parsed.success) {
+      return fail(400, {
+        ok: false,
+        section: 'import',
+        message: parsed.error.issues
+          .map((i) => `${i.path.join('.')}: ${i.message}`)
+          .join('; '),
+      } satisfies ImportResult);
+    }
+    const rows = parseCsv(parsed.data.csv);
+    if (rows.length === 0) {
+      return fail(400, {
+        ok: false,
+        section: 'import',
+        message: 'No usable rows found',
+      } satisfies ImportResult);
+    }
+    if (rows.length > BULK_LIMIT) {
+      return fail(400, {
+        ok: false,
+        section: 'import',
+        message: `Too many rows (cap is ${BULK_LIMIT})`,
+      } satisfies ImportResult);
+    }
+    try {
+      const result = await bulkImportTranslations(
+        editor,
+        rows,
+        parsed.data.reason,
+        parsed.data.defaultAttribution
+          ? { sourceAttribution: parsed.data.defaultAttribution }
+          : {},
+      );
+      return {
+        ok: true,
+        section: 'import',
+        ...result,
+      } satisfies ImportResult;
+    } catch (e) {
+      const mapped = mapError(e);
+      return fail(mapped.status, {
+        ok: false,
+        section: 'import',
+        message: mapped.message,
+      } satisfies ImportResult);
+    }
+  },
+
+  promote: async ({ request, locals }) => {
+    if (!locals.user) throw error(401, 'Unauthorized');
+    const editor = { id: locals.user.id, role: locals.user.role };
+    const form = Object.fromEntries(await request.formData());
+    const parsed = promoteSchema.safeParse(form);
+    if (!parsed.success) {
+      return fail(400, {
+        ok: false,
+        section: 'promote',
+        message: parsed.error.issues
+          .map((i) => `${i.path.join('.')}: ${i.message}`)
+          .join('; '),
+      } satisfies PromoteResult);
+    }
+    const all = parseIds(parsed.data.ids);
+    const valid = all.filter((id) => UUID_RE.test(id));
+    const invalid = all.filter((id) => !UUID_RE.test(id));
+    if (valid.length === 0) {
+      return fail(400, {
+        ok: false,
+        section: 'promote',
+        message:
+          invalid.length > 0
+            ? `No valid UUIDs in the input (${invalid.length} non-uuid tokens skipped)`
+            : 'No ids provided',
+      } satisfies PromoteResult);
+    }
+    if (valid.length > BULK_LIMIT) {
+      return fail(400, {
+        ok: false,
+        section: 'promote',
+        message: `Too many ids (cap is ${BULK_LIMIT})`,
+      } satisfies PromoteResult);
+    }
+    try {
+      const result = await bulkPromoteTranslations(editor, valid, parsed.data.reason);
+      return {
+        ok: true,
+        section: 'promote',
+        ...result,
+      } satisfies PromoteResult;
+    } catch (e) {
+      const mapped = mapError(e);
+      return fail(mapped.status, {
+        ok: false,
+        section: 'promote',
+        message: mapped.message,
+      } satisfies PromoteResult);
+    }
+  },
+
+  attribution: async ({ request, locals }) => {
+    if (!locals.user) throw error(401, 'Unauthorized');
+    const editor = { id: locals.user.id, role: locals.user.role };
+    const form = Object.fromEntries(await request.formData());
+    const parsed = attributionSchema.safeParse(form);
+    if (!parsed.success) {
+      return fail(400, {
+        ok: false,
+        section: 'attribution',
+        message: parsed.error.issues
+          .map((i) => `${i.path.join('.')}: ${i.message}`)
+          .join('; '),
+      } satisfies AttributionResult);
+    }
+    const language = parsed.data.language;
+    if (language && language !== 'hi' && language !== 'mr' && language !== 'or') {
+      return fail(400, {
+        ok: false,
+        section: 'attribution',
+        message: `Unsupported language: ${language}`,
+      } satisfies AttributionResult);
+    }
+    try {
+      const result = await bulkUpdateAttribution(
+        editor,
+        {
+          source: parsed.data.source,
+          oldAttribution: parsed.data.oldAttribution,
+          newAttribution: parsed.data.clearAttribution
+            ? null
+            : parsed.data.newAttribution,
+          language: language as 'hi' | 'mr' | 'or' | undefined,
+        },
+        parsed.data.reason,
+      );
+      return {
+        ok: true,
+        section: 'attribution',
+        ...result,
+      } satisfies AttributionResult;
+    } catch (e) {
+      const mapped = mapError(e);
+      return fail(mapped.status, {
+        ok: false,
+        section: 'attribution',
+        message: mapped.message,
+      } satisfies AttributionResult);
+    }
+  },
+};

--- a/apps/web/src/routes/moderation/dictionary/bulk/+page.svelte
+++ b/apps/web/src/routes/moderation/dictionary/bulk/+page.svelte
@@ -1,0 +1,294 @@
+<script lang="ts">
+  import { enhance } from '$app/forms';
+  import type { ActionData, PageData } from './$types';
+
+  let {
+    data,
+    form,
+  }: { data: PageData; form: ActionData } = $props();
+
+  const importResult = $derived(form?.section === 'import' ? form : null);
+  const promoteResult = $derived(form?.section === 'promote' ? form : null);
+  const attributionResult = $derived(
+    form?.section === 'attribution' ? form : null,
+  );
+</script>
+
+<svelte:head>
+  <title>Bulk dictionary tools — CIA Reader</title>
+  <meta name="robots" content="noindex" />
+</svelte:head>
+
+<div class="page">
+  <p class="crumb">
+    <a href="/moderation/dictionary">← Back to dictionary</a>
+  </p>
+
+  <header>
+    <h1>Bulk curator tools</h1>
+    <p class="sub">
+      Admin-only. Each operation requires a reason and writes one audit row
+      per affected translation. Hard cap of {data.bulkLimit} rows per submission.
+    </p>
+  </header>
+
+  <!-- 1. CSV import ----------------------------------------------------- -->
+  <section>
+    <h2>Bulk import curator translations</h2>
+    <p class="sub">
+      Paste tab- or comma-separated rows. Each row resolves an existing lemma
+      by <code>(language, headword, pos)</code>; rows that don't match a known
+      lemma are listed as skipped — fix them in the dictionary editor first.
+    </p>
+    <p class="sub">
+      Columns:
+      <code>language, headword, pos, body[, targetLanguage, sourceAttribution]</code>.
+      Lines starting with <code>#</code> are treated as comments.
+    </p>
+
+    {#if importResult}
+      {#if importResult.ok}
+        <p class="ok">
+          Inserted {importResult.inserted}.
+          {#if importResult.skipped.length > 0}
+            Skipped {importResult.skipped.length}:
+          {/if}
+        </p>
+        {#if importResult.skipped.length > 0}
+          <ul class="skip-list">
+            {#each importResult.skipped as s (s.row)}
+              <li>row {s.row}: {s.reason}</li>
+            {/each}
+          </ul>
+        {/if}
+      {:else}
+        <p class="err">{importResult.message}</p>
+      {/if}
+    {/if}
+
+    <form method="post" action="?/import" use:enhance class="stack">
+      <label>
+        CSV / TSV rows
+        <textarea
+          name="csv"
+          rows="8"
+          placeholder="hi, बोलना, verb, to speak, en, My CSV 2026"
+          required
+        ></textarea>
+      </label>
+      <label>
+        Default attribution (optional — used when a row omits it)
+        <input name="defaultAttribution" placeholder="e.g. CIA Reader curators" />
+      </label>
+      <label>
+        Reason
+        <input name="reason" required minlength="3" placeholder="Why this import?" />
+      </label>
+      <button type="submit">Import rows</button>
+    </form>
+  </section>
+
+  <!-- 2. Bulk promote --------------------------------------------------- -->
+  <section>
+    <h2>Bulk promote community translations</h2>
+    <p class="sub">
+      Paste a list of translation IDs (one per line, or comma-separated). Each
+      <code>source='user'</code> row will be re-tagged as <code>curator</code>.
+      Officials and already-curator rows are skipped without error.
+    </p>
+
+    {#if promoteResult}
+      {#if promoteResult.ok}
+        <p class="ok">
+          Promoted {promoteResult.promoted}.
+          {#if promoteResult.skipped.length > 0}
+            Skipped {promoteResult.skipped.length}:
+          {/if}
+        </p>
+        {#if promoteResult.skipped.length > 0}
+          <ul class="skip-list">
+            {#each promoteResult.skipped as s (s.id)}
+              <li><code>{s.id}</code>: {s.reason}</li>
+            {/each}
+          </ul>
+        {/if}
+      {:else}
+        <p class="err">{promoteResult.message}</p>
+      {/if}
+    {/if}
+
+    <form method="post" action="?/promote" use:enhance class="stack">
+      <label>
+        Translation IDs
+        <textarea
+          name="ids"
+          rows="6"
+          placeholder="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
+bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+          required
+        ></textarea>
+      </label>
+      <label>
+        Reason
+        <input name="reason" required minlength="3" placeholder="e.g. endorsing top-voted Hindi gloss" />
+      </label>
+      <button type="submit">Promote to curator</button>
+    </form>
+  </section>
+
+  <!-- 3. Bulk attribution ---------------------------------------------- -->
+  <section>
+    <h2>Rewrite attribution</h2>
+    <p class="sub">
+      Replace every <code>sourceAttribution</code> matching the old value with
+      the new value, on translations of the chosen source. Optionally scope to
+      one language. Use this when an upstream dictionary rebrands.
+    </p>
+
+    {#if attributionResult}
+      {#if attributionResult.ok}
+        <p class="ok">Updated {attributionResult.updated} row(s).</p>
+      {:else}
+        <p class="err">{attributionResult.message}</p>
+      {/if}
+    {/if}
+
+    <form method="post" action="?/attribution" use:enhance class="stack">
+      <label>
+        Source class
+        <select name="source" required>
+          <option value="official_dictionary">Imported (official_dictionary)</option>
+          <option value="curator">Curator</option>
+        </select>
+      </label>
+      <label>
+        Old attribution (exact match)
+        <input name="oldAttribution" required />
+      </label>
+      <label>
+        New attribution
+        <input name="newAttribution" />
+      </label>
+      <label class="checkbox">
+        <input type="checkbox" name="clearAttribution" value="true" />
+        Clear attribution (set to NULL — overrides New attribution above)
+      </label>
+      <label>
+        Language scope (optional)
+        <select name="language">
+          <option value="">All languages</option>
+          <option value="hi">Hindi</option>
+          <option value="mr">Marathi</option>
+          <option value="or">Odia</option>
+        </select>
+      </label>
+      <label>
+        Reason
+        <input name="reason" required minlength="3" placeholder="e.g. upstream rebrand 2026" />
+      </label>
+      <button type="submit" class="danger">Rewrite attribution</button>
+    </form>
+  </section>
+</div>
+
+<style>
+  .page {
+    max-width: 44rem;
+    margin: 0 auto;
+    padding: 1.5rem 1.25rem 3rem;
+  }
+  .crumb {
+    margin: 0 0 1rem;
+    font-size: 0.9rem;
+  }
+  .crumb a {
+    color: var(--color-accent);
+  }
+  header h1 {
+    margin: 0 0 0.25rem;
+    font-size: 1.6rem;
+  }
+  .sub {
+    color: var(--color-fg-muted);
+    margin: 0 0 0.75rem;
+    font-size: 0.9rem;
+  }
+  section {
+    margin: 1.75rem 0;
+    padding: 1rem 1.25rem;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+  }
+  section h2 {
+    margin: 0 0 0.5rem;
+    font-size: 1.1rem;
+  }
+  form label {
+    display: block;
+    margin-bottom: 0.75rem;
+    font-size: 0.9rem;
+  }
+  form input,
+  form textarea,
+  form select {
+    display: block;
+    width: 100%;
+    margin-top: 0.25rem;
+    padding: 0.5rem 0.6rem;
+    font: inherit;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    background: var(--color-bg);
+    color: var(--color-fg);
+    min-height: 44px;
+  }
+  form textarea {
+    min-height: 6rem;
+    resize: vertical;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.85rem;
+  }
+  .stack > * {
+    margin-bottom: 0.75rem;
+  }
+  form button {
+    min-height: 44px;
+    padding: 0 1rem;
+    background: var(--color-accent);
+    color: var(--color-accent-fg, #fff);
+    border: 0;
+    border-radius: 6px;
+    cursor: pointer;
+  }
+  form button.danger {
+    background: #b03131;
+    color: #fff;
+  }
+  .checkbox {
+    display: flex;
+    gap: 0.4rem;
+    align-items: center;
+  }
+  .checkbox input {
+    display: inline;
+    width: auto;
+    min-height: 0;
+    margin: 0;
+  }
+  .skip-list {
+    margin: 0.4rem 0 0 1.2rem;
+    padding: 0;
+    font-size: 0.85rem;
+    color: var(--color-fg-muted);
+  }
+  .ok {
+    color: #197a2f;
+  }
+  .err {
+    color: #b03131;
+  }
+  code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.85em;
+  }
+</style>

--- a/apps/web/src/routes/moderation/dictionary/bulk/page-server.test.ts
+++ b/apps/web/src/routes/moderation/dictionary/bulk/page-server.test.ts
@@ -1,0 +1,225 @@
+// @vitest-environment node
+/**
+ * Tests for /moderation/dictionary/bulk SSR loader + actions (T-3.9).
+ *
+ * The page is admin-only; this suite verifies the loader gate plus that
+ * each action correctly delegates to the bulk service and shapes the
+ * result by `section`.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const bulkImportTranslations = vi.fn();
+const bulkPromoteTranslations = vi.fn();
+const bulkUpdateAttribution = vi.fn();
+
+vi.mock('$lib/server/dictionary/bulk.js', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/dictionary/bulk.js')>(
+    '$lib/server/dictionary/bulk.js',
+  );
+  return {
+    ...actual,
+    bulkImportTranslations: (...a: unknown[]) => bulkImportTranslations(...a),
+    bulkPromoteTranslations: (...a: unknown[]) => bulkPromoteTranslations(...a),
+    bulkUpdateAttribution: (...a: unknown[]) => bulkUpdateAttribution(...a),
+  };
+});
+
+type Mod = typeof import('./+page.server.js');
+const ADMIN = { id: 'admin-1', role: 'admin' as const };
+const CURATOR = { id: 'cur-1', role: 'curator' as const };
+
+async function callLoad(user: { id: string; role: 'admin' | 'curator' | 'user' } | null) {
+  const { load } = (await import('./+page.server.js')) as Mod;
+  const event = {
+    locals: { user },
+  } as unknown as Parameters<Mod['load']>[0];
+  try {
+    return await load(event);
+  } catch (e) {
+    return e as { status?: number; location?: string };
+  }
+}
+
+async function callAction(
+  name: 'import' | 'promote' | 'attribution',
+  fields: Record<string, string>,
+  user: { id: string; role: 'admin' | 'curator' | 'user' } | null = ADMIN,
+) {
+  const { actions } = (await import('./+page.server.js')) as Mod;
+  const fd = new FormData();
+  for (const [k, v] of Object.entries(fields)) fd.append(k, v);
+  const event = {
+    locals: { user },
+    request: {
+      formData: () => Promise.resolve(fd),
+    } as unknown as Request,
+  } as unknown as Parameters<Mod['actions'][string]>[0];
+  return actions[name]!(event);
+}
+
+beforeEach(() => {
+  bulkImportTranslations.mockReset();
+  bulkPromoteTranslations.mockReset();
+  bulkUpdateAttribution.mockReset();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('/moderation/dictionary/bulk loader', () => {
+  it('admins see the bulk page', async () => {
+    const data = (await callLoad(ADMIN)) as { bulkLimit: number };
+    expect(data.bulkLimit).toBeGreaterThan(0);
+  });
+
+  it('curators get a 403', async () => {
+    const res = (await callLoad(CURATOR)) as { status: number };
+    expect(res.status).toBe(403);
+  });
+
+  it('unauthenticated visitors are redirected to /login', async () => {
+    const res = (await callLoad(null)) as { status: number; location: string };
+    expect(res.status).toBe(303);
+    expect(res.location).toContain('/login');
+  });
+});
+
+describe('?/import action', () => {
+  it('parses tab-separated rows and forwards them to the service', async () => {
+    bulkImportTranslations.mockResolvedValueOnce({ inserted: 2, skipped: [] });
+    const result = (await callAction('import', {
+      csv: 'hi\tबोलना\tverb\tto speak\nhi\tसोना\tnoun\tgold',
+      reason: 'Importing curator gloss CSV',
+    })) as { ok: boolean; inserted: number };
+    expect(result.ok).toBe(true);
+    expect(result.inserted).toBe(2);
+    expect(bulkImportTranslations).toHaveBeenCalledWith(
+      ADMIN,
+      [
+        { language: 'hi', headword: 'बोलना', pos: 'verb', body: 'to speak' },
+        { language: 'hi', headword: 'सोना', pos: 'noun', body: 'gold' },
+      ],
+      'Importing curator gloss CSV',
+      {},
+    );
+  });
+
+  it('skips comment lines and empty lines', async () => {
+    bulkImportTranslations.mockResolvedValueOnce({ inserted: 1, skipped: [] });
+    await callAction('import', {
+      csv: '# header\n\nhi,बोलना,verb,to speak\n',
+      reason: 'with comments',
+    });
+    expect(bulkImportTranslations).toHaveBeenCalledWith(
+      ADMIN,
+      [{ language: 'hi', headword: 'बोलना', pos: 'verb', body: 'to speak' }],
+      'with comments',
+      {},
+    );
+  });
+
+  it('forwards a default attribution when supplied', async () => {
+    bulkImportTranslations.mockResolvedValueOnce({ inserted: 1, skipped: [] });
+    await callAction('import', {
+      csv: 'hi,बोलना,verb,to speak',
+      reason: 'with default',
+      defaultAttribution: 'CIA Reader curators',
+    });
+    expect(bulkImportTranslations).toHaveBeenCalledWith(
+      ADMIN,
+      expect.any(Array),
+      'with default',
+      { sourceAttribution: 'CIA Reader curators' },
+    );
+  });
+
+  it('returns a fail() with section=import when the CSV is empty', async () => {
+    const result = (await callAction('import', {
+      csv: '   ',
+      reason: 'whitespace',
+    })) as { status: number; data: { ok: boolean; section: string } };
+    expect(result.status).toBe(400);
+    expect(result.data.section).toBe('import');
+    expect(result.data.ok).toBe(false);
+  });
+});
+
+describe('?/promote action', () => {
+  const VALID_ID_1 = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+  const VALID_ID_2 = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+
+  it('parses newline / comma / whitespace and forwards UUIDs', async () => {
+    bulkPromoteTranslations.mockResolvedValueOnce({ promoted: 2, skipped: [] });
+    const result = (await callAction('promote', {
+      ids: `${VALID_ID_1}, ${VALID_ID_2}\nnot-a-uuid`,
+      reason: 'Endorsing community',
+    })) as { ok: boolean; promoted: number };
+    expect(result.ok).toBe(true);
+    expect(result.promoted).toBe(2);
+    expect(bulkPromoteTranslations).toHaveBeenCalledWith(
+      ADMIN,
+      [VALID_ID_1, VALID_ID_2],
+      'Endorsing community',
+    );
+  });
+
+  it('returns a fail when no UUIDs are present', async () => {
+    const result = (await callAction('promote', {
+      ids: 'foo bar baz',
+      reason: 'forced',
+    })) as { status: number; data: { ok: boolean; section: string } };
+    expect(result.status).toBe(400);
+    expect(result.data.section).toBe('promote');
+  });
+});
+
+describe('?/attribution action', () => {
+  it('forwards the attribution change with optional language scope', async () => {
+    bulkUpdateAttribution.mockResolvedValueOnce({ updated: 5 });
+    const result = (await callAction('attribution', {
+      source: 'official_dictionary',
+      oldAttribution: 'Hindi WordNet',
+      newAttribution: 'Hindi WordNet (CFILT, IIT-Bombay)',
+      language: 'hi',
+      reason: 'Add full attribution to imported rows',
+    })) as { ok: boolean; updated: number };
+    expect(result.ok).toBe(true);
+    expect(result.updated).toBe(5);
+    expect(bulkUpdateAttribution).toHaveBeenCalledWith(
+      ADMIN,
+      {
+        source: 'official_dictionary',
+        oldAttribution: 'Hindi WordNet',
+        newAttribution: 'Hindi WordNet (CFILT, IIT-Bombay)',
+        language: 'hi',
+      },
+      'Add full attribution to imported rows',
+    );
+  });
+
+  it('clears attribution when the clearAttribution checkbox is on', async () => {
+    bulkUpdateAttribution.mockResolvedValueOnce({ updated: 3 });
+    await callAction('attribution', {
+      source: 'curator',
+      oldAttribution: 'stale',
+      newAttribution: 'will-be-ignored',
+      clearAttribution: 'true',
+      reason: 'Clearing stale attribution',
+    });
+    const args = bulkUpdateAttribution.mock.calls[0]!;
+    expect(args[1]).toMatchObject({ newAttribution: null });
+  });
+
+  it('rejects an unsupported language code with 400', async () => {
+    const result = (await callAction('attribution', {
+      source: 'official_dictionary',
+      oldAttribution: 'Old',
+      newAttribution: 'New',
+      language: 'xx',
+      reason: 'forced',
+    })) as { status: number; data: { ok: boolean; section: string } };
+    expect(result.status).toBe(400);
+    expect(result.data.section).toBe('attribution');
+  });
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -46,11 +46,17 @@ export default defineConfig({
         'src/routes/**/+server.ts',
         'src/routes/**/+page.server.ts',
       ],
+      // Tightened in T-3.9 once M3 landed real curator logic. Actual
+      // numbers at the time of the bump are ~88% lines / ~88% branches /
+      // ~91% funcs across the included surface; the floor sits a few
+      // points below so a small regression is allowed but a wholesale
+      // drop trips CI. Tighten further as M5/M6 land reader + moderation
+      // logic.
       thresholds: {
-        lines: 40,
-        functions: 40,
-        branches: 60,
-        statements: 40,
+        lines: 80,
+        functions: 80,
+        branches: 80,
+        statements: 80,
       },
     },
   },


### PR DESCRIPTION
Closes #34

## Summary

Bulk curator dashboard at `/moderation/dictionary/bulk` plus the three admin-only `/api/v1/admin/translations/bulk-{import,promote,attribution}` endpoints that back it. Closes T-3.9 (last ticket of M3).

- `bulkImportTranslations` — CSV/TSV paste resolves `(language, headword, pos)` to existing lemmas, inserts curator-tagged translations. Per-row skips reported back instead of silent drops.
- `bulkPromoteTranslations` — re-tags `source='user'` rows as `source='curator'` in one pass; same one-way guard as the per-row editor (officials can't be re-tagged).
- `bulkUpdateAttribution` — rewrites `sourceAttribution` on every translation matching `(source, oldAttribution, language?)`. Hard cap at `BULK_LIMIT=1000` rows; an `oldAttribution` is required so a NULL sweep can't happen by accident.

Each operation requires a reason and writes one `lemma_edit_history` row per affected translation, tagged with a new bulk discriminator (`bulkImportRow` / `bulkPromote` / `bulkAttribution`) on `LemmaEditChangePayload` so the audit timeline can group bulk runs.

Also bumps vitest coverage thresholds 40% → 80% across lines/functions/branches/statements now that M3 has real curator logic. Actual is ~88% so there's headroom but a wholesale drop trips CI.

## Test plan

- [x] `pnpm --filter @ciareader/web test` — 365/365 passing across 48 files
- [x] `pnpm --filter @ciareader/web check` (svelte-check + tsc) — clean
- [x] `pnpm --filter @ciareader/web lint` — clean
- [x] `pnpm --filter @ciareader/web test:coverage` — passes 80% floor; bulk.ts at 97.18% lines, 91.02% branches
- [ ] Manual: paste a 3-row CSV at `/moderation/dictionary/bulk`, confirm rows insert / skips report
- [ ] Manual: bulk-promote a list of community translation UUIDs, confirm `source` flips and audit rows land
- [ ] Manual: rewrite an imported attribution scoped to one language, confirm only that language's rows update