### PR TITLE
T-4.3: EPUB ingest (server-side parser + multipart upload)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,6 +23,7 @@
     "@node-rs/argon2": "^2.0.2",
     "drizzle-orm": "^0.35.3",
     "jose": "^5.9.4",
+    "jszip": "^3.10.1",
     "nodemailer": "^6.9.15",
     "postgres": "^3.4.4",
     "zod": "^3.23.8"

--- a/apps/web/src/lib/server/texts/epub.test.ts
+++ b/apps/web/src/lib/server/texts/epub.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it } from 'vitest';
+import JSZip from 'jszip';
+
+import { EpubParseError, htmlToText, parseEpub } from './epub.js';
+
+// -----------------------------------------------------------------------
+// htmlToText
+// -----------------------------------------------------------------------
+
+describe('htmlToText', () => {
+  it('preserves paragraph breaks across <p> boundaries', () => {
+    const out = htmlToText('<p>One.</p><p>Two.</p>');
+    expect(out).toBe('One.\n\nTwo.');
+  });
+
+  it('treats <br> as a single line break, not a paragraph', () => {
+    const out = htmlToText('<p>Line one.<br/>Line two.</p>');
+    expect(out).toBe('Line one.\nLine two.');
+  });
+
+  it('strips inline tags without leaving punctuation gaps', () => {
+    const out = htmlToText('<p><em>Hello</em>, <strong>world</strong>!</p>');
+    expect(out).toBe('Hello, world!');
+  });
+
+  it('drops <script> + <style> bodies entirely', () => {
+    const out = htmlToText(
+      '<p>Body.</p><script>alert(1)</script><style>p{color:red}</style>',
+    );
+    expect(out).toBe('Body.');
+  });
+
+  it('decodes the named + numeric entities EPUBs actually use', () => {
+    expect(htmlToText('<p>A&amp;B &lt;C&gt; &quot;D&quot; &#39;E&#39; &nbsp;F</p>')).toBe(
+      'A&B <C> "D" \'E\' F',
+    );
+    expect(htmlToText('<p>&#x0905;&#x0906;</p>')).toBe('अआ');
+  });
+
+  it('collapses runs of whitespace + blank lines', () => {
+    expect(htmlToText('<p>One</p>\n\n\n<p>Two</p>')).toBe('One\n\nTwo');
+    expect(htmlToText('<p>spaced     out</p>')).toBe('spaced out');
+  });
+
+  it('strips XML doctype + comments + processing instructions', () => {
+    const out = htmlToText(
+      '<?xml version="1.0"?><!DOCTYPE html><!-- a comment --><p>Body.</p>',
+    );
+    expect(out).toBe('Body.');
+  });
+});
+
+// -----------------------------------------------------------------------
+// parseEpub
+// -----------------------------------------------------------------------
+
+/**
+ * Build a minimal valid EPUB archive on the fly so the tests don't
+ * depend on a checked-in binary fixture. The shape mirrors what
+ * Calibre / Sigil emit: META-INF/container.xml → content.opf → spine
+ * of XHTML chapters under OEBPS/.
+ */
+async function buildFixtureEpub(args: {
+  chapters: Array<{ id: string; href: string; title: string; bodyHtml: string }>;
+  /** Override fields for negative tests. */
+  containerXml?: string;
+  opfPath?: string;
+  opfXml?: string;
+}): Promise<Uint8Array> {
+  const opfPath = args.opfPath ?? 'OEBPS/content.opf';
+  const zip = new JSZip();
+  zip.file(
+    'mimetype',
+    'application/epub+zip',
+  );
+  zip.file(
+    'META-INF/container.xml',
+    args.containerXml ??
+      `<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="${opfPath}" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>`,
+  );
+  const manifest = args.chapters
+    .map(
+      (c) =>
+        `<item id="${c.id}" href="${c.href}" media-type="application/xhtml+xml"/>`,
+    )
+    .join('\n');
+  const spine = args.chapters.map((c) => `<itemref idref="${c.id}"/>`).join('\n');
+  zip.file(
+    opfPath,
+    args.opfXml ??
+      `<?xml version="1.0"?>
+<package version="3.0">
+  <manifest>${manifest}</manifest>
+  <spine>${spine}</spine>
+</package>`,
+  );
+  for (const c of args.chapters) {
+    const dir = opfPath.includes('/') ? opfPath.replace(/\/[^/]+$/, '') + '/' : '';
+    zip.file(
+      dir + c.href,
+      `<?xml version="1.0"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head><title>${c.title}</title></head>
+<body>${c.bodyHtml}</body>
+</html>`,
+    );
+  }
+  return zip.generateAsync({ type: 'uint8array' });
+}
+
+describe('parseEpub — happy path', () => {
+  it('returns chapters in spine order with title + plain-text body', async () => {
+    const bytes = await buildFixtureEpub({
+      chapters: [
+        {
+          id: 'ch1',
+          href: 'ch1.xhtml',
+          title: 'Chapter One',
+          bodyHtml: '<p>First paragraph.</p><p>Second paragraph.</p>',
+        },
+        {
+          id: 'ch2',
+          href: 'ch2.xhtml',
+          title: 'Chapter Two',
+          bodyHtml: '<h1>Heading</h1><p>Body of two.</p>',
+        },
+      ],
+    });
+    const chapters = await parseEpub(bytes);
+    expect(chapters).toHaveLength(2);
+    expect(chapters[0]!.title).toBe('Chapter One');
+    expect(chapters[0]!.body).toBe('First paragraph.\n\nSecond paragraph.');
+    expect(chapters[1]!.title).toBe('Chapter Two');
+    expect(chapters[1]!.body).toContain('Heading');
+    expect(chapters[1]!.body).toContain('Body of two.');
+  });
+
+  it('skips empty / whitespace-only chapters', async () => {
+    const bytes = await buildFixtureEpub({
+      chapters: [
+        { id: 'nav', href: 'nav.xhtml', title: 'Nav', bodyHtml: '   ' },
+        {
+          id: 'real',
+          href: 'real.xhtml',
+          title: 'Real',
+          bodyHtml: '<p>Actual body.</p>',
+        },
+      ],
+    });
+    const chapters = await parseEpub(bytes);
+    expect(chapters).toHaveLength(1);
+    expect(chapters[0]!.title).toBe('Real');
+  });
+
+  it('falls back to a heading when the document has no <title>', async () => {
+    const bytes = await buildFixtureEpub({
+      chapters: [
+        {
+          id: 'h',
+          href: 'h.xhtml',
+          // We override the title slot but the parser only looks at the
+          // <title> tag for that — by passing an empty title the
+          // generated <head><title></title></head> stays empty and the
+          // parser falls back to <h1>.
+          title: '',
+          bodyHtml: '<h2>Fallback Title</h2><p>Body.</p>',
+        },
+      ],
+    });
+    const chapters = await parseEpub(bytes);
+    expect(chapters[0]!.title).toBe('Fallback Title');
+  });
+});
+
+describe('parseEpub — error paths', () => {
+  it('rejects a non-zip blob with a clear EpubParseError', async () => {
+    await expect(parseEpub(new Uint8Array([1, 2, 3, 4]))).rejects.toBeInstanceOf(
+      EpubParseError,
+    );
+  });
+
+  it('rejects an archive missing META-INF/container.xml', async () => {
+    const zip = new JSZip();
+    zip.file('mimetype', 'application/epub+zip');
+    const bytes = (await zip.generateAsync({ type: 'uint8array' })) as Uint8Array;
+    await expect(parseEpub(bytes)).rejects.toBeInstanceOf(EpubParseError);
+  });
+
+  it('rejects an EPUB with an empty spine', async () => {
+    const bytes = await buildFixtureEpub({
+      chapters: [],
+      // Build an OPF by hand because the fixture helper requires
+      // chapters to populate the spine.
+      opfXml: '<?xml version="1.0"?><package><manifest></manifest><spine></spine></package>',
+    });
+    await expect(parseEpub(bytes)).rejects.toBeInstanceOf(EpubParseError);
+  });
+
+  it('rejects an EPUB whose chapters are all empty / non-readable', async () => {
+    const bytes = await buildFixtureEpub({
+      chapters: [
+        { id: 'ch1', href: 'ch1.xhtml', title: '', bodyHtml: '' },
+        { id: 'ch2', href: 'ch2.xhtml', title: '', bodyHtml: '<style>x{}</style>' },
+      ],
+    });
+    await expect(parseEpub(bytes)).rejects.toBeInstanceOf(EpubParseError);
+  });
+});

