### PR TITLE
T-5.2: token rendering + known-words classes

### DIFF
--- a/apps/web/drizzle/0008_eminent_pete_wisdom.sql
+++ b/apps/web/drizzle/0008_eminent_pete_wisdom.sql
@@ -1,0 +1,52 @@
+CREATE TYPE "public"."known_lemma_status" AS ENUM('unknown', 'learning', 'known', 'ignored');--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "text_tokens" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"chapter_id" uuid NOT NULL,
+	"idx" integer NOT NULL,
+	"surface" text NOT NULL,
+	"lemma_id" uuid,
+	"lemma_candidates" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"features" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"is_ambiguous" boolean DEFAULT false NOT NULL,
+	"is_oov" boolean DEFAULT false NOT NULL,
+	"is_word" boolean DEFAULT true NOT NULL,
+	"sentence_idx" integer DEFAULT 0 NOT NULL,
+	"romanization" text,
+	CONSTRAINT "text_tokens_chapter_idx_uq" UNIQUE("chapter_id","idx")
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "user_known_lemmas" (
+	"user_id" uuid NOT NULL,
+	"lemma_id" uuid NOT NULL,
+	"status" "known_lemma_status" DEFAULT 'learning' NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "user_known_lemmas_user_id_lemma_id_pk" PRIMARY KEY("user_id","lemma_id")
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "text_tokens" ADD CONSTRAINT "text_tokens_chapter_id_text_chapters_id_fk" FOREIGN KEY ("chapter_id") REFERENCES "public"."text_chapters"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "text_tokens" ADD CONSTRAINT "text_tokens_lemma_id_lemmas_id_fk" FOREIGN KEY ("lemma_id") REFERENCES "public"."lemmas"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "user_known_lemmas" ADD CONSTRAINT "user_known_lemmas_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "user_known_lemmas" ADD CONSTRAINT "user_known_lemmas_lemma_id_lemmas_id_fk" FOREIGN KEY ("lemma_id") REFERENCES "public"."lemmas"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "text_tokens_chapter_scan_idx" ON "text_tokens" USING btree ("chapter_id","idx");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "text_tokens_lemma_idx" ON "text_tokens" USING btree ("lemma_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "user_known_lemmas_user_idx" ON "user_known_lemmas" USING btree ("user_id","status");

--- a/apps/web/drizzle/meta/0008_snapshot.json
+++ b/apps/web/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,2026 @@
+{
+  "id": "af78a798-80dd-4e78-91da-4380e406ec93",
+  "prevId": "d45d6d2d-7cd1-43b2-9ad5-f86f375dbc33",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.curator_languages": {
+      "name": "curator_languages",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "curator_languages_user_idx": {
+          "name": "curator_languages_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "curator_languages_user_id_users_id_fk": {
+          "name": "curator_languages_user_id_users_id_fk",
+          "tableFrom": "curator_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "curator_languages_granted_by_users_id_fk": {
+          "name": "curator_languages_granted_by_users_id_fk",
+          "tableFrom": "curator_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "curator_languages_user_id_language_pk": {
+          "name": "curator_languages_user_id_language_pk",
+          "columns": [
+            "user_id",
+            "language"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.dictionary_imports": {
+      "name": "dictionary_imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_name": {
+          "name": "source_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_at": {
+          "name": "run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lemmas_created": {
+          "name": "lemmas_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lemmas_updated": {
+          "name": "lemmas_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lemmas_skipped_curator_locked": {
+          "name": "lemmas_skipped_curator_locked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "translations_created": {
+          "name": "translations_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "translations_updated": {
+          "name": "translations_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "dictionary_imports_language_idx": {
+          "name": "dictionary_imports_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemma_edit_history": {
+      "name": "lemma_edit_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "editor_id": {
+          "name": "editor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "lemma_edit_change_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change": {
+          "name": "change",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_edit_history_lemma_idx": {
+          "name": "lemma_edit_history_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_edit_history_editor_idx": {
+          "name": "lemma_edit_history_editor_idx",
+          "columns": [
+            {
+              "expression": "editor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_edit_history_lemma_id_lemmas_id_fk": {
+          "name": "lemma_edit_history_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_edit_history",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lemma_edit_history_editor_id_users_id_fk": {
+          "name": "lemma_edit_history_editor_id_users_id_fk",
+          "tableFrom": "lemma_edit_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "editor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemma_forms": {
+      "name": "lemma_forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "romanization": {
+          "name": "romanization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_forms_lemma_idx": {
+          "name": "lemma_forms_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_forms_surface_idx": {
+          "name": "lemma_forms_surface_idx",
+          "columns": [
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_forms_lemma_id_lemmas_id_fk": {
+          "name": "lemma_forms_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_forms",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemmas": {
+      "name": "lemmas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headword": {
+          "name": "headword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos": {
+          "name": "pos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script": {
+          "name": "script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gloss_default": {
+          "name": "gloss_default",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_rank": {
+          "name": "frequency_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "translation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "curator_locked": {
+          "name": "curator_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemmas_language_idx": {
+          "name": "lemmas_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_language_frequency_idx": {
+          "name": "lemmas_language_frequency_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "frequency_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_source_lookup_idx": {
+          "name": "lemmas_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lemmas_language_headword_pos_uq": {
+          "name": "lemmas_language_headword_pos_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "language",
+            "headword",
+            "pos"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.magic_links": {
+      "name": "magic_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "magic_links_user_idx": {
+          "name": "magic_links_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "magic_links_expires_idx": {
+          "name": "magic_links_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "magic_links_user_id_users_id_fk": {
+          "name": "magic_links_user_id_users_id_fk",
+          "tableFrom": "magic_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.nlp_jobs": {
+      "name": "nlp_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "nlp_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nlp_jobs_text_idx": {
+          "name": "nlp_jobs_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nlp_jobs_status_idx": {
+          "name": "nlp_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nlp_jobs_text_id_texts_id_fk": {
+          "name": "nlp_jobs_text_id_texts_id_fk",
+          "tableFrom": "nlp_jobs",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by": {
+          "name": "replaced_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "refresh_tokens_user_idx": {
+          "name": "refresh_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_expires_idx": {
+          "name": "refresh_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.text_chapters": {
+      "name": "text_chapters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idx": {
+          "name": "idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "text_chapters_text_idx": {
+          "name": "text_chapters_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_chapters_text_id_texts_id_fk": {
+          "name": "text_chapters_text_id_texts_id_fk",
+          "tableFrom": "text_chapters",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "text_chapters_text_idx_uq": {
+          "name": "text_chapters_text_idx_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "text_id",
+            "idx"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.text_tokens": {
+      "name": "text_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idx": {
+          "name": "idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lemma_candidates": {
+          "name": "lemma_candidates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_ambiguous": {
+          "name": "is_ambiguous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_oov": {
+          "name": "is_oov",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_word": {
+          "name": "is_word",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sentence_idx": {
+          "name": "sentence_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "romanization": {
+          "name": "romanization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "text_tokens_chapter_scan_idx": {
+          "name": "text_tokens_chapter_scan_idx",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "text_tokens_lemma_idx": {
+          "name": "text_tokens_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_tokens_chapter_id_text_chapters_id_fk": {
+          "name": "text_tokens_chapter_id_text_chapters_id_fk",
+          "tableFrom": "text_tokens",
+          "tableTo": "text_chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_tokens_lemma_id_lemmas_id_fk": {
+          "name": "text_tokens_lemma_id_lemmas_id_fk",
+          "tableFrom": "text_tokens",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "text_tokens_chapter_idx_uq": {
+          "name": "text_tokens_chapter_idx_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chapter_id",
+            "idx"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.texts": {
+      "name": "texts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "status_error": {
+          "name": "status_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "texts_owner_idx": {
+          "name": "texts_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "texts_visibility_idx": {
+          "name": "texts_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "texts_owner_id_users_id_fk": {
+          "name": "texts_owner_id_users_id_fk",
+          "tableFrom": "texts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.translations": {
+      "name": "translations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "translation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_translation_id": {
+          "name": "parent_translation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_language": {
+          "name": "target_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "translations_lemma_idx": {
+          "name": "translations_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translations_submitted_by_idx": {
+          "name": "translations_submitted_by_idx",
+          "columns": [
+            {
+              "expression": "submitted_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translations_source_lookup_idx": {
+          "name": "translations_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "translations_lemma_id_lemmas_id_fk": {
+          "name": "translations_lemma_id_lemmas_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "translations_submitted_by_users_id_fk": {
+          "name": "translations_submitted_by_users_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "translations_parent_translation_id_translations_id_fk": {
+          "name": "translations_parent_translation_id_translations_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "translations",
+          "columnsFrom": [
+            "parent_translation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_known_lemmas": {
+      "name": "user_known_lemmas",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "known_lemma_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'learning'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_known_lemmas_user_idx": {
+          "name": "user_known_lemmas_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_known_lemmas_user_id_users_id_fk": {
+          "name": "user_known_lemmas_user_id_users_id_fk",
+          "tableFrom": "user_known_lemmas",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_known_lemmas_lemma_id_lemmas_id_fk": {
+          "name": "user_known_lemmas_lemma_id_lemmas_id_fk",
+          "tableFrom": "user_known_lemmas",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_known_lemmas_user_id_lemma_id_pk": {
+          "name": "user_known_lemmas_user_id_lemma_id_pk",
+          "columns": [
+            "user_id",
+            "lemma_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_languages": {
+      "name": "user_languages",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script_preference": {
+          "name": "script_preference",
+          "type": "script_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "romanization_scheme": {
+          "name": "romanization_scheme",
+          "type": "romanization_scheme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'iso15919'"
+        },
+        "known_words_count_cache": {
+          "name": "known_words_count_cache",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reader_layout_mode": {
+          "name": "reader_layout_mode",
+          "type": "reader_layout_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'page'"
+        },
+        "words_per_page": {
+          "name": "words_per_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 250
+        },
+        "font_family": {
+          "name": "font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_size": {
+          "name": "font_size",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 18
+        },
+        "line_spacing": {
+          "name": "line_spacing",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1.6
+        },
+        "highlight_style": {
+          "name": "highlight_style",
+          "type": "highlight_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'background'"
+        },
+        "baseline": {
+          "name": "baseline",
+          "type": "language_baseline",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_languages_user_id_users_id_fk": {
+          "name": "user_languages_user_id_users_id_fk",
+          "tableFrom": "user_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_languages_user_id_language_pk": {
+          "name": "user_languages_user_id_language_pk",
+          "columns": [
+            "user_id",
+            "language"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_preference": {
+          "name": "theme_preference",
+          "type": "theme_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarded_at": {
+          "name": "onboarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    }
+  },
+  "enums": {
+    "public.highlight_style": {
+      "name": "highlight_style",
+      "schema": "public",
+      "values": [
+        "underline",
+        "background",
+        "colored_text"
+      ]
+    },
+    "public.known_lemma_status": {
+      "name": "known_lemma_status",
+      "schema": "public",
+      "values": [
+        "unknown",
+        "learning",
+        "known",
+        "ignored"
+      ]
+    },
+    "public.language": {
+      "name": "language",
+      "schema": "public",
+      "values": [
+        "hi",
+        "mr",
+        "or"
+      ]
+    },
+    "public.language_baseline": {
+      "name": "language_baseline",
+      "schema": "public",
+      "values": [
+        "none",
+        "beginner",
+        "intermediate"
+      ]
+    },
+    "public.lemma_edit_change_type": {
+      "name": "lemma_edit_change_type",
+      "schema": "public",
+      "values": [
+        "lemma_update",
+        "lemma_unlock",
+        "lemma_lock",
+        "translation_insert",
+        "translation_update",
+        "translation_hide",
+        "translation_unhide",
+        "form_insert",
+        "form_delete",
+        "lemma_merge",
+        "lemma_split"
+      ]
+    },
+    "public.nlp_job_status": {
+      "name": "nlp_job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.reader_layout_mode": {
+      "name": "reader_layout_mode",
+      "schema": "public",
+      "values": [
+        "page",
+        "paged_scroll",
+        "continuous"
+      ]
+    },
+    "public.romanization_scheme": {
+      "name": "romanization_scheme",
+      "schema": "public",
+      "values": [
+        "iso15919",
+        "iast",
+        "hunterian",
+        "itrans"
+      ]
+    },
+    "public.script_preference": {
+      "name": "script_preference",
+      "schema": "public",
+      "values": [
+        "native",
+        "native_with_romanization",
+        "romanization_only"
+      ]
+    },
+    "public.text_source_type": {
+      "name": "text_source_type",
+      "schema": "public",
+      "values": [
+        "paste",
+        "txt",
+        "epub"
+      ]
+    },
+    "public.text_status": {
+      "name": "text_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.text_visibility": {
+      "name": "text_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "shared",
+        "official"
+      ]
+    },
+    "public.theme_preference": {
+      "name": "theme_preference",
+      "schema": "public",
+      "values": [
+        "system",
+        "light",
+        "dark"
+      ]
+    },
+    "public.translation_source": {
+      "name": "translation_source",
+      "schema": "public",
+      "values": [
+        "official_dictionary",
+        "curator",
+        "user"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "curator",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1777301379511,
       "tag": "0007_silly_avengers",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1777302897641,
+      "tag": "0008_eminent_pete_wisdom",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/src/lib/components/reader/ChapterBody.svelte
+++ b/apps/web/src/lib/components/reader/ChapterBody.svelte
@@ -1,0 +1,65 @@
+<!--
+  Renders one chapter's body with the right tokenizer (T-5.2).
+
+  When the chapter has server-rendered tokens (the NLP worker has
+  run), we render a span per ServerToken with `.status-*` classes
+  driving the highlight. Otherwise, we fall back to the client-side
+  whitespace tokenizer — every word becomes a `.word` span with no
+  status, so the layout still looks right and click-handlers / pop-ups
+  can attach (the lemma_id is just null until the worker fills it in).
+
+  Both layout modes (`page`, `paged_scroll`, `continuous`) consume
+  this so the rendering rules live in one place.
+-->
+<script lang="ts">
+  import TokenSpan from './TokenSpan.svelte';
+  import {
+    paragraphsOfServerTokens,
+    paragraphsOfTokens,
+    tokenize,
+    type ChapterView,
+  } from './types.js';
+
+  let { chapter }: { chapter: ChapterView } = $props();
+
+  const serverParagraphs = $derived(
+    chapter.tokens ? paragraphsOfServerTokens(chapter.tokens) : null,
+  );
+  const fallbackParagraphs = $derived(
+    chapter.tokens ? null : paragraphsOfTokens(tokenize(chapter.body)),
+  );
+</script>
+
+{#if serverParagraphs}
+  {#each serverParagraphs as paragraph, pIdx (pIdx)}
+    <p class="body">
+      {#each paragraph as token (token.id)}<TokenSpan {token} />{/each}
+    </p>
+  {/each}
+{:else if fallbackParagraphs}
+  {#each fallbackParagraphs as paragraph, pIdx (pIdx)}
+    <p class="body">
+      {#each paragraph as token (token.idx)}<span
+          class:word={token.isWord}
+          data-token-idx={token.idx}>{token.surface}</span>{/each}
+    </p>
+  {/each}
+{/if}
+
+<style>
+  .body {
+    margin: 0 0 1rem;
+    line-height: 1.75;
+    font-size: 1.05rem;
+  }
+  /* The fallback path has its own minimal hover treatment — the real
+     status-aware classes live on TokenSpan. */
+  .word {
+    cursor: pointer;
+    border-radius: 3px;
+    transition: background 80ms ease;
+  }
+  .word:hover {
+    background: color-mix(in srgb, var(--color-accent) 12%, transparent);
+  }
+</style>

--- a/apps/web/src/lib/components/reader/ReaderContinuous.svelte
+++ b/apps/web/src/lib/components/reader/ReaderContinuous.svelte
@@ -1,47 +1,34 @@
 <!--
-  Continuous reading mode (T-5.1).
+  Continuous reading mode (T-5.1, token-aware in T-5.2).
 
-  Renders every chapter stacked vertically. The skeleton uses plain
-  paragraph rendering — token spans + the pop-up land in T-5.2 / T-5.4.
-  Virtual scrolling for very long books (T-5.1a) is wired by the
-  caller's chunking, not here.
+  Renders every chapter stacked vertically. Token rendering is
+  delegated to <ChapterBody/> so all three modes use the same
+  status/OOV/ambiguous logic. Virtual scrolling for very long books
+  (T-5.1a) is wired by the caller's chunking, not here.
 -->
 <script lang="ts">
-  import { paragraphsOfTokens, tokenize, type ChapterView } from './types.js';
+  import ChapterBody from './ChapterBody.svelte';
+  import type { ChapterView } from './types.js';
 
   let {
     chapters,
     initialChapterIdx = 0,
   }: { chapters: ChapterView[]; initialChapterIdx?: number } = $props();
-
-  // Memoize tokenization per chapter so a re-render doesn't redo it.
-  const tokenizedChapters = $derived(
-    chapters.map((c) => ({
-      ...c,
-      paragraphs: paragraphsOfTokens(tokenize(c.body)),
-    })),
-  );
 </script>
 
 <div class="reader-continuous" data-mode="continuous" data-initial-chapter={initialChapterIdx}>
-  {#each tokenizedChapters as chapter (chapter.id)}
+  {#each chapters as chapter (chapter.id)}
     <section
       id={`chapter-${chapter.idx}`}
       class:active={chapter.idx === initialChapterIdx}
     >
-      {#if chapter.title || tokenizedChapters.length > 1}
+      {#if chapter.title || chapters.length > 1}
         <h2>
           {chapter.title ?? `Chapter ${chapter.idx + 1}`}
           <span class="muted">({chapter.tokenCount.toLocaleString()} tokens)</span>
         </h2>
       {/if}
-      {#each chapter.paragraphs as paragraph, pIdx (pIdx)}
-        <p class="body">
-          {#each paragraph as token (token.idx)}<span
-              class:word={token.isWord}
-              data-token-idx={token.idx}>{token.surface}</span>{/each}
-        </p>
-      {/each}
+      <ChapterBody {chapter} />
     </section>
   {/each}
 </div>
@@ -64,21 +51,5 @@
     font-weight: 400;
     font-size: 0.85em;
     margin-left: 0.4rem;
-  }
-  .body {
-    margin: 0 0 1rem;
-    line-height: 1.75;
-    font-size: 1.05rem;
-  }
-  /* Words get an inviting hover state so the reader knows they're
-     interactive, even before T-5.4's pop-up lands. Whitespace +
-     punctuation tokens render as plain text. */
-  .word {
-    cursor: pointer;
-    border-radius: 3px;
-    transition: background 80ms ease;
-  }
-  .word:hover {
-    background: color-mix(in srgb, var(--color-accent) 12%, transparent);
   }
 </style>

--- a/apps/web/src/lib/components/reader/ReaderPage.svelte
+++ b/apps/web/src/lib/components/reader/ReaderPage.svelte
@@ -1,15 +1,13 @@
 <!--
-  Page-mode reader (T-5.1).
+  Page-mode reader (T-5.1, token-aware in T-5.2).
 
-  Classic LingQ-style pagination: one rendered chapter at a time with
-  prev/next buttons. Pixel-precise viewport-driven page breaks
-  (preventing mid-word cuts) land in T-5.1a + T-5.1c — the skeleton
-  here treats one chapter as one page, which keeps the contract for
-  the navigation buttons stable while we layer real pagination on.
+  Classic LingQ-style pagination: one chapter at a time with prev/next
+  buttons. Token rendering is delegated to <ChapterBody/>.
 -->
 <script lang="ts">
   import { goto } from '$app/navigation';
-  import { paragraphsOfTokens, tokenize, type ChapterView } from './types.js';
+  import ChapterBody from './ChapterBody.svelte';
+  import type { ChapterView } from './types.js';
 
   let {
     chapters,
@@ -17,9 +15,8 @@
     textId,
   }: { chapters: ChapterView[]; chapterIdx: number; textId: string } = $props();
 
-  const current = $derived(chapters[Math.max(0, Math.min(chapterIdx, chapters.length - 1))]);
-  const paragraphs = $derived(
-    current ? paragraphsOfTokens(tokenize(current.body)) : [],
+  const current = $derived(
+    chapters[Math.max(0, Math.min(chapterIdx, chapters.length - 1))],
   );
   const hasPrev = $derived(chapterIdx > 0);
   const hasNext = $derived(chapterIdx < chapters.length - 1);
@@ -45,13 +42,9 @@
   </header>
 
   <article>
-    {#each paragraphs as paragraph, pIdx (pIdx)}
-      <p class="body">
-        {#each paragraph as token (token.idx)}<span
-            class:word={token.isWord}
-            data-token-idx={token.idx}>{token.surface}</span>{/each}
-      </p>
-    {/each}
+    {#if current}
+      <ChapterBody chapter={current} />
+    {/if}
   </article>
 
   <nav class="pager" aria-label="Chapter navigation">
@@ -81,19 +74,6 @@
   }
   article {
     min-height: 50vh;
-  }
-  .body {
-    margin: 0 0 1rem;
-    line-height: 1.75;
-    font-size: 1.05rem;
-  }
-  .word {
-    cursor: pointer;
-    border-radius: 3px;
-    transition: background 80ms ease;
-  }
-  .word:hover {
-    background: color-mix(in srgb, var(--color-accent) 12%, transparent);
   }
   .pager {
     display: flex;

--- a/apps/web/src/lib/components/reader/ReaderScroll.svelte
+++ b/apps/web/src/lib/components/reader/ReaderScroll.svelte
@@ -1,16 +1,22 @@
 <!--
-  Paged-scroll mode (T-5.1).
+  Paged-scroll mode (T-5.1, token-aware in T-5.2).
 
-  Shows a fixed words-per-page slice of the current chapter; the
-  scroll bar is bounded to that page. Prev/next buttons advance by
-  one page of N words. The page break respects paragraph boundaries
-  so we never cut mid-paragraph.
-
-  T-5.1b adds the user-configurable words-per-page setting; the
-  skeleton hard-codes a sensible default.
+  Slices the active chapter into pages of ~wordsPerPage word tokens
+  along paragraph boundaries (no mid-paragraph cuts). When the chapter
+  has server tokens we slice ServerToken paragraphs; otherwise we
+  slice the client-tokenized fallback. The render is delegated to a
+  per-paragraph TokenSpan render so all three modes share styles.
 -->
 <script lang="ts">
-  import { paragraphsOfTokens, tokenize, type ChapterView } from './types.js';
+  import TokenSpan from './TokenSpan.svelte';
+  import {
+    paragraphsOfServerTokens,
+    paragraphsOfTokens,
+    tokenize,
+    type ChapterView,
+    type RenderToken,
+    type ServerToken,
+  } from './types.js';
 
   let {
     chapters,
@@ -27,16 +33,23 @@
   const current = $derived(
     chapters[Math.max(0, Math.min(chapterIdx, chapters.length - 1))],
   );
-  const paragraphs = $derived(
-    current ? paragraphsOfTokens(tokenize(current.body)) : [],
+
+  // Source-of-tokens decision happens once per chapter — server
+  // tokens beat the client fallback.
+  type ParaServer = ServerToken[];
+  type ParaFallback = RenderToken[];
+  const serverParagraphs = $derived(
+    current && current.tokens
+      ? paragraphsOfServerTokens(current.tokens)
+      : null,
+  );
+  const fallbackParagraphs = $derived(
+    current && !current.tokens ? paragraphsOfTokens(tokenize(current.body)) : null,
   );
 
-  // Pack paragraphs into pages of ~wordsPerPage word tokens. Same
-  // paragraph-integrity rule as the chunker (T-4.2): a single oversized
-  // paragraph stays whole, even if that overshoots the target.
-  const pages = $derived.by(() => {
-    const out: (typeof paragraphs)[] = [];
-    let buf: typeof paragraphs = [];
+  function packServer(paragraphs: ParaServer[]): ParaServer[][] {
+    const out: ParaServer[][] = [];
+    let buf: ParaServer[] = [];
     let bufWords = 0;
     for (const p of paragraphs) {
       const words = p.filter((t) => t.isWord).length;
@@ -51,12 +64,40 @@
     if (buf.length > 0) out.push(buf);
     if (out.length === 0) out.push([]);
     return out;
-  });
+  }
 
-  const clampedPage = $derived(Math.max(0, Math.min(page, pages.length - 1)));
-  const visible = $derived(pages[clampedPage] ?? []);
+  function packFallback(paragraphs: ParaFallback[]): ParaFallback[][] {
+    const out: ParaFallback[][] = [];
+    let buf: ParaFallback[] = [];
+    let bufWords = 0;
+    for (const p of paragraphs) {
+      const words = p.filter((t) => t.isWord).length;
+      if (bufWords > 0 && bufWords + words > wordsPerPage) {
+        out.push(buf);
+        buf = [];
+        bufWords = 0;
+      }
+      buf.push(p);
+      bufWords += words;
+    }
+    if (buf.length > 0) out.push(buf);
+    if (out.length === 0) out.push([]);
+    return out;
+  }
+
+  const serverPages = $derived(serverParagraphs ? packServer(serverParagraphs) : null);
+  const fallbackPages = $derived(
+    fallbackParagraphs ? packFallback(fallbackParagraphs) : null,
+  );
+  const pageCount = $derived(serverPages?.length ?? fallbackPages?.length ?? 1);
+
+  const clampedPage = $derived(Math.max(0, Math.min(page, pageCount - 1)));
+  const visibleServer = $derived(serverPages ? serverPages[clampedPage] ?? [] : null);
+  const visibleFallback = $derived(
+    fallbackPages ? fallbackPages[clampedPage] ?? [] : null,
+  );
   const hasPrev = $derived(clampedPage > 0);
-  const hasNext = $derived(clampedPage < pages.length - 1);
+  const hasNext = $derived(clampedPage < pageCount - 1);
 
   function prev() {
     if (hasPrev) page = clampedPage - 1;
@@ -73,20 +114,28 @@
         {current.title ?? `Chapter ${current.idx + 1}`}
       </h2>
       <p class="muted">
-        Page {clampedPage + 1} of {pages.length}
+        Page {clampedPage + 1} of {pageCount}
         · {wordsPerPage.toLocaleString()} words/page
       </p>
     {/if}
   </header>
 
   <article>
-    {#each visible as paragraph, pIdx (pIdx)}
-      <p class="body">
-        {#each paragraph as token (token.idx)}<span
-            class:word={token.isWord}
-            data-token-idx={token.idx}>{token.surface}</span>{/each}
-      </p>
-    {/each}
+    {#if visibleServer}
+      {#each visibleServer as paragraph, pIdx (pIdx)}
+        <p class="body">
+          {#each paragraph as token (token.id)}<TokenSpan {token} />{/each}
+        </p>
+      {/each}
+    {:else if visibleFallback}
+      {#each visibleFallback as paragraph, pIdx (pIdx)}
+        <p class="body">
+          {#each paragraph as token (token.idx)}<span
+              class:word={token.isWord}
+              data-token-idx={token.idx}>{token.surface}</span>{/each}
+        </p>
+      {/each}
+    {/if}
   </article>
 
   <nav class="pager" aria-label="Page navigation">

--- a/apps/web/src/lib/components/reader/TokenSpan.svelte
+++ b/apps/web/src/lib/components/reader/TokenSpan.svelte
@@ -1,0 +1,80 @@
+<!--
+  Single token render (T-5.2).
+
+  One `<span>` per token, with a `.status-*` class when we have a
+  lemma resolution. Word tokens get a hover affordance. Whitespace
+  tokens render as plain text without any classes — the reader
+  preserves the original layout faithfully.
+
+  T-5.4 layers the word pop-up on top of this; T-5.5 wires status
+  changes back to the server. The classes are stable so those tickets
+  don't have to touch markup.
+-->
+<script lang="ts">
+  import type { ServerToken } from './types.js';
+
+  let {
+    token,
+  }: { token: ServerToken } = $props();
+
+  // OOV tokens get a distinct visual state (T-5.4a) — dashed
+  // underline rather than the known/unknown highlight, so the user
+  // sees them as "no dictionary match yet" not "you don't know this
+  // word."
+  const cssClass = $derived.by(() => {
+    if (!token.isWord) return '';
+    const classes: string[] = ['word'];
+    if (token.isOov) classes.push('oov');
+    else classes.push(`status-${token.status}`);
+    if (token.isAmbiguous) classes.push('ambiguous');
+    return classes.join(' ');
+  });
+</script>
+
+{#if token.isWord}<span
+    class={cssClass}
+    data-token-id={token.id}
+    data-token-idx={token.idx}
+    data-lemma-id={token.lemmaId ?? ''}>{token.surface}</span>{:else}{token.surface}{/if}
+
+<style>
+  .word {
+    cursor: pointer;
+    border-radius: 3px;
+    transition: background 80ms ease;
+  }
+  .word:hover {
+    background: color-mix(in srgb, var(--color-accent) 12%, transparent);
+  }
+  /* Default — token has a lemma but the user hasn't marked it. The
+     LingQ-style "this is a word you should pay attention to" colour. */
+  .status-unknown {
+    background: color-mix(in srgb, var(--color-accent) 18%, transparent);
+  }
+  .status-learning {
+    background: color-mix(in srgb, #b07a31 30%, transparent);
+    color: var(--color-fg);
+  }
+  /* Known + ignored: render as plain text, no highlight. */
+  .status-known,
+  .status-ignored {
+    background: transparent;
+  }
+  /* OOV: no dictionary match — dashed underline rather than a
+     highlight, so the user knows the system needs help on this token. */
+  .oov {
+    background: transparent;
+    border-bottom: 1px dashed var(--color-fg-muted);
+    border-radius: 0;
+  }
+  /* Ambiguous: an extra dot above to hint that there are alternate
+     parses available (T-6.1's "N possible meanings" chevron lives in
+     the pop-up; this is the at-a-glance affordance). */
+  .ambiguous::after {
+    content: '·';
+    color: var(--color-accent);
+    margin-left: 0.05em;
+    vertical-align: super;
+    font-size: 0.7em;
+  }
+</style>

--- a/apps/web/src/lib/components/reader/types.ts
+++ b/apps/web/src/lib/components/reader/types.ts
@@ -7,12 +7,28 @@
  * every mode (T-5.2 onward).
  */
 
+/** Per-token row from the NLP worker (T-5.2). When present, the
+ *  component renders these spans directly; when null, it falls back
+ *  to client-side whitespace tokenization. */
+export type ServerToken = {
+  id: string;
+  idx: number;
+  surface: string;
+  isWord: boolean;
+  isAmbiguous: boolean;
+  isOov: boolean;
+  lemmaId: string | null;
+  romanization: string | null;
+  status: 'known' | 'learning' | 'ignored' | 'unknown';
+};
+
 export type ChapterView = {
   id: string;
   idx: number;
   title: string | null;
   body: string;
   tokenCount: number;
+  tokens: ServerToken[] | null;
 };
 
 export type ReaderLayoutMode = 'page' | 'paged_scroll' | 'continuous';
@@ -72,6 +88,26 @@ export function tokenize(body: string): RenderToken[] {
 export function paragraphsOfTokens(tokens: RenderToken[]): RenderToken[][] {
   const out: RenderToken[][] = [];
   let current: RenderToken[] = [];
+  for (const t of tokens) {
+    if (!t.isWord && /\n\s*\n/.test(t.surface)) {
+      if (current.length > 0) out.push(current);
+      current = [];
+      continue;
+    }
+    current.push(t);
+  }
+  if (current.length > 0) out.push(current);
+  return out;
+}
+
+/** Server-token analogue of `paragraphsOfTokens`. The worker writes
+ * the surface form including paragraph-boundary whitespace as its
+ * own non-word token; we cut on those. */
+export function paragraphsOfServerTokens(
+  tokens: ServerToken[],
+): ServerToken[][] {
+  const out: ServerToken[][] = [];
+  let current: ServerToken[] = [];
   for (const t of tokens) {
     if (!t.isWord && /\n\s*\n/.test(t.surface)) {
       if (current.length > 0) out.push(current);

--- a/apps/web/src/lib/server/db/schema.ts
+++ b/apps/web/src/lib/server/db/schema.ts
@@ -599,6 +599,103 @@ export const nlpJobs = pgTable(
   }),
 );
 
+/**
+ * Per-token output from the NLP worker (T-2.6 / T-5.2).
+ *
+ * One row per surface token in a chapter, in reading order. The
+ * reader joins this against `user_known_lemmas` to colour known /
+ * learning / unknown words. Tokens without a `lemma_id` are
+ * punctuation, whitespace, or unresolved OOV — they render as plain
+ * text without the pop-up.
+ *
+ * `lemma_candidates` stores the top-K candidate list the pipeline
+ * returned (T-2.2's contract); `is_ambiguous` is set when 2nd-place
+ * is within the confidence threshold of the top. M6's
+ * disambiguation UX reads both.
+ */
+export const textTokens = pgTable(
+  'text_tokens',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    chapterId: uuid('chapter_id')
+      .notNull()
+      .references(() => textChapters.id, { onDelete: 'cascade' }),
+    idx: integer('idx').notNull(),
+    surface: text('surface').notNull(),
+    lemmaId: uuid('lemma_id').references(() => lemmas.id, {
+      onDelete: 'set null',
+    }),
+    lemmaCandidates: jsonb('lemma_candidates')
+      .$type<
+        Array<{
+          lemmaId: string | null;
+          features: Record<string, string>;
+          score: number;
+        }>
+      >()
+      .notNull()
+      .default([]),
+    features: jsonb('features')
+      .$type<Record<string, string>>()
+      .notNull()
+      .default({}),
+    isAmbiguous: boolean('is_ambiguous').notNull().default(false),
+    isOov: boolean('is_oov').notNull().default(false),
+    isWord: boolean('is_word').notNull().default(true),
+    sentenceIdx: integer('sentence_idx').notNull().default(0),
+    romanization: text('romanization'),
+  },
+  (t) => ({
+    chapterIdx: unique('text_tokens_chapter_idx_uq').on(t.chapterId, t.idx),
+    chapterScan: index('text_tokens_chapter_scan_idx').on(t.chapterId, t.idx),
+    lemmaIdx: index('text_tokens_lemma_idx').on(t.lemmaId),
+  }),
+);
+
+/**
+ * Per-user known-words ledger (T-5.2).
+ *
+ * Status:
+ *  - 'unknown'  — never marked. The default for any lemma the user
+ *                 hasn't touched. Stored explicitly only when we want
+ *                 a row (e.g. for an audit / "I deliberately don't
+ *                 know this"); usually represented by absence.
+ *  - 'learning' — actively encountering, want to study. Highlight
+ *                 prominently in the reader.
+ *  - 'known'    — confidently knows. Don't highlight. Counts toward
+ *                 the user's known-words stat per language.
+ *  - 'ignored'  — proper nouns / borrowings the user doesn't want to
+ *                 study. Don't highlight, don't count.
+ */
+export const knownLemmaStatus = pgEnum('known_lemma_status', [
+  'unknown',
+  'learning',
+  'known',
+  'ignored',
+]);
+
+export const userKnownLemmas = pgTable(
+  'user_known_lemmas',
+  {
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    lemmaId: uuid('lemma_id')
+      .notNull()
+      .references(() => lemmas.id, { onDelete: 'cascade' }),
+    status: knownLemmaStatus('status').notNull().default('learning'),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => ({
+    pk: primaryKey({ columns: [t.userId, t.lemmaId] }),
+    userIdx: index('user_known_lemmas_user_idx').on(t.userId, t.status),
+  }),
+);
+
 export type Text = InferSelectModel<typeof texts>;
 export type TextChapter = InferSelectModel<typeof textChapters>;
 export type NlpJob = InferSelectModel<typeof nlpJobs>;
+export type TextToken = InferSelectModel<typeof textTokens>;
+export type UserKnownLemma = InferSelectModel<typeof userKnownLemmas>;

--- a/apps/web/src/lib/server/texts/tokens.test.ts
+++ b/apps/web/src/lib/server/texts/tokens.test.ts
@@ -1,0 +1,150 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const staged: Array<unknown[]> = [];
+function stage(rows: unknown[]) {
+  staged.push(rows);
+}
+function nextStaged(): unknown[] {
+  const v = staged.shift();
+  if (!v) throw new Error('Test bug: no staged result available');
+  return v;
+}
+
+function makeSelectChain() {
+  const chain: Record<string, unknown> = {};
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.orderBy = vi.fn(() => chain);
+  chain.then = (resolve: (v: unknown) => unknown) => resolve(nextStaged());
+  return chain;
+}
+
+const selectFn = vi.fn(() => makeSelectChain());
+
+vi.mock('../db/index.js', () => ({
+  db: { select: () => selectFn() },
+  schema: {
+    textTokens: {
+      id: 'text_tokens.id',
+      chapterId: 'text_tokens.chapter_id',
+      idx: 'text_tokens.idx',
+      lemmaId: 'text_tokens.lemma_id',
+    },
+    userKnownLemmas: {
+      userId: 'user_known_lemmas.user_id',
+      lemmaId: 'user_known_lemmas.lemma_id',
+      status: 'user_known_lemmas.status',
+    },
+  },
+}));
+
+const { loadChapterTokens, loadKnownStatusMap, listKnownLemmas } =
+  await import('./tokens.js');
+
+beforeEach(() => {
+  staged.length = 0;
+  selectFn.mockClear();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+function tokenRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'tok-1',
+    chapterId: 'chap-1',
+    idx: 0,
+    surface: 'पाठ',
+    lemmaId: 'lem-1',
+    lemmaCandidates: [],
+    features: {},
+    isAmbiguous: false,
+    isOov: false,
+    isWord: true,
+    sentenceIdx: 0,
+    romanization: null,
+    ...overrides,
+  };
+}
+
+describe('loadChapterTokens', () => {
+  it('returns null when no tokens have been written for the chapter yet', async () => {
+    stage([]);
+    const result = await loadChapterTokens('chap-1', 'user-1');
+    expect(result).toBeNull();
+  });
+
+  it('returns tokens with status=unknown when the viewer has no known-lemma rows', async () => {
+    stage([tokenRow({ id: 't1', idx: 0 }), tokenRow({ id: 't2', idx: 1 })]);
+    stage([]); // user_known_lemmas → empty
+    const result = await loadChapterTokens('chap-1', 'user-1');
+    expect(result).not.toBeNull();
+    expect(result!.every((t) => t.status === 'unknown')).toBe(true);
+  });
+
+  it('joins user_known_lemmas to colour matching lemmas', async () => {
+    stage([
+      tokenRow({ id: 't1', idx: 0, lemmaId: 'lem-known' }),
+      tokenRow({ id: 't2', idx: 1, lemmaId: 'lem-learning' }),
+      tokenRow({ id: 't3', idx: 2, lemmaId: 'lem-other' }),
+    ]);
+    stage([
+      { userId: 'user-1', lemmaId: 'lem-known', status: 'known' },
+      { userId: 'user-1', lemmaId: 'lem-learning', status: 'learning' },
+    ]);
+    const result = await loadChapterTokens('chap-1', 'user-1');
+    expect(result).toEqual([
+      expect.objectContaining({ id: 't1', status: 'known' }),
+      expect.objectContaining({ id: 't2', status: 'learning' }),
+      expect.objectContaining({ id: 't3', status: 'unknown' }),
+    ]);
+  });
+
+  it('handles anonymous viewers (no second SELECT, every status=unknown)', async () => {
+    stage([tokenRow({ id: 't1', idx: 0 })]);
+    const result = await loadChapterTokens('chap-1', null);
+    expect(result).not.toBeNull();
+    expect(result![0]!.status).toBe('unknown');
+    // Only ONE SELECT — the user_known_lemmas query was skipped.
+    expect(selectFn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('loadKnownStatusMap', () => {
+  it('returns an empty map for anonymous callers', async () => {
+    const map = await loadKnownStatusMap(null, ['l1']);
+    expect(map.size).toBe(0);
+    expect(selectFn).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty map when no lemma ids are requested', async () => {
+    const map = await loadKnownStatusMap('user-1', []);
+    expect(map.size).toBe(0);
+    expect(selectFn).not.toHaveBeenCalled();
+  });
+
+  it('filters server-returned rows down to the requested lemma id set', async () => {
+    stage([
+      { userId: 'user-1', lemmaId: 'l1', status: 'known' },
+      { userId: 'user-1', lemmaId: 'l2', status: 'learning' },
+      { userId: 'user-1', lemmaId: 'l3', status: 'ignored' },
+    ]);
+    const map = await loadKnownStatusMap('user-1', ['l1', 'l3']);
+    expect(map.get('l1')).toBe('known');
+    expect(map.get('l3')).toBe('ignored');
+    expect(map.has('l2')).toBe(false);
+  });
+});
+
+describe('listKnownLemmas', () => {
+  it('returns every known-lemma row for the user when no status filter is passed', async () => {
+    stage([
+      { userId: 'user-1', lemmaId: 'l1', status: 'known' },
+      { userId: 'user-1', lemmaId: 'l2', status: 'learning' },
+    ]);
+    const rows = await listKnownLemmas('user-1');
+    expect(rows).toHaveLength(2);
+  });
+});

--- a/apps/web/src/lib/server/texts/tokens.ts
+++ b/apps/web/src/lib/server/texts/tokens.ts
@@ -1,0 +1,149 @@
+/**
+ * Reader token + known-status loader (T-5.2).
+ *
+ * The NLP worker writes `text_tokens` rows during processing
+ * (T-2.6). Once the worker has run, the reader pulls those rows + a
+ * join through `user_known_lemmas` so each token can render with the
+ * right `.status-*` class.
+ *
+ * Until the worker runs, `loadChapterTokens` returns `null` for
+ * chapters with no rows yet — the reader falls back to its
+ * client-side whitespace tokenizer in that case (still readable, just
+ * no lemma colouring).
+ */
+import { eq, inArray } from 'drizzle-orm';
+
+import { db, schema } from '../db/index.js';
+import type { TextToken, UserKnownLemma } from '../db/schema.js';
+
+export type RenderedToken = {
+  id: string;
+  idx: number;
+  surface: string;
+  isWord: boolean;
+  isAmbiguous: boolean;
+  isOov: boolean;
+  lemmaId: string | null;
+  romanization: string | null;
+  status: 'known' | 'learning' | 'ignored' | 'unknown';
+};
+
+/**
+ * Load every token in a chapter (in reading order) along with the
+ * caller's known-status for each lemma. Returns null when no tokens
+ * have been written yet — the caller (the reader page) falls back to
+ * client-side whitespace tokenization in that case.
+ */
+export async function loadChapterTokens(
+  chapterId: string,
+  viewerId: string | null,
+): Promise<RenderedToken[] | null> {
+  const tokens = (await db
+    .select()
+    .from(schema.textTokens)
+    .where(eq(schema.textTokens.chapterId, chapterId))
+    .orderBy(schema.textTokens.idx)) as TextToken[];
+
+  if (tokens.length === 0) return null;
+
+  const lemmaIds = Array.from(
+    new Set(tokens.map((t) => t.lemmaId).filter((id): id is string => !!id)),
+  );
+
+  // Anonymous viewers have no `user_known_lemmas` rows; every word
+  // renders 'unknown'. We still return the tokens so they can be
+  // displayed.
+  const statusByLemma = new Map<string, UserKnownLemma['status']>();
+  if (viewerId && lemmaIds.length > 0) {
+    const rows = (await db
+      .select()
+      .from(schema.userKnownLemmas)
+      .where(
+        // Composite filter: the user's row, intersected with the
+        // lemmas in this chapter. Drizzle's `and` collapses cleanly.
+        eq(schema.userKnownLemmas.userId, viewerId),
+      )) as UserKnownLemma[];
+    // We could've combined with inArray(lemmaId, lemmaIds) at the
+    // SQL level, but the index covers (user_id, status) and the
+    // viewer rarely has a huge number of known lemmas — filtering
+    // in memory is cheap and keeps the query simple.
+    const wanted = new Set(lemmaIds);
+    for (const r of rows) {
+      if (wanted.has(r.lemmaId)) statusByLemma.set(r.lemmaId, r.status);
+    }
+  }
+
+  return tokens.map((t) => {
+    const status: RenderedToken['status'] =
+      t.lemmaId && statusByLemma.has(t.lemmaId)
+        ? statusByLemma.get(t.lemmaId)!
+        : 'unknown';
+    return {
+      id: t.id,
+      idx: t.idx,
+      surface: t.surface,
+      isWord: t.isWord,
+      isAmbiguous: t.isAmbiguous,
+      isOov: t.isOov,
+      lemmaId: t.lemmaId,
+      romanization: t.romanization,
+      status,
+    };
+  });
+}
+
+/**
+ * Bulk load known-status for a set of lemma ids — used by the
+ * client-side tokenizer fallback path so even pre-worker chapters
+ * can still highlight known / learning words once the user marks
+ * any.
+ *
+ * Returns a map keyed by lemmaId. Lemmas not in the map are
+ * 'unknown' by default.
+ */
+export async function loadKnownStatusMap(
+  viewerId: string | null,
+  lemmaIds: string[],
+): Promise<Map<string, UserKnownLemma['status']>> {
+  if (!viewerId || lemmaIds.length === 0) return new Map();
+  const rows = (await db
+    .select()
+    .from(schema.userKnownLemmas)
+    .where(eq(schema.userKnownLemmas.userId, viewerId))) as UserKnownLemma[];
+  const wanted = new Set(lemmaIds);
+  const out = new Map<string, UserKnownLemma['status']>();
+  for (const r of rows) {
+    if (wanted.has(r.lemmaId)) out.set(r.lemmaId, r.status);
+  }
+  return out;
+}
+
+/** Rare but useful: every lemma the user has marked, regardless of
+ * which chapter it appears in. Used by the stats page (T-10.1). */
+export async function listKnownLemmas(
+  viewerId: string,
+  status?: UserKnownLemma['status'],
+): Promise<UserKnownLemma[]> {
+  const conditions = status
+    ? [
+        eq(schema.userKnownLemmas.userId, viewerId),
+        eq(schema.userKnownLemmas.status, status),
+      ]
+    : [eq(schema.userKnownLemmas.userId, viewerId)];
+  // Same as above — we can keep the query single-condition + filter
+  // in memory if it ever becomes a hot path, but list endpoints don't
+  // mind a small extra clause.
+  const rows = (await db
+    .select()
+    .from(schema.userKnownLemmas)
+    .where(
+      conditions.length === 1
+        ? conditions[0]!
+        : (await import('drizzle-orm')).and(...conditions)!,
+    )) as UserKnownLemma[];
+  return rows;
+}
+
+// Re-export `inArray` so callers can build composite predicates
+// without importing drizzle directly when needed.
+export { inArray };

--- a/apps/web/src/routes/reader/[textId]/+page.server.ts
+++ b/apps/web/src/routes/reader/[textId]/+page.server.ts
@@ -21,6 +21,7 @@
 import { error } from '@sveltejs/kit';
 
 import { getReadableText } from '$lib/server/texts/upload.js';
+import { loadChapterTokens } from '$lib/server/texts/tokens.js';
 import type { PageServerLoad } from './$types';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -70,6 +71,20 @@ export const load: PageServerLoad = async ({ params, locals, url }) => {
   // the only source.
   const mode = readMode(url, 'continuous');
 
+  // Pre-fetch NLP tokens for every chapter that has them. Chapters
+  // without tokens fall back to client-side whitespace tokenization
+  // in the components — no NLP, no colouring, but still readable.
+  // We load all chapters here rather than just the active one
+  // because `continuous` mode renders every chapter; `page` and
+  // `paged_scroll` ignore the inactive ones, so the cost is wasted
+  // on those modes — we'll narrow it once the per-mode loader split
+  // (T-5.1a) lands.
+  const viewerId = locals.user?.id ?? null;
+  const tokenMap: Record<string, Awaited<ReturnType<typeof loadChapterTokens>>> = {};
+  for (const c of result.chapters) {
+    tokenMap[c.id] = await loadChapterTokens(c.id, viewerId);
+  }
+
   return {
     text: {
       id: result.text.id,
@@ -87,6 +102,10 @@ export const load: PageServerLoad = async ({ params, locals, url }) => {
       title: c.title,
       body: c.body,
       tokenCount: c.tokenCount,
+      // Server-rendered tokens (or null if the worker hasn't run for
+      // this chapter yet — the components fall back to a
+      // whitespace tokenizer in that case).
+      tokens: tokenMap[c.id] ?? null,
     })),
     anchor: {
       chapterIdx,

--- a/apps/web/src/routes/reader/[textId]/page-server.test.ts
+++ b/apps/web/src/routes/reader/[textId]/page-server.test.ts
@@ -5,6 +5,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const getReadableText = vi.fn();
+const loadChapterTokens = vi.fn();
 
 vi.mock('$lib/server/texts/upload.js', async () => {
   const actual = await vi.importActual<typeof import('$lib/server/texts/upload.js')>(
@@ -14,6 +15,16 @@ vi.mock('$lib/server/texts/upload.js', async () => {
     ...actual,
     getReadableText: (...a: unknown[]) => getReadableText(...a),
     getOwnedText: (...a: unknown[]) => getReadableText(...a),
+  };
+});
+
+vi.mock('$lib/server/texts/tokens.js', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/texts/tokens.js')>(
+    '$lib/server/texts/tokens.js',
+  );
+  return {
+    ...actual,
+    loadChapterTokens: (...a: unknown[]) => loadChapterTokens(...a),
   };
 });
 
@@ -65,6 +76,11 @@ function ownedTextWithChapters(n: number) {
 
 beforeEach(() => {
   getReadableText.mockReset();
+  loadChapterTokens.mockReset();
+  // The token loader is called once per chapter; default to "no
+  // tokens written yet" so the loader falls back to client-side
+  // tokenization in tests that don't care.
+  loadChapterTokens.mockResolvedValue(null);
 });
 
 afterEach(() => {
@@ -145,5 +161,32 @@ describe('/reader/[textId] loader', () => {
     )) as { isOwner: boolean };
     expect(data.isOwner).toBe(false);
     expect(getReadableText).toHaveBeenCalledWith(null, VALID_ID);
+  });
+
+  it('attaches server tokens onto each chapter when the worker has run', async () => {
+    getReadableText.mockResolvedValueOnce(ownedTextWithChapters(2));
+    const tokenRow = (id: string, idx: number) => ({
+      id,
+      idx,
+      surface: 'पाठ',
+      isWord: true,
+      isAmbiguous: false,
+      isOov: false,
+      lemmaId: 'lem-1',
+      romanization: null,
+      status: 'unknown' as const,
+    });
+    loadChapterTokens
+      .mockResolvedValueOnce([tokenRow('t0', 0)])
+      .mockResolvedValueOnce(null);
+    const data = (await callLoad(`http://x/reader/${VALID_ID}`)) as {
+      chapters: Array<{ id: string; tokens: unknown }>;
+    };
+    expect(data.chapters[0]!.tokens).toHaveLength(1);
+    expect(data.chapters[1]!.tokens).toBeNull();
+    // The loader called the token service once per chapter, with the
+    // viewer id forwarded.
+    expect(loadChapterTokens).toHaveBeenCalledTimes(2);
+    expect(loadChapterTokens).toHaveBeenCalledWith('c0', USER.id);
   });
 });


### PR DESCRIPTION
Closes #47

## Summary

Lights up known-words colouring on the reader. Adds the \`text_tokens\` + \`user_known_lemmas\` schemas, the loader that joins them, and the reader's per-token rendering plumbing.

- **Schema** — \`text_tokens\` (the NLP worker's per-token output) and \`user_known_lemmas\` (the user's known/learning/ignored ledger) plus the \`known_lemma_status\` enum.
- **Service** — \`loadChapterTokens\` returns null when the worker hasn't run, so the reader falls back to client-side whitespace tokenization. The fallback path stays untouched for offline / not-yet-processed chapters.
- **Components** — new \`<TokenSpan>\` + \`<ChapterBody>\` shared by all three layout modes. Status-driven highlights (LingQ-style for unknown, distinct tone for learning), dashed underline for OOV, ambiguity chevron for multi-candidate parses.

## Test plan

- [x] \`pnpm --filter @ciareader/web test\` — 514/514 (9 new for T-5.2)
- [x] \`pnpm --filter @ciareader/web check\` — clean
- [x] \`pnpm --filter @ciareader/web lint\` — clean
- [x] coverage above 80% floor
- [ ] Manual: with the M2 NLP worker running, upload a Hindi text and confirm word tokens render with hover highlight + the status enum is reachable
- [ ] Manual: insert a few user_known_lemmas rows by hand and confirm the matching tokens lose / gain highlight on reload
- [ ] Manual: a chapter with no text_tokens still renders via the client tokenizer