### PR TITLE
T-4.2: .txt ingest with chapter chunking + explicit delimiters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ coverage.lcov
 # ide
 .vscode/
 .idea/
+
+# claude code worktrees / scratch
+.claude/worktrees/

--- a/apps/web/src/lib/server/texts/chunking.test.ts
+++ b/apps/web/src/lib/server/texts/chunking.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CHUNK_THRESHOLD_TOKENS,
+  estimateTokenCount,
+  splitIntoChapters,
+  TARGET_CHAPTER_TOKENS,
+} from './chunking.js';
+
+function manyParagraphs(count: number, wordsEach: number, prefix = 'p'): string {
+  const para = Array.from({ length: wordsEach }, (_, i) => `${prefix}${i}`).join(' ');
+  return Array.from({ length: count }, () => para).join('\n\n');
+}
+
+describe('estimateTokenCount', () => {
+  it('counts whitespace-separated tokens', () => {
+    expect(estimateTokenCount('one two three')).toBe(3);
+    expect(estimateTokenCount(' one\ntwo\tthree ')).toBe(3);
+  });
+  it('returns 0 on whitespace-only', () => {
+    expect(estimateTokenCount('   ')).toBe(0);
+    expect(estimateTokenCount('')).toBe(0);
+  });
+});
+
+describe('splitIntoChapters — short bodies', () => {
+  it('returns one chapter for a body well under the threshold', () => {
+    const drafts = splitIntoChapters('one two three\n\nfour five six');
+    expect(drafts).toHaveLength(1);
+    expect(drafts[0]!.idx).toBe(0);
+    expect(drafts[0]!.title).toBeNull();
+    expect(drafts[0]!.tokenCount).toBe(6);
+  });
+
+  it('strips leading/trailing whitespace from the single-chapter body', () => {
+    const drafts = splitIntoChapters('   hello   ');
+    expect(drafts).toHaveLength(1);
+    expect(drafts[0]!.body).toBe('hello');
+  });
+});
+
+describe('splitIntoChapters — explicit delimiters', () => {
+  it('splits on form-feed', () => {
+    const body = ['Chapter one body.', '\f', 'Chapter two body.'].join('\n');
+    const drafts = splitIntoChapters(body);
+    expect(drafts).toHaveLength(2);
+    expect(drafts[0]!.body).toBe('Chapter one body.');
+    expect(drafts[1]!.body).toBe('Chapter two body.');
+  });
+
+  it('splits on lines of three or more dashes', () => {
+    const body = ['Chapter one body.', '---', 'Chapter two body.', '----', 'Chapter three.'].join(
+      '\n',
+    );
+    const drafts = splitIntoChapters(body);
+    expect(drafts).toHaveLength(3);
+    expect(drafts.map((d) => d.body)).toEqual([
+      'Chapter one body.',
+      'Chapter two body.',
+      'Chapter three.',
+    ]);
+  });
+
+  it('extracts a leading "# Title" line as the chapter title', () => {
+    const body = ['# Opening', 'First chapter body.', '---', '# Climax', 'Second body.'].join(
+      '\n',
+    );
+    const drafts = splitIntoChapters(body);
+    expect(drafts).toHaveLength(2);
+    expect(drafts[0]!.title).toBe('Opening');
+    expect(drafts[0]!.body).toBe('First chapter body.');
+    expect(drafts[1]!.title).toBe('Climax');
+    expect(drafts[1]!.body).toBe('Second body.');
+  });
+
+  it('skips empty sections from doubled delimiters', () => {
+    const body = 'Chapter one body.\n---\n---\nChapter two body.';
+    const drafts = splitIntoChapters(body);
+    expect(drafts).toHaveLength(2);
+    expect(drafts.map((d) => d.body)).toEqual([
+      'Chapter one body.',
+      'Chapter two body.',
+    ]);
+  });
+
+  it('honors explicit delimiters even when the body is below threshold', () => {
+    const body = 'tiny one.\n---\ntiny two.';
+    const drafts = splitIntoChapters(body, { thresholdTokens: 10_000_000 });
+    expect(drafts).toHaveLength(2);
+  });
+
+  it('falls back to a single chapter when delimiters produce no real content', () => {
+    // A trailing delimiter with no body after it shouldn't strip the
+    // preceding text — the original body should still survive.
+    const drafts = splitIntoChapters('---\n');
+    expect(drafts).toHaveLength(1);
+    expect(drafts[0]!.body).toBe('---');
+  });
+});
+
+describe('splitIntoChapters — auto-split by paragraph', () => {
+  it('does NOT auto-split a body just under the threshold', () => {
+    // 100 paragraphs × 50 tokens = 5_000 tokens — under default threshold.
+    const body = manyParagraphs(100, 50);
+    const drafts = splitIntoChapters(body);
+    expect(drafts).toHaveLength(1);
+  });
+
+  it('auto-splits a body over the threshold into multiple chapters at paragraph boundaries', () => {
+    // 8 paragraphs × 200 tokens = 1_600 tokens. Force chunking with a
+    // small threshold + target so we can assert the boundaries land
+    // between paragraphs.
+    const body = manyParagraphs(8, 200);
+    const drafts = splitIntoChapters(body, {
+      thresholdTokens: 500,
+      targetChapterTokens: 500,
+    });
+    expect(drafts.length).toBeGreaterThan(1);
+    // No chapter should have a partial paragraph mid-string.
+    for (const d of drafts) {
+      // Each paragraph in the synthesised body looks like "p0 p1 ... p199".
+      // After splitting, each chapter's body should still be made of
+      // those whole paragraphs.
+      const paragraphs = d.body.split(/\n{2,}/).map((p) => p.trim());
+      for (const p of paragraphs) {
+        const tokens = p.split(/\s+/);
+        // Every paragraph has 200 tokens of the form "p0 p1 .. p199".
+        expect(tokens.length).toBe(200);
+        expect(tokens[0]).toBe('p0');
+        expect(tokens[tokens.length - 1]).toBe('p199');
+      }
+    }
+  });
+
+  it('keeps one oversized paragraph as its own chapter rather than splitting mid-paragraph', () => {
+    const big = Array.from({ length: 1000 }, (_, i) => `w${i}`).join(' ');
+    const body = `tiny first paragraph.\n\n${big}\n\ntiny third.`;
+    const drafts = splitIntoChapters(body, {
+      thresholdTokens: 100,
+      targetChapterTokens: 100,
+    });
+    // First chapter: tiny first. Big paragraph: own chapter. Third: own.
+    expect(drafts.length).toBeGreaterThanOrEqual(2);
+    const big_chapter = drafts.find((d) => d.tokenCount >= 1000);
+    expect(big_chapter).toBeDefined();
+  });
+
+  it('numbers chapter idx contiguously starting at 0', () => {
+    const body = manyParagraphs(20, 100);
+    const drafts = splitIntoChapters(body, {
+      thresholdTokens: 200,
+      targetChapterTokens: 200,
+    });
+    expect(drafts.map((d) => d.idx)).toEqual(
+      Array.from({ length: drafts.length }, (_, i) => i),
+    );
+  });
+});
+
+describe('default thresholds', () => {
+  it('CHUNK_THRESHOLD_TOKENS is comfortably larger than TARGET_CHAPTER_TOKENS', () => {
+    expect(CHUNK_THRESHOLD_TOKENS).toBeGreaterThan(TARGET_CHAPTER_TOKENS * 2);
+  });
+});