--- a/apps/web/src/lib/server/texts/epub.ts
+++ b/apps/web/src/lib/server/texts/epub.ts
@@ -1,0 +1,229 @@
+/**
+ * Minimal server-side EPUB parser (T-4.3).
+ *
+ * EPUB is a ZIP archive of XHTML chapters with a small XML manifest
+ * describing chapter order. Pulling in a full epub library was
+ * tempting, but everything we need lives in three places:
+ *
+ *   1. `META-INF/container.xml` — the only fixed entry point. It
+ *      tells us the OPF path inside the zip.
+ *   2. The OPF file's `<spine>` — the canonical chapter ordering, by
+ *      id-reference into the `<manifest>` map.
+ *   3. Each chapter's XHTML — the readable content. We strip tags
+ *      ourselves, preserving paragraph breaks.
+ *
+ * Plain regex parsing is fine for these specific shapes because EPUB
+ * authors aren't writing creative XML — they're emitting from
+ * Calibre, Sigil, or a publisher pipeline that produces tightly
+ * conventional structure. Anything weird enough to break the regex
+ * would fail in real readers too.
+ *
+ * Output is a list of `{ title, body }` chapters in spine order. The
+ * upload service feeds these straight into `text_chapters` rows
+ * without going through the auto-splitter — EPUB chapters are
+ * authored, not heuristic.
+ */
+import JSZip from 'jszip';
+
+export class EpubParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'EpubParseError';
+  }
+}
+
+export type EpubChapter = {
+  title: string | null;
+  body: string;
+};
+
+const OPF_PATH_RE = /<rootfile\b[^>]*\bfull-path="([^"]+)"/i;
+const MANIFEST_ITEM_RE = /<item\b([^>]*?)\/?>/gi;
+const ATTR_RE = (name: string) => new RegExp(`\\b${name}="([^"]*)"`, 'i');
+const SPINE_ITEMREF_RE = /<itemref\b[^>]*\bidref="([^"]+)"/gi;
+const TITLE_TAG_RE = /<title[^>]*>([\s\S]*?)<\/title>/i;
+const HEADING_RE = /<h[1-6][^>]*>([\s\S]*?)<\/h[1-6]>/i;
+
+function joinPath(base: string, rel: string): string {
+  // EPUB hrefs are relative to the OPF file's directory. Resolve them
+  // by hand — `URL` doesn't fit because zip entries aren't URLs.
+  const lastSlash = base.lastIndexOf('/');
+  const dir = lastSlash >= 0 ? base.slice(0, lastSlash + 1) : '';
+  const combined = dir + rel;
+  // Normalize `./` and `../` segments.
+  const parts: string[] = [];
+  for (const part of combined.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') parts.pop();
+    else parts.push(part);
+  }
+  return parts.join('/');
+}
+
+/**
+ * Decode the small set of HTML entities we encounter in EPUB text.
+ * Numeric (`&#10;`, `&#x0a;`) and the named entities the spec
+ * actually uses; anything more exotic gets dropped to its source
+ * form, which is rarely present in published EPUBs anyway.
+ */
+function decodeEntities(s: string): string {
+  return s
+    .replace(/&#x([0-9a-fA-F]+);/g, (_m, hex: string) =>
+      String.fromCodePoint(parseInt(hex, 16)),
+    )
+    .replace(/&#(\d+);/g, (_m, dec: string) => String.fromCodePoint(parseInt(dec, 10)))
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&nbsp;/g, ' ');
+}
+
+/**
+ * Strip XHTML to plain text, preserving paragraph breaks.
+ *
+ * Block-level tags (`<p>`, `<div>`, `<br>`, headings) become a single
+ * `\n` boundary; consecutive boundaries collapse to a paragraph break.
+ * All other tags are removed entirely. Script / style content is
+ * dropped before tag-stripping so nothing leaks into the body.
+ */
+export function htmlToText(html: string): string {
+  let s = html;
+  // Drop the document head wholesale — its <title> + <meta> would
+  // otherwise leak into the visible text once we strip tags.
+  s = s.replace(/<head\b[\s\S]*?<\/head>/gi, '');
+  // Drop script + style content wholesale — they'd otherwise survive
+  // as text once we strip tags.
+  s = s.replace(/<script\b[\s\S]*?<\/script>/gi, '');
+  s = s.replace(/<style\b[\s\S]*?<\/style>/gi, '');
+  // Drop any leftover XML processing instructions, doctypes, comments.
+  s = s.replace(/<!--[\s\S]*?-->/g, '');
+  s = s.replace(/<\?[\s\S]*?\?>/g, '');
+  s = s.replace(/<!DOCTYPE[\s\S]*?>/gi, '');
+  // Block-level boundaries → newline before/after.
+  s = s.replace(/<\s*br\s*\/?\s*>/gi, '\n');
+  s = s.replace(/<\/?\s*(p|div|section|article|li|ul|ol|h[1-6]|blockquote|pre|hr)\b[^>]*>/gi, '\n');
+  // Strip remaining tags.
+  s = s.replace(/<[^>]+>/g, '');
+  s = decodeEntities(s);
+  // Collapse runs of spaces / tabs (newlines are kept as paragraph
+  // boundaries).
+  s = s.replace(/[ \t]+/g, ' ');
+  // Trim per line, then collapse 2+ blank lines → exactly one blank
+  // line (so paragraph breaks survive intact for the chunker).
+  s = s
+    .split('\n')
+    .map((line) => line.trim())
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+  return s;
+}
+
+function extractFirstTitle(html: string): string | null {
+  // Prefer the document <title> tag (Calibre puts the chapter name
+  // there); fall back to the first heading inside the body.
+  const t = TITLE_TAG_RE.exec(html);
+  if (t) {
+    const text = htmlToText(t[1]!).trim();
+    if (text.length > 0) return text;
+  }
+  const h = HEADING_RE.exec(html);
+  if (h) {
+    const text = htmlToText(h[1]!).trim();
+    if (text.length > 0) return text;
+  }
+  return null;
+}
+
+/**
+ * Parse an EPUB blob into ordered `{ title, body }` chapters.
+ *
+ * `epubBytes` is the raw archive (ArrayBuffer / Uint8Array / Buffer).
+ * Throws `EpubParseError` on malformed archives or missing OPF; the
+ * caller maps it to a 400 with the message verbatim so the user knows
+ * what went wrong with their file.
+ */
+export async function parseEpub(
+  epubBytes: ArrayBuffer | Uint8Array,
+): Promise<EpubChapter[]> {
+  let zip: JSZip;
+  try {
+    zip = await JSZip.loadAsync(epubBytes);
+  } catch (e) {
+    throw new EpubParseError(
+      `Could not open EPUB archive: ${(e as Error).message}`,
+    );
+  }
+
+  const containerEntry = zip.file('META-INF/container.xml');
+  if (!containerEntry) {
+    throw new EpubParseError('EPUB is missing META-INF/container.xml');
+  }
+  const containerXml = await containerEntry.async('string');
+  const opfMatch = OPF_PATH_RE.exec(containerXml);
+  if (!opfMatch) {
+    throw new EpubParseError('EPUB container.xml does not point to an OPF file');
+  }
+  const opfPath = opfMatch[1]!;
+  const opfEntry = zip.file(opfPath);
+  if (!opfEntry) {
+    throw new EpubParseError(`EPUB OPF file '${opfPath}' is missing from the archive`);
+  }
+  const opfXml = await opfEntry.async('string');
+
+  // Build manifest map: id → { href, mediaType }.
+  const manifest = new Map<string, { href: string; mediaType: string }>();
+  let m: RegExpExecArray | null;
+  while ((m = MANIFEST_ITEM_RE.exec(opfXml))) {
+    const attrs = m[1] ?? '';
+    const id = ATTR_RE('id').exec(attrs)?.[1];
+    const href = ATTR_RE('href').exec(attrs)?.[1];
+    const mediaType = ATTR_RE('media-type').exec(attrs)?.[1] ?? '';
+    if (id && href) manifest.set(id, { href, mediaType });
+  }
+
+  // Read the spine — the only canonical chapter order.
+  const spineIds: string[] = [];
+  let s: RegExpExecArray | null;
+  while ((s = SPINE_ITEMREF_RE.exec(opfXml))) {
+    spineIds.push(s[1]!);
+  }
+  if (spineIds.length === 0) {
+    throw new EpubParseError('EPUB spine is empty (no chapters to import)');
+  }
+
+  const chapters: EpubChapter[] = [];
+  for (const id of spineIds) {
+    const item = manifest.get(id);
+    if (!item) continue;
+    if (
+      item.mediaType &&
+      !item.mediaType.includes('xhtml') &&
+      !item.mediaType.includes('html')
+    ) {
+      // Some EPUBs put nav.xhtml in the spine — keep XHTML-ish, skip
+      // images / metadata / fonts.
+      continue;
+    }
+    const chapterPath = joinPath(opfPath, item.href);
+    const chapterEntry = zip.file(chapterPath);
+    if (!chapterEntry) continue;
+    const html = await chapterEntry.async('string');
+    const title = extractFirstTitle(html);
+    const body = htmlToText(html);
+    if (body.trim().length === 0) {
+      // Empty chapters (e.g. nav landmarks) are useless — skip them
+      // rather than persisting placeholder rows.
+      continue;
+    }
+    chapters.push({ title, body });
+  }
+  if (chapters.length === 0) {
+    throw new EpubParseError(
+      'EPUB contains no readable chapters (every spine item was empty or non-HTML)',
+    );
+  }
+  return chapters;
+}

