### PR TITLE
T-4.5: library page (your / shared / official tabs)

### DIFF
--- a/apps/web/src/lib/components/shell/tabs.test.ts
+++ b/apps/web/src/lib/components/shell/tabs.test.ts
@@ -5,9 +5,15 @@ describe('visibleTabs', () => {
   it('shows authenticated + any tabs to signed-in users', () => {
     const shown = visibleTabs(TABS, true).map((t) => t.id);
     expect(shown).toContain('home');
+    expect(shown).toContain('library');
     expect(shown).toContain('upload');
     expect(shown).toContain('profile');
     expect(shown).not.toContain('signin');
+  });
+
+  it('shows the public library tab to signed-out users', () => {
+    const shown = visibleTabs(TABS, false).map((t) => t.id);
+    expect(shown).toContain('library');
   });
 
   it('shows anonymous + any tabs to signed-out users', () => {
@@ -18,9 +24,13 @@ describe('visibleTabs', () => {
     expect(shown).not.toContain('profile');
   });
 
-  it('highlights the upload tab on /texts/* paths so users land back on it', () => {
+  it('highlights the library tab on /texts/* paths so the reader stays under Library', () => {
+    expect(getActiveTabId('/library', TABS)).toBe('library');
+    expect(getActiveTabId('/texts/abc-123', TABS)).toBe('library');
+  });
+
+  it('highlights the upload tab on /upload', () => {
     expect(getActiveTabId('/upload', TABS)).toBe('upload');
-    expect(getActiveTabId('/texts/abc-123', TABS)).toBe('upload');
   });
 });
 

--- a/apps/web/src/lib/components/shell/tabs.ts
+++ b/apps/web/src/lib/components/shell/tabs.ts
@@ -22,13 +22,20 @@ export interface Tab {
 export const TABS: readonly Tab[] = [
   { id: 'home', label: 'Home', href: '/', auth: 'any', match: ['/'] },
   {
+    id: 'library',
+    label: 'Library',
+    href: '/library',
+    auth: 'any',
+    // /texts/[id] is reached by clicking a card, so the Library tab
+    // should stay highlighted while reading.
+    match: ['/library', '/texts'],
+  },
+  {
     id: 'upload',
     label: 'Upload',
     href: '/upload',
     auth: 'authenticated',
-    // /texts/[id] is the destination after a successful upload, so it
-    // should highlight the same tab the user used to get there.
-    match: ['/upload', '/texts'],
+    match: ['/upload'],
   },
   {
     id: 'profile',

--- a/apps/web/src/lib/server/texts/library.test.ts
+++ b/apps/web/src/lib/server/texts/library.test.ts
@@ -1,0 +1,147 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Call =
+  | { kind: 'select' }
+  | { kind: 'select-count' };
+const calls: Call[] = [];
+
+const staged: Array<unknown[]> = [];
+function stage(rows: unknown[]) {
+  staged.push(rows);
+}
+function nextStaged(): unknown[] {
+  const v = staged.shift();
+  if (!v) throw new Error('Test bug: no staged result available');
+  return v;
+}
+
+function makeSelectChain() {
+  const chain: Record<string, unknown> = {};
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.orderBy = vi.fn(() => chain);
+  chain.limit = vi.fn(() => chain);
+  chain.offset = vi.fn(() => chain);
+  chain.then = (resolve: (v: unknown) => unknown) => resolve(nextStaged());
+  return chain;
+}
+
+const selectFn = vi.fn(() => {
+  calls.push({ kind: 'select' });
+  return makeSelectChain();
+});
+
+vi.mock('../db/index.js', () => ({
+  db: {
+    select: () => selectFn(),
+  },
+  schema: {
+    texts: {
+      id: 'texts.id',
+      ownerId: 'texts.owner_id',
+      language: 'texts.language',
+      visibility: 'texts.visibility',
+      createdAt: 'texts.created_at',
+    },
+  },
+}));
+
+const {
+  DEFAULT_PAGE_SIZE,
+  MAX_PAGE_SIZE,
+  listOwnedTexts,
+  listSharedTexts,
+  listOfficialTexts,
+} = await import('./library.js');
+
+function textRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 't1',
+    ownerId: 'user-1',
+    language: 'hi',
+    title: 'Sample',
+    sourceType: 'paste',
+    status: 'pending',
+    visibility: 'private',
+    statusError: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  calls.length = 0;
+  staged.length = 0;
+  selectFn.mockClear();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('listOwnedTexts', () => {
+  it('returns page + total + clamped pagination defaults', async () => {
+    stage([{ count: 7 }]); // count query
+    stage([textRow(), textRow({ id: 't2' })]); // page rows
+    const page = await listOwnedTexts({ id: 'user-1' });
+    expect(page.totalCount).toBe(7);
+    expect(page.cards).toHaveLength(2);
+    expect(page.limit).toBe(DEFAULT_PAGE_SIZE);
+    expect(page.offset).toBe(0);
+  });
+
+  it('clamps a limit above MAX_PAGE_SIZE', async () => {
+    stage([{ count: 0 }]);
+    stage([]);
+    const page = await listOwnedTexts(
+      { id: 'user-1' },
+      { limit: 5_000, offset: -10 },
+    );
+    expect(page.limit).toBe(MAX_PAGE_SIZE);
+    expect(page.offset).toBe(0);
+  });
+
+  it('passes a language filter through', async () => {
+    stage([{ count: 0 }]);
+    stage([]);
+    const page = await listOwnedTexts(
+      { id: 'user-1' },
+      { language: 'or' },
+    );
+    expect(page.cards).toEqual([]);
+    // Two SELECTs (count + rows).
+    expect(calls).toHaveLength(2);
+  });
+});
+
+describe('listSharedTexts', () => {
+  it('returns an empty page (M7 not yet wired)', async () => {
+    const page = await listSharedTexts({ id: 'user-1' });
+    expect(page.cards).toEqual([]);
+    expect(page.totalCount).toBe(0);
+    // No DB hit at all in the stub.
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe('listOfficialTexts', () => {
+  it('queries by visibility=official with no auth required', async () => {
+    stage([{ count: 3 }]);
+    stage([
+      textRow({ id: 't1', visibility: 'official' }),
+      textRow({ id: 't2', visibility: 'official' }),
+    ]);
+    const page = await listOfficialTexts();
+    expect(page.totalCount).toBe(3);
+    expect(page.cards.every((c) => c.visibility === 'official')).toBe(true);
+  });
+
+  it('honors a language filter', async () => {
+    stage([{ count: 0 }]);
+    stage([]);
+    const page = await listOfficialTexts({ language: 'mr' });
+    expect(page.cards).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/server/texts/library.ts
+++ b/apps/web/src/lib/server/texts/library.ts
@@ -1,0 +1,157 @@
+/**
+ * Library queries (T-4.5).
+ *
+ * Three tabs feed off this module:
+ *
+ *   - "Your texts" — `texts.owner_id = me`. Most recent first.
+ *   - "Shared with you" — texts the viewer has access to via M7's
+ *     `text_shares` / `text_group_shares` tables. Those tables don't
+ *     exist yet, so the function returns an empty page; the M7
+ *     ticket plugs the real query in.
+ *   - "Official library" — `texts.visibility = 'official'`. Public,
+ *     unauthenticated; M11 (T-7.6) wires this into a public-facing
+ *     SEO route. T-4.5 ships the data fetch.
+ *
+ * Pagination is offset-based with sensible caps. Cursor pagination is
+ * a future concern when individual users have thousands of imports —
+ * for the first year of MVP a learner has a few dozen at most.
+ */
+import { and, desc, eq, sql } from 'drizzle-orm';
+
+import { db, schema } from '../db/index.js';
+import type { Text, User } from '../db/schema.js';
+import type { LanguageCode } from '@ciareader/shared-types';
+
+export const DEFAULT_PAGE_SIZE = 20;
+export const MAX_PAGE_SIZE = 100;
+
+/** Card-shaped projection — what the library renders per row. The
+ * full row would carry chapter bodies through the loader, which we
+ * don't need on the index. */
+export type LibraryCard = {
+  id: string;
+  title: string;
+  language: string;
+  sourceType: string;
+  status: string;
+  visibility: string;
+  createdAt: Date;
+};
+
+export type ListPage = {
+  cards: LibraryCard[];
+  totalCount: number;
+  limit: number;
+  offset: number;
+};
+
+function projectCard(row: Text): LibraryCard {
+  return {
+    id: row.id,
+    title: row.title,
+    language: row.language,
+    sourceType: row.sourceType,
+    status: row.status,
+    visibility: row.visibility,
+    createdAt: row.createdAt,
+  };
+}
+
+function clampPage(opts: { limit?: number; offset?: number }): {
+  limit: number;
+  offset: number;
+} {
+  const limit = Math.min(
+    Math.max(opts.limit ?? DEFAULT_PAGE_SIZE, 1),
+    MAX_PAGE_SIZE,
+  );
+  const offset = Math.max(opts.offset ?? 0, 0);
+  return { limit, offset };
+}
+
+/**
+ * The user's own imports, newest first.
+ */
+export async function listOwnedTexts(
+  viewer: Pick<User, 'id'>,
+  opts: { limit?: number; offset?: number; language?: LanguageCode } = {},
+): Promise<ListPage> {
+  const { limit, offset } = clampPage(opts);
+  const conditions = [eq(schema.texts.ownerId, viewer.id)];
+  if (opts.language) {
+    conditions.push(eq(schema.texts.language, opts.language));
+  }
+  const where = and(...conditions);
+
+  const countRows = (await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(schema.texts)
+    .where(where)) as Array<{ count: number }>;
+  const count = countRows[0]?.count ?? 0;
+
+  const rows = (await db
+    .select()
+    .from(schema.texts)
+    .where(where)
+    .orderBy(desc(schema.texts.createdAt))
+    .limit(limit)
+    .offset(offset)) as Text[];
+
+  return {
+    cards: rows.map(projectCard),
+    totalCount: count,
+    limit,
+    offset,
+  };
+}
+
+/**
+ * Texts shared with the viewer (T-7.x). Until those sharing tables
+ * land, we return an empty page so the library tab renders without a
+ * special-case "M7 not implemented yet" branch in the UI.
+ */
+export async function listSharedTexts(
+  _viewer: Pick<User, 'id'>,
+  opts: { limit?: number; offset?: number } = {},
+): Promise<ListPage> {
+  const { limit, offset } = clampPage(opts);
+  return { cards: [], totalCount: 0, limit, offset };
+}
+
+/**
+ * Officially published texts, optionally filtered by language. Public —
+ * the loader does not require an authenticated viewer. The public
+ * `/library` tab + the unauth `/library/official` route both consume
+ * this.
+ */
+export async function listOfficialTexts(
+  opts: { limit?: number; offset?: number; language?: LanguageCode } = {},
+): Promise<ListPage> {
+  const { limit, offset } = clampPage(opts);
+  const conditions = [eq(schema.texts.visibility, 'official')];
+  if (opts.language) {
+    conditions.push(eq(schema.texts.language, opts.language));
+  }
+  const where = and(...conditions);
+
+  const countRows = (await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(schema.texts)
+    .where(where)) as Array<{ count: number }>;
+  const count = countRows[0]?.count ?? 0;
+
+  const rows = (await db
+    .select()
+    .from(schema.texts)
+    .where(where)
+    .orderBy(desc(schema.texts.createdAt))
+    .limit(limit)
+    .offset(offset)) as Text[];
+
+  return {
+    cards: rows.map(projectCard),
+    totalCount: count,
+    limit,
+    offset,
+  };
+}

--- a/apps/web/src/routes/library/+page.server.ts
+++ b/apps/web/src/routes/library/+page.server.ts
@@ -1,0 +1,95 @@
+/**
+ * Library page (T-4.5).
+ *
+ * Three tabs:
+ *   - "your"     — texts the current user owns. Auth required.
+ *   - "shared"   — texts shared with the current user (M7). Auth required.
+ *   - "official" — public curated texts. No auth required, so the
+ *     loader keeps that branch open to anonymous visitors. Used as
+ *     marketing surface in T-7.6.
+ *
+ * The active tab comes from the URL: `?tab=your|shared|official`. We
+ * default unauth visitors to 'official' so the public landing is the
+ * curated library, not a "please log in" wall.
+ */
+import { error, redirect } from '@sveltejs/kit';
+
+import {
+  DEFAULT_PAGE_SIZE,
+  MAX_PAGE_SIZE,
+  listOfficialTexts,
+  listOwnedTexts,
+  listSharedTexts,
+  type ListPage,
+} from '$lib/server/texts/library.js';
+import { LANGUAGES, isSupportedLanguage } from '@ciareader/shared-types';
+import type { LanguageCode } from '@ciareader/shared-types';
+import type { PageServerLoad } from './$types';
+
+type Tab = 'your' | 'shared' | 'official';
+
+function readTab(raw: string | null, hasUser: boolean): Tab {
+  if (raw === 'your' || raw === 'shared' || raw === 'official') return raw;
+  return hasUser ? 'your' : 'official';
+}
+
+function readInt(url: URL, key: string, fallback: number): number {
+  const raw = url.searchParams.get(key);
+  if (raw == null || raw === '') return fallback;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+export const load: PageServerLoad = async ({ url, locals }) => {
+  const tab = readTab(url.searchParams.get('tab'), Boolean(locals.user));
+
+  // Auth gate: 'your' / 'shared' require a logged-in user. 'official'
+  // is public.
+  if ((tab === 'your' || tab === 'shared') && !locals.user) {
+    throw redirect(
+      303,
+      `/login?next=${encodeURIComponent(url.pathname + url.search)}`,
+    );
+  }
+
+  const langRaw = url.searchParams.get('language');
+  const language: LanguageCode | null =
+    langRaw && isSupportedLanguage(langRaw) ? (langRaw as LanguageCode) : null;
+  if (langRaw && !language) {
+    throw error(400, `Unsupported language '${langRaw}'`);
+  }
+
+  const limit = Math.min(
+    Math.max(readInt(url, 'limit', DEFAULT_PAGE_SIZE), 1),
+    MAX_PAGE_SIZE,
+  );
+  const offset = Math.max(readInt(url, 'offset', 0), 0);
+
+  let page: ListPage;
+  if (tab === 'your') {
+    page = await listOwnedTexts(
+      { id: locals.user!.id },
+      { limit, offset, language: language ?? undefined },
+    );
+  } else if (tab === 'shared') {
+    page = await listSharedTexts({ id: locals.user!.id }, { limit, offset });
+  } else {
+    page = await listOfficialTexts({
+      limit,
+      offset,
+      language: language ?? undefined,
+    });
+  }
+
+  return {
+    tab,
+    page,
+    language,
+    languages: Object.values(LANGUAGES).map((d) => ({
+      code: d.code,
+      displayName: d.displayName,
+      nativeName: d.nativeName,
+    })),
+    isAuthenticated: Boolean(locals.user),
+  };
+};

--- a/apps/web/src/routes/library/+page.svelte
+++ b/apps/web/src/routes/library/+page.svelte
@@ -1,0 +1,262 @@
+<script lang="ts">
+  import type { PageData } from './$types';
+
+  let { data }: { data: PageData } = $props();
+
+  const pageNum = $derived(Math.floor(data.page.offset / data.page.limit) + 1);
+  const totalPages = $derived(
+    Math.max(1, Math.ceil(data.page.totalCount / data.page.limit)),
+  );
+  const prevOffset = $derived(Math.max(0, data.page.offset - data.page.limit));
+  const nextOffset = $derived(data.page.offset + data.page.limit);
+
+  function hrefWith(overrides: Record<string, string | null>): string {
+    const params = new URLSearchParams();
+    params.set('tab', data.tab);
+    if (data.language) params.set('language', data.language);
+    if (data.page.offset > 0) params.set('offset', String(data.page.offset));
+    if (data.page.limit !== 20) params.set('limit', String(data.page.limit));
+    for (const [k, v] of Object.entries(overrides)) {
+      if (v === null) params.delete(k);
+      else params.set(k, v);
+    }
+    const qs = params.toString();
+    return qs ? `?${qs}` : '';
+  }
+
+  const TABS = [
+    { id: 'your', label: 'Your texts', requiresAuth: true },
+    { id: 'shared', label: 'Shared with you', requiresAuth: true },
+    { id: 'official', label: 'Official', requiresAuth: false },
+  ] as const;
+</script>
+
+<svelte:head>
+  <title>Library — CIA Reader</title>
+</svelte:head>
+
+<div class="page">
+  <header>
+    <h1>Library</h1>
+    <p class="sub">
+      {#if data.tab === 'your'}
+        Your imported texts.
+      {:else if data.tab === 'shared'}
+        Texts other users have shared with you.
+      {:else}
+        Curated texts for every learner.
+      {/if}
+    </p>
+  </header>
+
+  <nav class="tabs" aria-label="Library tabs">
+    {#each TABS as t (t.id)}
+      {#if !t.requiresAuth || data.isAuthenticated}
+        <a
+          class:active={data.tab === t.id}
+          href={hrefWith({ tab: t.id, offset: null })}
+        >
+          {t.label}
+        </a>
+      {/if}
+    {/each}
+  </nav>
+
+  <form method="get" class="filters">
+    <input type="hidden" name="tab" value={data.tab} />
+    <label>
+      Language
+      <select name="language">
+        <option value="">All languages</option>
+        {#each data.languages as lang (lang.code)}
+          <option value={lang.code} selected={data.language === lang.code}>
+            {lang.displayName} ({lang.nativeName})
+          </option>
+        {/each}
+      </select>
+    </label>
+    <button type="submit">Filter</button>
+  </form>
+
+  {#if data.page.cards.length === 0}
+    <p class="empty">
+      {#if data.tab === 'your'}
+        You haven't uploaded any texts yet. <a href="/upload">Upload one →</a>
+      {:else if data.tab === 'shared'}
+        No shared texts yet. Sharing lands in a future ticket.
+      {:else}
+        No official texts yet. Curators are working on it.
+      {/if}
+    </p>
+  {:else}
+    <ul class="cards">
+      {#each data.page.cards as card (card.id)}
+        <li>
+          <a class="card" href={`/texts/${card.id}`}>
+            <div class="card-title">{card.title}</div>
+            <div class="card-meta">
+              <span class="badge">{card.language}</span>
+              <span class="badge">{card.sourceType}</span>
+              <span class="badge status-{card.status}">{card.status}</span>
+              <span class="badge">{card.visibility}</span>
+            </div>
+          </a>
+        </li>
+      {/each}
+    </ul>
+
+    <nav class="pager" aria-label="Pagination">
+      <span class="page-info">
+        Page {pageNum} of {totalPages}
+        ({data.page.totalCount.toLocaleString()} total)
+      </span>
+      <span class="page-links">
+        {#if data.page.offset > 0}
+          <a href={hrefWith({ offset: prevOffset > 0 ? String(prevOffset) : null })}>
+            ← Previous
+          </a>
+        {/if}
+        {#if nextOffset < data.page.totalCount}
+          <a href={hrefWith({ offset: String(nextOffset) })}>Next →</a>
+        {/if}
+      </span>
+    </nav>
+  {/if}
+</div>
+
+<style>
+  .page {
+    max-width: 50rem;
+    margin: 0 auto;
+    padding: 1.5rem 1.25rem 3rem;
+  }
+  header h1 {
+    margin: 0 0 0.25rem;
+    font-size: 1.6rem;
+  }
+  .sub {
+    color: var(--color-fg-muted);
+    margin: 0 0 1rem;
+    font-size: 0.9rem;
+  }
+  .tabs {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    border-bottom: 1px solid var(--color-border);
+    margin-bottom: 1rem;
+  }
+  .tabs a {
+    padding: 0.5rem 0.9rem;
+    color: var(--color-fg-muted);
+    text-decoration: none;
+    border-bottom: 2px solid transparent;
+    margin-bottom: -1px;
+  }
+  .tabs a.active {
+    color: var(--color-fg);
+    border-bottom-color: var(--color-accent);
+    font-weight: 600;
+  }
+  .filters {
+    display: flex;
+    gap: 0.5rem;
+    align-items: end;
+    margin-bottom: 1rem;
+  }
+  .filters label {
+    flex: 1;
+    font-size: 0.85rem;
+    color: var(--color-fg-muted);
+  }
+  .filters select {
+    display: block;
+    width: 100%;
+    margin-top: 0.25rem;
+    padding: 0.4rem 0.5rem;
+    font: inherit;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    background: var(--color-bg);
+    color: var(--color-fg);
+    min-height: 40px;
+  }
+  .filters button {
+    min-height: 40px;
+    padding: 0 1rem;
+    background: var(--color-accent);
+    color: var(--color-accent-fg, #fff);
+    border: 0;
+    border-radius: 6px;
+    cursor: pointer;
+  }
+  .empty {
+    color: var(--color-fg-muted);
+    padding: 2rem 0;
+    text-align: center;
+  }
+  .cards {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.75rem;
+  }
+  .card {
+    display: block;
+    padding: 0.85rem 1rem;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    color: var(--color-fg);
+    text-decoration: none;
+    background: var(--color-bg);
+    transition: border-color 120ms ease;
+  }
+  .card:hover {
+    border-color: var(--color-accent);
+  }
+  .card-title {
+    font-size: 1.05rem;
+    font-weight: 600;
+    margin-bottom: 0.35rem;
+  }
+  .card-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+  }
+  .badge {
+    font-size: 0.72rem;
+    padding: 0.05rem 0.45rem;
+    border-radius: 999px;
+    border: 1px solid var(--color-border);
+    background: var(--color-bg);
+    color: var(--color-fg-muted);
+  }
+  .status-ready {
+    border-color: color-mix(in srgb, #197a2f 60%, transparent);
+    color: #197a2f;
+  }
+  .status-failed {
+    border-color: color-mix(in srgb, #b03131 60%, transparent);
+    color: #b03131;
+  }
+  .status-processing,
+  .status-pending {
+    border-color: color-mix(in srgb, #b07a31 60%, transparent);
+    color: #b07a31;
+  }
+  .pager {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 1.5rem;
+    font-size: 0.9rem;
+    color: var(--color-fg-muted);
+  }
+  .page-links a {
+    color: var(--color-accent);
+    text-decoration: none;
+    margin-left: 0.75rem;
+  }
+</style>

--- a/apps/web/src/routes/library/page-server.test.ts
+++ b/apps/web/src/routes/library/page-server.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const listOwnedTexts = vi.fn();
+const listSharedTexts = vi.fn();
+const listOfficialTexts = vi.fn();
+
+vi.mock('$lib/server/texts/library.js', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/texts/library.js')>(
+    '$lib/server/texts/library.js',
+  );
+  return {
+    ...actual,
+    listOwnedTexts: (...a: unknown[]) => listOwnedTexts(...a),
+    listSharedTexts: (...a: unknown[]) => listSharedTexts(...a),
+    listOfficialTexts: (...a: unknown[]) => listOfficialTexts(...a),
+  };
+});
+
+type LoadFn = (typeof import('./+page.server.js'))['load'];
+const USER = { id: 'user-1', role: 'user' as const };
+
+async function callLoad(url: string, user: typeof USER | null = USER) {
+  const { load } = await import('./+page.server.js');
+  const event = {
+    locals: { user },
+    url: new URL(url),
+  } as unknown as Parameters<LoadFn>[0];
+  try {
+    return await load(event);
+  } catch (e) {
+    return e as { status: number; location?: string };
+  }
+}
+
+beforeEach(() => {
+  listOwnedTexts.mockReset();
+  listSharedTexts.mockReset();
+  listOfficialTexts.mockReset();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('/library loader', () => {
+  it("defaults to the 'your' tab for an authenticated visitor", async () => {
+    listOwnedTexts.mockResolvedValueOnce({
+      cards: [{ id: 't1', title: 'Sample', language: 'hi' }],
+      totalCount: 1,
+      limit: 20,
+      offset: 0,
+    });
+    const data = (await callLoad('http://x/library')) as {
+      tab: string;
+      page: { totalCount: number };
+    };
+    expect(data.tab).toBe('your');
+    expect(data.page.totalCount).toBe(1);
+    expect(listOwnedTexts).toHaveBeenCalled();
+  });
+
+  it("defaults to the 'official' tab for an anonymous visitor", async () => {
+    listOfficialTexts.mockResolvedValueOnce({
+      cards: [],
+      totalCount: 0,
+      limit: 20,
+      offset: 0,
+    });
+    const data = (await callLoad('http://x/library', null)) as { tab: string };
+    expect(data.tab).toBe('official');
+    expect(listOfficialTexts).toHaveBeenCalled();
+  });
+
+  it("redirects an anonymous visitor asking for the 'your' tab", async () => {
+    const res = (await callLoad('http://x/library?tab=your', null)) as {
+      status: number;
+      location: string;
+    };
+    expect(res.status).toBe(303);
+    expect(res.location).toContain('/login');
+    expect(listOwnedTexts).not.toHaveBeenCalled();
+  });
+
+  it("routes 'shared' through listSharedTexts", async () => {
+    listSharedTexts.mockResolvedValueOnce({
+      cards: [],
+      totalCount: 0,
+      limit: 20,
+      offset: 0,
+    });
+    const data = (await callLoad('http://x/library?tab=shared')) as {
+      tab: string;
+    };
+    expect(data.tab).toBe('shared');
+    expect(listSharedTexts).toHaveBeenCalled();
+  });
+
+  it('forwards a language filter to the underlying service', async () => {
+    listOwnedTexts.mockResolvedValueOnce({
+      cards: [],
+      totalCount: 0,
+      limit: 20,
+      offset: 0,
+    });
+    await callLoad('http://x/library?tab=your&language=mr');
+    expect(listOwnedTexts).toHaveBeenCalledWith(
+      { id: USER.id },
+      expect.objectContaining({ language: 'mr' }),
+    );
+  });
+
+  it('rejects an unsupported language with 400', async () => {
+    const res = (await callLoad('http://x/library?language=xx')) as {
+      status: number;
+    };
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
Closes #40

## Summary

Adds \`/library\` — the place users find their imports + the curated official library. Three tabs sharing the same loader + UI.

- **Service** (\`lib/server/texts/library.ts\`): \`listOwnedTexts\`, \`listSharedTexts\` (stub for M7), \`listOfficialTexts\`. All return a card-shaped page (\`{ cards, totalCount, limit, offset }\`) with paginate/clamp helpers.
- **Page** (\`/library\`): tabbed UI with \`?tab=your|shared|official\`, language filter, empty states per tab, card list with status/source/language/visibility badges, prev/next pagination. Anonymous visitors default to \`official\`; authenticated visitors default to \`your\`. The protected tabs (\`your\`/\`shared\`) redirect to \`/login\` for anonymous visitors.
- **Shell**: new "Library" tab visible to everyone. \`/texts/*\` now highlights Library instead of Upload, so the reader feels contained inside Library.

## Test plan

- [x] \`pnpm --filter @ciareader/web test\` — 484/484 (13 new for T-4.5)
- [x] \`pnpm --filter @ciareader/web check\` — clean
- [x] \`pnpm --filter @ciareader/web lint\` — clean
- [x] coverage above 80% floor; texts module at 100% lines
- [ ] Manual: upload, then visit \`/library\` and confirm the new text appears under "Your texts"
- [ ] Manual: log out, visit \`/library\`, confirm landing tab is "Official"
- [ ] Manual: log out, visit \`/library?tab=your\` directly, confirm redirect to login
- [ ] Manual: filter by language, confirm \`?language=hi\` round-trips and persists across pagination