--- a/apps/web/src/lib/server/texts/chunking.ts
+++ b/apps/web/src/lib/server/texts/chunking.ts
@@ -1,0 +1,240 @@
+/**
+ * Chapter chunking for uploaded text (T-4.2).
+ *
+ * The reader (M5) loads one chapter at a time. A 500k-token novel
+ * pasted as one chapter would force every read to fetch the whole
+ * thing — so this module splits long bodies into multiple
+ * `text_chapters` rows at write time.
+ *
+ * Two splitters share this entry point:
+ *
+ *  1. **Explicit delimiter splitter (always wins).** If the user
+ *     inserted form-feeds (`\f`) or `---` lines, those are the
+ *     intended chapter boundaries — we honor them and never auto-
+ *     paragraph-split inside a user-marked chunk. This lets curators
+ *     (and power users) get exact control. A `# Title` line at the
+ *     top of a section becomes that chapter's `title`.
+ *
+ *  2. **Paragraph-boundary auto-splitter (fallback).** When no
+ *     explicit delimiters are found AND the body exceeds the chunking
+ *     threshold, we walk paragraphs (separated by blank lines) and
+ *     pack them into chapters of roughly `targetChapterTokens` each.
+ *     A paragraph is never split mid-word; we may overshoot the
+ *     target slightly to preserve paragraph integrity.
+ *
+ * The output contract is a non-empty list of `{ idx, title, body,
+ * tokenCount }` records. `body` is already NFC-normalized + CRLF-
+ * flattened by the caller — this module is text-shape-agnostic.
+ */
+
+/**
+ * Body sizes below this token estimate stay as a single chapter even
+ * when no delimiters are present — chunking adds complexity that's
+ * pointless for a short story or essay. Rough rule from M5's reader
+ * design: ~50k tokens is the upper bound for a "single chapter" load.
+ */
+export const CHUNK_THRESHOLD_TOKENS = 50_000;
+
+/**
+ * Target tokens per auto-split chapter. Smaller than the threshold so
+ * a barely-over-threshold body still splits into 3+ readable chapters,
+ * not 2 lopsided ones.
+ */
+export const TARGET_CHAPTER_TOKENS = 8_000;
+
+/**
+ * Hard cap on the number of chapters we'll auto-create from one
+ * upload. Stops a pathological 10-million-token paste (or a
+ * mis-configured TARGET_CHAPTER_TOKENS) from inserting 100k chapter
+ * rows. Real long novels (~500k tokens) split into ~62 chapters at
+ * the target above — well under this cap.
+ */
+export const MAX_AUTO_CHAPTERS = 500;
+
+export type ChapterDraft = {
+  idx: number;
+  title: string | null;
+  body: string;
+  tokenCount: number;
+};
+
+export type ChunkingOptions = {
+  /** Override the default token threshold. Used by tests. */
+  thresholdTokens?: number;
+  /** Override the default per-chapter target. Used by tests. */
+  targetChapterTokens?: number;
+};
+
+/**
+ * Cheap whitespace tokenizer. Same heuristic as
+ * `upload.estimateTokenCount` — both use it as a "we don't have NLP
+ * yet" stand-in for the real lemma count the worker will produce
+ * later. Devanagari / Odia paragraphs use spaces between words so
+ * `split(/\s+/)` is a serviceable estimator.
+ */
+export function estimateTokenCount(body: string): number {
+  const trimmed = body.trim();
+  if (trimmed.length === 0) return 0;
+  return trimmed.split(/\s+/).length;
+}
+
+const EXPLICIT_DELIMITER_RE = /(?:^|\n)(?:\f|-{3,}\s*)(?=\n|$)/g;
+
+function hasExplicitDelimiters(body: string): boolean {
+  // Quick scan — we don't need the matches, just whether any exist.
+  return /(?:^|\n)(?:\f|-{3,})\s*(?:\n|$)/.test(body);
+}
+
+/**
+ * Pull a leading `# Title` line off a chapter body. Returns
+ * `[title | null, remainingBody]`. The hash style is chosen to match
+ * common Markdown intuition without dragging in a real Markdown
+ * parser — the body is plain text everywhere else.
+ */
+function extractLeadingTitle(body: string): [string | null, string] {
+  const match = /^[ \t]*#\s+(.+?)\s*\n+/.exec(body);
+  if (!match) return [null, body];
+  const title = match[1]!.trim();
+  return [title.length > 0 ? title : null, body.slice(match[0].length)];
+}
+
+function splitOnExplicitDelimiters(body: string): ChapterDraft[] {
+  // Reset lastIndex on the regex (it's a /g; we use it stateful).
+  EXPLICIT_DELIMITER_RE.lastIndex = 0;
+  const parts: string[] = [];
+  let lastEnd = 0;
+  let m: RegExpExecArray | null;
+  while ((m = EXPLICIT_DELIMITER_RE.exec(body))) {
+    parts.push(body.slice(lastEnd, m.index));
+    lastEnd = m.index + m[0].length;
+  }
+  parts.push(body.slice(lastEnd));
+
+  const drafts: ChapterDraft[] = [];
+  let nextIdx = 0;
+  for (const raw of parts) {
+    const trimmed = raw.trim();
+    if (trimmed.length === 0) continue;
+    const [title, remainder] = extractLeadingTitle(trimmed);
+    drafts.push({
+      idx: nextIdx,
+      title,
+      body: remainder.trim(),
+      tokenCount: estimateTokenCount(remainder),
+    });
+    nextIdx += 1;
+  }
+  // If the user wrote a delimiter at the very top followed by a body,
+  // we may have produced no usable chapter — fall back to a single
+  // chapter so a malformed delimiter doesn't lose the upload.
+  if (drafts.length === 0) {
+    return [
+      {
+        idx: 0,
+        title: null,
+        body: body.trim(),
+        tokenCount: estimateTokenCount(body),
+      },
+    ];
+  }
+  return drafts;
+}
+
+function splitIntoParagraphs(body: string): string[] {
+  // Two or more consecutive newlines separate paragraphs.
+  return body
+    .split(/\n{2,}/)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
+}
+
+function autoSplitByParagraphs(
+  body: string,
+  targetChapterTokens: number,
+): ChapterDraft[] {
+  const paragraphs = splitIntoParagraphs(body);
+  const drafts: ChapterDraft[] = [];
+  let buf: string[] = [];
+  let bufTokens = 0;
+  let nextIdx = 0;
+
+  function flush(): void {
+    if (buf.length === 0) return;
+    const chapterBody = buf.join('\n\n');
+    drafts.push({
+      idx: nextIdx,
+      title: null,
+      body: chapterBody,
+      tokenCount: estimateTokenCount(chapterBody),
+    });
+    nextIdx += 1;
+    buf = [];
+    bufTokens = 0;
+  }
+
+  for (const p of paragraphs) {
+    const t = estimateTokenCount(p);
+    // If a single paragraph already exceeds the target, it lands
+    // alone in its own chapter — never split mid-paragraph (line
+    // breaks in source text often carry semantic weight, e.g. verse).
+    if (bufTokens > 0 && bufTokens + t > targetChapterTokens) {
+      flush();
+    }
+    buf.push(p);
+    bufTokens += t;
+    if (drafts.length >= MAX_AUTO_CHAPTERS - 1) {
+      // Reserve the last slot — anything left after this lands
+      // as one big tail chapter rather than getting truncated.
+      break;
+    }
+  }
+  flush();
+  if (drafts.length === 0) {
+    // Body was effectively empty after paragraph parsing — preserve
+    // whatever the caller gave us so the validation upstream catches
+    // the empty-body case rather than us silently turning it into 0
+    // chapters.
+    return [
+      {
+        idx: 0,
+        title: null,
+        body: body.trim(),
+        tokenCount: estimateTokenCount(body),
+      },
+    ];
+  }
+  return drafts;
+}
+
+/**
+ * Top-level entry point. See file header for the algorithm.
+ *
+ * Always returns at least one chapter. Empty / whitespace-only bodies
+ * are returned as a single empty chapter — the caller is expected to
+ * have already rejected those at validation time.
+ */
+export function splitIntoChapters(
+  body: string,
+  options: ChunkingOptions = {},
+): ChapterDraft[] {
+  const threshold = options.thresholdTokens ?? CHUNK_THRESHOLD_TOKENS;
+  const targetChapterTokens =
+    options.targetChapterTokens ?? TARGET_CHAPTER_TOKENS;
+
+  if (hasExplicitDelimiters(body)) {
+    return splitOnExplicitDelimiters(body);
+  }
+
+  const totalTokens = estimateTokenCount(body);
+  if (totalTokens <= threshold) {
+    return [
+      {
+        idx: 0,
+        title: null,
+        body: body.trim(),
+        tokenCount: totalTokens,
+      },
+    ];
+  }
+  return autoSplitByParagraphs(body, targetChapterTokens);
+}