--- a/apps/web/src/lib/server/texts/upload.test.ts
+++ b/apps/web/src/lib/server/texts/upload.test.ts
@@ -73,14 +73,58 @@ vi.mock('../db/index.js', () => ({
 
 const {
   TextValidationError,
+  EpubParseError,
   createPastedText,
   createTxtText,
+  createEpubText,
   estimateTokenCount,
   getOwnedText,
   MAX_PASTE_BYTES,
   MAX_TXT_BYTES,
+  MAX_EPUB_BYTES,
   MAX_TITLE_LEN,
 } = await import('./upload.js');
+
+const JSZip = (await import('jszip')).default;
+
+async function buildFixtureEpub(
+  chapters: Array<{ id: string; href: string; title: string; bodyHtml: string }>,
+): Promise<Uint8Array> {
+  const zip = new JSZip();
+  zip.file('mimetype', 'application/epub+zip');
+  zip.file(
+    'META-INF/container.xml',
+    `<?xml version="1.0"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>`,
+  );
+  const manifest = chapters
+    .map((c) => `<item id="${c.id}" href="${c.href}" media-type="application/xhtml+xml"/>`)
+    .join('\n');
+  const spine = chapters.map((c) => `<itemref idref="${c.id}"/>`).join('\n');
+  zip.file(
+    'OEBPS/content.opf',
+    `<?xml version="1.0"?>
+<package version="3.0">
+  <manifest>${manifest}</manifest>
+  <spine>${spine}</spine>
+</package>`,
+  );
+  for (const c of chapters) {
+    zip.file(
+      `OEBPS/${c.href}`,
+      `<?xml version="1.0"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head><title>${c.title}</title></head>
+<body>${c.bodyHtml}</body>
+</html>`,
+    );
+  }
+  return zip.generateAsync({ type: 'uint8array' });
+}
 
 const OWNER = { id: 'user-1' };
 
@@ -317,6 +361,106 @@ describe('createTxtText', () => {
       body: oversized,
     });
     // Did not throw.
+  });
+});
+
+// -----------------------------------------------------------------------
+// createEpubText (T-4.3)
+// -----------------------------------------------------------------------
+
+describe('createEpubText', () => {
+  it('parses an EPUB and inserts one chapter row per spine item', async () => {
+    stage([textRow({ sourceType: 'epub' })]);
+    stage([
+      chapterRow({ id: 'c0', idx: 0, body: 'one body.' }),
+      chapterRow({ id: 'c1', idx: 1, body: 'two body.' }),
+    ]);
+
+    const epubBytes = await buildFixtureEpub([
+      {
+        id: 'ch1',
+        href: 'ch1.xhtml',
+        title: 'Chapter One',
+        bodyHtml: '<p>one body.</p>',
+      },
+      {
+        id: 'ch2',
+        href: 'ch2.xhtml',
+        title: 'Chapter Two',
+        bodyHtml: '<p>two body.</p>',
+      },
+    ]);
+
+    const result = await createEpubText(OWNER, {
+      language: 'hi',
+      title: 'Imported novel',
+      epubBytes,
+    });
+
+    expect(result.chapters).toHaveLength(2);
+    const insertCalls = calls.filter(
+      (c): c is Extract<Call, { kind: 'insert' }> => c.kind === 'insert',
+    );
+    expect(insertCalls[0]!.values).toMatchObject({ sourceType: 'epub' });
+    const chapterValues = insertCalls[1]!.values as Array<{
+      idx: number;
+      title: string | null;
+      body: string;
+    }>;
+    expect(chapterValues).toHaveLength(2);
+    expect(chapterValues.map((c) => c.title)).toEqual(['Chapter One', 'Chapter Two']);
+    expect(chapterValues[0]!.body).toBe('one body.');
+  });
+
+  it('rejects an unsupported language without parsing', async () => {
+    const epubBytes = await buildFixtureEpub([
+      { id: 'ch1', href: 'ch1.xhtml', title: 'X', bodyHtml: '<p>body.</p>' },
+    ]);
+    await expect(
+      createEpubText(OWNER, { language: 'xx', title: 'X', epubBytes }),
+    ).rejects.toBeInstanceOf(TextValidationError);
+  });
+
+  it('rejects a missing title', async () => {
+    const epubBytes = await buildFixtureEpub([
+      { id: 'ch1', href: 'ch1.xhtml', title: 'X', bodyHtml: '<p>body.</p>' },
+    ]);
+    await expect(
+      createEpubText(OWNER, { language: 'hi', title: '', epubBytes }),
+    ).rejects.toBeInstanceOf(TextValidationError);
+  });
+
+  it('rejects an empty file', async () => {
+    await expect(
+      createEpubText(OWNER, {
+        language: 'hi',
+        title: 'X',
+        epubBytes: new Uint8Array(0),
+      }),
+    ).rejects.toBeInstanceOf(TextValidationError);
+  });
+
+  it('rejects an oversize archive', async () => {
+    // We don't actually allocate 50MB — just lie about the byte length
+    // via a fake ArrayBuffer subview that reports the cap.
+    const tooBig = new ArrayBuffer(MAX_EPUB_BYTES + 1);
+    await expect(
+      createEpubText(OWNER, {
+        language: 'hi',
+        title: 'X',
+        epubBytes: tooBig,
+      }),
+    ).rejects.toBeInstanceOf(TextValidationError);
+  });
+
+  it('surfaces parse failures as EpubParseError', async () => {
+    await expect(
+      createEpubText(OWNER, {
+        language: 'hi',
+        title: 'X',
+        epubBytes: new Uint8Array([1, 2, 3, 4]),
+      }),
+    ).rejects.toBeInstanceOf(EpubParseError);
   });
 });
 

