### PR TITLE
T-4.1: text upload UI + texts/text_chapters schema (paste path)

### DIFF
--- a/apps/web/drizzle/0006_public_bedlam.sql
+++ b/apps/web/drizzle/0006_public_bedlam.sql
@@ -1,0 +1,42 @@
+CREATE TYPE "public"."text_source_type" AS ENUM('paste', 'txt', 'epub');--> statement-breakpoint
+CREATE TYPE "public"."text_status" AS ENUM('pending', 'processing', 'ready', 'failed');--> statement-breakpoint
+CREATE TYPE "public"."text_visibility" AS ENUM('private', 'shared', 'official');--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "text_chapters" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"text_id" uuid NOT NULL,
+	"idx" integer NOT NULL,
+	"title" text,
+	"body" text NOT NULL,
+	"token_count" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "text_chapters_text_idx_uq" UNIQUE("text_id","idx")
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "texts" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"owner_id" uuid,
+	"language" "language" NOT NULL,
+	"title" text NOT NULL,
+	"source_type" "text_source_type" NOT NULL,
+	"status" "text_status" DEFAULT 'pending' NOT NULL,
+	"visibility" "text_visibility" DEFAULT 'private' NOT NULL,
+	"status_error" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "text_chapters" ADD CONSTRAINT "text_chapters_text_id_texts_id_fk" FOREIGN KEY ("text_id") REFERENCES "public"."texts"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "texts" ADD CONSTRAINT "texts_owner_id_users_id_fk" FOREIGN KEY ("owner_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "text_chapters_text_idx" ON "text_chapters" USING btree ("text_id","idx");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "texts_owner_idx" ON "texts" USING btree ("owner_id","created_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "texts_visibility_idx" ON "texts" USING btree ("visibility","language");

--- a/apps/web/drizzle/meta/0006_snapshot.json
+++ b/apps/web/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,1640 @@
+{
+  "id": "3a9545e4-5522-49e5-8021-a4e922c9a05d",
+  "prevId": "8fbc7081-12d4-4469-8d40-9327ade2045b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.curator_languages": {
+      "name": "curator_languages",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "curator_languages_user_idx": {
+          "name": "curator_languages_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "curator_languages_user_id_users_id_fk": {
+          "name": "curator_languages_user_id_users_id_fk",
+          "tableFrom": "curator_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "curator_languages_granted_by_users_id_fk": {
+          "name": "curator_languages_granted_by_users_id_fk",
+          "tableFrom": "curator_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "curator_languages_user_id_language_pk": {
+          "name": "curator_languages_user_id_language_pk",
+          "columns": [
+            "user_id",
+            "language"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.dictionary_imports": {
+      "name": "dictionary_imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_name": {
+          "name": "source_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_at": {
+          "name": "run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lemmas_created": {
+          "name": "lemmas_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lemmas_updated": {
+          "name": "lemmas_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lemmas_skipped_curator_locked": {
+          "name": "lemmas_skipped_curator_locked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "translations_created": {
+          "name": "translations_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "translations_updated": {
+          "name": "translations_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "dictionary_imports_language_idx": {
+          "name": "dictionary_imports_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemma_edit_history": {
+      "name": "lemma_edit_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "editor_id": {
+          "name": "editor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "lemma_edit_change_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change": {
+          "name": "change",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_edit_history_lemma_idx": {
+          "name": "lemma_edit_history_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_edit_history_editor_idx": {
+          "name": "lemma_edit_history_editor_idx",
+          "columns": [
+            {
+              "expression": "editor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_edit_history_lemma_id_lemmas_id_fk": {
+          "name": "lemma_edit_history_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_edit_history",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lemma_edit_history_editor_id_users_id_fk": {
+          "name": "lemma_edit_history_editor_id_users_id_fk",
+          "tableFrom": "lemma_edit_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "editor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemma_forms": {
+      "name": "lemma_forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "romanization": {
+          "name": "romanization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_forms_lemma_idx": {
+          "name": "lemma_forms_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_forms_surface_idx": {
+          "name": "lemma_forms_surface_idx",
+          "columns": [
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_forms_lemma_id_lemmas_id_fk": {
+          "name": "lemma_forms_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_forms",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemmas": {
+      "name": "lemmas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headword": {
+          "name": "headword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos": {
+          "name": "pos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script": {
+          "name": "script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gloss_default": {
+          "name": "gloss_default",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_rank": {
+          "name": "frequency_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "translation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "curator_locked": {
+          "name": "curator_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemmas_language_idx": {
+          "name": "lemmas_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_language_frequency_idx": {
+          "name": "lemmas_language_frequency_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "frequency_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_source_lookup_idx": {
+          "name": "lemmas_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lemmas_language_headword_pos_uq": {
+          "name": "lemmas_language_headword_pos_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "language",
+            "headword",
+            "pos"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.magic_links": {
+      "name": "magic_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "magic_links_user_idx": {
+          "name": "magic_links_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "magic_links_expires_idx": {
+          "name": "magic_links_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "magic_links_user_id_users_id_fk": {
+          "name": "magic_links_user_id_users_id_fk",
+          "tableFrom": "magic_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by": {
+          "name": "replaced_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "refresh_tokens_user_idx": {
+          "name": "refresh_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_expires_idx": {
+          "name": "refresh_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.text_chapters": {
+      "name": "text_chapters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idx": {
+          "name": "idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "text_chapters_text_idx": {
+          "name": "text_chapters_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_chapters_text_id_texts_id_fk": {
+          "name": "text_chapters_text_id_texts_id_fk",
+          "tableFrom": "text_chapters",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "text_chapters_text_idx_uq": {
+          "name": "text_chapters_text_idx_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "text_id",
+            "idx"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.texts": {
+      "name": "texts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "status_error": {
+          "name": "status_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "texts_owner_idx": {
+          "name": "texts_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "texts_visibility_idx": {
+          "name": "texts_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "texts_owner_id_users_id_fk": {
+          "name": "texts_owner_id_users_id_fk",
+          "tableFrom": "texts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.translations": {
+      "name": "translations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "translation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_translation_id": {
+          "name": "parent_translation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_language": {
+          "name": "target_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "translations_lemma_idx": {
+          "name": "translations_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translations_submitted_by_idx": {
+          "name": "translations_submitted_by_idx",
+          "columns": [
+            {
+              "expression": "submitted_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translations_source_lookup_idx": {
+          "name": "translations_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "translations_lemma_id_lemmas_id_fk": {
+          "name": "translations_lemma_id_lemmas_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "translations_submitted_by_users_id_fk": {
+          "name": "translations_submitted_by_users_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "translations_parent_translation_id_translations_id_fk": {
+          "name": "translations_parent_translation_id_translations_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "translations",
+          "columnsFrom": [
+            "parent_translation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_languages": {
+      "name": "user_languages",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script_preference": {
+          "name": "script_preference",
+          "type": "script_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "romanization_scheme": {
+          "name": "romanization_scheme",
+          "type": "romanization_scheme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'iso15919'"
+        },
+        "known_words_count_cache": {
+          "name": "known_words_count_cache",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reader_layout_mode": {
+          "name": "reader_layout_mode",
+          "type": "reader_layout_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'page'"
+        },
+        "words_per_page": {
+          "name": "words_per_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 250
+        },
+        "font_family": {
+          "name": "font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_size": {
+          "name": "font_size",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 18
+        },
+        "line_spacing": {
+          "name": "line_spacing",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1.6
+        },
+        "highlight_style": {
+          "name": "highlight_style",
+          "type": "highlight_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'background'"
+        },
+        "baseline": {
+          "name": "baseline",
+          "type": "language_baseline",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_languages_user_id_users_id_fk": {
+          "name": "user_languages_user_id_users_id_fk",
+          "tableFrom": "user_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_languages_user_id_language_pk": {
+          "name": "user_languages_user_id_language_pk",
+          "columns": [
+            "user_id",
+            "language"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_preference": {
+          "name": "theme_preference",
+          "type": "theme_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarded_at": {
+          "name": "onboarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    }
+  },
+  "enums": {
+    "public.highlight_style": {
+      "name": "highlight_style",
+      "schema": "public",
+      "values": [
+        "underline",
+        "background",
+        "colored_text"
+      ]
+    },
+    "public.language": {
+      "name": "language",
+      "schema": "public",
+      "values": [
+        "hi",
+        "mr",
+        "or"
+      ]
+    },
+    "public.language_baseline": {
+      "name": "language_baseline",
+      "schema": "public",
+      "values": [
+        "none",
+        "beginner",
+        "intermediate"
+      ]
+    },
+    "public.lemma_edit_change_type": {
+      "name": "lemma_edit_change_type",
+      "schema": "public",
+      "values": [
+        "lemma_update",
+        "lemma_unlock",
+        "lemma_lock",
+        "translation_insert",
+        "translation_update",
+        "translation_hide",
+        "translation_unhide",
+        "form_insert",
+        "form_delete",
+        "lemma_merge",
+        "lemma_split"
+      ]
+    },
+    "public.reader_layout_mode": {
+      "name": "reader_layout_mode",
+      "schema": "public",
+      "values": [
+        "page",
+        "paged_scroll",
+        "continuous"
+      ]
+    },
+    "public.romanization_scheme": {
+      "name": "romanization_scheme",
+      "schema": "public",
+      "values": [
+        "iso15919",
+        "iast",
+        "hunterian",
+        "itrans"
+      ]
+    },
+    "public.script_preference": {
+      "name": "script_preference",
+      "schema": "public",
+      "values": [
+        "native",
+        "native_with_romanization",
+        "romanization_only"
+      ]
+    },
+    "public.text_source_type": {
+      "name": "text_source_type",
+      "schema": "public",
+      "values": [
+        "paste",
+        "txt",
+        "epub"
+      ]
+    },
+    "public.text_status": {
+      "name": "text_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.text_visibility": {
+      "name": "text_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "shared",
+        "official"
+      ]
+    },
+    "public.theme_preference": {
+      "name": "theme_preference",
+      "schema": "public",
+      "values": [
+        "system",
+        "light",
+        "dark"
+      ]
+    },
+    "public.translation_source": {
+      "name": "translation_source",
+      "schema": "public",
+      "values": [
+        "official_dictionary",
+        "curator",
+        "user"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "curator",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1777010005356,
       "tag": "0005_powerful_lady_bullseye",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1777299520720,
+      "tag": "0006_public_bedlam",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -45,6 +45,12 @@ export default [
         KeyboardEvent: 'readonly',
         MouseEvent: 'readonly',
         FocusEvent: 'readonly',
+        // Drag-and-drop + file upload globals (T-4.1).
+        DragEvent: 'readonly',
+        File: 'readonly',
+        FileList: 'readonly',
+        TextEncoder: 'readonly',
+        TextDecoder: 'readonly',
       },
     },
   },

--- a/apps/web/src/lib/components/shell/tabs.test.ts
+++ b/apps/web/src/lib/components/shell/tabs.test.ts
@@ -5,6 +5,7 @@ describe('visibleTabs', () => {
   it('shows authenticated + any tabs to signed-in users', () => {
     const shown = visibleTabs(TABS, true).map((t) => t.id);
     expect(shown).toContain('home');
+    expect(shown).toContain('upload');
     expect(shown).toContain('profile');
     expect(shown).not.toContain('signin');
   });
@@ -13,7 +14,13 @@ describe('visibleTabs', () => {
     const shown = visibleTabs(TABS, false).map((t) => t.id);
     expect(shown).toContain('home');
     expect(shown).toContain('signin');
+    expect(shown).not.toContain('upload');
     expect(shown).not.toContain('profile');
+  });
+
+  it('highlights the upload tab on /texts/* paths so users land back on it', () => {
+    expect(getActiveTabId('/upload', TABS)).toBe('upload');
+    expect(getActiveTabId('/texts/abc-123', TABS)).toBe('upload');
   });
 });
 

--- a/apps/web/src/lib/components/shell/tabs.ts
+++ b/apps/web/src/lib/components/shell/tabs.ts
@@ -22,6 +22,15 @@ export interface Tab {
 export const TABS: readonly Tab[] = [
   { id: 'home', label: 'Home', href: '/', auth: 'any', match: ['/'] },
   {
+    id: 'upload',
+    label: 'Upload',
+    href: '/upload',
+    auth: 'authenticated',
+    // /texts/[id] is the destination after a successful upload, so it
+    // should highlight the same tab the user used to get there.
+    match: ['/upload', '/texts'],
+  },
+  {
     id: 'profile',
     label: 'Profile',
     href: '/profile',

--- a/apps/web/src/lib/server/db/schema.ts
+++ b/apps/web/src/lib/server/db/schema.ts
@@ -453,6 +453,98 @@ export type LemmaEditChangePayload = {
   bulkAttribution?: boolean;
 };
 
+/**
+ * User-imported texts (T-4.1, milestone M4).
+ *
+ * `source_type` records how the text was uploaded so we can show a
+ * friendly badge in the library and run source-specific re-import logic
+ * later (e.g. re-parsing the original EPUB after we improve chapter
+ * detection). `status` is the NLP processing state — at T-4.1 every new
+ * text starts `pending` and is flipped to `ready` once T-4.4 wires up
+ * the worker; `failed` lets the library show a retry affordance instead
+ * of a stuck spinner.
+ *
+ * `visibility` defaults to `private`. `shared` is granted via a row in
+ * `text_shares` / `text_group_shares` (M7); `official` can only be set
+ * by an admin/curator after a "make official" request and is gated on
+ * licensing review (T-7.1). owner_id is nullable because official
+ * curated texts are not owned by any one user.
+ *
+ * `text_chapters` is the natural pagination unit (EPUB chapters are
+ * preserved; pasted texts default to one chapter; long .txt files are
+ * auto-split at paragraph boundaries in T-4.2 / T-5.1a). The reader
+ * loads one chapter at a time, so the chapter table holds the raw
+ * `body` plus precomputed `token_count` for progress / library cards.
+ */
+export const textSourceType = pgEnum('text_source_type', [
+  'paste',
+  'txt',
+  'epub',
+]);
+
+export const textStatus = pgEnum('text_status', [
+  'pending',
+  'processing',
+  'ready',
+  'failed',
+]);
+
+export const textVisibility = pgEnum('text_visibility', [
+  'private',
+  'shared',
+  'official',
+]);
+
+export const texts = pgTable(
+  'texts',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    // Nullable so curated/official texts can exist without a user owning
+    // them. The auth helper in T-4.6 (`assertCanRead`) treats a null
+    // owner_id as "publicly readable iff visibility='official'."
+    ownerId: uuid('owner_id').references(() => users.id, {
+      onDelete: 'cascade',
+    }),
+    language: language('language').notNull(),
+    title: text('title').notNull(),
+    sourceType: textSourceType('source_type').notNull(),
+    status: textStatus('status').notNull().default('pending'),
+    visibility: textVisibility('visibility').notNull().default('private'),
+    statusError: text('status_error'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    // Library "your texts" tab needs a fast scan over the user's own
+    // imports ordered by recency.
+    ownerIdx: index('texts_owner_idx').on(t.ownerId, t.createdAt),
+    // Public official-library page needs a fast scan over (visibility,
+    // language) — see T-4.5.
+    visibilityIdx: index('texts_visibility_idx').on(t.visibility, t.language),
+  }),
+);
+
+export const textChapters = pgTable(
+  'text_chapters',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    textId: uuid('text_id')
+      .notNull()
+      .references(() => texts.id, { onDelete: 'cascade' }),
+    idx: integer('idx').notNull(),
+    title: text('title'),
+    body: text('body').notNull(),
+    // Cheap precompute on insert. The reader's library cards and
+    // progress bars need it; computing it on read is wasteful.
+    tokenCount: integer('token_count').notNull().default(0),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    textOrderUq: unique('text_chapters_text_idx_uq').on(t.textId, t.idx),
+    textIdx: index('text_chapters_text_idx').on(t.textId, t.idx),
+  }),
+);
+
 export type User = InferSelectModel<typeof users>;
 export type Session = InferSelectModel<typeof sessions>;
 export type RefreshToken = InferSelectModel<typeof refreshTokens>;
@@ -464,3 +556,5 @@ export type Translation = InferSelectModel<typeof translations>;
 export type DictionaryImport = InferSelectModel<typeof dictionaryImports>;
 export type CuratorLanguage = InferSelectModel<typeof curatorLanguages>;
 export type LemmaEditHistoryEntry = InferSelectModel<typeof lemmaEditHistory>;
+export type Text = InferSelectModel<typeof texts>;
+export type TextChapter = InferSelectModel<typeof textChapters>;

--- a/apps/web/src/lib/server/texts/upload.test.ts
+++ b/apps/web/src/lib/server/texts/upload.test.ts
@@ -1,0 +1,282 @@
+// @vitest-environment node
+/**
+ * Unit tests for the text upload service (T-4.1).
+ *
+ * Same staged-mock pattern as `dictionary/curator.test.ts`: each DB call
+ * returns a thenable chain that resolves the next staged result. We
+ * stage the inserts in order and read back what was passed via the
+ * `calls` log.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Call =
+  | { kind: 'select' }
+  | { kind: 'insert'; values?: unknown };
+const calls: Call[] = [];
+
+const staged: Array<unknown[]> = [];
+function stage(rows: unknown[]) {
+  staged.push(rows);
+}
+function nextStaged(): unknown[] {
+  const v = staged.shift();
+  if (!v) throw new Error('Test bug: no staged result available');
+  return v;
+}
+
+function makeSelectChain() {
+  const chain: Record<string, unknown> = {};
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.limit = vi.fn(() => chain);
+  chain.orderBy = vi.fn(() => chain);
+  chain.then = (resolve: (v: unknown) => unknown) => resolve(nextStaged());
+  return chain;
+}
+
+function makeInsertChain() {
+  const entry: Call = { kind: 'insert' };
+  calls.push(entry);
+  const chain: Record<string, unknown> = {};
+  chain.values = vi.fn((v: unknown) => {
+    entry.values = v;
+    return chain;
+  });
+  chain.returning = vi.fn(() => nextStaged());
+  chain.then = (resolve: (v: unknown) => unknown) => resolve(undefined);
+  return chain;
+}
+
+const selectFn = vi.fn(() => {
+  calls.push({ kind: 'select' });
+  return makeSelectChain();
+});
+const insertFn = vi.fn(() => makeInsertChain());
+
+vi.mock('../db/index.js', () => ({
+  db: {
+    select: () => selectFn(),
+    insert: () => insertFn(),
+  },
+  schema: {
+    texts: {
+      id: 'texts.id',
+      ownerId: 'texts.owner_id',
+    },
+    textChapters: {
+      id: 'text_chapters.id',
+      textId: 'text_chapters.text_id',
+      idx: 'text_chapters.idx',
+    },
+  },
+}));
+
+const {
+  TextValidationError,
+  createPastedText,
+  estimateTokenCount,
+  getOwnedText,
+  MAX_PASTE_BYTES,
+  MAX_TITLE_LEN,
+} = await import('./upload.js');
+
+const OWNER = { id: 'user-1' };
+
+function textRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'text-1',
+    ownerId: OWNER.id,
+    language: 'hi',
+    title: 'My text',
+    sourceType: 'paste',
+    status: 'pending',
+    visibility: 'private',
+    statusError: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function chapterRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'chap-1',
+    textId: 'text-1',
+    idx: 0,
+    title: null,
+    body: 'पाठ का मूल पाठ।',
+    tokenCount: 4,
+    createdAt: new Date(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  calls.length = 0;
+  staged.length = 0;
+  selectFn.mockClear();
+  insertFn.mockClear();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// -----------------------------------------------------------------------
+// createPastedText
+// -----------------------------------------------------------------------
+
+describe('createPastedText', () => {
+  it('inserts a text + first chapter and returns both', async () => {
+    stage([textRow()]);
+    stage([chapterRow()]);
+
+    const result = await createPastedText(OWNER, {
+      language: 'hi',
+      title: '  My text  ',
+      body: 'पाठ का मूल पाठ।',
+    });
+    expect(result.text.id).toBe('text-1');
+    expect(result.chapter.id).toBe('chap-1');
+
+    const insertCalls = calls.filter(
+      (c): c is Extract<Call, { kind: 'insert' }> => c.kind === 'insert',
+    );
+    expect(insertCalls).toHaveLength(2);
+    expect(insertCalls[0]!.values).toMatchObject({
+      ownerId: OWNER.id,
+      language: 'hi',
+      title: 'My text', // collapsed whitespace
+      sourceType: 'paste',
+      status: 'pending',
+      visibility: 'private',
+    });
+    expect(insertCalls[1]!.values).toMatchObject({
+      textId: 'text-1',
+      idx: 0,
+      title: null,
+    });
+  });
+
+  it('NFC-normalises body and flattens CRLF', async () => {
+    stage([textRow()]);
+    const captured = chapterRow({ body: '' });
+    stage([captured]);
+
+    // Decomposed form + Windows line endings.
+    const body = 'line one\r\nline two\rline three'.normalize('NFD');
+    await createPastedText(OWNER, {
+      language: 'hi',
+      title: 'X',
+      body,
+    });
+    const chapterInsert = calls.filter(
+      (c): c is Extract<Call, { kind: 'insert' }> => c.kind === 'insert',
+    )[1]!;
+    const inserted = chapterInsert.values as { body: string };
+    // No CR characters survive the normalize.
+    expect(inserted.body).toBe('line one\nline two\nline three');
+  });
+
+  it('rejects an unsupported language', async () => {
+    await expect(
+      createPastedText(OWNER, {
+        language: 'xx',
+        title: 'X',
+        body: 'hello',
+      }),
+    ).rejects.toBeInstanceOf(TextValidationError);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('rejects an empty title', async () => {
+    await expect(
+      createPastedText(OWNER, {
+        language: 'hi',
+        title: '   ',
+        body: 'hello',
+      }),
+    ).rejects.toBeInstanceOf(TextValidationError);
+  });
+
+  it('rejects a title over MAX_TITLE_LEN', async () => {
+    await expect(
+      createPastedText(OWNER, {
+        language: 'hi',
+        title: 'x'.repeat(MAX_TITLE_LEN + 1),
+        body: 'hello',
+      }),
+    ).rejects.toBeInstanceOf(TextValidationError);
+  });
+
+  it('rejects an empty body', async () => {
+    await expect(
+      createPastedText(OWNER, {
+        language: 'hi',
+        title: 'X',
+        body: '   \n\n  ',
+      }),
+    ).rejects.toBeInstanceOf(TextValidationError);
+  });
+
+  it('rejects a body over the byte cap', async () => {
+    // ~1.05 MB string of single-byte chars
+    const oversized = 'a'.repeat(MAX_PASTE_BYTES + 1);
+    await expect(
+      createPastedText(OWNER, {
+        language: 'hi',
+        title: 'X',
+        body: oversized,
+      }),
+    ).rejects.toBeInstanceOf(TextValidationError);
+  });
+});
+
+// -----------------------------------------------------------------------
+// estimateTokenCount
+// -----------------------------------------------------------------------
+
+describe('estimateTokenCount', () => {
+  it('counts whitespace-separated tokens', () => {
+    expect(estimateTokenCount('hello world')).toBe(2);
+    expect(estimateTokenCount('  hello   world  ')).toBe(2);
+    expect(estimateTokenCount('one\ntwo\tthree')).toBe(3);
+  });
+  it('returns 0 on an empty / whitespace-only body', () => {
+    expect(estimateTokenCount('')).toBe(0);
+    expect(estimateTokenCount('   \n  ')).toBe(0);
+  });
+});
+
+// -----------------------------------------------------------------------
+// getOwnedText
+// -----------------------------------------------------------------------
+
+describe('getOwnedText', () => {
+  it('returns the text + ordered chapters when the viewer owns it', async () => {
+    stage([textRow()]);
+    stage([
+      chapterRow({ id: 'c0', idx: 0 }),
+      chapterRow({ id: 'c1', idx: 1, body: 'दूसरा अध्याय' }),
+    ]);
+    const result = await getOwnedText(OWNER, 'text-1');
+    expect(result).not.toBeNull();
+    expect(result!.text.id).toBe('text-1');
+    expect(result!.chapters).toHaveLength(2);
+    expect(result!.chapters.map((c) => c.id)).toEqual(['c0', 'c1']);
+  });
+
+  it('returns null when the text does not exist', async () => {
+    stage([]); // SELECT empty
+    const result = await getOwnedText(OWNER, 'missing');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the viewer is not the owner (no chapter SELECT)', async () => {
+    stage([textRow({ ownerId: 'someone-else' })]);
+    const result = await getOwnedText(OWNER, 'text-1');
+    expect(result).toBeNull();
+    // Only one SELECT — chapters were never queried.
+    expect(calls.filter((c) => c.kind === 'select')).toHaveLength(1);
+  });
+});

--- a/apps/web/src/lib/server/texts/upload.ts
+++ b/apps/web/src/lib/server/texts/upload.ts
@@ -1,0 +1,193 @@
+/**
+ * Text upload service (T-4.1).
+ *
+ * Front door for everything that lands in `texts` + `text_chapters`.
+ * The reader/loader and library views read from those tables; the NLP
+ * worker (T-4.4) processes them async. Keeping the create paths here
+ * means downstream code has a single seam to add behaviors like "kick
+ * the queue after insert" without touching every callsite.
+ *
+ * MVP scope (T-4.1):
+ *  - `createPastedText` is the only public creator. It writes one
+ *    `texts` row + a single `text_chapters` row holding the NFC-
+ *    normalized body. Status starts `pending`; T-4.4 will flip it to
+ *    `ready` after NLP runs.
+ *  - `.txt` and `.epub` ingest land in T-4.2 / T-4.3 and will reuse
+ *    this module — `createPastedText` becomes one of several creators,
+ *    all sharing validation + visibility defaults.
+ *
+ * Authorization: every text gets `owner_id = creator.id` and
+ * `visibility = 'private'` by default. Sharing + official promotion go
+ * through M7 endpoints, never this one.
+ */
+import { eq } from 'drizzle-orm';
+
+import { db, schema } from '../db/index.js';
+import type { LanguageCode } from '@ciareader/shared-types';
+import { isSupportedLanguage } from '@ciareader/shared-types';
+import type { Text, TextChapter, User } from '../db/schema.js';
+
+export class TextValidationError extends Error {
+  constructor(
+    message: string,
+    public readonly status: 400 | 403 | 404 = 400,
+  ) {
+    super(message);
+    this.name = 'TextValidationError';
+  }
+}
+
+/** Hard cap on a single pasted body. 1 MB of UTF-8 is comfortably bigger
+ * than a typical short story but small enough that we don't accidentally
+ * accept a whole novel pasted into the textarea (use EPUB upload for
+ * that — T-4.3). */
+export const MAX_PASTE_BYTES = 1_000_000;
+
+/** Hard cap on the visible title; the library card and `<title>` tag
+ * both render this without truncation. */
+export const MAX_TITLE_LEN = 200;
+export const MIN_TITLE_LEN = 1;
+
+export type CreatePastedTextInput = {
+  language: string;
+  title: string;
+  body: string;
+};
+
+export type CreatePastedTextResult = {
+  text: Text;
+  chapter: TextChapter;
+};
+
+function normalizeBody(body: string): string {
+  // NFC is the canonical form for Indic scripts in our DB; doing it once
+  // at write time means every downstream reader (tokenizer, search,
+  // diff) compares apples to apples. Internal CR / CRLF are flattened
+  // to LF so paragraph splitting in T-4.2 doesn't need to special-case
+  // line-ending styles.
+  return body.normalize('NFC').replace(/\r\n?/g, '\n');
+}
+
+function normalizeTitle(title: string): string {
+  // Collapse internal whitespace so "Chapter   1" doesn't silently
+  // become a different title from "Chapter 1" depending on copy-paste.
+  return title.normalize('NFC').trim().replace(/\s+/g, ' ');
+}
+
+/**
+ * Cheap whitespace-based token estimator. The real token count comes
+ * from the NLP worker (T-4.4) and overwrites this. We seed it to
+ * something useful so the library card has a number to render even
+ * before the worker has run.
+ */
+export function estimateTokenCount(body: string): number {
+  const trimmed = body.trim();
+  if (trimmed.length === 0) return 0;
+  return trimmed.split(/\s+/).length;
+}
+
+function validateInput(input: CreatePastedTextInput): {
+  language: LanguageCode;
+  title: string;
+  body: string;
+} {
+  if (!isSupportedLanguage(input.language)) {
+    throw new TextValidationError(
+      `Unsupported language '${input.language}' (expected one of: hi, mr, or)`,
+    );
+  }
+  const title = normalizeTitle(input.title ?? '');
+  if (title.length < MIN_TITLE_LEN) {
+    throw new TextValidationError('title is required');
+  }
+  if (title.length > MAX_TITLE_LEN) {
+    throw new TextValidationError(`title exceeds ${MAX_TITLE_LEN} characters`);
+  }
+  const body = normalizeBody(input.body ?? '');
+  if (body.trim().length === 0) {
+    throw new TextValidationError('body cannot be empty');
+  }
+  // UTF-8 byte length, not char length — the cap is about bytes flowing
+  // over the wire and into a Postgres TEXT column, not codepoints.
+  const bodyBytes = new TextEncoder().encode(body).byteLength;
+  if (bodyBytes > MAX_PASTE_BYTES) {
+    throw new TextValidationError(
+      `body exceeds ${MAX_PASTE_BYTES.toLocaleString()} bytes; use EPUB upload for longer texts`,
+    );
+  }
+  return { language: input.language as LanguageCode, title, body };
+}
+
+/**
+ * Create a pasted text + a single chapter for the given owner.
+ *
+ * The chapter holds the entire body. When T-4.2 lands, long pastes will
+ * auto-split into multiple chapter rows at paragraph boundaries; this
+ * function's contract (returns the freshly created text + the *first*
+ * chapter) is stable regardless.
+ */
+export async function createPastedText(
+  owner: Pick<User, 'id'>,
+  input: CreatePastedTextInput,
+  now: Date = new Date(),
+): Promise<CreatePastedTextResult> {
+  const { language, title, body } = validateInput(input);
+
+  const [text] = await db
+    .insert(schema.texts)
+    .values({
+      ownerId: owner.id,
+      language,
+      title,
+      sourceType: 'paste',
+      status: 'pending',
+      visibility: 'private',
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning();
+  if (!text) throw new Error('Failed to insert text row');
+
+  const [chapter] = await db
+    .insert(schema.textChapters)
+    .values({
+      textId: (text as Text).id,
+      idx: 0,
+      title: null,
+      body,
+      tokenCount: estimateTokenCount(body),
+      createdAt: now,
+    })
+    .returning();
+  if (!chapter) throw new Error('Failed to insert chapter row');
+
+  return { text: text as Text, chapter: chapter as TextChapter };
+}
+
+/**
+ * Read one of the user's own texts plus its chapters, in order. Used by
+ * the placeholder reader page T-4.1 ships (a temporary view of the raw
+ * body — the real reader lands in M5). Returns `null` if the text
+ * doesn't exist OR is not readable by `viewer`.
+ *
+ * Sharing / official-text reads go through `assertCanRead` in T-4.6;
+ * for now the rule is simply "owner can read their own private texts."
+ */
+export async function getOwnedText(
+  viewer: Pick<User, 'id'>,
+  textId: string,
+): Promise<{ text: Text; chapters: TextChapter[] } | null> {
+  const [text] = await db
+    .select()
+    .from(schema.texts)
+    .where(eq(schema.texts.id, textId))
+    .limit(1);
+  if (!text) return null;
+  if ((text as Text).ownerId !== viewer.id) return null;
+  const chapters = (await db
+    .select()
+    .from(schema.textChapters)
+    .where(eq(schema.textChapters.textId, (text as Text).id))
+    .orderBy(schema.textChapters.idx)) as TextChapter[];
+  return { text: text as Text, chapters };
+}

--- a/apps/web/src/routes/api/v1/texts/+server.ts
+++ b/apps/web/src/routes/api/v1/texts/+server.ts
@@ -1,0 +1,70 @@
+/**
+ * POST /api/v1/texts (T-4.1).
+ *
+ * Create a pasted text. The web upload UI calls this through the
+ * SvelteKit form action; mobile / API clients can hit it directly with
+ * a bearer token. Both go through the same `createPastedText` service.
+ *
+ * `.txt` and `.epub` ingest land in T-4.2 / T-4.3 — until those ship,
+ * `sourceType` is fixed to `'paste'` and the body must be supplied
+ * inline. The schema allows the field for forward compatibility.
+ *
+ * Response: 201 with the freshly created `text` (sans body) so the
+ * caller can navigate to `/texts/:id`. Chapter content is NOT echoed
+ * back to keep the create response small — the read endpoint serves it.
+ */
+import { error, json } from '@sveltejs/kit';
+import { z } from 'zod';
+
+import { requireUser } from '$lib/server/auth/require-user.js';
+import {
+  createPastedText,
+  TextValidationError,
+  MAX_PASTE_BYTES,
+  MAX_TITLE_LEN,
+} from '$lib/server/texts/upload.js';
+import type { RequestHandler } from './$types';
+import { parseJson } from '../auth/_helpers.js';
+
+const body = z.object({
+  language: z.enum(['hi', 'mr', 'or']),
+  title: z.string().min(1).max(MAX_TITLE_LEN),
+  // Validated again in the service for byte length; the cap here is a
+  // cheap shot to reject obviously-too-large requests before we copy
+  // the string.
+  body: z.string().min(1).max(MAX_PASTE_BYTES),
+  sourceType: z.literal('paste').optional(),
+});
+
+export const POST: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  const input = await parseJson(event.request, body);
+  try {
+    const { text } = await createPastedText(
+      { id: user.id },
+      {
+        language: input.language,
+        title: input.title,
+        body: input.body,
+      },
+    );
+    return json(
+      {
+        text: {
+          id: text.id,
+          ownerId: text.ownerId,
+          language: text.language,
+          title: text.title,
+          sourceType: text.sourceType,
+          status: text.status,
+          visibility: text.visibility,
+          createdAt: text.createdAt,
+        },
+      },
+      { status: 201 },
+    );
+  } catch (err) {
+    if (err instanceof TextValidationError) throw error(err.status, err.message);
+    throw err;
+  }
+};

--- a/apps/web/src/routes/api/v1/texts/texts-server.test.ts
+++ b/apps/web/src/routes/api/v1/texts/texts-server.test.ts
@@ -1,0 +1,147 @@
+// @vitest-environment node
+/**
+ * Route tests for POST /api/v1/texts (T-4.1).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const createPastedText = vi.fn();
+const requireUser = vi.fn();
+
+vi.mock('$lib/server/texts/upload.js', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/texts/upload.js')>(
+    '$lib/server/texts/upload.js',
+  );
+  return {
+    ...actual,
+    createPastedText: (...a: unknown[]) => createPastedText(...a),
+  };
+});
+
+vi.mock('$lib/server/auth/require-user.js', () => ({
+  requireUser: (...a: unknown[]) => requireUser(...a),
+}));
+
+type PostFn = (typeof import('./+server.js'))['POST'];
+
+const USER = { id: 'user-1', role: 'user' as const };
+
+async function callPost(body: unknown, user: typeof USER | null = USER) {
+  if (user) {
+    requireUser.mockResolvedValueOnce(user);
+  } else {
+    // Simulate the require-user 401 path.
+    requireUser.mockImplementationOnce(() => {
+      throw { status: 401, body: { message: 'Unauthorized' } };
+    });
+  }
+  const { POST } = await import('./+server.js');
+  const event = {
+    params: {},
+    request: new Request('http://x/api/v1/texts', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+  } as unknown as Parameters<PostFn>[0];
+  try {
+    return await POST(event);
+  } catch (e) {
+    return e as { status: number };
+  }
+}
+
+beforeEach(() => {
+  createPastedText.mockReset();
+  requireUser.mockReset();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('POST /api/v1/texts', () => {
+  it('returns 201 with the new text on a happy path', async () => {
+    createPastedText.mockResolvedValueOnce({
+      text: {
+        id: 'text-1',
+        ownerId: USER.id,
+        language: 'hi',
+        title: 'My text',
+        sourceType: 'paste',
+        status: 'pending',
+        visibility: 'private',
+        createdAt: new Date('2026-04-27T00:00:00Z'),
+      },
+      chapter: { id: 'chap-1' },
+    });
+    const res = (await callPost({
+      language: 'hi',
+      title: 'My text',
+      body: 'पाठ का मूल पाठ।',
+    })) as Response;
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.text).toMatchObject({
+      id: 'text-1',
+      status: 'pending',
+      visibility: 'private',
+      sourceType: 'paste',
+    });
+    expect(createPastedText).toHaveBeenCalledWith(
+      { id: USER.id },
+      { language: 'hi', title: 'My text', body: 'पाठ का मूल पाठ।' },
+    );
+  });
+
+  it('rejects an unsupported language with 400 before calling the service', async () => {
+    const res = (await callPost({
+      language: 'xx',
+      title: 'X',
+      body: 'hello',
+    })) as { status: number };
+    expect(res.status).toBe(400);
+    expect(createPastedText).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty title with 400', async () => {
+    const res = (await callPost({
+      language: 'hi',
+      title: '',
+      body: 'hello',
+    })) as { status: number };
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects an empty body with 400', async () => {
+    const res = (await callPost({
+      language: 'hi',
+      title: 'X',
+      body: '',
+    })) as { status: number };
+    expect(res.status).toBe(400);
+  });
+
+  it('maps TextValidationError(400) to 400', async () => {
+    const { TextValidationError } = await import(
+      '$lib/server/texts/upload.js'
+    );
+    createPastedText.mockRejectedValueOnce(
+      new TextValidationError('body cannot be empty'),
+    );
+    const res = (await callPost({
+      language: 'hi',
+      title: 'X',
+      body: 'hello',
+    })) as { status: number };
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const res = (await callPost(
+      { language: 'hi', title: 'X', body: 'hello' },
+      null,
+    )) as { status: number };
+    expect(res.status).toBe(401);
+    expect(createPastedText).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/routes/texts/[id]/+page.server.ts
+++ b/apps/web/src/routes/texts/[id]/+page.server.ts
@@ -1,0 +1,48 @@
+/**
+ * Placeholder text viewer (T-4.1).
+ *
+ * Renders the freshly uploaded text's chapters as raw paragraphs so the
+ * upload flow has somewhere to land. The real reader (M5) replaces this
+ * with token-aware rendering, the pop-up, paginated/continuous modes,
+ * and known-words tracking. The contract this loader returns
+ * (`{ text, chapters }`) is what the M5 reader will keep — it just
+ * adds the tokenization layer on top.
+ *
+ * Authorization at T-4.1 is "owner only." T-4.6 swaps this out for
+ * the central `assertCanRead` helper that also handles shared / official
+ * visibility — for now, sharing is a future ticket so a non-owner gets
+ * a flat 404 to avoid leaking text existence.
+ */
+import { error, redirect } from '@sveltejs/kit';
+
+import { getOwnedText } from '$lib/server/texts/upload.js';
+import type { PageServerLoad } from './$types';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const load: PageServerLoad = async ({ params, locals, url }) => {
+  if (!locals.user) {
+    throw redirect(303, `/login?next=${encodeURIComponent(url.pathname)}`);
+  }
+  if (!UUID_RE.test(params.id)) throw error(400, 'Invalid text id');
+  const result = await getOwnedText({ id: locals.user.id }, params.id);
+  if (!result) throw error(404, 'Text not found');
+  return {
+    text: {
+      id: result.text.id,
+      title: result.text.title,
+      language: result.text.language,
+      sourceType: result.text.sourceType,
+      status: result.text.status,
+      visibility: result.text.visibility,
+      createdAt: result.text.createdAt,
+    },
+    chapters: result.chapters.map((c) => ({
+      id: c.id,
+      idx: c.idx,
+      title: c.title,
+      body: c.body,
+      tokenCount: c.tokenCount,
+    })),
+  };
+};

--- a/apps/web/src/routes/texts/[id]/+page.svelte
+++ b/apps/web/src/routes/texts/[id]/+page.svelte
@@ -1,0 +1,142 @@
+<script lang="ts">
+  import type { PageData } from './$types';
+
+  let { data }: { data: PageData } = $props();
+
+  // The placeholder viewer just renders paragraphs from the raw chapter
+  // body. M5 swaps each paragraph for token-aware rendering with the
+  // word pop-up, known-words highlighting, and the three reading modes.
+  function paragraphs(body: string): string[] {
+    return body.split(/\n\s*\n+/).map((p) => p.trim()).filter((p) => p.length > 0);
+  }
+
+  const statusLabel = $derived(
+    {
+      pending: 'Waiting to be processed',
+      processing: 'Processing — refresh in a moment',
+      ready: 'Ready',
+      failed: 'Processing failed',
+    }[data.text.status] ?? data.text.status,
+  );
+</script>
+
+<svelte:head>
+  <title>{data.text.title} — CIA Reader</title>
+</svelte:head>
+
+<div class="page">
+  <p class="crumb">
+    <a href="/upload">← Upload another</a>
+  </p>
+
+  <header>
+    <h1>{data.text.title}</h1>
+    <p class="meta">
+      <span>{data.text.language}</span>
+      <span class="dot">·</span>
+      <span class="badge">{data.text.sourceType}</span>
+      <span class="dot">·</span>
+      <span class="badge status-{data.text.status}">{statusLabel}</span>
+      <span class="dot">·</span>
+      <span class="badge">{data.text.visibility}</span>
+    </p>
+  </header>
+
+  <p class="placeholder-note">
+    This is a placeholder view — the full tap-to-translate reader lands
+    in milestone M5. For now you can confirm your upload made it to the
+    database.
+  </p>
+
+  {#each data.chapters as chapter (chapter.id)}
+    <section>
+      {#if chapter.title || data.chapters.length > 1}
+        <h2>
+          {chapter.title ?? `Chapter ${chapter.idx + 1}`}
+          <span class="muted">({chapter.tokenCount.toLocaleString()} tokens)</span>
+        </h2>
+      {/if}
+      {#each paragraphs(chapter.body) as p}
+        <p class="body">{p}</p>
+      {/each}
+    </section>
+  {/each}
+</div>
+
+<style>
+  .page {
+    max-width: 42rem;
+    margin: 0 auto;
+    padding: 1.5rem 1.25rem 3rem;
+  }
+  .crumb {
+    margin: 0 0 1rem;
+    font-size: 0.9rem;
+  }
+  .crumb a {
+    color: var(--color-accent);
+  }
+  header h1 {
+    margin: 0 0 0.25rem;
+    font-size: 1.6rem;
+  }
+  .meta {
+    margin: 0 0 1rem;
+    font-size: 0.85rem;
+    color: var(--color-fg-muted);
+    display: flex;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+  .meta .dot {
+    color: var(--color-border);
+  }
+  .badge {
+    font-size: 0.72rem;
+    padding: 0.05rem 0.45rem;
+    border-radius: 999px;
+    border: 1px solid var(--color-border);
+    background: var(--color-bg);
+    color: var(--color-fg-muted);
+  }
+  .status-pending {
+    border-color: color-mix(in srgb, #b07a31 60%, transparent);
+    color: #b07a31;
+  }
+  .status-ready {
+    border-color: color-mix(in srgb, #197a2f 60%, transparent);
+    color: #197a2f;
+  }
+  .status-failed {
+    border-color: color-mix(in srgb, #b03131 60%, transparent);
+    color: #b03131;
+  }
+  .placeholder-note {
+    background: color-mix(in srgb, var(--color-accent) 8%, transparent);
+    border: 1px solid color-mix(in srgb, var(--color-accent) 30%, transparent);
+    border-radius: 8px;
+    padding: 0.75rem 1rem;
+    color: var(--color-fg);
+    font-size: 0.85rem;
+    margin-bottom: 1.5rem;
+  }
+  section {
+    margin: 1.5rem 0;
+  }
+  section h2 {
+    font-size: 1.05rem;
+    margin: 0 0 0.5rem;
+  }
+  .muted {
+    font-weight: 400;
+    color: var(--color-fg-muted);
+    font-size: 0.85em;
+    margin-left: 0.4rem;
+  }
+  .body {
+    margin: 0 0 0.75rem;
+    line-height: 1.7;
+    font-size: 1.05rem;
+  }
+</style>

--- a/apps/web/src/routes/texts/[id]/page-server.test.ts
+++ b/apps/web/src/routes/texts/[id]/page-server.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment node
+/**
+ * Tests for /texts/[id] SSR loader (T-4.1).
+ *
+ * Placeholder viewer — at T-4.1 it's owner-only; T-4.6 swaps in the
+ * full assertCanRead helper.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getOwnedText = vi.fn();
+
+vi.mock('$lib/server/texts/upload.js', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/texts/upload.js')>(
+    '$lib/server/texts/upload.js',
+  );
+  return {
+    ...actual,
+    getOwnedText: (...a: unknown[]) => getOwnedText(...a),
+  };
+});
+
+type LoadFn = (typeof import('./+page.server.js'))['load'];
+
+const VALID_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const USER = { id: 'user-1', role: 'user' as const };
+
+async function callLoad(
+  id: string,
+  user: typeof USER | null = USER,
+) {
+  const { load } = await import('./+page.server.js');
+  const event = {
+    params: { id },
+    locals: { user },
+    url: new URL(`http://x/texts/${id}`),
+  } as unknown as Parameters<LoadFn>[0];
+  try {
+    return await load(event);
+  } catch (e) {
+    return e as { status: number; location?: string };
+  }
+}
+
+beforeEach(() => {
+  getOwnedText.mockReset();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('/texts/[id] loader', () => {
+  it('returns the text + chapters on a happy path', async () => {
+    getOwnedText.mockResolvedValueOnce({
+      text: {
+        id: VALID_ID,
+        title: 'My text',
+        language: 'hi',
+        sourceType: 'paste',
+        status: 'pending',
+        visibility: 'private',
+        createdAt: new Date('2026-04-27T00:00:00Z'),
+      },
+      chapters: [
+        { id: 'c0', idx: 0, title: null, body: 'पाठ', tokenCount: 1 },
+      ],
+    });
+    const data = (await callLoad(VALID_ID)) as {
+      text: { id: string; status: string };
+      chapters: Array<{ id: string }>;
+    };
+    expect(data.text.id).toBe(VALID_ID);
+    expect(data.text.status).toBe('pending');
+    expect(data.chapters).toHaveLength(1);
+    expect(getOwnedText).toHaveBeenCalledWith({ id: USER.id }, VALID_ID);
+  });
+
+  it('redirects unauthenticated visitors to /login', async () => {
+    const res = (await callLoad(VALID_ID, null)) as {
+      status: number;
+      location: string;
+    };
+    expect(res.status).toBe(303);
+    expect(res.location).toContain('/login');
+    expect(getOwnedText).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid uuid with 400', async () => {
+    const res = (await callLoad('not-a-uuid')) as { status: number };
+    expect(res.status).toBe(400);
+    expect(getOwnedText).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the text does not exist or is not owned', async () => {
+    getOwnedText.mockResolvedValueOnce(null);
+    const res = (await callLoad(VALID_ID)) as { status: number };
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/web/src/routes/upload/+page.server.ts
+++ b/apps/web/src/routes/upload/+page.server.ts
@@ -1,0 +1,91 @@
+/**
+ * Text upload form (T-4.1).
+ *
+ * Browser side renders a paste box + a file drop-zone shell. `.txt`
+ * file content is read on the client and dropped into the textarea
+ * (small, inline ingest); `.epub` and large `.txt` chunking land in
+ * T-4.2 / T-4.3 — the dropzone surfaces a "coming soon" message for
+ * those file types so we don't quietly drop user data.
+ *
+ * The server action calls the same `createPastedText` service the JSON
+ * API uses, so validation + visibility defaults are identical between
+ * web form and programmatic client. On success we 303 to
+ * `/texts/[id]`, which is a placeholder reader for now (M5 builds the
+ * real one).
+ */
+import { fail, redirect } from '@sveltejs/kit';
+import { z } from 'zod';
+
+import {
+  createPastedText,
+  TextValidationError,
+  MAX_PASTE_BYTES,
+  MAX_TITLE_LEN,
+} from '$lib/server/texts/upload.js';
+import { LANGUAGES, SUPPORTED_LANGUAGE_CODES } from '@ciareader/shared-types';
+import type { Actions, PageServerLoad } from './$types';
+
+const formSchema = z.object({
+  language: z.enum(['hi', 'mr', 'or']),
+  title: z.string().min(1).max(MAX_TITLE_LEN),
+  body: z.string().min(1).max(MAX_PASTE_BYTES),
+});
+
+export const load: PageServerLoad = async ({ locals, url }) => {
+  if (!locals.user) {
+    throw redirect(303, `/login?next=${encodeURIComponent(url.pathname)}`);
+  }
+  return {
+    languages: SUPPORTED_LANGUAGE_CODES.map((code) => ({
+      code,
+      displayName: LANGUAGES[code].displayName,
+      nativeName: LANGUAGES[code].nativeName,
+    })),
+    limits: {
+      maxTitleLength: MAX_TITLE_LEN,
+      maxBodyBytes: MAX_PASTE_BYTES,
+    },
+  };
+};
+
+export const actions: Actions = {
+  default: async ({ request, locals }) => {
+    if (!locals.user) {
+      throw redirect(303, '/login?next=/upload');
+    }
+    const fd = await request.formData();
+    const raw = {
+      language: fd.get('language')?.toString() ?? '',
+      title: fd.get('title')?.toString() ?? '',
+      body: fd.get('body')?.toString() ?? '',
+    };
+    const parsed = formSchema.safeParse(raw);
+    if (!parsed.success) {
+      return fail(400, {
+        ok: false,
+        message: parsed.error.issues
+          .map((i) => `${i.path.join('.')}: ${i.message}`)
+          .join('; '),
+        // Echo the raw values back so the user doesn't lose their paste
+        // on a validation error.
+        values: raw,
+      });
+    }
+    try {
+      const { text } = await createPastedText(
+        { id: locals.user.id },
+        parsed.data,
+      );
+      throw redirect(303, `/texts/${text.id}`);
+    } catch (err) {
+      if (err instanceof TextValidationError) {
+        return fail(err.status, {
+          ok: false,
+          message: err.message,
+          values: raw,
+        });
+      }
+      throw err;
+    }
+  },
+};

--- a/apps/web/src/routes/upload/+page.svelte
+++ b/apps/web/src/routes/upload/+page.svelte
@@ -1,0 +1,248 @@
+<script lang="ts">
+  import { enhance } from '$app/forms';
+  import { untrack } from 'svelte';
+  import type { ActionData, PageData } from './$types';
+
+  let {
+    data,
+    form,
+  }: { data: PageData; form: ActionData } = $props();
+
+  // Initial form state, prefilled from the last failed submission's
+  // echoed values so the user doesn't have to re-type their paste. We
+  // wrap the prop reads in `untrack` so Svelte 5 doesn't flag them as
+  // a reactivity mistake — we deliberately want a one-time snapshot,
+  // not a binding to the prop.
+  let language = $state(
+    untrack(() => form?.values?.language ?? data.languages[0]!.code),
+  );
+  let title = $state(untrack(() => form?.values?.title ?? ''));
+  let body = $state(untrack(() => form?.values?.body ?? ''));
+  let dropMessage = $state<string | null>(null);
+
+  // Cheap UTF-8 byte count for the live counter — `TextEncoder` exists
+  // in every browser we care about. Match the server's MAX_PASTE_BYTES
+  // cap so we can disable submit before hitting the wire.
+  const byteCount = $derived(new TextEncoder().encode(body).byteLength);
+  const overLimit = $derived(byteCount > data.limits.maxBodyBytes);
+
+  async function handleFileDrop(file: File) {
+    const lower = file.name.toLowerCase();
+    if (lower.endsWith('.epub')) {
+      dropMessage =
+        'EPUB upload is coming in T-4.3 — for now, paste the chapter text directly.';
+      return;
+    }
+    if (!lower.endsWith('.txt')) {
+      dropMessage = `Unsupported file type: ${file.name}`;
+      return;
+    }
+    if (file.size > data.limits.maxBodyBytes) {
+      dropMessage = `File is too large (max ${(
+        data.limits.maxBodyBytes / 1000
+      ).toLocaleString()} KB).`;
+      return;
+    }
+    try {
+      const text = await file.text();
+      body = text;
+      if (!title) title = file.name.replace(/\.txt$/i, '');
+      dropMessage = `Loaded ${file.name} (${(file.size / 1000).toFixed(1)} KB).`;
+    } catch {
+      dropMessage = `Failed to read ${file.name}.`;
+    }
+  }
+
+  function onDragOver(event: DragEvent) {
+    event.preventDefault();
+  }
+
+  function onDrop(event: DragEvent) {
+    event.preventDefault();
+    const file = event.dataTransfer?.files?.[0];
+    if (file) void handleFileDrop(file);
+  }
+
+  function onFilePick(event: Event) {
+    const target = event.currentTarget as HTMLInputElement;
+    const file = target.files?.[0];
+    if (file) void handleFileDrop(file);
+  }
+</script>
+
+<svelte:head>
+  <title>Upload text — CIA Reader</title>
+</svelte:head>
+
+<div class="page">
+  <header>
+    <h1>Upload a text</h1>
+    <p class="sub">
+      Paste a passage or drop a <code>.txt</code> file. Texts are private to
+      your account by default — sharing options come later.
+    </p>
+  </header>
+
+  {#if form && !form.ok}
+    <p class="err" role="alert">{form.message}</p>
+  {/if}
+
+  <form method="post" use:enhance class="stack">
+    <label>
+      Language
+      <select name="language" bind:value={language} required>
+        {#each data.languages as lang (lang.code)}
+          <option value={lang.code}>
+            {lang.displayName} ({lang.nativeName})
+          </option>
+        {/each}
+      </select>
+    </label>
+
+    <label>
+      Title
+      <input
+        name="title"
+        bind:value={title}
+        maxlength={data.limits.maxTitleLength}
+        required
+        placeholder="e.g. Chapter 1 — A short story"
+      />
+    </label>
+
+    <div
+      class="dropzone"
+      ondragover={onDragOver}
+      ondrop={onDrop}
+      role="region"
+      aria-label="File drop zone"
+    >
+      <p>
+        Drag &amp; drop a <code>.txt</code> file here, or
+        <label class="file-pick">
+          <input type="file" accept=".txt,.epub" onchange={onFilePick} />
+          choose a file
+        </label>
+        .
+      </p>
+      {#if dropMessage}
+        <p class="drop-msg">{dropMessage}</p>
+      {/if}
+    </div>
+
+    <label>
+      Body
+      <textarea
+        name="body"
+        bind:value={body}
+        rows="14"
+        required
+        placeholder="Paste your text here in the language's native script."
+      ></textarea>
+      <span class="counter" class:over={overLimit}>
+        {byteCount.toLocaleString()} / {data.limits.maxBodyBytes.toLocaleString()} bytes
+      </span>
+    </label>
+
+    <button type="submit" disabled={overLimit}>Upload</button>
+  </form>
+</div>
+
+<style>
+  .page {
+    max-width: 42rem;
+    margin: 0 auto;
+    padding: 1.5rem 1.25rem 3rem;
+  }
+  header h1 {
+    margin: 0 0 0.25rem;
+    font-size: 1.6rem;
+  }
+  .sub {
+    color: var(--color-fg-muted);
+    margin: 0 0 1rem;
+    font-size: 0.9rem;
+  }
+  form label {
+    display: block;
+    margin-bottom: 0.75rem;
+    font-size: 0.9rem;
+  }
+  form input,
+  form textarea,
+  form select {
+    display: block;
+    width: 100%;
+    margin-top: 0.25rem;
+    padding: 0.5rem 0.6rem;
+    font: inherit;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    background: var(--color-bg);
+    color: var(--color-fg);
+    min-height: 44px;
+  }
+  form textarea {
+    min-height: 12rem;
+    resize: vertical;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.95rem;
+  }
+  .stack > * {
+    margin-bottom: 0.75rem;
+  }
+  form button {
+    min-height: 44px;
+    padding: 0 1rem;
+    background: var(--color-accent);
+    color: var(--color-accent-fg, #fff);
+    border: 0;
+    border-radius: 6px;
+    cursor: pointer;
+  }
+  form button[disabled] {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  .dropzone {
+    border: 2px dashed var(--color-border);
+    border-radius: 8px;
+    padding: 1rem;
+    text-align: center;
+    color: var(--color-fg-muted);
+    font-size: 0.9rem;
+    margin-bottom: 0.75rem;
+  }
+  .dropzone p {
+    margin: 0.25rem 0;
+  }
+  .file-pick {
+    color: var(--color-accent);
+    text-decoration: underline;
+    cursor: pointer;
+  }
+  .file-pick input {
+    display: none;
+  }
+  .drop-msg {
+    margin-top: 0.5rem;
+    color: var(--color-fg);
+  }
+  .counter {
+    display: block;
+    margin-top: 0.25rem;
+    font-size: 0.8rem;
+    color: var(--color-fg-muted);
+  }
+  .counter.over {
+    color: #b03131;
+    font-weight: 600;
+  }
+  .err {
+    color: #b03131;
+  }
+  code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.85em;
+  }
+</style>

--- a/apps/web/src/routes/upload/page-server.test.ts
+++ b/apps/web/src/routes/upload/page-server.test.ts
@@ -1,0 +1,141 @@
+// @vitest-environment node
+/**
+ * Tests for /upload SSR loader + default action (T-4.1).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const createPastedText = vi.fn();
+
+vi.mock('$lib/server/texts/upload.js', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/texts/upload.js')>(
+    '$lib/server/texts/upload.js',
+  );
+  return {
+    ...actual,
+    createPastedText: (...a: unknown[]) => createPastedText(...a),
+  };
+});
+
+type Mod = typeof import('./+page.server.js');
+
+const USER = { id: 'user-1', role: 'user' as const };
+
+async function callLoad(user: typeof USER | null) {
+  const { load } = (await import('./+page.server.js')) as Mod;
+  const event = {
+    locals: { user },
+    url: new URL('http://x/upload'),
+  } as unknown as Parameters<Mod['load']>[0];
+  try {
+    return await load(event);
+  } catch (e) {
+    return e as { status: number; location?: string };
+  }
+}
+
+async function callAction(
+  fields: Record<string, string>,
+  user: typeof USER | null = USER,
+) {
+  const { actions } = (await import('./+page.server.js')) as Mod;
+  const fd = new FormData();
+  for (const [k, v] of Object.entries(fields)) fd.append(k, v);
+  const event = {
+    locals: { user },
+    request: { formData: () => Promise.resolve(fd) } as unknown as Request,
+  } as unknown as Parameters<Mod['actions']['default']>[0];
+  try {
+    return await actions.default!(event);
+  } catch (e) {
+    return e as { status: number; location?: string };
+  }
+}
+
+beforeEach(() => {
+  createPastedText.mockReset();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('/upload loader', () => {
+  it('returns the language list and the input limits for an authenticated user', async () => {
+    const data = (await callLoad(USER)) as {
+      languages: Array<{ code: string }>;
+      limits: { maxTitleLength: number; maxBodyBytes: number };
+    };
+    expect(data.languages.length).toBeGreaterThan(0);
+    expect(data.languages.map((l) => l.code)).toEqual(
+      expect.arrayContaining(['hi', 'mr', 'or']),
+    );
+    expect(data.limits.maxBodyBytes).toBeGreaterThan(0);
+  });
+
+  it('redirects unauthenticated visitors to /login with a next param', async () => {
+    const res = (await callLoad(null)) as { status: number; location: string };
+    expect(res.status).toBe(303);
+    expect(res.location).toBe('/login?next=%2Fupload');
+  });
+});
+
+describe('/upload default action', () => {
+  it('calls createPastedText with the form values and 303s to the new text', async () => {
+    createPastedText.mockResolvedValueOnce({
+      text: { id: 'text-1', ownerId: USER.id },
+      chapter: { id: 'chap-1' },
+    });
+    const res = (await callAction({
+      language: 'hi',
+      title: 'My text',
+      body: 'पाठ का मूल पाठ।',
+    })) as { status: number; location: string };
+    expect(res.status).toBe(303);
+    expect(res.location).toBe('/texts/text-1');
+    expect(createPastedText).toHaveBeenCalledWith(
+      { id: USER.id },
+      { language: 'hi', title: 'My text', body: 'पाठ का मूल पाठ।' },
+    );
+  });
+
+  it('returns a fail() with echoed values on validation failure', async () => {
+    const result = (await callAction({
+      language: 'xx',
+      title: '',
+      body: 'hello',
+    })) as {
+      status: number;
+      data: { ok: boolean; values: { title: string; body: string } };
+    };
+    expect(result.status).toBe(400);
+    expect(result.data.ok).toBe(false);
+    expect(result.data.values.body).toBe('hello');
+    expect(createPastedText).not.toHaveBeenCalled();
+  });
+
+  it('returns a fail() when the service raises a TextValidationError', async () => {
+    const { TextValidationError } = await import(
+      '$lib/server/texts/upload.js'
+    );
+    createPastedText.mockRejectedValueOnce(
+      new TextValidationError('body cannot be empty'),
+    );
+    const result = (await callAction({
+      language: 'hi',
+      title: 'X',
+      body: 'hello',
+    })) as { status: number; data: { ok: boolean; message: string } };
+    expect(result.status).toBe(400);
+    expect(result.data.ok).toBe(false);
+    expect(result.data.message).toMatch(/empty/);
+  });
+
+  it('redirects unauthenticated submissions to /login', async () => {
+    const res = (await callAction(
+      { language: 'hi', title: 'X', body: 'hello' },
+      null,
+    )) as { status: number; location: string };
+    expect(res.status).toBe(303);
+    expect(res.location).toContain('/login');
+  });
+});


### PR DESCRIPTION
Closes #36

## Summary

First ticket of M4 — lays down the texts schema and the upload UI. Paste path only; .txt and .epub ingestion are T-4.2 / T-4.3, NLP enqueue is T-4.4, library tabs T-4.5, central authz helper T-4.6.

- **Schema**: \`texts\` + \`text_chapters\` tables, plus the \`text_source_type\` / \`text_status\` / \`text_visibility\` enums. Indexed for the user's library scan and the future official-library scan. Visibility defaults to \`private\`.
- **Service** (\`lib/server/texts/upload.ts\`): \`createPastedText\` (NFC + CRLF normalize, byte-cap validation, owner+private defaults, single-chapter insert) and \`getOwnedText\` (owner-only read for the placeholder viewer).
- **API**: \`POST /api/v1/texts\` for both web (form action) and bearer-token clients. Returns 201 with text metadata only — chapter body comes from the read endpoint.
- **UI**: \`/upload\` (paste + .txt drop-zone + live byte counter, .epub deferred with a friendly message) and a placeholder \`/texts/[id]\` viewer that paragraphizes the chapter body. AppShell gets an "Upload" tab; \`/texts/*\` highlights it.

## Test plan

- [x] \`pnpm --filter @ciareader/web test\` — 394/394 passing across 52 files (29 new tests for T-4.1)
- [x] \`pnpm --filter @ciareader/web check\` — clean
- [x] \`pnpm --filter @ciareader/web lint\` — clean (added DragEvent / File / TextEncoder to svelte globals)
- [x] \`pnpm --filter @ciareader/web test:coverage\` — passes 80% floor; \`lib/server/texts\` at 100% lines
- [ ] Manual: paste a Hindi paragraph at \`/upload\`, confirm 303 → \`/texts/[id]\` shows the body and status='pending'
- [ ] Manual: drop a small .txt file, confirm body populates and title autofills from the filename
- [ ] Manual: drop a .epub, confirm the friendly "T-4.3" message rather than a silent drop
- [ ] Manual: visit another user's text id directly, confirm 404