### PR TITLE
T-4.6: assertCanRead helper + open the reader to public official texts

### DIFF
--- a/apps/web/src/lib/server/auth/can-read.test.ts
+++ b/apps/web/src/lib/server/auth/can-read.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import { ForbiddenError } from '../dictionary/permissions.js';
+import { assertCanReadText, canReadText } from './can-read.js';
+
+const VIEWER = { id: 'viewer-1' };
+const OTHER = { id: 'someone-else' };
+
+function text(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 't1',
+    ownerId: VIEWER.id,
+    visibility: 'private' as const,
+    ...overrides,
+  };
+}
+
+describe('canReadText', () => {
+  it('allows the owner of a private text', async () => {
+    expect(await canReadText(VIEWER, text())).toBe(true);
+  });
+
+  it('denies a non-owner of a private text', async () => {
+    expect(await canReadText(OTHER, text())).toBe(false);
+  });
+
+  it('denies anonymous viewers of a private text', async () => {
+    expect(await canReadText(null, text())).toBe(false);
+  });
+
+  it('allows anyone (including anonymous) to read official texts', async () => {
+    expect(await canReadText(null, text({ visibility: 'official' }))).toBe(true);
+    expect(await canReadText(OTHER, text({ visibility: 'official' }))).toBe(true);
+  });
+
+  it('denies non-owners of texts with visibility=shared (M7 not yet wired)', async () => {
+    // The shared-visibility row exists but the text_shares lookup
+    // hasn't been implemented yet — until M7 lands, deny-by-default.
+    expect(await canReadText(OTHER, text({ visibility: 'shared' }))).toBe(false);
+  });
+
+  it('still allows the owner of a shared-visibility text (sharing to self is meaningless but the owner path wins)', async () => {
+    expect(
+      await canReadText(VIEWER, text({ visibility: 'shared', ownerId: VIEWER.id })),
+    ).toBe(true);
+  });
+});
+
+describe('assertCanReadText', () => {
+  it('returns void on allow', async () => {
+    await expect(assertCanReadText(VIEWER, text())).resolves.toBeUndefined();
+  });
+
+  it('throws ForbiddenError on deny', async () => {
+    await expect(assertCanReadText(OTHER, text())).rejects.toBeInstanceOf(
+      ForbiddenError,
+    );
+  });
+});

--- a/apps/web/src/lib/server/auth/can-read.ts
+++ b/apps/web/src/lib/server/auth/can-read.ts
@@ -1,0 +1,59 @@
+/**
+ * Central read-authorization helper for `texts` (T-4.6).
+ *
+ * Every reader, stats, and progress endpoint funnels its "may this
+ * viewer see this text?" question through here so the policy lives in
+ * exactly one place. Deny-by-default — if none of the explicit allow
+ * paths match, access is rejected.
+ *
+ * Allow paths today:
+ *   - **Owner**: `text.owner_id === viewer.id`. The most common case.
+ *   - **Official**: `text.visibility === 'official'`. Public; the
+ *     viewer may be `null` (anonymous), e.g. SEO crawls of T-7.6.
+ *
+ * Allow paths the plan calls for that aren't wired yet (M7):
+ *   - **Direct share**: a row in `text_shares` matching
+ *     `(text_id, shared_with_user_id = viewer.id)`.
+ *   - **Group share**: the viewer is a member of a group that holds a
+ *     `text_group_shares` row for the text.
+ *
+ * Both M7 paths require a DB lookup, so the helper is async even
+ * though today's logic is purely in-memory. M7 plugs in the lookups
+ * without touching any call site. `canReadText` always returns a
+ * boolean; `assertCanReadText` throws a `ForbiddenError` so endpoints
+ * can map to 403 / 404 as they prefer (privacy preference: 404 so we
+ * don't leak text existence to non-readers).
+ */
+import type { Text, User } from '../db/schema.js';
+import { ForbiddenError } from '../dictionary/permissions.js';
+
+export type Viewer = Pick<User, 'id'> | null | undefined;
+export type ReadableText = Pick<Text, 'id' | 'ownerId' | 'visibility'>;
+
+/**
+ * Pure predicate. Returns true iff the viewer is allowed to read the
+ * text under the current policy. Async because M7 will need DB
+ * lookups for the share-table branches; today nothing here awaits.
+ */
+export async function canReadText(
+  viewer: Viewer,
+  text: ReadableText,
+): Promise<boolean> {
+  // 1. Public official texts are readable by anyone, including
+  //    anonymous visitors.
+  if (text.visibility === 'official') return true;
+  // 2. The owner can always read their own text.
+  if (viewer && text.ownerId && text.ownerId === viewer.id) return true;
+  // 3. Direct + group shares (M7) — placeholder for the M7 ticket to
+  //    fill in. Falling through to false here is the deny-by-default
+  //    policy.
+  return false;
+}
+
+export async function assertCanReadText(
+  viewer: Viewer,
+  text: ReadableText,
+): Promise<void> {
+  const ok = await canReadText(viewer, text);
+  if (!ok) throw new ForbiddenError('You do not have access to this text');
+}