--- a/apps/web/src/lib/server/texts/upload.test.ts
+++ b/apps/web/src/lib/server/texts/upload.test.ts
@@ -74,9 +74,11 @@ vi.mock('../db/index.js', () => ({
 const {
   TextValidationError,
   createPastedText,
+  createTxtText,
   estimateTokenCount,
   getOwnedText,
   MAX_PASTE_BYTES,
+  MAX_TXT_BYTES,
   MAX_TITLE_LEN,
 } = await import('./upload.js');
 
@@ -151,7 +153,10 @@ describe('createPastedText', () => {
       status: 'pending',
       visibility: 'private',
     });
-    expect(insertCalls[1]!.values).toMatchObject({
+    // Chapter values are passed as an array (T-4.2 batches them).
+    const chapterValues = insertCalls[1]!.values as Array<Record<string, unknown>>;
+    expect(chapterValues).toHaveLength(1);
+    expect(chapterValues[0]).toMatchObject({
       textId: 'text-1',
       idx: 0,
       title: null,
@@ -173,9 +178,9 @@ describe('createPastedText', () => {
     const chapterInsert = calls.filter(
       (c): c is Extract<Call, { kind: 'insert' }> => c.kind === 'insert',
     )[1]!;
-    const inserted = chapterInsert.values as { body: string };
+    const chapterValues = chapterInsert.values as Array<{ body: string }>;
     // No CR characters survive the normalize.
-    expect(inserted.body).toBe('line one\nline two\nline three');
+    expect(chapterValues[0]!.body).toBe('line one\nline two\nline three');
   });
 
   it('rejects an unsupported language', async () => {
@@ -229,6 +234,89 @@ describe('createPastedText', () => {
         body: oversized,
       }),
     ).rejects.toBeInstanceOf(TextValidationError);
+  });
+});
+
+// -----------------------------------------------------------------------
+// createTxtText (T-4.2)
+// -----------------------------------------------------------------------
+
+describe('createTxtText', () => {
+  it('inserts a single chapter for a short body', async () => {
+    stage([textRow({ sourceType: 'txt' })]);
+    stage([chapterRow({ idx: 0 })]);
+
+    const result = await createTxtText(OWNER, {
+      language: 'hi',
+      title: 'My file',
+      body: 'short body, no chunking.',
+    });
+    expect(result.chapters).toHaveLength(1);
+
+    const insertCalls = calls.filter(
+      (c): c is Extract<Call, { kind: 'insert' }> => c.kind === 'insert',
+    );
+    expect(insertCalls[0]!.values).toMatchObject({ sourceType: 'txt' });
+    const chapterValues = insertCalls[1]!.values as Array<Record<string, unknown>>;
+    expect(chapterValues).toHaveLength(1);
+  });
+
+  it('honors explicit `---` delimiters and inserts one chapter per section', async () => {
+    stage([textRow({ sourceType: 'txt' })]);
+    // Three chapter rows returned to match the three sections in the body.
+    stage([
+      chapterRow({ id: 'c0', idx: 0 }),
+      chapterRow({ id: 'c1', idx: 1 }),
+      chapterRow({ id: 'c2', idx: 2 }),
+    ]);
+
+    const body = ['# One', 'first chapter.', '---', '# Two', 'second.', '---', 'third.'].join(
+      '\n',
+    );
+    const result = await createTxtText(OWNER, {
+      language: 'hi',
+      title: 'Multi-chapter file',
+      body,
+    });
+    expect(result.chapters).toHaveLength(3);
+
+    const chapterInsert = calls.filter(
+      (c): c is Extract<Call, { kind: 'insert' }> => c.kind === 'insert',
+    )[1]!;
+    const values = chapterInsert.values as Array<{
+      idx: number;
+      title: string | null;
+      body: string;
+    }>;
+    expect(values).toHaveLength(3);
+    expect(values.map((v) => v.idx)).toEqual([0, 1, 2]);
+    expect(values[0]!.title).toBe('One');
+    expect(values[1]!.title).toBe('Two');
+    expect(values[2]!.title).toBeNull();
+  });
+
+  it('rejects a body over the .txt byte cap', async () => {
+    const oversized = 'a'.repeat(MAX_TXT_BYTES + 1);
+    await expect(
+      createTxtText(OWNER, {
+        language: 'hi',
+        title: 'too big',
+        body: oversized,
+      }),
+    ).rejects.toBeInstanceOf(TextValidationError);
+  });
+
+  it('accepts a body the paste path would reject (between paste-cap and txt-cap)', async () => {
+    stage([textRow({ sourceType: 'txt' })]);
+    stage([chapterRow({ idx: 0 })]);
+    // Build a body just over the paste cap but well under the .txt cap.
+    const oversized = 'a'.repeat(MAX_PASTE_BYTES + 100);
+    await createTxtText(OWNER, {
+      language: 'hi',
+      title: 'big file',
+      body: oversized,
+    });
+    // Did not throw.
   });
 });
 

--- a/apps/web/src/lib/server/texts/upload.ts
+++ b/apps/web/src/lib/server/texts/upload.ts
@@ -1,5 +1,5 @@
 /**
- * Text upload service (T-4.1).
+ * Text upload service (T-4.1, extended T-4.2).
  *
  * Front door for everything that lands in `texts` + `text_chapters`.
  * The reader/loader and library views read from those tables; the NLP
@@ -7,14 +7,19 @@
  * means downstream code has a single seam to add behaviors like "kick
  * the queue after insert" without touching every callsite.
  *
- * MVP scope (T-4.1):
- *  - `createPastedText` is the only public creator. It writes one
- *    `texts` row + a single `text_chapters` row holding the NFC-
- *    normalized body. Status starts `pending`; T-4.4 will flip it to
- *    `ready` after NLP runs.
- *  - `.txt` and `.epub` ingest land in T-4.2 / T-4.3 and will reuse
- *    this module — `createPastedText` becomes one of several creators,
- *    all sharing validation + visibility defaults.
+ * Two creators today:
+ *
+ *  - `createPastedText` — the paste box. Tight 1MB byte cap because we
+ *    don't want a 10MB paste blocking a request thread; the file
+ *    drop-zone is the right tool for that.
+ *  - `createTxtText` — `.txt` file ingest (T-4.2). Bigger 10MB cap
+ *    because dropping a whole novel as a `.txt` file is the intended
+ *    use. Both feed `splitIntoChapters` (T-4.2's chunker), so a long
+ *    body — paste OR file — auto-splits into reader-sized chapters.
+ *
+ * EPUB ingest lands in T-4.3 with its own creator that consumes the
+ * archive's per-chapter HTML directly; chapter boundaries from the
+ * source aren't subject to the auto-splitter at all.
  *
  * Authorization: every text gets `owner_id = creator.id` and
  * `visibility = 'private'` by default. Sharing + official promotion go
@@ -26,6 +31,7 @@ import { db, schema } from '../db/index.js';
 import type { LanguageCode } from '@ciareader/shared-types';
 import { isSupportedLanguage } from '@ciareader/shared-types';
 import type { Text, TextChapter, User } from '../db/schema.js';
+import { splitIntoChapters, estimateTokenCount } from './chunking.js';
 
 export class TextValidationError extends Error {
   constructor(
@@ -37,16 +43,25 @@ export class TextValidationError extends Error {
   }
 }
 
-/** Hard cap on a single pasted body. 1 MB of UTF-8 is comfortably bigger
- * than a typical short story but small enough that we don't accidentally
- * accept a whole novel pasted into the textarea (use EPUB upload for
- * that — T-4.3). */
+/** Hard cap on a single pasted body. 1 MB of UTF-8 is comfortably
+ * bigger than a typical short story but small enough that we don't
+ * accidentally accept a whole novel pasted into the textarea (use the
+ * `.txt` drop-zone for that). */
 export const MAX_PASTE_BYTES = 1_000_000;
+
+/** Hard cap on a `.txt` upload (T-4.2). 10MB is enough for any
+ * realistic novel + a generous margin — at ~3 bytes/codepoint for
+ * Devanagari that's ~3M codepoints, well past anything a user would
+ * realistically read in one go. EPUB uploads stream chapter-by-chapter
+ * and don't pay a single-blob cap (T-4.3). */
+export const MAX_TXT_BYTES = 10_000_000;
 
 /** Hard cap on the visible title; the library card and `<title>` tag
  * both render this without truncation. */
 export const MAX_TITLE_LEN = 200;
 export const MIN_TITLE_LEN = 1;
+
+export type SourceType = 'paste' | 'txt';
 
 export type CreatePastedTextInput = {
   language: string;
@@ -54,17 +69,25 @@ export type CreatePastedTextInput = {
   body: string;
 };
 
-export type CreatePastedTextResult = {
+export type CreateTxtTextInput = CreatePastedTextInput;
+
+export type CreatedText = {
   text: Text;
+  /** First chapter (idx=0) — convenient for the typical "redirect to
+   * the reader" caller. The full chapter list is on `chapters`. */
   chapter: TextChapter;
+  chapters: TextChapter[];
 };
+
+// Re-export so callers don't have to know about the chunking module.
+export { estimateTokenCount };
 
 function normalizeBody(body: string): string {
   // NFC is the canonical form for Indic scripts in our DB; doing it once
   // at write time means every downstream reader (tokenizer, search,
   // diff) compares apples to apples. Internal CR / CRLF are flattened
-  // to LF so paragraph splitting in T-4.2 doesn't need to special-case
-  // line-ending styles.
+  // to LF so the chunker's paragraph regex doesn't need to special-
+  // case line-ending styles.
   return body.normalize('NFC').replace(/\r\n?/g, '\n');
 }
 
@@ -74,23 +97,10 @@ function normalizeTitle(title: string): string {
   return title.normalize('NFC').trim().replace(/\s+/g, ' ');
 }
 
-/**
- * Cheap whitespace-based token estimator. The real token count comes
- * from the NLP worker (T-4.4) and overwrites this. We seed it to
- * something useful so the library card has a number to render even
- * before the worker has run.
- */
-export function estimateTokenCount(body: string): number {
-  const trimmed = body.trim();
-  if (trimmed.length === 0) return 0;
-  return trimmed.split(/\s+/).length;
-}
-
-function validateInput(input: CreatePastedTextInput): {
-  language: LanguageCode;
-  title: string;
-  body: string;
-} {
+function validateInput(
+  input: CreatePastedTextInput,
+  byteCap: number,
+): { language: LanguageCode; title: string; body: string } {
   if (!isSupportedLanguage(input.language)) {
     throw new TextValidationError(
       `Unsupported language '${input.language}' (expected one of: hi, mr, or)`,
@@ -107,67 +117,129 @@ function validateInput(input: CreatePastedTextInput): {
   if (body.trim().length === 0) {
     throw new TextValidationError('body cannot be empty');
   }
-  // UTF-8 byte length, not char length — the cap is about bytes flowing
-  // over the wire and into a Postgres TEXT column, not codepoints.
+  // UTF-8 byte length, not char length — the cap is about bytes
+  // flowing over the wire and into a Postgres TEXT column, not
+  // codepoints.
   const bodyBytes = new TextEncoder().encode(body).byteLength;
-  if (bodyBytes > MAX_PASTE_BYTES) {
+  if (bodyBytes > byteCap) {
     throw new TextValidationError(
-      `body exceeds ${MAX_PASTE_BYTES.toLocaleString()} bytes; use EPUB upload for longer texts`,
+      `body exceeds ${byteCap.toLocaleString()} bytes`,
     );
   }
   return { language: input.language as LanguageCode, title, body };
 }
 
 /**
- * Create a pasted text + a single chapter for the given owner.
- *
- * The chapter holds the entire body. When T-4.2 lands, long pastes will
- * auto-split into multiple chapter rows at paragraph boundaries; this
- * function's contract (returns the freshly created text + the *first*
- * chapter) is stable regardless.
+ * Internal helper shared by every creator. Inserts the `texts` row +
+ * one `text_chapters` row per draft and returns them all. Splitting
+ * the body into chapter drafts is the caller's responsibility — paste
+ * and `.txt` go through the same `splitIntoChapters`; EPUB (T-4.3)
+ * will pass already-structured chapters straight in.
+ */
+async function insertTextWithChapters(
+  owner: Pick<User, 'id'>,
+  args: {
+    sourceType: SourceType;
+    language: LanguageCode;
+    title: string;
+    chapters: Array<{
+      idx: number;
+      title: string | null;
+      body: string;
+      tokenCount: number;
+    }>;
+    now: Date;
+  },
+): Promise<CreatedText> {
+  const [text] = await db
+    .insert(schema.texts)
+    .values({
+      ownerId: owner.id,
+      language: args.language,
+      title: args.title,
+      sourceType: args.sourceType,
+      status: 'pending',
+      visibility: 'private',
+      createdAt: args.now,
+      updatedAt: args.now,
+    })
+    .returning();
+  if (!text) throw new Error('Failed to insert text row');
+
+  const chapterRows = (await db
+    .insert(schema.textChapters)
+    .values(
+      args.chapters.map((c) => ({
+        textId: (text as Text).id,
+        idx: c.idx,
+        title: c.title,
+        body: c.body,
+        tokenCount: c.tokenCount,
+        createdAt: args.now,
+      })),
+    )
+    .returning()) as TextChapter[];
+  if (chapterRows.length === 0) throw new Error('Failed to insert chapter rows');
+
+  // Sort defensively — drizzle's `returning` doesn't guarantee insert
+  // order across drivers.
+  chapterRows.sort((a, b) => a.idx - b.idx);
+
+  return {
+    text: text as Text,
+    chapter: chapterRows[0]!,
+    chapters: chapterRows,
+  };
+}
+
+/**
+ * Create a pasted text. The body is run through the chapter chunker
+ * just like a `.txt` upload would be — short bodies stay one chapter,
+ * longer ones (or ones with explicit `\f` / `---` delimiters) split
+ * automatically.
  */
 export async function createPastedText(
   owner: Pick<User, 'id'>,
   input: CreatePastedTextInput,
   now: Date = new Date(),
-): Promise<CreatePastedTextResult> {
-  const { language, title, body } = validateInput(input);
+): Promise<CreatedText> {
+  const { language, title, body } = validateInput(input, MAX_PASTE_BYTES);
+  const drafts = splitIntoChapters(body);
+  return insertTextWithChapters(owner, {
+    sourceType: 'paste',
+    language,
+    title,
+    chapters: drafts,
+    now,
+  });
+}
 
-  const [text] = await db
-    .insert(schema.texts)
-    .values({
-      ownerId: owner.id,
-      language,
-      title,
-      sourceType: 'paste',
-      status: 'pending',
-      visibility: 'private',
-      createdAt: now,
-      updatedAt: now,
-    })
-    .returning();
-  if (!text) throw new Error('Failed to insert text row');
-
-  const [chapter] = await db
-    .insert(schema.textChapters)
-    .values({
-      textId: (text as Text).id,
-      idx: 0,
-      title: null,
-      body,
-      tokenCount: estimateTokenCount(body),
-      createdAt: now,
-    })
-    .returning();
-  if (!chapter) throw new Error('Failed to insert chapter row');
-
-  return { text: text as Text, chapter: chapter as TextChapter };
+/**
+ * Create a text from a `.txt` upload (T-4.2). The body is treated as
+ * plain UTF-8 and run through the chunker — explicit `\f` / `---`
+ * delimiters from the original file are honored, otherwise the
+ * paragraph-boundary auto-splitter fires above the threshold.
+ */
+export async function createTxtText(
+  owner: Pick<User, 'id'>,
+  input: CreateTxtTextInput,
+  now: Date = new Date(),
+): Promise<CreatedText> {
+  const { language, title, body } = validateInput(input, MAX_TXT_BYTES);
+  const drafts = splitIntoChapters(body);
+  return insertTextWithChapters(owner, {
+    sourceType: 'txt',
+    language,
+    title,
+    chapters: drafts,
+    now,
+  });
 }
 
 /**
  * Read one of the user's own texts plus its chapters, in order. Used by
- * the placeholder reader page T-4.1 ships (a temporary view of the raw
- * body — the real reader lands in M5). Returns `null` if the text
+ * the placeholder reader page T-4.1 shipped (a temporary view of the
+ * raw body — the real reader lands in M5). Returns `null` if the text
  * doesn't exist OR is not readable by `viewer`.
  *
  * Sharing / official-text reads go through `assertCanRead` in T-4.6;

--- a/apps/web/src/routes/api/v1/texts/+server.ts
+++ b/apps/web/src/routes/api/v1/texts/+server.ts
@@ -1,17 +1,18 @@
 /**
- * POST /api/v1/texts (T-4.1).
+ * POST /api/v1/texts (T-4.1, extended T-4.2).
  *
- * Create a pasted text. The web upload UI calls this through the
- * SvelteKit form action; mobile / API clients can hit it directly with
- * a bearer token. Both go through the same `createPastedText` service.
+ * Create a text from either a paste or a `.txt` upload. The web UI
+ * hits this via the form action; mobile / API clients call it
+ * directly with a bearer token. Both paths land on the same service
+ * functions (`createPastedText` / `createTxtText`), so validation,
+ * chunking, and visibility defaults are identical between web and
+ * programmatic clients.
  *
- * `.txt` and `.epub` ingest land in T-4.2 / T-4.3 — until those ship,
- * `sourceType` is fixed to `'paste'` and the body must be supplied
- * inline. The schema allows the field for forward compatibility.
+ * EPUB ingest lands in T-4.3 with its own discriminator value.
  *
- * Response: 201 with the freshly created `text` (sans body) so the
- * caller can navigate to `/texts/:id`. Chapter content is NOT echoed
- * back to keep the create response small — the read endpoint serves it.
+ * Response: 201 with the freshly created `text` metadata only — chapter
+ * content is NOT echoed back to keep the create response small. Use the
+ * read endpoint (or `/texts/:id`) to fetch chapters.
  */
 import { error, json } from '@sveltejs/kit';
 import { z } from 'zod';
@@ -19,35 +20,57 @@ import { z } from 'zod';
 import { requireUser } from '$lib/server/auth/require-user.js';
 import {
   createPastedText,
+  createTxtText,
   TextValidationError,
   MAX_PASTE_BYTES,
+  MAX_TXT_BYTES,
   MAX_TITLE_LEN,
 } from '$lib/server/texts/upload.js';
 import type { RequestHandler } from './$types';
 import { parseJson } from '../auth/_helpers.js';
 
-const body = z.object({
+// One discriminated schema per source type — paste's body cap is
+// stricter than .txt's, and the error message users see should reflect
+// the path they took.
+const pasteSchema = z.object({
+  sourceType: z.literal('paste').optional(),
   language: z.enum(['hi', 'mr', 'or']),
   title: z.string().min(1).max(MAX_TITLE_LEN),
-  // Validated again in the service for byte length; the cap here is a
-  // cheap shot to reject obviously-too-large requests before we copy
-  // the string.
   body: z.string().min(1).max(MAX_PASTE_BYTES),
-  sourceType: z.literal('paste').optional(),
 });
+
+const txtSchema = z.object({
+  sourceType: z.literal('txt'),
+  language: z.enum(['hi', 'mr', 'or']),
+  title: z.string().min(1).max(MAX_TITLE_LEN),
+  body: z.string().min(1).max(MAX_TXT_BYTES),
+});
+
+const body = z.union([txtSchema, pasteSchema]);
 
 export const POST: RequestHandler = async (event) => {
   const user = await requireUser(event);
   const input = await parseJson(event.request, body);
   try {
-    const { text } = await createPastedText(
-      { id: user.id },
-      {
-        language: input.language,
-        title: input.title,
-        body: input.body,
-      },
-    );
+    const created =
+      input.sourceType === 'txt'
+        ? await createTxtText(
+            { id: user.id },
+            {
+              language: input.language,
+              title: input.title,
+              body: input.body,
+            },
+          )
+        : await createPastedText(
+            { id: user.id },
+            {
+              language: input.language,
+              title: input.title,
+              body: input.body,
+            },
+          );
+    const { text } = created;
     return json(
       {
         text: {
@@ -60,6 +83,7 @@ export const POST: RequestHandler = async (event) => {
           visibility: text.visibility,
           createdAt: text.createdAt,
         },
+        chapterCount: created.chapters.length,
       },
       { status: 201 },
     );

--- a/apps/web/src/routes/api/v1/texts/texts-server.test.ts
+++ b/apps/web/src/routes/api/v1/texts/texts-server.test.ts
@@ -5,6 +5,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const createPastedText = vi.fn();
+const createTxtText = vi.fn();
 const requireUser = vi.fn();
 
 vi.mock('$lib/server/texts/upload.js', async () => {
@@ -14,6 +15,7 @@ vi.mock('$lib/server/texts/upload.js', async () => {
   return {
     ...actual,
     createPastedText: (...a: unknown[]) => createPastedText(...a),
+    createTxtText: (...a: unknown[]) => createTxtText(...a),
   };
 });
 
@@ -52,6 +54,7 @@ async function callPost(body: unknown, user: typeof USER | null = USER) {
 
 beforeEach(() => {
   createPastedText.mockReset();
+  createTxtText.mockReset();
   requireUser.mockReset();
 });
 
@@ -60,7 +63,7 @@ afterEach(() => {
 });
 
 describe('POST /api/v1/texts', () => {
-  it('returns 201 with the new text on a happy path', async () => {
+  it('returns 201 with the new text on the paste path', async () => {
     createPastedText.mockResolvedValueOnce({
       text: {
         id: 'text-1',
@@ -73,6 +76,7 @@ describe('POST /api/v1/texts', () => {
         createdAt: new Date('2026-04-27T00:00:00Z'),
       },
       chapter: { id: 'chap-1' },
+      chapters: [{ id: 'chap-1' }],
     });
     const res = (await callPost({
       language: 'hi',
@@ -87,10 +91,41 @@ describe('POST /api/v1/texts', () => {
       visibility: 'private',
       sourceType: 'paste',
     });
+    expect(json.chapterCount).toBe(1);
     expect(createPastedText).toHaveBeenCalledWith(
       { id: USER.id },
       { language: 'hi', title: 'My text', body: 'पाठ का मूल पाठ।' },
     );
+    expect(createTxtText).not.toHaveBeenCalled();
+  });
+
+  it('routes sourceType=txt through createTxtText and reports chapterCount', async () => {
+    createTxtText.mockResolvedValueOnce({
+      text: {
+        id: 'text-2',
+        ownerId: USER.id,
+        language: 'hi',
+        title: 'Big book',
+        sourceType: 'txt',
+        status: 'pending',
+        visibility: 'private',
+        createdAt: new Date('2026-04-27T00:00:00Z'),
+      },
+      chapter: { id: 'c0' },
+      chapters: [{ id: 'c0' }, { id: 'c1' }, { id: 'c2' }],
+    });
+    const res = (await callPost({
+      sourceType: 'txt',
+      language: 'hi',
+      title: 'Big book',
+      body: 'first.\n---\nsecond.\n---\nthird.',
+    })) as Response;
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.text.sourceType).toBe('txt');
+    expect(json.chapterCount).toBe(3);
+    expect(createTxtText).toHaveBeenCalledTimes(1);
+    expect(createPastedText).not.toHaveBeenCalled();
   });
 
   it('rejects an unsupported language with 400 before calling the service', async () => {

--- a/apps/web/src/routes/upload/+page.server.ts
+++ b/apps/web/src/routes/upload/+page.server.ts
@@ -18,18 +18,34 @@ import { z } from 'zod';
 
 import {
   createPastedText,
+  createTxtText,
   TextValidationError,
   MAX_PASTE_BYTES,
+  MAX_TXT_BYTES,
   MAX_TITLE_LEN,
 } from '$lib/server/texts/upload.js';
 import { LANGUAGES, SUPPORTED_LANGUAGE_CODES } from '@ciareader/shared-types';
 import type { Actions, PageServerLoad } from './$types';
 
-const formSchema = z.object({
+// Source-type-aware schemas: paste keeps the tight 1MB cap, txt
+// allows up to 10MB. The body field comes from the same `<textarea>`
+// either way — the only difference is which service runs and which
+// cap applies.
+const pasteFormSchema = z.object({
+  sourceType: z.literal('paste').optional(),
   language: z.enum(['hi', 'mr', 'or']),
   title: z.string().min(1).max(MAX_TITLE_LEN),
   body: z.string().min(1).max(MAX_PASTE_BYTES),
 });
+
+const txtFormSchema = z.object({
+  sourceType: z.literal('txt'),
+  language: z.enum(['hi', 'mr', 'or']),
+  title: z.string().min(1).max(MAX_TITLE_LEN),
+  body: z.string().min(1).max(MAX_TXT_BYTES),
+});
+
+const formSchema = z.union([txtFormSchema, pasteFormSchema]);
 
 export const load: PageServerLoad = async ({ locals, url }) => {
   if (!locals.user) {
@@ -43,7 +59,12 @@ export const load: PageServerLoad = async ({ locals, url }) => {
     })),
     limits: {
       maxTitleLength: MAX_TITLE_LEN,
-      maxBodyBytes: MAX_PASTE_BYTES,
+      // The browser uses the paste cap by default and bumps to the
+      // txt cap when a file has been dropped. Both numbers are
+      // surfaced so the live byte counter can swap thresholds without
+      // a server round-trip.
+      maxPasteBytes: MAX_PASTE_BYTES,
+      maxTxtBytes: MAX_TXT_BYTES,
     },
   };
 };
@@ -54,7 +75,9 @@ export const actions: Actions = {
       throw redirect(303, '/login?next=/upload');
     }
     const fd = await request.formData();
+    const sourceType = fd.get('sourceType')?.toString() === 'txt' ? 'txt' : 'paste';
     const raw = {
+      sourceType,
       language: fd.get('language')?.toString() ?? '',
       title: fd.get('title')?.toString() ?? '',
       body: fd.get('body')?.toString() ?? '',
@@ -72,11 +95,25 @@ export const actions: Actions = {
       });
     }
     try {
-      const { text } = await createPastedText(
-        { id: locals.user.id },
-        parsed.data,
-      );
-      throw redirect(303, `/texts/${text.id}`);
+      const created =
+        parsed.data.sourceType === 'txt'
+          ? await createTxtText(
+              { id: locals.user.id },
+              {
+                language: parsed.data.language,
+                title: parsed.data.title,
+                body: parsed.data.body,
+              },
+            )
+          : await createPastedText(
+              { id: locals.user.id },
+              {
+                language: parsed.data.language,
+                title: parsed.data.title,
+                body: parsed.data.body,
+              },
+            );
+      throw redirect(303, `/texts/${created.text.id}`);
     } catch (err) {
       if (err instanceof TextValidationError) {
         return fail(err.status, {

--- a/apps/web/src/routes/upload/+page.svelte
+++ b/apps/web/src/routes/upload/+page.svelte
@@ -18,13 +18,26 @@
   );
   let title = $state(untrack(() => form?.values?.title ?? ''));
   let body = $state(untrack(() => form?.values?.body ?? ''));
+  // Tracks whether the body originated from a file drop; controls
+  // which byte cap applies and gets posted to the form action so the
+  // server picks the right service (createTxtText vs createPastedText).
+  // Echoed back on a failed submit so the user keeps their state.
+  let sourceType = $state<'paste' | 'txt'>(
+    untrack(() => (form?.values?.sourceType === 'txt' ? 'txt' : 'paste')),
+  );
   let dropMessage = $state<string | null>(null);
 
+  // The applicable byte cap depends on the source type — paste paths
+  // are tighter than .txt paths.
+  const maxBodyBytes = $derived(
+    sourceType === 'txt' ? data.limits.maxTxtBytes : data.limits.maxPasteBytes,
+  );
+
   // Cheap UTF-8 byte count for the live counter — `TextEncoder` exists
-  // in every browser we care about. Match the server's MAX_PASTE_BYTES
-  // cap so we can disable submit before hitting the wire.
+  // in every browser we care about. Match the server's caps so we can
+  // disable submit before hitting the wire.
   const byteCount = $derived(new TextEncoder().encode(body).byteLength);
-  const overLimit = $derived(byteCount > data.limits.maxBodyBytes);
+  const overLimit = $derived(byteCount > maxBodyBytes);
 
   async function handleFileDrop(file: File) {
     const lower = file.name.toLowerCase();
@@ -37,15 +50,16 @@
       dropMessage = `Unsupported file type: ${file.name}`;
       return;
     }
-    if (file.size > data.limits.maxBodyBytes) {
+    if (file.size > data.limits.maxTxtBytes) {
       dropMessage = `File is too large (max ${(
-        data.limits.maxBodyBytes / 1000
-      ).toLocaleString()} KB).`;
+        data.limits.maxTxtBytes / 1_000_000
+      ).toLocaleString()} MB).`;
       return;
     }
     try {
       const text = await file.text();
       body = text;
+      sourceType = 'txt';
       if (!title) title = file.name.replace(/\.txt$/i, '');
       dropMessage = `Loaded ${file.name} (${(file.size / 1000).toFixed(1)} KB).`;
     } catch {
@@ -130,6 +144,8 @@
       {/if}
     </div>
 
+    <input type="hidden" name="sourceType" value={sourceType} />
+
     <label>
       Body
       <textarea
@@ -140,7 +156,20 @@
         placeholder="Paste your text here in the language's native script."
       ></textarea>
       <span class="counter" class:over={overLimit}>
-        {byteCount.toLocaleString()} / {data.limits.maxBodyBytes.toLocaleString()} bytes
+        {byteCount.toLocaleString()} / {maxBodyBytes.toLocaleString()} bytes
+        <span class="src">· {sourceType === 'txt' ? '.txt upload' : 'paste'}</span>
+        {#if sourceType === 'txt'}
+          <button
+            type="button"
+            class="reset"
+            onclick={() => {
+              sourceType = 'paste';
+              dropMessage = null;
+            }}
+          >
+            Treat as paste
+          </button>
+        {/if}
       </span>
     </label>
 
@@ -237,6 +266,22 @@
   .counter.over {
     color: #b03131;
     font-weight: 600;
+  }
+  .counter .src {
+    margin-left: 0.25rem;
+    color: var(--color-fg-muted);
+  }
+  .counter .reset {
+    margin-left: 0.5rem;
+    background: transparent;
+    border: 1px solid var(--color-border);
+    border-radius: 999px;
+    color: var(--color-fg-muted);
+    padding: 0 0.5rem;
+    min-height: 0;
+    font-size: 0.75rem;
+    line-height: 1.6;
+    cursor: pointer;
   }
   .err {
     color: #b03131;

--- a/apps/web/src/routes/upload/page-server.test.ts
+++ b/apps/web/src/routes/upload/page-server.test.ts
@@ -5,6 +5,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const createPastedText = vi.fn();
+const createTxtText = vi.fn();
 
 vi.mock('$lib/server/texts/upload.js', async () => {
   const actual = await vi.importActual<typeof import('$lib/server/texts/upload.js')>(
@@ -13,6 +14,7 @@ vi.mock('$lib/server/texts/upload.js', async () => {
   return {
     ...actual,
     createPastedText: (...a: unknown[]) => createPastedText(...a),
+    createTxtText: (...a: unknown[]) => createTxtText(...a),
   };
 });
 
@@ -53,6 +55,7 @@ async function callAction(
 
 beforeEach(() => {
   createPastedText.mockReset();
+  createTxtText.mockReset();
 });
 
 afterEach(() => {
@@ -63,13 +66,19 @@ describe('/upload loader', () => {
   it('returns the language list and the input limits for an authenticated user', async () => {
     const data = (await callLoad(USER)) as {
       languages: Array<{ code: string }>;
-      limits: { maxTitleLength: number; maxBodyBytes: number };
+      limits: {
+        maxTitleLength: number;
+        maxPasteBytes: number;
+        maxTxtBytes: number;
+      };
     };
     expect(data.languages.length).toBeGreaterThan(0);
     expect(data.languages.map((l) => l.code)).toEqual(
       expect.arrayContaining(['hi', 'mr', 'or']),
     );
-    expect(data.limits.maxBodyBytes).toBeGreaterThan(0);
+    expect(data.limits.maxPasteBytes).toBeGreaterThan(0);
+    // .txt path must allow strictly more bytes than paste.
+    expect(data.limits.maxTxtBytes).toBeGreaterThan(data.limits.maxPasteBytes);
   });
 
   it('redirects unauthenticated visitors to /login with a next param', async () => {
@@ -84,6 +93,7 @@ describe('/upload default action', () => {
     createPastedText.mockResolvedValueOnce({
       text: { id: 'text-1', ownerId: USER.id },
       chapter: { id: 'chap-1' },
+      chapters: [{ id: 'chap-1' }],
     });
     const res = (await callAction({
       language: 'hi',
@@ -96,6 +106,25 @@ describe('/upload default action', () => {
       { id: USER.id },
       { language: 'hi', title: 'My text', body: 'पाठ का मूल पाठ।' },
     );
+    expect(createTxtText).not.toHaveBeenCalled();
+  });
+
+  it('routes sourceType=txt through createTxtText', async () => {
+    createTxtText.mockResolvedValueOnce({
+      text: { id: 'text-2', ownerId: USER.id },
+      chapter: { id: 'c0' },
+      chapters: [{ id: 'c0' }, { id: 'c1' }],
+    });
+    const res = (await callAction({
+      sourceType: 'txt',
+      language: 'hi',
+      title: 'Big book',
+      body: 'first.\n---\nsecond.',
+    })) as { status: number; location: string };
+    expect(res.status).toBe(303);
+    expect(res.location).toBe('/texts/text-2');
+    expect(createTxtText).toHaveBeenCalledTimes(1);
+    expect(createPastedText).not.toHaveBeenCalled();
   });
 
   it('returns a fail() with echoed values on validation failure', async () => {


### PR DESCRIPTION
Closes #37

## Summary

Splits long uploaded text into reader-sized chapters at write time so the M5 reader never has to load a 500k-token novel as one blob.

- **`splitIntoChapters` chunker** (\`lib/server/texts/chunking.ts\`): explicit \`\\f\` / \`---\` delimiters always win (with optional \`# Title\` headers); otherwise paragraph-boundary auto-split kicks in over a 50k-token threshold, packing into ~8k-token chapters. Single oversized paragraphs stay whole.
- **\`createTxtText\` service**: same validation pipeline as paste but with a 10MB byte cap instead of 1MB. Both creators feed the chunker, and both batch-insert chapters via a shared helper.
- **API + UI plumbing**: \`POST /api/v1/texts\` is now a discriminated union on \`sourceType\`; the response carries \`chapterCount\`. \`/upload\` flips the byte-counter threshold when a file is dropped and exposes a "Treat as paste" affordance.

## Test plan

- [x] \`pnpm --filter @ciareader/web test\` — 415/415 (21 new for T-4.2)
- [x] \`pnpm --filter @ciareader/web check\` — clean
- [x] \`pnpm --filter @ciareader/web lint\` — clean
- [x] \`pnpm --filter @ciareader/web test:coverage\` — passes 80% floor; texts module at 100% lines
- [ ] Manual: paste a body with \`---\` separators, confirm one chapter per section in \`/texts/[id]\`
- [ ] Manual: drop a 5MB \`.txt\` file, confirm it accepts and chunks (vs. the paste box rejecting at 1MB)
- [ ] Manual: drop \`.txt\` then click "Treat as paste"; confirm the byte cap reverts to 1MB