--- a/apps/web/src/lib/server/texts/upload.ts
+++ b/apps/web/src/lib/server/texts/upload.ts
@@ -31,7 +31,14 @@ import { db, schema } from '../db/index.js';
 import type { LanguageCode } from '@ciareader/shared-types';
 import { isSupportedLanguage } from '@ciareader/shared-types';
 import type { Text, TextChapter, User } from '../db/schema.js';
-import { splitIntoChapters, estimateTokenCount } from './chunking.js';
+import {
+  splitIntoChapters,
+  estimateTokenCount,
+  type ChapterDraft,
+} from './chunking.js';
+import { parseEpub, EpubParseError } from './epub.js';
+
+export { EpubParseError };
 
 export class TextValidationError extends Error {
   constructor(
@@ -52,16 +59,20 @@ export const MAX_PASTE_BYTES = 1_000_000;
 /** Hard cap on a `.txt` upload (T-4.2). 10MB is enough for any
  * realistic novel + a generous margin — at ~3 bytes/codepoint for
  * Devanagari that's ~3M codepoints, well past anything a user would
- * realistically read in one go. EPUB uploads stream chapter-by-chapter
- * and don't pay a single-blob cap (T-4.3). */
+ * realistically read in one go. */
 export const MAX_TXT_BYTES = 10_000_000;
+
+/** Hard cap on the raw EPUB archive size (T-4.3). 50MB covers anything
+ * with reasonable images; bigger files almost always indicate
+ * embedded video / audio that we can't use anyway. */
+export const MAX_EPUB_BYTES = 50_000_000;
 
 /** Hard cap on the visible title; the library card and `<title>` tag
  * both render this without truncation. */
 export const MAX_TITLE_LEN = 200;
 export const MIN_TITLE_LEN = 1;
 
-export type SourceType = 'paste' | 'txt';
+export type SourceType = 'paste' | 'txt' | 'epub';
 
 export type CreatePastedTextInput = {
   language: string;
@@ -229,6 +240,100 @@ export async function createTxtText(
   const drafts = splitIntoChapters(body);
   return insertTextWithChapters(owner, {
     sourceType: 'txt',
+    language,
+    title,
+    chapters: drafts,
+    now,
+  });
+}
+
+export type CreateEpubTextInput = {
+  language: string;
+  title: string;
+  /** Raw EPUB archive bytes. */
+  epubBytes: ArrayBuffer | Uint8Array;
+};
+
+/**
+ * Create a text from an EPUB upload (T-4.3).
+ *
+ * EPUB chapter structure is authored — the spine is the canonical
+ * order, each spine item is a chapter — so we feed the parsed
+ * chapters straight into `text_chapters` without going through the
+ * paragraph auto-splitter. The chunker WOULD fire only if a single
+ * EPUB chapter is itself enormous (>50k tokens), which essentially
+ * never happens in real publishing.
+ *
+ * Per-chapter NFC normalization happens here rather than in the
+ * parser so the parser stays a pure XML/HTML utility usable elsewhere
+ * (e.g. an admin re-import path later).
+ */
+export async function createEpubText(
+  owner: Pick<User, 'id'>,
+  input: CreateEpubTextInput,
+  now: Date = new Date(),
+): Promise<CreatedText> {
+  if (!isSupportedLanguage(input.language)) {
+    throw new TextValidationError(
+      `Unsupported language '${input.language}' (expected one of: hi, mr, or)`,
+    );
+  }
+  const language = input.language as LanguageCode;
+  const title = normalizeTitle(input.title ?? '');
+  if (title.length < MIN_TITLE_LEN) {
+    throw new TextValidationError('title is required');
+  }
+  if (title.length > MAX_TITLE_LEN) {
+    throw new TextValidationError(`title exceeds ${MAX_TITLE_LEN} characters`);
+  }
+  const byteLength =
+    input.epubBytes instanceof Uint8Array
+      ? input.epubBytes.byteLength
+      : input.epubBytes.byteLength;
+  if (byteLength > MAX_EPUB_BYTES) {
+    throw new TextValidationError(
+      `EPUB exceeds ${MAX_EPUB_BYTES.toLocaleString()} bytes`,
+    );
+  }
+  if (byteLength === 0) {
+    throw new TextValidationError('EPUB file is empty');
+  }
+
+  const parsed = await parseEpub(input.epubBytes);
+
+  // For each parsed chapter, run it through the chunker — short
+  // chapters stay one row, freakishly long ones get split. We then
+  // re-number `idx` across the flattened result so the order is
+  // contiguous regardless of any per-chapter sub-splits.
+  const drafts: ChapterDraft[] = [];
+  let nextIdx = 0;
+  for (const c of parsed) {
+    const body = c.body.normalize('NFC').replace(/\r\n?/g, '\n');
+    const subChapters = splitIntoChapters(body);
+    for (let i = 0; i < subChapters.length; i += 1) {
+      const sub = subChapters[i]!;
+      // The first sub-chapter inherits the EPUB chapter's title; any
+      // additional splits within that chapter get a derived title or
+      // fall back to "{title} (cont.)".
+      let derivedTitle: string | null;
+      if (i === 0) derivedTitle = c.title;
+      else if (c.title) derivedTitle = `${c.title} (cont. ${i})`;
+      else derivedTitle = sub.title;
+      drafts.push({
+        idx: nextIdx,
+        title: derivedTitle,
+        body: sub.body,
+        tokenCount: sub.tokenCount,
+      });
+      nextIdx += 1;
+    }
+  }
+  if (drafts.length === 0) {
+    throw new TextValidationError('EPUB has no readable chapters');
+  }
+
+  return insertTextWithChapters(owner, {
+    sourceType: 'epub',
     language,
     title,
     chapters: drafts,

--- a/apps/web/src/routes/api/v1/texts/epub/+server.ts
+++ b/apps/web/src/routes/api/v1/texts/epub/+server.ts
@@ -1,0 +1,108 @@
+/**
+ * POST /api/v1/texts/epub (T-4.3).
+ *
+ * Multipart endpoint for EPUB uploads. The request body is form-data
+ * with three fields:
+ *
+ *   - `language` — 'hi' | 'mr' | 'or' (string)
+ *   - `title` — visible title (string; optional, defaults to filename)
+ *   - `file` — the .epub File blob
+ *
+ * We keep this on its own URL because EPUB is binary and JSON-encoding
+ * the bytes (base64 → JSON) would inflate by ~33% on the wire and
+ * force the client to parse the file twice. Multipart is the right
+ * primitive — every browser <input type="file"> form action posts it
+ * natively.
+ *
+ * Response shape mirrors POST /api/v1/texts (T-4.1/T-4.2): 201 with
+ * the new text metadata + `chapterCount` so the redirect target can
+ * surface "uploaded N chapters" in M5.
+ */
+import { error, json } from '@sveltejs/kit';
+
+import { requireUser } from '$lib/server/auth/require-user.js';
+import {
+  createEpubText,
+  EpubParseError,
+  TextValidationError,
+  MAX_EPUB_BYTES,
+  MAX_TITLE_LEN,
+  MIN_TITLE_LEN,
+} from '$lib/server/texts/upload.js';
+import type { RequestHandler } from './$types';
+
+const SUPPORTED_LANGS = new Set(['hi', 'mr', 'or']);
+
+export const POST: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  let fd: FormData;
+  try {
+    fd = await event.request.formData();
+  } catch {
+    throw error(400, 'Expected multipart/form-data body');
+  }
+  const language = fd.get('language')?.toString() ?? '';
+  const titleRaw = fd.get('title')?.toString() ?? '';
+  const file = fd.get('file');
+  if (!SUPPORTED_LANGS.has(language)) {
+    throw error(400, `Unsupported language '${language}'`);
+  }
+  if (!(file instanceof File)) {
+    throw error(400, 'Missing file field');
+  }
+  if (file.size === 0) {
+    throw error(400, 'File is empty');
+  }
+  if (file.size > MAX_EPUB_BYTES) {
+    throw error(
+      400,
+      `File exceeds ${MAX_EPUB_BYTES.toLocaleString()} bytes`,
+    );
+  }
+  // If no title was provided, fall back to the filename without the
+  // extension. Easier than asking the user to retype something they
+  // already named on disk.
+  let title = titleRaw.trim();
+  if (title.length === 0) {
+    title = file.name.replace(/\.epub$/i, '').trim();
+  }
+  if (title.length < MIN_TITLE_LEN) {
+    throw error(400, 'title is required');
+  }
+  if (title.length > MAX_TITLE_LEN) {
+    throw error(400, `title exceeds ${MAX_TITLE_LEN} characters`);
+  }
+
+  const epubBytes = new Uint8Array(await file.arrayBuffer());
+  try {
+    const created = await createEpubText(
+      { id: user.id },
+      {
+        language,
+        title,
+        epubBytes,
+      },
+    );
+    const { text } = created;
+    return json(
+      {
+        text: {
+          id: text.id,
+          ownerId: text.ownerId,
+          language: text.language,
+          title: text.title,
+          sourceType: text.sourceType,
+          status: text.status,
+          visibility: text.visibility,
+          createdAt: text.createdAt,
+        },
+        chapterCount: created.chapters.length,
+      },
+      { status: 201 },
+    );
+  } catch (err) {
+    if (err instanceof TextValidationError) throw error(err.status, err.message);
+    if (err instanceof EpubParseError) throw error(400, err.message);
+    throw err;
+  }
+};

--- a/apps/web/src/routes/api/v1/texts/epub/epub-server.test.ts
+++ b/apps/web/src/routes/api/v1/texts/epub/epub-server.test.ts
@@ -1,0 +1,169 @@
+// @vitest-environment node
+/**
+ * Route tests for POST /api/v1/texts/epub (T-4.3).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const createEpubText = vi.fn();
+const requireUser = vi.fn();
+
+vi.mock('$lib/server/texts/upload.js', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/texts/upload.js')>(
+    '$lib/server/texts/upload.js',
+  );
+  return {
+    ...actual,
+    createEpubText: (...a: unknown[]) => createEpubText(...a),
+  };
+});
+
+vi.mock('$lib/server/auth/require-user.js', () => ({
+  requireUser: (...a: unknown[]) => requireUser(...a),
+}));
+
+type PostFn = (typeof import('./+server.js'))['POST'];
+
+const USER = { id: 'user-1', role: 'user' as const };
+
+function buildEpubFile(bytes = new Uint8Array([1, 2, 3, 4]), name = 'novel.epub') {
+  return new File([bytes], name, { type: 'application/epub+zip' });
+}
+
+async function callPost(
+  fields: { language?: string; title?: string; file?: File | null },
+  user: typeof USER | null = USER,
+) {
+  if (user) {
+    requireUser.mockResolvedValueOnce(user);
+  } else {
+    requireUser.mockImplementationOnce(() => {
+      throw { status: 401 };
+    });
+  }
+  const fd = new FormData();
+  if (fields.language !== undefined) fd.append('language', fields.language);
+  if (fields.title !== undefined) fd.append('title', fields.title);
+  if (fields.file) fd.append('file', fields.file);
+
+  const { POST } = await import('./+server.js');
+  const event = {
+    params: {},
+    request: new Request('http://x/api/v1/texts/epub', {
+      method: 'POST',
+      body: fd,
+    }),
+  } as unknown as Parameters<PostFn>[0];
+  try {
+    return await POST(event);
+  } catch (e) {
+    return e as { status: number };
+  }
+}
+
+beforeEach(() => {
+  createEpubText.mockReset();
+  requireUser.mockReset();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('POST /api/v1/texts/epub', () => {
+  it('returns 201 with chapterCount on a happy path', async () => {
+    createEpubText.mockResolvedValueOnce({
+      text: {
+        id: 'text-1',
+        ownerId: USER.id,
+        language: 'hi',
+        title: 'My novel',
+        sourceType: 'epub',
+        status: 'pending',
+        visibility: 'private',
+        createdAt: new Date('2026-04-27T00:00:00Z'),
+      },
+      chapter: { id: 'c0' },
+      chapters: [{ id: 'c0' }, { id: 'c1' }, { id: 'c2' }],
+    });
+    const res = (await callPost({
+      language: 'hi',
+      title: 'My novel',
+      file: buildEpubFile(),
+    })) as Response;
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.text.sourceType).toBe('epub');
+    expect(json.chapterCount).toBe(3);
+  });
+
+  it('falls back to the filename when no title is supplied', async () => {
+    createEpubText.mockResolvedValueOnce({
+      text: {
+        id: 'text-1',
+        ownerId: USER.id,
+        language: 'hi',
+        title: 'autotitled',
+        sourceType: 'epub',
+        status: 'pending',
+        visibility: 'private',
+        createdAt: new Date(),
+      },
+      chapter: { id: 'c0' },
+      chapters: [{ id: 'c0' }],
+    });
+    await callPost({
+      language: 'hi',
+      file: buildEpubFile(undefined, 'A Hindi Novel.epub'),
+    });
+    expect(createEpubText).toHaveBeenCalledWith(
+      { id: USER.id },
+      expect.objectContaining({ title: 'A Hindi Novel' }),
+    );
+  });
+
+  it('rejects an unsupported language with 400', async () => {
+    const res = (await callPost({
+      language: 'xx',
+      title: 'X',
+      file: buildEpubFile(),
+    })) as { status: number };
+    expect(res.status).toBe(400);
+    expect(createEpubText).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing file with 400', async () => {
+    const res = (await callPost({ language: 'hi', title: 'X' })) as {
+      status: number;
+    };
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects an empty file with 400', async () => {
+    const res = (await callPost({
+      language: 'hi',
+      title: 'X',
+      file: buildEpubFile(new Uint8Array(0)),
+    })) as { status: number };
+    expect(res.status).toBe(400);
+  });
+
+  it('maps EpubParseError to 400', async () => {
+    const { EpubParseError } = await import('$lib/server/texts/upload.js');
+    createEpubText.mockRejectedValueOnce(new EpubParseError('bad zip'));
+    const res = (await callPost({
+      language: 'hi',
+      title: 'X',
+      file: buildEpubFile(),
+    })) as { status: number };
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const res = (await callPost(
+      { language: 'hi', title: 'X', file: buildEpubFile() },
+      null,
+    )) as { status: number };
+    expect(res.status).toBe(401);
+    expect(createEpubText).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/routes/upload/+page.server.ts
+++ b/apps/web/src/routes/upload/+page.server.ts
@@ -17,12 +17,16 @@ import { fail, redirect } from '@sveltejs/kit';
 import { z } from 'zod';
 
 import {
+  createEpubText,
   createPastedText,
   createTxtText,
+  EpubParseError,
   TextValidationError,
+  MAX_EPUB_BYTES,
   MAX_PASTE_BYTES,
   MAX_TXT_BYTES,
   MAX_TITLE_LEN,
+  MIN_TITLE_LEN,
 } from '$lib/server/texts/upload.js';
 import { LANGUAGES, SUPPORTED_LANGUAGE_CODES } from '@ciareader/shared-types';
 import type { Actions, PageServerLoad } from './$types';
@@ -65,6 +69,7 @@ export const load: PageServerLoad = async ({ locals, url }) => {
       // a server round-trip.
       maxPasteBytes: MAX_PASTE_BYTES,
       maxTxtBytes: MAX_TXT_BYTES,
+      maxEpubBytes: MAX_EPUB_BYTES,
     },
   };
 };
@@ -120,6 +125,88 @@ export const actions: Actions = {
           ok: false,
           message: err.message,
           values: raw,
+        });
+      }
+      throw err;
+    }
+  },
+
+  epub: async ({ request, locals }) => {
+    if (!locals.user) {
+      throw redirect(303, '/login?next=/upload');
+    }
+    const fd = await request.formData();
+    const language = fd.get('language')?.toString() ?? '';
+    const titleRaw = fd.get('title')?.toString() ?? '';
+    const file = fd.get('file');
+    if (
+      language !== 'hi' &&
+      language !== 'mr' &&
+      language !== 'or'
+    ) {
+      return fail(400, {
+        ok: false,
+        section: 'epub',
+        message: `Unsupported language '${language}'`,
+      });
+    }
+    if (!(file instanceof File)) {
+      return fail(400, {
+        ok: false,
+        section: 'epub',
+        message: 'Please select an .epub file to upload',
+      });
+    }
+    if (file.size === 0) {
+      return fail(400, {
+        ok: false,
+        section: 'epub',
+        message: 'EPUB file is empty',
+      });
+    }
+    if (file.size > MAX_EPUB_BYTES) {
+      return fail(400, {
+        ok: false,
+        section: 'epub',
+        message: `EPUB exceeds ${MAX_EPUB_BYTES.toLocaleString()} bytes`,
+      });
+    }
+    let title = titleRaw.trim();
+    if (title.length === 0) title = file.name.replace(/\.epub$/i, '').trim();
+    if (title.length < MIN_TITLE_LEN) {
+      return fail(400, {
+        ok: false,
+        section: 'epub',
+        message: 'title is required',
+      });
+    }
+    if (title.length > MAX_TITLE_LEN) {
+      return fail(400, {
+        ok: false,
+        section: 'epub',
+        message: `title exceeds ${MAX_TITLE_LEN} characters`,
+      });
+    }
+    const epubBytes = new Uint8Array(await file.arrayBuffer());
+    try {
+      const created = await createEpubText(
+        { id: locals.user.id },
+        { language, title, epubBytes },
+      );
+      throw redirect(303, `/texts/${created.text.id}`);
+    } catch (err) {
+      if (err instanceof TextValidationError) {
+        return fail(err.status, {
+          ok: false,
+          section: 'epub',
+          message: err.message,
+        });
+      }
+      if (err instanceof EpubParseError) {
+        return fail(400, {
+          ok: false,
+          section: 'epub',
+          message: err.message,
         });
       }
       throw err;

--- a/apps/web/src/routes/upload/+page.svelte
+++ b/apps/web/src/routes/upload/+page.svelte
@@ -43,7 +43,7 @@
     const lower = file.name.toLowerCase();
     if (lower.endsWith('.epub')) {
       dropMessage =
-        'EPUB upload is coming in T-4.3 — for now, paste the chapter text directly.';
+        `EPUB '${file.name}' selected — upload it via the EPUB section below.`;
       return;
     }
     if (!lower.endsWith('.txt')) {
@@ -66,6 +66,36 @@
       dropMessage = `Failed to read ${file.name}.`;
     }
   }
+
+  // The EPUB upload uses its own form action (multipart) rather than
+  // re-using the JSON paste/txt path. This separation keeps the JSON
+  // validator schema strict and avoids dragging EPUB-specific concerns
+  // (file picker, multipart, parser-driven errors) into the paste UI.
+  let epubLanguage = $state(
+    untrack(() => form?.values?.language ?? data.languages[0]!.code),
+  );
+  let epubTitle = $state('');
+  let epubFileName = $state<string | null>(null);
+  let epubFileSize = $state(0);
+
+  function onEpubPick(event: Event) {
+    const input = event.currentTarget as HTMLInputElement;
+    const file = input.files?.[0];
+    if (!file) {
+      epubFileName = null;
+      epubFileSize = 0;
+      return;
+    }
+    epubFileName = file.name;
+    epubFileSize = file.size;
+    if (!epubTitle) epubTitle = file.name.replace(/\.epub$/i, '');
+  }
+
+  const epubMessage = $derived(
+    form && 'section' in form && form.section === 'epub' && !form.ok
+      ? form.message
+      : null,
+  );
 
   function onDragOver(event: DragEvent) {
     event.preventDefault();
@@ -175,6 +205,71 @@
 
     <button type="submit" disabled={overLimit}>Upload</button>
   </form>
+
+  <hr class="divider" />
+
+  <section class="epub-section">
+    <h2>Upload an EPUB</h2>
+    <p class="sub">
+      Chapters are imported as authored — the EPUB's own table of
+      contents drives the chapter list. Up to {(
+        data.limits.maxEpubBytes / 1_000_000
+      ).toLocaleString()} MB.
+    </p>
+
+    {#if epubMessage}
+      <p class="err" role="alert">{epubMessage}</p>
+    {/if}
+
+    <form
+      method="post"
+      action="?/epub"
+      enctype="multipart/form-data"
+      use:enhance
+      class="stack"
+    >
+      <label>
+        Language
+        <select name="language" bind:value={epubLanguage} required>
+          {#each data.languages as lang (lang.code)}
+            <option value={lang.code}>
+              {lang.displayName} ({lang.nativeName})
+            </option>
+          {/each}
+        </select>
+      </label>
+
+      <label>
+        Title (optional — defaults to the filename)
+        <input
+          name="title"
+          bind:value={epubTitle}
+          maxlength={data.limits.maxTitleLength}
+          placeholder="e.g. The Far Pavilions"
+        />
+      </label>
+
+      <label>
+        EPUB file
+        <input
+          type="file"
+          name="file"
+          accept=".epub,application/epub+zip"
+          required
+          onchange={onEpubPick}
+        />
+      </label>
+
+      {#if epubFileName}
+        <p class="muted">
+          Selected: <code>{epubFileName}</code>
+          ({(epubFileSize / 1000).toFixed(1)} KB)
+        </p>
+      {/if}
+
+      <button type="submit" disabled={!epubFileName}>Upload EPUB</button>
+    </form>
+  </section>
 </div>
 
 <style>
@@ -289,5 +384,19 @@
   code {
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 0.85em;
+  }
+  .divider {
+    border: 0;
+    border-top: 1px solid var(--color-border);
+    margin: 2rem 0 1.25rem;
+  }
+  .epub-section h2 {
+    margin: 0 0 0.4rem;
+    font-size: 1.2rem;
+  }
+  .muted {
+    color: var(--color-fg-muted);
+    font-size: 0.85rem;
+    margin: 0 0 0.5rem;
   }
 </style>

--- a/apps/web/src/routes/upload/page-server.test.ts
+++ b/apps/web/src/routes/upload/page-server.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const createPastedText = vi.fn();
 const createTxtText = vi.fn();
+const createEpubText = vi.fn();
 
 vi.mock('$lib/server/texts/upload.js', async () => {
   const actual = await vi.importActual<typeof import('$lib/server/texts/upload.js')>(
@@ -15,6 +16,7 @@ vi.mock('$lib/server/texts/upload.js', async () => {
     ...actual,
     createPastedText: (...a: unknown[]) => createPastedText(...a),
     createTxtText: (...a: unknown[]) => createTxtText(...a),
+    createEpubText: (...a: unknown[]) => createEpubText(...a),
   };
 });
 
@@ -56,7 +58,28 @@ async function callAction(
 beforeEach(() => {
   createPastedText.mockReset();
   createTxtText.mockReset();
+  createEpubText.mockReset();
 });
+
+async function callEpubAction(
+  fields: { language?: string; title?: string; file?: File | null },
+  user: typeof USER | null = USER,
+) {
+  const { actions } = (await import('./+page.server.js')) as Mod;
+  const fd = new FormData();
+  if (fields.language !== undefined) fd.append('language', fields.language);
+  if (fields.title !== undefined) fd.append('title', fields.title);
+  if (fields.file) fd.append('file', fields.file);
+  const event = {
+    locals: { user },
+    request: { formData: () => Promise.resolve(fd) } as unknown as Request,
+  } as unknown as Parameters<Mod['actions']['epub']>[0];
+  try {
+    return await actions.epub!(event);
+  } catch (e) {
+    return e as { status: number; location?: string };
+  }
+}
 
 afterEach(() => {
   vi.resetModules();
@@ -162,6 +185,110 @@ describe('/upload default action', () => {
   it('redirects unauthenticated submissions to /login', async () => {
     const res = (await callAction(
       { language: 'hi', title: 'X', body: 'hello' },
+      null,
+    )) as { status: number; location: string };
+    expect(res.status).toBe(303);
+    expect(res.location).toContain('/login');
+  });
+});
+
+describe('/upload epub action', () => {
+  function fakeFile(size = 100, name = 'novel.epub') {
+    const bytes = new Uint8Array(size);
+    return new File([bytes], name, { type: 'application/epub+zip' });
+  }
+
+  it('creates an EPUB-sourced text and 303s to it', async () => {
+    createEpubText.mockResolvedValueOnce({
+      text: { id: 'text-3', ownerId: USER.id },
+      chapter: { id: 'c0' },
+      chapters: [{ id: 'c0' }, { id: 'c1' }],
+    });
+    const res = (await callEpubAction({
+      language: 'hi',
+      title: 'My EPUB',
+      file: fakeFile(),
+    })) as { status: number; location: string };
+    expect(res.status).toBe(303);
+    expect(res.location).toBe('/texts/text-3');
+    expect(createEpubText).toHaveBeenCalledWith(
+      { id: USER.id },
+      expect.objectContaining({ language: 'hi', title: 'My EPUB' }),
+    );
+  });
+
+  it('falls back to filename when no title is given', async () => {
+    createEpubText.mockResolvedValueOnce({
+      text: { id: 'text-3', ownerId: USER.id },
+      chapter: { id: 'c0' },
+      chapters: [{ id: 'c0' }],
+    });
+    await callEpubAction({
+      language: 'hi',
+      file: fakeFile(100, 'A Hindi Novel.epub'),
+    });
+    expect(createEpubText).toHaveBeenCalledWith(
+      { id: USER.id },
+      expect.objectContaining({ title: 'A Hindi Novel' }),
+    );
+  });
+
+  it('rejects an unsupported language with a section=epub fail', async () => {
+    const result = (await callEpubAction({
+      language: 'xx',
+      title: 'X',
+      file: fakeFile(),
+    })) as {
+      status: number;
+      data: { ok: boolean; section: string; message: string };
+    };
+    expect(result.status).toBe(400);
+    expect(result.data.section).toBe('epub');
+    expect(createEpubText).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing file', async () => {
+    const result = (await callEpubAction({
+      language: 'hi',
+      title: 'X',
+    })) as {
+      status: number;
+      data: { ok: boolean; section: string; message: string };
+    };
+    expect(result.status).toBe(400);
+    expect(result.data.section).toBe('epub');
+  });
+
+  it('rejects an empty file', async () => {
+    const result = (await callEpubAction({
+      language: 'hi',
+      title: 'X',
+      file: fakeFile(0),
+    })) as {
+      status: number;
+      data: { ok: boolean; section: string; message: string };
+    };
+    expect(result.status).toBe(400);
+  });
+
+  it('surfaces an EpubParseError as a section=epub fail', async () => {
+    const { EpubParseError } = await import('$lib/server/texts/upload.js');
+    createEpubText.mockRejectedValueOnce(new EpubParseError('bad zip'));
+    const result = (await callEpubAction({
+      language: 'hi',
+      title: 'X',
+      file: fakeFile(),
+    })) as {
+      status: number;
+      data: { ok: boolean; section: string; message: string };
+    };
+    expect(result.status).toBe(400);
+    expect(result.data.message).toMatch(/bad zip/);
+  });
+
+  it('redirects unauthenticated EPUB submissions to /login', async () => {
+    const res = (await callEpubAction(
+      { language: 'hi', title: 'X', file: fakeFile() },
       null,
     )) as { status: number; location: string };
     expect(res.status).toBe(303);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       jose:
         specifier: ^5.9.4
         version: 5.10.0
+      jszip:
+        specifier: ^3.10.1
+        version: 3.10.1
       nodemailer:
         specifier: ^6.9.15
         version: 6.10.1
@@ -1260,6 +1263,9 @@ packages:
     resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
     engines: {node: '>= 0.6'}
 
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1679,6 +1685,9 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -1686,6 +1695,9 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
@@ -1714,6 +1726,9 @@ packages:
 
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
+
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1768,6 +1783,9 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -1781,6 +1799,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lilconfig@2.1.0:
     resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
@@ -1884,6 +1905,9 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -1975,12 +1999,18 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -2013,6 +2043,9 @@ packages:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
     engines: {node: '>=6'}
 
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -2027,6 +2060,9 @@ packages:
 
   set-cookie-parser@3.1.0:
     resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -2071,6 +2107,9 @@ packages:
   string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -3275,6 +3314,8 @@ snapshots:
 
   cookie@0.6.0: {}
 
+  core-util-is@1.0.3: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -3687,12 +3728,16 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  immediate@3.0.6: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  inherits@2.0.4: {}
 
   is-core-module@2.16.1:
     dependencies:
@@ -3717,6 +3762,8 @@ snapshots:
   is-reference@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
+
+  isarray@1.0.0: {}
 
   isexe@2.0.0: {}
 
@@ -3791,6 +3838,13 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -3803,6 +3857,10 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   lilconfig@2.1.0: {}
 
@@ -3889,6 +3947,8 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  pako@1.0.11: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -3959,9 +4019,21 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  process-nextick-args@2.0.1: {}
+
   punycode@2.3.1: {}
 
   react-is@17.0.2: {}
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
 
   readdirp@4.1.2: {}
 
@@ -4015,6 +4087,8 @@ snapshots:
     dependencies:
       mri: 1.2.0
 
+  safe-buffer@5.1.2: {}
+
   safer-buffer@2.1.2: {}
 
   saxes@6.0.0:
@@ -4024,6 +4098,8 @@ snapshots:
   semver@7.7.4: {}
 
   set-cookie-parser@3.1.0: {}
+
+  setimmediate@1.0.5: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -4065,6 +4141,10 @@ snapshots:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
       strip-ansi: 7.2.0
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   strip-ansi@6.0.1:
     dependencies:


### PR DESCRIPTION
Closes #38

## Summary

Last text-ingest format: EPUB. Adds a small server-side parser (jszip + regex on the OPF + html-to-text stripper) and a multipart endpoint, plus a section in \`/upload\` that posts directly to it.

- **\`epub.ts\`** — opens the archive, walks \`container.xml → OPF → spine\`, returns \`{ title, body }\` per spine item. \`htmlToText\` strips \`<head>/<script>/<style>\` first so metadata doesn't leak into the body, converts block-level tags into paragraph boundaries, and decodes named + numeric HTML entities.
- **\`createEpubText\` service** — validates language/title/50MB-cap, parses, feeds each chapter through the chunker (so a freakishly long chapter still sub-splits at paragraph boundaries), inserts text + chapters with \`sourceType='epub'\`.
- **\`POST /api/v1/texts/epub\`** — multipart-form-data endpoint. Falls back to the filename when no title is provided.
- **\`/upload\` UI** — new EPUB section with its own form action; the \`.txt\` drop-zone above now points users at it instead of silently dropping \`.epub\` files.

## Test plan

- [x] \`pnpm --filter @ciareader/web test\` — 449/449 (35 new for T-4.3)
- [x] \`pnpm --filter @ciareader/web check\` — clean
- [x] \`pnpm --filter @ciareader/web lint\` — clean
- [x] coverage above 80% floor; texts module at 100% lines
- [ ] Manual: upload a real \`.epub\` via the UI, confirm \`/texts/[id]\` lists chapters with their authored titles
- [ ] Manual: upload a non-EPUB renamed to \`.epub\`, confirm a friendly parse-error message
- [ ] Manual: try to upload a 60MB EPUB, confirm the size cap rejects it