### PR TITLE
T-4.4: NLP job enqueue + status polling on the reader page

### DIFF
--- a/apps/web/drizzle/0007_silly_avengers.sql
+++ b/apps/web/drizzle/0007_silly_avengers.sql
@@ -1,0 +1,19 @@
+CREATE TYPE "public"."nlp_job_status" AS ENUM('pending', 'processing', 'completed', 'failed');--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "nlp_jobs" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"text_id" uuid NOT NULL,
+	"status" "nlp_job_status" DEFAULT 'pending' NOT NULL,
+	"error" text,
+	"started_at" timestamp with time zone,
+	"finished_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "nlp_jobs" ADD CONSTRAINT "nlp_jobs_text_id_texts_id_fk" FOREIGN KEY ("text_id") REFERENCES "public"."texts"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "nlp_jobs_text_idx" ON "nlp_jobs" USING btree ("text_id","created_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "nlp_jobs_status_idx" ON "nlp_jobs" USING btree ("status");

--- a/apps/web/drizzle/meta/0007_snapshot.json
+++ b/apps/web/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,1758 @@
+{
+  "id": "d45d6d2d-7cd1-43b2-9ad5-f86f375dbc33",
+  "prevId": "3a9545e4-5522-49e5-8021-a4e922c9a05d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.curator_languages": {
+      "name": "curator_languages",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "curator_languages_user_idx": {
+          "name": "curator_languages_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "curator_languages_user_id_users_id_fk": {
+          "name": "curator_languages_user_id_users_id_fk",
+          "tableFrom": "curator_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "curator_languages_granted_by_users_id_fk": {
+          "name": "curator_languages_granted_by_users_id_fk",
+          "tableFrom": "curator_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "curator_languages_user_id_language_pk": {
+          "name": "curator_languages_user_id_language_pk",
+          "columns": [
+            "user_id",
+            "language"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.dictionary_imports": {
+      "name": "dictionary_imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_name": {
+          "name": "source_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_at": {
+          "name": "run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lemmas_created": {
+          "name": "lemmas_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lemmas_updated": {
+          "name": "lemmas_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lemmas_skipped_curator_locked": {
+          "name": "lemmas_skipped_curator_locked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "translations_created": {
+          "name": "translations_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "translations_updated": {
+          "name": "translations_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "dictionary_imports_language_idx": {
+          "name": "dictionary_imports_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemma_edit_history": {
+      "name": "lemma_edit_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "editor_id": {
+          "name": "editor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "lemma_edit_change_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change": {
+          "name": "change",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_edit_history_lemma_idx": {
+          "name": "lemma_edit_history_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_edit_history_editor_idx": {
+          "name": "lemma_edit_history_editor_idx",
+          "columns": [
+            {
+              "expression": "editor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_edit_history_lemma_id_lemmas_id_fk": {
+          "name": "lemma_edit_history_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_edit_history",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lemma_edit_history_editor_id_users_id_fk": {
+          "name": "lemma_edit_history_editor_id_users_id_fk",
+          "tableFrom": "lemma_edit_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "editor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemma_forms": {
+      "name": "lemma_forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "romanization": {
+          "name": "romanization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_forms_lemma_idx": {
+          "name": "lemma_forms_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_forms_surface_idx": {
+          "name": "lemma_forms_surface_idx",
+          "columns": [
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_forms_lemma_id_lemmas_id_fk": {
+          "name": "lemma_forms_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_forms",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemmas": {
+      "name": "lemmas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headword": {
+          "name": "headword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos": {
+          "name": "pos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script": {
+          "name": "script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gloss_default": {
+          "name": "gloss_default",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_rank": {
+          "name": "frequency_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "translation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "curator_locked": {
+          "name": "curator_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemmas_language_idx": {
+          "name": "lemmas_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_language_frequency_idx": {
+          "name": "lemmas_language_frequency_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "frequency_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_source_lookup_idx": {
+          "name": "lemmas_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lemmas_language_headword_pos_uq": {
+          "name": "lemmas_language_headword_pos_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "language",
+            "headword",
+            "pos"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.magic_links": {
+      "name": "magic_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "magic_links_user_idx": {
+          "name": "magic_links_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "magic_links_expires_idx": {
+          "name": "magic_links_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "magic_links_user_id_users_id_fk": {
+          "name": "magic_links_user_id_users_id_fk",
+          "tableFrom": "magic_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.nlp_jobs": {
+      "name": "nlp_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "nlp_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nlp_jobs_text_idx": {
+          "name": "nlp_jobs_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nlp_jobs_status_idx": {
+          "name": "nlp_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nlp_jobs_text_id_texts_id_fk": {
+          "name": "nlp_jobs_text_id_texts_id_fk",
+          "tableFrom": "nlp_jobs",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by": {
+          "name": "replaced_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "refresh_tokens_user_idx": {
+          "name": "refresh_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_expires_idx": {
+          "name": "refresh_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.text_chapters": {
+      "name": "text_chapters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idx": {
+          "name": "idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "text_chapters_text_idx": {
+          "name": "text_chapters_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_chapters_text_id_texts_id_fk": {
+          "name": "text_chapters_text_id_texts_id_fk",
+          "tableFrom": "text_chapters",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "text_chapters_text_idx_uq": {
+          "name": "text_chapters_text_idx_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "text_id",
+            "idx"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.texts": {
+      "name": "texts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "status_error": {
+          "name": "status_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "texts_owner_idx": {
+          "name": "texts_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "texts_visibility_idx": {
+          "name": "texts_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "texts_owner_id_users_id_fk": {
+          "name": "texts_owner_id_users_id_fk",
+          "tableFrom": "texts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.translations": {
+      "name": "translations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "translation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_translation_id": {
+          "name": "parent_translation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_language": {
+          "name": "target_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "translations_lemma_idx": {
+          "name": "translations_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translations_submitted_by_idx": {
+          "name": "translations_submitted_by_idx",
+          "columns": [
+            {
+              "expression": "submitted_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translations_source_lookup_idx": {
+          "name": "translations_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "translations_lemma_id_lemmas_id_fk": {
+          "name": "translations_lemma_id_lemmas_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "translations_submitted_by_users_id_fk": {
+          "name": "translations_submitted_by_users_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "translations_parent_translation_id_translations_id_fk": {
+          "name": "translations_parent_translation_id_translations_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "translations",
+          "columnsFrom": [
+            "parent_translation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_languages": {
+      "name": "user_languages",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script_preference": {
+          "name": "script_preference",
+          "type": "script_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "romanization_scheme": {
+          "name": "romanization_scheme",
+          "type": "romanization_scheme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'iso15919'"
+        },
+        "known_words_count_cache": {
+          "name": "known_words_count_cache",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reader_layout_mode": {
+          "name": "reader_layout_mode",
+          "type": "reader_layout_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'page'"
+        },
+        "words_per_page": {
+          "name": "words_per_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 250
+        },
+        "font_family": {
+          "name": "font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_size": {
+          "name": "font_size",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 18
+        },
+        "line_spacing": {
+          "name": "line_spacing",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1.6
+        },
+        "highlight_style": {
+          "name": "highlight_style",
+          "type": "highlight_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'background'"
+        },
+        "baseline": {
+          "name": "baseline",
+          "type": "language_baseline",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_languages_user_id_users_id_fk": {
+          "name": "user_languages_user_id_users_id_fk",
+          "tableFrom": "user_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_languages_user_id_language_pk": {
+          "name": "user_languages_user_id_language_pk",
+          "columns": [
+            "user_id",
+            "language"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_preference": {
+          "name": "theme_preference",
+          "type": "theme_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarded_at": {
+          "name": "onboarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    }
+  },
+  "enums": {
+    "public.highlight_style": {
+      "name": "highlight_style",
+      "schema": "public",
+      "values": [
+        "underline",
+        "background",
+        "colored_text"
+      ]
+    },
+    "public.language": {
+      "name": "language",
+      "schema": "public",
+      "values": [
+        "hi",
+        "mr",
+        "or"
+      ]
+    },
+    "public.language_baseline": {
+      "name": "language_baseline",
+      "schema": "public",
+      "values": [
+        "none",
+        "beginner",
+        "intermediate"
+      ]
+    },
+    "public.lemma_edit_change_type": {
+      "name": "lemma_edit_change_type",
+      "schema": "public",
+      "values": [
+        "lemma_update",
+        "lemma_unlock",
+        "lemma_lock",
+        "translation_insert",
+        "translation_update",
+        "translation_hide",
+        "translation_unhide",
+        "form_insert",
+        "form_delete",
+        "lemma_merge",
+        "lemma_split"
+      ]
+    },
+    "public.nlp_job_status": {
+      "name": "nlp_job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.reader_layout_mode": {
+      "name": "reader_layout_mode",
+      "schema": "public",
+      "values": [
+        "page",
+        "paged_scroll",
+        "continuous"
+      ]
+    },
+    "public.romanization_scheme": {
+      "name": "romanization_scheme",
+      "schema": "public",
+      "values": [
+        "iso15919",
+        "iast",
+        "hunterian",
+        "itrans"
+      ]
+    },
+    "public.script_preference": {
+      "name": "script_preference",
+      "schema": "public",
+      "values": [
+        "native",
+        "native_with_romanization",
+        "romanization_only"
+      ]
+    },
+    "public.text_source_type": {
+      "name": "text_source_type",
+      "schema": "public",
+      "values": [
+        "paste",
+        "txt",
+        "epub"
+      ]
+    },
+    "public.text_status": {
+      "name": "text_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.text_visibility": {
+      "name": "text_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "shared",
+        "official"
+      ]
+    },
+    "public.theme_preference": {
+      "name": "theme_preference",
+      "schema": "public",
+      "values": [
+        "system",
+        "light",
+        "dark"
+      ]
+    },
+    "public.translation_source": {
+      "name": "translation_source",
+      "schema": "public",
+      "values": [
+        "official_dictionary",
+        "curator",
+        "user"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "curator",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1777299520720,
       "tag": "0006_public_bedlam",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1777301379511,
+      "tag": "0007_silly_avengers",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/src/lib/server/db/schema.ts
+++ b/apps/web/src/lib/server/db/schema.ts
@@ -556,5 +556,49 @@ export type Translation = InferSelectModel<typeof translations>;
 export type DictionaryImport = InferSelectModel<typeof dictionaryImports>;
 export type CuratorLanguage = InferSelectModel<typeof curatorLanguages>;
 export type LemmaEditHistoryEntry = InferSelectModel<typeof lemmaEditHistory>;
+/**
+ * NLP job bookkeeping (T-4.4).
+ *
+ * One row per "process this text" job. Inserted by the upload service
+ * right after the `texts` row + chapters land; the NLP worker (T-2.6)
+ * consumes from a Redis queue and writes back to this table when it
+ * picks the job up, finishes successfully, or hits an error.
+ *
+ * Why a separate table from `texts.status`:
+ *  - A text can be re-processed (T-6.8 admin re-run) without dropping
+ *    the original audit trail; a new `nlp_jobs` row records the
+ *    second run while the previous one stays in history.
+ *  - Errors are captured per-job, not per-text — useful when the
+ *    second attempt succeeds.
+ *  - The web UI's status badge reads from `texts.status`; this table
+ *    drives admin/monitoring views.
+ */
+export const nlpJobStatus = pgEnum('nlp_job_status', [
+  'pending',
+  'processing',
+  'completed',
+  'failed',
+]);
+
+export const nlpJobs = pgTable(
+  'nlp_jobs',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    textId: uuid('text_id')
+      .notNull()
+      .references(() => texts.id, { onDelete: 'cascade' }),
+    status: nlpJobStatus('status').notNull().default('pending'),
+    error: text('error'),
+    startedAt: timestamp('started_at', { withTimezone: true }),
+    finishedAt: timestamp('finished_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    textIdx: index('nlp_jobs_text_idx').on(t.textId, t.createdAt),
+    statusIdx: index('nlp_jobs_status_idx').on(t.status),
+  }),
+);
+
 export type Text = InferSelectModel<typeof texts>;
 export type TextChapter = InferSelectModel<typeof textChapters>;
+export type NlpJob = InferSelectModel<typeof nlpJobs>;

--- a/apps/web/src/lib/server/texts/jobs.test.ts
+++ b/apps/web/src/lib/server/texts/jobs.test.ts
@@ -1,0 +1,233 @@
+// @vitest-environment node
+/**
+ * Unit tests for the NLP job lifecycle helpers (T-4.4).
+ *
+ * Same staged-mock pattern as the rest of lib/server/texts.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Call =
+  | { kind: 'select' }
+  | { kind: 'update'; set?: unknown }
+  | { kind: 'insert'; values?: unknown };
+const calls: Call[] = [];
+
+const staged: Array<unknown[]> = [];
+function stage(rows: unknown[]) {
+  staged.push(rows);
+}
+function nextStaged(): unknown[] {
+  const v = staged.shift();
+  if (!v) throw new Error('Test bug: no staged result available');
+  return v;
+}
+
+function makeSelectChain() {
+  const chain: Record<string, unknown> = {};
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.limit = vi.fn(() => chain);
+  chain.orderBy = vi.fn(() => chain);
+  chain.then = (resolve: (v: unknown) => unknown) => resolve(nextStaged());
+  return chain;
+}
+
+function makeUpdateChain() {
+  const entry: Call = { kind: 'update' };
+  calls.push(entry);
+  const chain: Record<string, unknown> = {};
+  chain.set = vi.fn((v: unknown) => {
+    entry.set = v;
+    return chain;
+  });
+  chain.where = vi.fn(() => chain);
+  chain.then = (resolve: (v: unknown) => unknown) => resolve(undefined);
+  return chain;
+}
+
+function makeInsertChain() {
+  const entry: Call = { kind: 'insert' };
+  calls.push(entry);
+  const chain: Record<string, unknown> = {};
+  chain.values = vi.fn((v: unknown) => {
+    entry.values = v;
+    return chain;
+  });
+  chain.returning = vi.fn(() => nextStaged());
+  return chain;
+}
+
+const selectFn = vi.fn(() => {
+  calls.push({ kind: 'select' });
+  return makeSelectChain();
+});
+const updateFn = vi.fn(() => makeUpdateChain());
+const insertFn = vi.fn(() => makeInsertChain());
+
+vi.mock('../db/index.js', () => ({
+  db: {
+    select: () => selectFn(),
+    update: () => updateFn(),
+    insert: () => insertFn(),
+  },
+  schema: {
+    texts: { id: 'texts.id', ownerId: 'texts.owner_id' },
+    nlpJobs: {
+      id: 'nlp_jobs.id',
+      textId: 'nlp_jobs.text_id',
+      status: 'nlp_jobs.status',
+      createdAt: 'nlp_jobs.created_at',
+    },
+  },
+}));
+
+const {
+  enqueueNlpJob,
+  markTextProcessing,
+  markTextReady,
+  markTextFailed,
+  getTextStatus,
+  setJobDispatcher,
+  resetJobDispatcher,
+} = await import('./jobs.js');
+
+beforeEach(() => {
+  calls.length = 0;
+  staged.length = 0;
+  selectFn.mockClear();
+  updateFn.mockClear();
+  insertFn.mockClear();
+  resetJobDispatcher();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  resetJobDispatcher();
+});
+
+describe('enqueueNlpJob', () => {
+  it('inserts an nlp_jobs row and dispatches via the active dispatcher', async () => {
+    stage([
+      {
+        id: 'job-1',
+        textId: 'text-1',
+        status: 'pending',
+        createdAt: new Date(),
+      },
+    ]);
+    const dispatch = vi.fn().mockResolvedValueOnce(undefined);
+    setJobDispatcher({ dispatch });
+
+    const result = await enqueueNlpJob({
+      textId: 'text-1',
+      chapterIds: ['c0', 'c1'],
+    });
+    expect(result.job.id).toBe('job-1');
+
+    const inserts = calls.filter(
+      (c): c is Extract<Call, { kind: 'insert' }> => c.kind === 'insert',
+    );
+    expect(inserts).toHaveLength(1);
+    expect(inserts[0]!.values).toMatchObject({
+      textId: 'text-1',
+      status: 'pending',
+    });
+    expect(dispatch).toHaveBeenCalledWith({
+      jobId: 'job-1',
+      textId: 'text-1',
+      chapterIds: ['c0', 'c1'],
+    });
+  });
+
+  it('uses the no-op dispatcher by default (no exception, no observable side-effect)', async () => {
+    stage([
+      {
+        id: 'job-2',
+        textId: 'text-2',
+        status: 'pending',
+        createdAt: new Date(),
+      },
+    ]);
+    const result = await enqueueNlpJob({
+      textId: 'text-2',
+      chapterIds: ['c0'],
+    });
+    expect(result.job.id).toBe('job-2');
+  });
+});
+
+describe('markTextProcessing / Ready / Failed', () => {
+  it('markTextProcessing flips text + job to processing', async () => {
+    await markTextProcessing('text-1');
+    const updates = calls.filter(
+      (c): c is Extract<Call, { kind: 'update' }> => c.kind === 'update',
+    );
+    expect(updates).toHaveLength(2);
+    expect(updates[0]!.set).toMatchObject({ status: 'processing' });
+    expect(updates[1]!.set).toMatchObject({ status: 'processing' });
+  });
+
+  it('markTextReady flips text to ready and job to completed', async () => {
+    await markTextReady('text-1');
+    const updates = calls.filter(
+      (c): c is Extract<Call, { kind: 'update' }> => c.kind === 'update',
+    );
+    expect(updates[0]!.set).toMatchObject({ status: 'ready', statusError: null });
+    expect(updates[1]!.set).toMatchObject({ status: 'completed' });
+  });
+
+  it('markTextFailed truncates very long error messages', async () => {
+    const longErr = 'x'.repeat(2000);
+    await markTextFailed('text-1', longErr);
+    const updates = calls.filter(
+      (c): c is Extract<Call, { kind: 'update' }> => c.kind === 'update',
+    );
+    const textErr = (updates[0]!.set as { statusError: string }).statusError;
+    expect(textErr.length).toBeLessThanOrEqual(1001);
+    expect(textErr.endsWith('…')).toBe(true);
+  });
+});
+
+describe('getTextStatus', () => {
+  it('returns status + latest job for the owner', async () => {
+    stage([
+      {
+        id: 'text-1',
+        ownerId: 'user-1',
+        status: 'processing',
+        statusError: null,
+      },
+    ]);
+    stage([
+      {
+        id: 'job-1',
+        textId: 'text-1',
+        status: 'processing',
+        startedAt: new Date(),
+      },
+    ]);
+    const view = await getTextStatus({ id: 'user-1' }, 'text-1');
+    expect(view).not.toBeNull();
+    expect(view!.status).toBe('processing');
+    expect(view!.job?.id).toBe('job-1');
+  });
+
+  it('returns null when the text does not exist', async () => {
+    stage([]);
+    const view = await getTextStatus({ id: 'user-1' }, 'missing');
+    expect(view).toBeNull();
+  });
+
+  it('returns null when the viewer is not the owner', async () => {
+    stage([{ id: 'text-1', ownerId: 'someone-else', status: 'pending' }]);
+    const view = await getTextStatus({ id: 'user-1' }, 'text-1');
+    expect(view).toBeNull();
+  });
+
+  it('returns a null job when no nlp_jobs row exists', async () => {
+    stage([{ id: 'text-1', ownerId: 'user-1', status: 'pending', statusError: null }]);
+    stage([]);
+    const view = await getTextStatus({ id: 'user-1' }, 'text-1');
+    expect(view!.job).toBeNull();
+  });
+});

--- a/apps/web/src/lib/server/texts/jobs.ts
+++ b/apps/web/src/lib/server/texts/jobs.ts
@@ -1,0 +1,181 @@
+/**
+ * NLP job lifecycle helpers (T-4.4).
+ *
+ * Every uploaded text needs to be tokenized + lemmatized before the
+ * reader can show known-words or pop-ups. The actual NLP work is an
+ * arq job in services/nlp; this module is the web app's view of the
+ * lifecycle:
+ *
+ *   - `enqueueNlpJob(textId)` — called right after upload. Inserts
+ *     the bookkeeping row in `nlp_jobs` and dispatches via the
+ *     pluggable `JobDispatcher`. The default dispatcher is a no-op,
+ *     which is fine for tests + dev where the worker isn't running;
+ *     the prod wiring (Redis push + arq pickup) lands as a
+ *     dispatcher implementation in T-13.x.
+ *   - `markTextProcessing` / `markTextReady` / `markTextFailed` —
+ *     status transitions the worker calls back into via an admin
+ *     endpoint. Mirrors the NLP service's `TextStore` contract from
+ *     services/nlp/app/worker/store.py so the worker can be wired
+ *     against Postgres or against a fake.
+ *   - `getTextStatus(textId, viewer)` — polling endpoint backing the
+ *     reader's "processing" → "ready" UX. Owner-scoped; null for
+ *     anyone else (we don't leak text existence).
+ */
+import { desc, eq } from 'drizzle-orm';
+
+import { db, schema } from '../db/index.js';
+import type { NlpJob, Text, User } from '../db/schema.js';
+
+/**
+ * Pluggable transport for actually triggering the worker. The default
+ * implementation is a no-op — fine for tests + early dev. A later
+ * ticket adds a Redis-backed dispatcher that pushes onto the arq
+ * queue. Keeping this an injected interface (rather than a hardcoded
+ * Redis call) means tests don't need a Redis mock, and the prod
+ * dispatcher can be swapped without touching upload code.
+ */
+export interface JobDispatcher {
+  dispatch(args: { jobId: string; textId: string; chapterIds: string[] }): Promise<void>;
+}
+
+const NOOP_DISPATCHER: JobDispatcher = {
+  async dispatch() {
+    // Intentionally empty — see file header.
+  },
+};
+
+let activeDispatcher: JobDispatcher = NOOP_DISPATCHER;
+
+/**
+ * Swap the dispatcher used by `enqueueNlpJob`. Production wiring calls
+ * this once at boot with the Redis-backed implementation; tests can
+ * pass a spy here.
+ */
+export function setJobDispatcher(d: JobDispatcher): void {
+  activeDispatcher = d;
+}
+
+export function resetJobDispatcher(): void {
+  activeDispatcher = NOOP_DISPATCHER;
+}
+
+export type EnqueueResult = {
+  job: NlpJob;
+};
+
+/**
+ * Insert a `nlp_jobs` row and tell the dispatcher to wake the worker.
+ * The text's own `status` stays `pending` until the worker flips it
+ * via `markTextProcessing` — splitting "queued" from "started" lets
+ * the UI show "waiting in queue" vs "processing" if we add that
+ * distinction later.
+ */
+export async function enqueueNlpJob(args: {
+  textId: string;
+  chapterIds: string[];
+  now?: Date;
+}): Promise<EnqueueResult> {
+  const now = args.now ?? new Date();
+  const [job] = await db
+    .insert(schema.nlpJobs)
+    .values({
+      textId: args.textId,
+      status: 'pending',
+      createdAt: now,
+    })
+    .returning();
+  if (!job) throw new Error('Failed to insert nlp_jobs row');
+  await activeDispatcher.dispatch({
+    jobId: (job as NlpJob).id,
+    textId: args.textId,
+    chapterIds: args.chapterIds,
+  });
+  return { job: job as NlpJob };
+}
+
+/** Worker callback: mark a text as actively being processed. */
+export async function markTextProcessing(
+  textId: string,
+  now: Date = new Date(),
+): Promise<void> {
+  await db
+    .update(schema.texts)
+    .set({ status: 'processing', statusError: null, updatedAt: now })
+    .where(eq(schema.texts.id, textId));
+  await db
+    .update(schema.nlpJobs)
+    .set({ status: 'processing', startedAt: now })
+    .where(eq(schema.nlpJobs.textId, textId));
+}
+
+/** Worker callback: tokenization succeeded. */
+export async function markTextReady(
+  textId: string,
+  now: Date = new Date(),
+): Promise<void> {
+  await db
+    .update(schema.texts)
+    .set({ status: 'ready', statusError: null, updatedAt: now })
+    .where(eq(schema.texts.id, textId));
+  await db
+    .update(schema.nlpJobs)
+    .set({ status: 'completed', finishedAt: now })
+    .where(eq(schema.nlpJobs.textId, textId));
+}
+
+/** Worker callback: tokenization failed. The error message is shown in
+ * the reader's status badge, so it should be human-friendly (the
+ * worker truncates long Python tracebacks to a single line). */
+export async function markTextFailed(
+  textId: string,
+  error: string,
+  now: Date = new Date(),
+): Promise<void> {
+  const trimmed = error.length > 1000 ? error.slice(0, 1000) + '…' : error;
+  await db
+    .update(schema.texts)
+    .set({ status: 'failed', statusError: trimmed, updatedAt: now })
+    .where(eq(schema.texts.id, textId));
+  await db
+    .update(schema.nlpJobs)
+    .set({ status: 'failed', error: trimmed, finishedAt: now })
+    .where(eq(schema.nlpJobs.textId, textId));
+}
+
+export type StatusView = {
+  status: Text['status'];
+  statusError: string | null;
+  /** Most recent job tied to this text, or null if none was queued
+   * (shouldn't happen in normal flow but the polling UI shouldn't
+   * crash if it does). */
+  job: NlpJob | null;
+};
+
+/**
+ * Owner-scoped status lookup for the polling endpoint. Returns null
+ * for non-owners + missing texts; the endpoint maps that to 404 so
+ * we don't leak text existence.
+ */
+export async function getTextStatus(
+  viewer: Pick<User, 'id'>,
+  textId: string,
+): Promise<StatusView | null> {
+  const [text] = await db
+    .select()
+    .from(schema.texts)
+    .where(eq(schema.texts.id, textId))
+    .limit(1);
+  if (!text) return null;
+  if ((text as Text).ownerId !== viewer.id) return null;
+  const [job] = await db
+    .select()
+    .from(schema.nlpJobs)
+    .where(eq(schema.nlpJobs.textId, textId))
+    .orderBy(desc(schema.nlpJobs.createdAt))
+    .limit(1);
+  return {
+    status: (text as Text).status,
+    statusError: (text as Text).statusError,
+    job: (job as NlpJob | undefined) ?? null,
+  };
+}

--- a/apps/web/src/lib/server/texts/upload.test.ts
+++ b/apps/web/src/lib/server/texts/upload.test.ts
@@ -68,6 +68,12 @@ vi.mock('../db/index.js', () => ({
       textId: 'text_chapters.text_id',
       idx: 'text_chapters.idx',
     },
+    nlpJobs: {
+      id: 'nlp_jobs.id',
+      textId: 'nlp_jobs.text_id',
+      status: 'nlp_jobs.status',
+      createdAt: 'nlp_jobs.created_at',
+    },
   },
 }));
 
@@ -157,6 +163,31 @@ function chapterRow(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function jobRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'job-1',
+    textId: 'text-1',
+    status: 'pending',
+    error: null,
+    startedAt: null,
+    finishedAt: null,
+    createdAt: new Date(),
+    ...overrides,
+  };
+}
+
+/** Convenience: stage all three returning() rows for a happy-path
+ * create-text call (text + chapters + nlp_jobs). */
+function stageHappyPath(opts: {
+  text?: ReturnType<typeof textRow>;
+  chapters?: ReturnType<typeof chapterRow>[];
+  job?: ReturnType<typeof jobRow>;
+} = {}) {
+  stage([opts.text ?? textRow()]);
+  stage(opts.chapters ?? [chapterRow()]);
+  stage([opts.job ?? jobRow()]);
+}
+
 beforeEach(() => {
   calls.length = 0;
   staged.length = 0;
@@ -173,9 +204,8 @@ afterEach(() => {
 // -----------------------------------------------------------------------
 
 describe('createPastedText', () => {
-  it('inserts a text + first chapter and returns both', async () => {
-    stage([textRow()]);
-    stage([chapterRow()]);
+  it('inserts a text + first chapter + nlp_jobs row, returns text/chapters', async () => {
+    stageHappyPath();
 
     const result = await createPastedText(OWNER, {
       language: 'hi',
@@ -188,7 +218,8 @@ describe('createPastedText', () => {
     const insertCalls = calls.filter(
       (c): c is Extract<Call, { kind: 'insert' }> => c.kind === 'insert',
     );
-    expect(insertCalls).toHaveLength(2);
+    // T-4.4: text + chapters + nlp_jobs.
+    expect(insertCalls).toHaveLength(3);
     expect(insertCalls[0]!.values).toMatchObject({
       ownerId: OWNER.id,
       language: 'hi',
@@ -205,12 +236,18 @@ describe('createPastedText', () => {
       idx: 0,
       title: null,
     });
+    // nlp_jobs insert (T-4.4).
+    expect(insertCalls[2]!.values).toMatchObject({
+      textId: 'text-1',
+      status: 'pending',
+    });
   });
 
   it('NFC-normalises body and flattens CRLF', async () => {
     stage([textRow()]);
     const captured = chapterRow({ body: '' });
     stage([captured]);
+    stage([jobRow()]);
 
     // Decomposed form + Windows line endings.
     const body = 'line one\r\nline two\rline three'.normalize('NFD');
@@ -287,8 +324,10 @@ describe('createPastedText', () => {
 
 describe('createTxtText', () => {
   it('inserts a single chapter for a short body', async () => {
-    stage([textRow({ sourceType: 'txt' })]);
-    stage([chapterRow({ idx: 0 })]);
+    stageHappyPath({
+      text: textRow({ sourceType: 'txt' }),
+      chapters: [chapterRow({ idx: 0 })],
+    });
 
     const result = await createTxtText(OWNER, {
       language: 'hi',
@@ -313,6 +352,7 @@ describe('createTxtText', () => {
       chapterRow({ id: 'c1', idx: 1 }),
       chapterRow({ id: 'c2', idx: 2 }),
     ]);
+    stage([jobRow()]);
 
     const body = ['# One', 'first chapter.', '---', '# Two', 'second.', '---', 'third.'].join(
       '\n',
@@ -351,8 +391,10 @@ describe('createTxtText', () => {
   });
 
   it('accepts a body the paste path would reject (between paste-cap and txt-cap)', async () => {
-    stage([textRow({ sourceType: 'txt' })]);
-    stage([chapterRow({ idx: 0 })]);
+    stageHappyPath({
+      text: textRow({ sourceType: 'txt' }),
+      chapters: [chapterRow({ idx: 0 })],
+    });
     // Build a body just over the paste cap but well under the .txt cap.
     const oversized = 'a'.repeat(MAX_PASTE_BYTES + 100);
     await createTxtText(OWNER, {
@@ -375,6 +417,7 @@ describe('createEpubText', () => {
       chapterRow({ id: 'c0', idx: 0, body: 'one body.' }),
       chapterRow({ id: 'c1', idx: 1, body: 'two body.' }),
     ]);
+    stage([jobRow()]);
 
     const epubBytes = await buildFixtureEpub([
       {

--- a/apps/web/src/lib/server/texts/upload.ts
+++ b/apps/web/src/lib/server/texts/upload.ts
@@ -37,6 +37,7 @@ import {
   type ChapterDraft,
 } from './chunking.js';
 import { parseEpub, EpubParseError } from './epub.js';
+import { enqueueNlpJob } from './jobs.js';
 
 export { EpubParseError };
 
@@ -195,6 +196,15 @@ async function insertTextWithChapters(
   // Sort defensively — drizzle's `returning` doesn't guarantee insert
   // order across drivers.
   chapterRows.sort((a, b) => a.idx - b.idx);
+
+  // Kick the NLP worker (T-4.4). The default dispatcher is a no-op so
+  // tests + dev environments without arq still succeed; production
+  // wiring registers a Redis-backed dispatcher at boot.
+  await enqueueNlpJob({
+    textId: (text as Text).id,
+    chapterIds: chapterRows.map((c) => c.id),
+    now: args.now,
+  });
 
   return {
     text: text as Text,

--- a/apps/web/src/routes/api/v1/admin/texts/[id]/mark-failed/+server.ts
+++ b/apps/web/src/routes/api/v1/admin/texts/[id]/mark-failed/+server.ts
@@ -1,0 +1,41 @@
+/**
+ * POST /api/v1/admin/texts/:id/mark-failed (T-4.4).
+ *
+ * Admin-only callback for the NLP worker's failure path. Body:
+ * `{ error: string }` — the worker's truncated traceback. Empty body
+ * defaults to a generic message.
+ */
+import { error, json } from '@sveltejs/kit';
+import { z } from 'zod';
+
+import { requireUser } from '$lib/server/auth/require-user.js';
+import { isAdmin } from '$lib/server/dictionary/permissions.js';
+import { markTextFailed } from '$lib/server/texts/jobs.js';
+import type { RequestHandler } from './$types';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const body = z.object({
+  error: z.string().min(1).max(2000),
+});
+
+export const POST: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  if (!isAdmin({ role: user.role })) {
+    throw error(403, 'Admin role required');
+  }
+  const id = event.params.id;
+  if (!id || !UUID_RE.test(id)) throw error(400, 'Invalid text id');
+  let parsed: { error: string };
+  try {
+    const json_body = await event.request.json();
+    const result = body.safeParse(json_body);
+    if (!result.success) throw error(400, 'Invalid body');
+    parsed = result.data;
+  } catch (e) {
+    if (e && typeof e === 'object' && 'status' in e) throw e;
+    throw error(400, 'Invalid JSON body');
+  }
+  await markTextFailed(id, parsed.error);
+  return json({ ok: true });
+};

--- a/apps/web/src/routes/api/v1/admin/texts/[id]/mark-failed/mark-failed-server.test.ts
+++ b/apps/web/src/routes/api/v1/admin/texts/[id]/mark-failed/mark-failed-server.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const markTextFailed = vi.fn();
+const requireUser = vi.fn();
+
+vi.mock('$lib/server/texts/jobs.js', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/texts/jobs.js')>(
+    '$lib/server/texts/jobs.js',
+  );
+  return {
+    ...actual,
+    markTextFailed: (...a: unknown[]) => markTextFailed(...a),
+  };
+});
+
+vi.mock('$lib/server/auth/require-user.js', () => ({
+  requireUser: (...a: unknown[]) => requireUser(...a),
+}));
+
+type PostFn = (typeof import('./+server.js'))['POST'];
+
+const VALID_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const ADMIN = { id: 'admin-1', role: 'admin' as const };
+const USER = { id: 'user-1', role: 'user' as const };
+
+async function callPost(
+  body: unknown,
+  id = VALID_ID,
+  user: typeof ADMIN | typeof USER | null = ADMIN,
+) {
+  if (user) {
+    requireUser.mockResolvedValueOnce(user);
+  } else {
+    requireUser.mockImplementationOnce(() => {
+      throw { status: 401 };
+    });
+  }
+  const { POST } = await import('./+server.js');
+  const event = {
+    params: { id },
+    request: new Request(`http://x/api/v1/admin/texts/${id}/mark-failed`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: typeof body === 'string' ? body : JSON.stringify(body),
+    }),
+  } as unknown as Parameters<PostFn>[0];
+  try {
+    return await POST(event);
+  } catch (e) {
+    return e as { status: number };
+  }
+}
+
+beforeEach(() => {
+  markTextFailed.mockReset();
+  requireUser.mockReset();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('POST /api/v1/admin/texts/:id/mark-failed', () => {
+  it('flips the text to failed with the supplied error', async () => {
+    markTextFailed.mockResolvedValueOnce(undefined);
+    const res = (await callPost({ error: 'Stanza model crash' })) as Response;
+    expect(res.status).toBe(200);
+    expect(markTextFailed).toHaveBeenCalledWith(VALID_ID, 'Stanza model crash');
+  });
+
+  it('rejects an empty error body with 400', async () => {
+    const res = (await callPost({ error: '' })) as { status: number };
+    expect(res.status).toBe(400);
+    expect(markTextFailed).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-admin callers with 403', async () => {
+    const res = (await callPost({ error: 'x' }, VALID_ID, USER)) as { status: number };
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects an invalid uuid with 400', async () => {
+    const res = (await callPost({ error: 'x' }, 'not-a-uuid')) as { status: number };
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/web/src/routes/api/v1/admin/texts/[id]/mark-ready/+server.ts
+++ b/apps/web/src/routes/api/v1/admin/texts/[id]/mark-ready/+server.ts
@@ -1,0 +1,28 @@
+/**
+ * POST /api/v1/admin/texts/:id/mark-ready (T-4.4).
+ *
+ * Admin-only callback the NLP worker invokes when tokenization
+ * succeeds. Also handy for dev/testing — without it, exercising the
+ * polling UI requires standing up the full arq worker. The worker's
+ * public contract (services/nlp/app/worker/store.py) maps directly
+ * onto this endpoint + its `mark-failed` sibling.
+ */
+import { error, json } from '@sveltejs/kit';
+
+import { requireUser } from '$lib/server/auth/require-user.js';
+import { isAdmin } from '$lib/server/dictionary/permissions.js';
+import { markTextReady } from '$lib/server/texts/jobs.js';
+import type { RequestHandler } from './$types';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const POST: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  if (!isAdmin({ role: user.role })) {
+    throw error(403, 'Admin role required');
+  }
+  const id = event.params.id;
+  if (!id || !UUID_RE.test(id)) throw error(400, 'Invalid text id');
+  await markTextReady(id);
+  return json({ ok: true });
+};

--- a/apps/web/src/routes/api/v1/admin/texts/[id]/mark-ready/mark-ready-server.test.ts
+++ b/apps/web/src/routes/api/v1/admin/texts/[id]/mark-ready/mark-ready-server.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const markTextReady = vi.fn();
+const requireUser = vi.fn();
+
+vi.mock('$lib/server/texts/jobs.js', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/texts/jobs.js')>(
+    '$lib/server/texts/jobs.js',
+  );
+  return {
+    ...actual,
+    markTextReady: (...a: unknown[]) => markTextReady(...a),
+  };
+});
+
+vi.mock('$lib/server/auth/require-user.js', () => ({
+  requireUser: (...a: unknown[]) => requireUser(...a),
+}));
+
+type PostFn = (typeof import('./+server.js'))['POST'];
+
+const VALID_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const ADMIN = { id: 'admin-1', role: 'admin' as const };
+const USER = { id: 'user-1', role: 'user' as const };
+
+async function callPost(id: string, user: typeof ADMIN | typeof USER | null = ADMIN) {
+  if (user) {
+    requireUser.mockResolvedValueOnce(user);
+  } else {
+    requireUser.mockImplementationOnce(() => {
+      throw { status: 401 };
+    });
+  }
+  const { POST } = await import('./+server.js');
+  const event = {
+    params: { id },
+    request: new Request(`http://x/api/v1/admin/texts/${id}/mark-ready`, {
+      method: 'POST',
+    }),
+  } as unknown as Parameters<PostFn>[0];
+  try {
+    return await POST(event);
+  } catch (e) {
+    return e as { status: number };
+  }
+}
+
+beforeEach(() => {
+  markTextReady.mockReset();
+  requireUser.mockReset();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('POST /api/v1/admin/texts/:id/mark-ready', () => {
+  it('flips the text to ready as admin', async () => {
+    markTextReady.mockResolvedValueOnce(undefined);
+    const res = (await callPost(VALID_ID)) as Response;
+    expect(res.status).toBe(200);
+    expect(markTextReady).toHaveBeenCalledWith(VALID_ID);
+  });
+
+  it('rejects non-admin callers with 403', async () => {
+    const res = (await callPost(VALID_ID, USER)) as { status: number };
+    expect(res.status).toBe(403);
+    expect(markTextReady).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid uuid with 400', async () => {
+    const res = (await callPost('not-a-uuid')) as { status: number };
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/web/src/routes/api/v1/texts/[id]/status/+server.ts
+++ b/apps/web/src/routes/api/v1/texts/[id]/status/+server.ts
@@ -1,0 +1,41 @@
+/**
+ * GET /api/v1/texts/:id/status (T-4.4).
+ *
+ * Lightweight polling endpoint the reader page hits while a text is
+ * still being processed by the NLP worker. Returns the current
+ * `status` enum value + any `statusError` and the most recent
+ * `nlp_jobs` row's progress fields.
+ *
+ * Owner-scoped — non-owners get a flat 404 to avoid leaking text
+ * existence. Sharing visibility lands in T-4.6 with the central
+ * `assertCanRead` helper.
+ */
+import { error, json } from '@sveltejs/kit';
+
+import { requireUser } from '$lib/server/auth/require-user.js';
+import { getTextStatus } from '$lib/server/texts/jobs.js';
+import type { RequestHandler } from './$types';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const GET: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  const id = event.params.id;
+  if (!id || !UUID_RE.test(id)) throw error(400, 'Invalid text id');
+  const view = await getTextStatus({ id: user.id }, id);
+  if (!view) throw error(404, 'Text not found');
+  return json({
+    status: view.status,
+    statusError: view.statusError,
+    job: view.job
+      ? {
+          id: view.job.id,
+          status: view.job.status,
+          error: view.job.error,
+          startedAt: view.job.startedAt,
+          finishedAt: view.job.finishedAt,
+          createdAt: view.job.createdAt,
+        }
+      : null,
+  });
+};

--- a/apps/web/src/routes/api/v1/texts/[id]/status/status-server.test.ts
+++ b/apps/web/src/routes/api/v1/texts/[id]/status/status-server.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getTextStatus = vi.fn();
+const requireUser = vi.fn();
+
+vi.mock('$lib/server/texts/jobs.js', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/texts/jobs.js')>(
+    '$lib/server/texts/jobs.js',
+  );
+  return {
+    ...actual,
+    getTextStatus: (...a: unknown[]) => getTextStatus(...a),
+  };
+});
+
+vi.mock('$lib/server/auth/require-user.js', () => ({
+  requireUser: (...a: unknown[]) => requireUser(...a),
+}));
+
+type GetFn = (typeof import('./+server.js'))['GET'];
+
+const VALID_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const USER = { id: 'user-1', role: 'user' as const };
+
+async function callGet(id: string, user: typeof USER | null = USER) {
+  if (user) {
+    requireUser.mockResolvedValueOnce(user);
+  } else {
+    requireUser.mockImplementationOnce(() => {
+      throw { status: 401 };
+    });
+  }
+  const { GET } = await import('./+server.js');
+  const event = {
+    params: { id },
+    request: new Request(`http://x/api/v1/texts/${id}/status`),
+  } as unknown as Parameters<GetFn>[0];
+  try {
+    return await GET(event);
+  } catch (e) {
+    return e as { status: number };
+  }
+}
+
+beforeEach(() => {
+  getTextStatus.mockReset();
+  requireUser.mockReset();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('GET /api/v1/texts/:id/status', () => {
+  it('returns status + job for the owner', async () => {
+    getTextStatus.mockResolvedValueOnce({
+      status: 'processing',
+      statusError: null,
+      job: {
+        id: 'job-1',
+        status: 'processing',
+        error: null,
+        startedAt: new Date('2026-04-27T01:00:00Z'),
+        finishedAt: null,
+        createdAt: new Date('2026-04-27T00:59:00Z'),
+      },
+    });
+    const res = (await callGet(VALID_ID)) as Response;
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.status).toBe('processing');
+    expect(json.job.id).toBe('job-1');
+  });
+
+  it('returns null job when no nlp_jobs row exists', async () => {
+    getTextStatus.mockResolvedValueOnce({
+      status: 'pending',
+      statusError: null,
+      job: null,
+    });
+    const res = (await callGet(VALID_ID)) as Response;
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.job).toBeNull();
+  });
+
+  it('rejects an invalid uuid with 400', async () => {
+    const res = (await callGet('not-a-uuid')) as { status: number };
+    expect(res.status).toBe(400);
+    expect(getTextStatus).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the text is missing or not owned by the viewer', async () => {
+    getTextStatus.mockResolvedValueOnce(null);
+    const res = (await callGet(VALID_ID)) as { status: number };
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const res = (await callGet(VALID_ID, null)) as { status: number };
+    expect(res.status).toBe(401);
+    expect(getTextStatus).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/routes/texts/[id]/+page.server.ts
+++ b/apps/web/src/routes/texts/[id]/+page.server.ts
@@ -34,6 +34,7 @@ export const load: PageServerLoad = async ({ params, locals, url }) => {
       language: result.text.language,
       sourceType: result.text.sourceType,
       status: result.text.status,
+      statusError: result.text.statusError,
       visibility: result.text.visibility,
       createdAt: result.text.createdAt,
     },

--- a/apps/web/src/routes/texts/[id]/+page.svelte
+++ b/apps/web/src/routes/texts/[id]/+page.svelte
@@ -1,7 +1,21 @@
 <script lang="ts">
+  import { invalidateAll } from '$app/navigation';
+  import { onMount, untrack } from 'svelte';
   import type { PageData } from './$types';
 
   let { data }: { data: PageData } = $props();
+
+  // Polling state — drives the "processing" → "ready" UX without a
+  // page reload. We hit GET /api/v1/texts/:id/status every couple of
+  // seconds while status is pending or processing, then call
+  // `invalidateAll()` to re-run the loader so the new chapters /
+  // status are reflected without losing scroll position.
+  let liveStatus = $state(untrack(() => data.text.status));
+  let liveError = $state<string | null>(null);
+
+  function shouldPoll(s: typeof data.text.status): boolean {
+    return s === 'pending' || s === 'processing';
+  }
 
   // The placeholder viewer just renders paragraphs from the raw chapter
   // body. M5 swaps each paragraph for token-aware rendering with the
@@ -13,11 +27,47 @@
   const statusLabel = $derived(
     {
       pending: 'Waiting to be processed',
-      processing: 'Processing — refresh in a moment',
+      processing: 'Processing — please wait',
       ready: 'Ready',
       failed: 'Processing failed',
-    }[data.text.status] ?? data.text.status,
+    }[liveStatus] ?? liveStatus,
   );
+
+  onMount(() => {
+    // Sync our local mirror to whatever the loader saw on first load,
+    // then start polling if needed.
+    liveStatus = data.text.status;
+
+    if (!shouldPoll(liveStatus)) return;
+
+    // Conservative 2.5s interval — fast enough that the user feels the
+    // "ready" flip is responsive, slow enough that an idle queue
+    // doesn't burn a request per second per open tab.
+    const interval = window.setInterval(async () => {
+      try {
+        const res = await fetch(`/api/v1/texts/${data.text.id}/status`, {
+          headers: { accept: 'application/json' },
+        });
+        if (!res.ok) return;
+        const payload = (await res.json()) as {
+          status: typeof data.text.status;
+          statusError: string | null;
+        };
+        liveStatus = payload.status;
+        liveError = payload.statusError;
+        if (!shouldPoll(payload.status)) {
+          window.clearInterval(interval);
+          // Re-run the loader so chapter content + tokenCount that
+          // changed during processing are picked up.
+          await invalidateAll();
+        }
+      } catch {
+        // Network blips just retry on the next tick.
+      }
+    }, 2500);
+
+    return () => window.clearInterval(interval);
+  });
 </script>
 
 <svelte:head>
@@ -36,11 +86,15 @@
       <span class="dot">·</span>
       <span class="badge">{data.text.sourceType}</span>
       <span class="dot">·</span>
-      <span class="badge status-{data.text.status}">{statusLabel}</span>
+      <span class="badge status-{liveStatus}">{statusLabel}</span>
       <span class="dot">·</span>
       <span class="badge">{data.text.visibility}</span>
     </p>
   </header>
+
+  {#if liveStatus === 'failed' && liveError}
+    <p class="err" role="alert">Processing error: {liveError}</p>
+  {/if}
 
   <p class="placeholder-note">
     This is a placeholder view — the full tap-to-translate reader lands
@@ -138,5 +192,13 @@
     margin: 0 0 0.75rem;
     line-height: 1.7;
     font-size: 1.05rem;
+  }
+  .err {
+    color: #b03131;
+    background: color-mix(in srgb, #b03131 8%, transparent);
+    border: 1px solid color-mix(in srgb, #b03131 30%, transparent);
+    border-radius: 8px;
+    padding: 0.75rem 1rem;
+    margin-bottom: 1rem;
   }
 </style>


### PR DESCRIPTION
Closes #39

## Summary

Wires upload → enqueue → poll → ready. Drops in the \`nlp_jobs\` table the M4 plan calls for, plus a pluggable \`JobDispatcher\` so the actual Redis push lands in deployment without coupling upload code to it.

- **Schema**: \`nlp_jobs\` (text_id, status enum, error, started_at/finished_at). Indexed on \`(text_id, created_at)\` and \`status\`.
- **Service**: \`enqueueNlpJob\` (inserts the row, fans out via the dispatcher) + \`markTextProcessing/Ready/Failed\` worker callbacks mirroring \`services/nlp/app/worker/store.py\`'s TextStore contract.
- **Hook**: every text creator (paste / txt / epub) writes a pending \`nlp_jobs\` row right after the chapter rows.
- **Endpoints**: \`GET /api/v1/texts/:id/status\` for owner polling; \`POST /api/v1/admin/texts/:id/{mark-ready,mark-failed}\` for the worker callbacks (also useful for testing the polling UX without a real worker).
- **UI**: \`/texts/[id]\` polls every 2.5s while \`pending|processing\`, surfaces the live status badge + worker error message, and runs \`invalidateAll()\` once status flips so chapter content / tokenCount updates pick up without a reload.

## Test plan

- [x] \`pnpm --filter @ciareader/web test\` — 470/470 (21 new)
- [x] \`pnpm --filter @ciareader/web check\` — clean
- [x] \`pnpm --filter @ciareader/web lint\` — clean
- [x] coverage above 80% floor; texts module at 100% lines
- [ ] Manual: upload, watch the badge flip from pending → ready when an admin POSTs \`/mark-ready\`
- [ ] Manual: upload, POST \`/mark-failed\` with an error string, confirm the error banner shows
- [ ] Manual: confirm two browser tabs both flip when one admin call fires