--- a/apps/web/src/lib/server/texts/jobs.ts
+++ b/apps/web/src/lib/server/texts/jobs.ts
@@ -152,21 +152,24 @@ export type StatusView = {
 };
 
 /**
- * Owner-scoped status lookup for the polling endpoint. Returns null
- * for non-owners + missing texts; the endpoint maps that to 404 so
- * we don't leak text existence.
+ * Status lookup for the polling endpoint, gated by the central
+ * `canReadText` helper (T-4.6). Returns null for missing or
+ * unreadable texts; the endpoint maps that to 404 so we don't leak
+ * text existence to non-readers.
  */
 export async function getTextStatus(
-  viewer: Pick<User, 'id'>,
+  viewer: Pick<User, 'id'> | null,
   textId: string,
 ): Promise<StatusView | null> {
+  const { canReadText } = await import('../auth/can-read.js');
   const [text] = await db
     .select()
     .from(schema.texts)
     .where(eq(schema.texts.id, textId))
     .limit(1);
   if (!text) return null;
-  if ((text as Text).ownerId !== viewer.id) return null;
+  const ok = await canReadText(viewer, text as Text);
+  if (!ok) return null;
   const [job] = await db
     .select()
     .from(schema.nlpJobs)

--- a/apps/web/src/lib/server/texts/upload.test.ts
+++ b/apps/web/src/lib/server/texts/upload.test.ts
@@ -524,10 +524,10 @@ describe('estimateTokenCount', () => {
 });
 
 // -----------------------------------------------------------------------
-// getOwnedText
+// getReadableText (T-4.6)
 // -----------------------------------------------------------------------
 
-describe('getOwnedText', () => {
+describe('getReadableText', () => {
   it('returns the text + ordered chapters when the viewer owns it', async () => {
     stage([textRow()]);
     stage([
@@ -547,11 +547,32 @@ describe('getOwnedText', () => {
     expect(result).toBeNull();
   });
 
-  it('returns null when the viewer is not the owner (no chapter SELECT)', async () => {
+  it('returns null when the viewer is not the owner of a private text (no chapter SELECT)', async () => {
     stage([textRow({ ownerId: 'someone-else' })]);
     const result = await getOwnedText(OWNER, 'text-1');
     expect(result).toBeNull();
     // Only one SELECT — chapters were never queried.
     expect(calls.filter((c) => c.kind === 'select')).toHaveLength(1);
+  });
+
+  it('lets a non-owner read an official text', async () => {
+    stage([textRow({ ownerId: null, visibility: 'official' })]);
+    stage([chapterRow({ id: 'c0', idx: 0 })]);
+    const result = await getOwnedText(OWNER, 'text-1');
+    expect(result).not.toBeNull();
+    expect(result!.text.visibility).toBe('official');
+  });
+
+  it('lets an anonymous viewer read an official text', async () => {
+    stage([textRow({ ownerId: null, visibility: 'official' })]);
+    stage([chapterRow({ id: 'c0', idx: 0 })]);
+    const result = await getOwnedText(null, 'text-1');
+    expect(result).not.toBeNull();
+  });
+
+  it('rejects an anonymous viewer of a private text', async () => {
+    stage([textRow()]);
+    const result = await getOwnedText(null, 'text-1');
+    expect(result).toBeNull();
   });
 });

--- a/apps/web/src/lib/server/texts/upload.ts
+++ b/apps/web/src/lib/server/texts/upload.ts
@@ -352,25 +352,27 @@ export async function createEpubText(
 }
 
 /**
- * Read one of the user's own texts plus its chapters, in order. Used by
- * the placeholder reader page T-4.1 shipped (a temporary view of the
- * raw body — the real reader lands in M5). Returns `null` if the text
- * doesn't exist OR is not readable by `viewer`.
+ * Read a text + its chapters, gated by the central `canReadText`
+ * helper (T-4.6). Returns `null` if the text doesn't exist OR the
+ * viewer isn't allowed to read it (deny-by-default). Endpoints map
+ * `null` to 404 so we don't leak existence to non-readers.
  *
- * Sharing / official-text reads go through `assertCanRead` in T-4.6;
- * for now the rule is simply "owner can read their own private texts."
+ * This replaces the old owner-only `getOwnedText`. Public endpoints
+ * (e.g. anonymous reads of an official text) pass `viewer = null`.
  */
-export async function getOwnedText(
-  viewer: Pick<User, 'id'>,
+export async function getReadableText(
+  viewer: { id: string } | null,
   textId: string,
 ): Promise<{ text: Text; chapters: TextChapter[] } | null> {
+  const { canReadText } = await import('../auth/can-read.js');
   const [text] = await db
     .select()
     .from(schema.texts)
     .where(eq(schema.texts.id, textId))
     .limit(1);
   if (!text) return null;
-  if ((text as Text).ownerId !== viewer.id) return null;
+  const ok = await canReadText(viewer, text as Text);
+  if (!ok) return null;
   const chapters = (await db
     .select()
     .from(schema.textChapters)
@@ -378,3 +380,12 @@ export async function getOwnedText(
     .orderBy(schema.textChapters.idx)) as TextChapter[];
   return { text: text as Text, chapters };
 }
+
+/**
+ * Backwards-compatible alias for the old `getOwnedText` name. Prefer
+ * `getReadableText` in new code; this exists so existing callers
+ * (and their tests) don't all need to flip in one ticket.
+ *
+ * @deprecated Use `getReadableText` directly.
+ */
+export const getOwnedText = getReadableText;

--- a/apps/web/src/routes/texts/[id]/+page.server.ts
+++ b/apps/web/src/routes/texts/[id]/+page.server.ts
@@ -1,31 +1,31 @@
 /**
- * Placeholder text viewer (T-4.1).
+ * Placeholder text viewer (T-4.1, generalized in T-4.6).
  *
- * Renders the freshly uploaded text's chapters as raw paragraphs so the
- * upload flow has somewhere to land. The real reader (M5) replaces this
- * with token-aware rendering, the pop-up, paginated/continuous modes,
- * and known-words tracking. The contract this loader returns
- * (`{ text, chapters }`) is what the M5 reader will keep — it just
- * adds the tokenization layer on top.
+ * Renders the text's chapters as raw paragraphs. The real reader
+ * (M5) replaces this with token-aware rendering, the pop-up, the
+ * three reading modes, and known-words tracking. The contract this
+ * loader returns (`{ text, chapters }`) is what the M5 reader will
+ * keep — it just adds the tokenization layer on top.
  *
- * Authorization at T-4.1 is "owner only." T-4.6 swaps this out for
- * the central `assertCanRead` helper that also handles shared / official
- * visibility — for now, sharing is a future ticket so a non-owner gets
- * a flat 404 to avoid leaking text existence.
+ * Authorization runs through the central `getReadableText` helper
+ * (T-4.6): owner OR official visibility passes, anything else falls
+ * through to a 404 to avoid leaking text existence. This means
+ * official texts are readable without signing in — important for the
+ * public marketing surface (T-7.6).
  */
-import { error, redirect } from '@sveltejs/kit';
+import { error } from '@sveltejs/kit';
 
-import { getOwnedText } from '$lib/server/texts/upload.js';
+import { getReadableText } from '$lib/server/texts/upload.js';
 import type { PageServerLoad } from './$types';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-export const load: PageServerLoad = async ({ params, locals, url }) => {
-  if (!locals.user) {
-    throw redirect(303, `/login?next=${encodeURIComponent(url.pathname)}`);
-  }
+export const load: PageServerLoad = async ({ params, locals }) => {
   if (!UUID_RE.test(params.id)) throw error(400, 'Invalid text id');
-  const result = await getOwnedText({ id: locals.user.id }, params.id);
+  // `viewer` is null for anonymous visitors — the helper allows them
+  // to read official texts but rejects everything else.
+  const viewer = locals.user ? { id: locals.user.id } : null;
+  const result = await getReadableText(viewer, params.id);
   if (!result) throw error(404, 'Text not found');
   return {
     text: {
@@ -45,5 +45,6 @@ export const load: PageServerLoad = async ({ params, locals, url }) => {
       body: c.body,
       tokenCount: c.tokenCount,
     })),
+    isOwner: Boolean(locals.user && locals.user.id === result.text.ownerId),
   };
 };

--- a/apps/web/src/routes/texts/[id]/+page.svelte
+++ b/apps/web/src/routes/texts/[id]/+page.svelte
@@ -38,6 +38,9 @@
     // then start polling if needed.
     liveStatus = data.text.status;
 
+    // Only the owner can hit the status endpoint; anonymous viewers
+    // of an official text would just get 401s in a tight loop.
+    if (!data.isOwner) return;
     if (!shouldPoll(liveStatus)) return;
 
     // Conservative 2.5s interval — fast enough that the user feels the

--- a/apps/web/src/routes/texts/[id]/page-server.test.ts
+++ b/apps/web/src/routes/texts/[id]/page-server.test.ts
@@ -1,13 +1,10 @@
 // @vitest-environment node
 /**
- * Tests for /texts/[id] SSR loader (T-4.1).
- *
- * Placeholder viewer — at T-4.1 it's owner-only; T-4.6 swaps in the
- * full assertCanRead helper.
+ * Tests for /texts/[id] SSR loader (T-4.1, generalized in T-4.6).
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const getOwnedText = vi.fn();
+const getReadableText = vi.fn();
 
 vi.mock('$lib/server/texts/upload.js', async () => {
   const actual = await vi.importActual<typeof import('$lib/server/texts/upload.js')>(
@@ -15,7 +12,8 @@ vi.mock('$lib/server/texts/upload.js', async () => {
   );
   return {
     ...actual,
-    getOwnedText: (...a: unknown[]) => getOwnedText(...a),
+    getReadableText: (...a: unknown[]) => getReadableText(...a),
+    getOwnedText: (...a: unknown[]) => getReadableText(...a),
   };
 });
 
@@ -42,7 +40,7 @@ async function callLoad(
 }
 
 beforeEach(() => {
-  getOwnedText.mockReset();
+  getReadableText.mockReset();
 });
 
 afterEach(() => {
@@ -50,14 +48,16 @@ afterEach(() => {
 });
 
 describe('/texts/[id] loader', () => {
-  it('returns the text + chapters on a happy path', async () => {
-    getOwnedText.mockResolvedValueOnce({
+  it('returns the text + chapters + isOwner=true for the owner', async () => {
+    getReadableText.mockResolvedValueOnce({
       text: {
         id: VALID_ID,
+        ownerId: USER.id,
         title: 'My text',
         language: 'hi',
         sourceType: 'paste',
         status: 'pending',
+        statusError: null,
         visibility: 'private',
         createdAt: new Date('2026-04-27T00:00:00Z'),
       },
@@ -66,34 +66,54 @@ describe('/texts/[id] loader', () => {
       ],
     });
     const data = (await callLoad(VALID_ID)) as {
-      text: { id: string; status: string };
-      chapters: Array<{ id: string }>;
+      text: { id: string };
+      isOwner: boolean;
     };
     expect(data.text.id).toBe(VALID_ID);
-    expect(data.text.status).toBe('pending');
-    expect(data.chapters).toHaveLength(1);
-    expect(getOwnedText).toHaveBeenCalledWith({ id: USER.id }, VALID_ID);
+    expect(data.isOwner).toBe(true);
+    expect(getReadableText).toHaveBeenCalledWith({ id: USER.id }, VALID_ID);
   });
 
-  it('redirects unauthenticated visitors to /login', async () => {
-    const res = (await callLoad(VALID_ID, null)) as {
-      status: number;
-      location: string;
+  it('lets anonymous visitors read an official text and reports isOwner=false', async () => {
+    getReadableText.mockResolvedValueOnce({
+      text: {
+        id: VALID_ID,
+        ownerId: null,
+        title: 'Curated short story',
+        language: 'hi',
+        sourceType: 'paste',
+        status: 'ready',
+        statusError: null,
+        visibility: 'official',
+        createdAt: new Date(),
+      },
+      chapters: [{ id: 'c0', idx: 0, title: null, body: 'x', tokenCount: 1 }],
+    });
+    const data = (await callLoad(VALID_ID, null)) as {
+      text: { visibility: string };
+      isOwner: boolean;
     };
-    expect(res.status).toBe(303);
-    expect(res.location).toContain('/login');
-    expect(getOwnedText).not.toHaveBeenCalled();
+    expect(data.text.visibility).toBe('official');
+    expect(data.isOwner).toBe(false);
+    // Anonymous viewer was passed as null to the helper.
+    expect(getReadableText).toHaveBeenCalledWith(null, VALID_ID);
   });
 
-  it('rejects an invalid uuid with 400', async () => {
+  it('rejects an invalid uuid with 400 before calling the service', async () => {
     const res = (await callLoad('not-a-uuid')) as { status: number };
     expect(res.status).toBe(400);
-    expect(getOwnedText).not.toHaveBeenCalled();
+    expect(getReadableText).not.toHaveBeenCalled();
   });
 
-  it('returns 404 when the text does not exist or is not owned', async () => {
-    getOwnedText.mockResolvedValueOnce(null);
+  it('returns 404 when the text is missing or unreadable', async () => {
+    getReadableText.mockResolvedValueOnce(null);
     const res = (await callLoad(VALID_ID)) as { status: number };
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 when an anonymous viewer asks for a private text', async () => {
+    getReadableText.mockResolvedValueOnce(null);
+    const res = (await callLoad(VALID_ID, null)) as { status: number };
     expect(res.status).toBe(404);
   });
 });


### PR DESCRIPTION
Closes #41

## Summary

Closes M4. Adds the central \`canReadText\` / \`assertCanReadText\` helper the plan calls for, then routes the existing reader + status paths through it. Net effect: anonymous visitors can now read \`visibility='official'\` texts without signing in (important for the public marketing surface in T-7.6), but private texts stay locked down by default.

- **\`lib/server/auth/can-read.ts\`** — pure async predicate, deny-by-default. Today: owner OR official passes. Forward-shape for M7's share-table lookups; when those land, this is the one place to extend.
- **Service refactor** — \`getOwnedText\` → \`getReadableText\` (alias kept), \`getTextStatus\` accepts \`viewer | null\`. Both now route through the helper.
- **\`/texts/[id]\`** — drops its own auth gate. Anonymous viewers of official texts get \`isOwner=false\`, which suppresses the status-polling loop (no point hammering an endpoint that requires auth).

## Test plan

- [x] \`pnpm --filter @ciareader/web test\` — 496/496 (12 new for T-4.6)
- [x] \`pnpm --filter @ciareader/web check\` — clean
- [x] \`pnpm --filter @ciareader/web lint\` — clean
- [x] coverage above 80% floor
- [ ] Manual: log out, navigate to an official text's URL, confirm it renders
- [ ] Manual: log out, navigate to another user's private text URL, confirm 404
- [ ] Manual: log in as the owner, confirm polling still flips status badge live