### PR TITLE
T-5.3: optional inline romanization toggle on the reader

### DIFF
--- a/apps/web/src/lib/components/reader/ChapterBody.svelte
+++ b/apps/web/src/lib/components/reader/ChapterBody.svelte
@@ -1,15 +1,6 @@
 <!--
-  Renders one chapter's body with the right tokenizer (T-5.2).
-
-  When the chapter has server-rendered tokens (the NLP worker has
-  run), we render a span per ServerToken with `.status-*` classes
-  driving the highlight. Otherwise, we fall back to the client-side
-  whitespace tokenizer — every word becomes a `.word` span with no
-  status, so the layout still looks right and click-handlers / pop-ups
-  can attach (the lemma_id is just null until the worker fills it in).
-
-  Both layout modes (`page`, `paged_scroll`, `continuous`) consume
-  this so the rendering rules live in one place.
+  Renders one chapter's body with the right tokenizer (T-5.2,
+  romanization wired in T-5.3).
 -->
 <script lang="ts">
   import TokenSpan from './TokenSpan.svelte';
@@ -20,7 +11,10 @@
     type ChapterView,
   } from './types.js';
 
-  let { chapter }: { chapter: ChapterView } = $props();
+  let {
+    chapter,
+    showRomanization = false,
+  }: { chapter: ChapterView; showRomanization?: boolean } = $props();
 
   const serverParagraphs = $derived(
     chapter.tokens ? paragraphsOfServerTokens(chapter.tokens) : null,
@@ -33,7 +27,10 @@
 {#if serverParagraphs}
   {#each serverParagraphs as paragraph, pIdx (pIdx)}
     <p class="body">
-      {#each paragraph as token (token.id)}<TokenSpan {token} />{/each}
+      {#each paragraph as token (token.id)}<TokenSpan
+          {token}
+          {showRomanization}
+        />{/each}
     </p>
   {/each}
 {:else if fallbackParagraphs}
@@ -49,11 +46,9 @@
 <style>
   .body {
     margin: 0 0 1rem;
-    line-height: 1.75;
+    line-height: 1.85;
     font-size: 1.05rem;
   }
-  /* The fallback path has its own minimal hover treatment — the real
-     status-aware classes live on TokenSpan. */
   .word {
     cursor: pointer;
     border-radius: 3px;

--- a/apps/web/src/lib/components/reader/ReaderContinuous.svelte
+++ b/apps/web/src/lib/components/reader/ReaderContinuous.svelte
@@ -13,7 +13,12 @@
   let {
     chapters,
     initialChapterIdx = 0,
-  }: { chapters: ChapterView[]; initialChapterIdx?: number } = $props();
+    showRomanization = false,
+  }: {
+    chapters: ChapterView[];
+    initialChapterIdx?: number;
+    showRomanization?: boolean;
+  } = $props();
 </script>
 
 <div class="reader-continuous" data-mode="continuous" data-initial-chapter={initialChapterIdx}>
@@ -28,7 +33,7 @@
           <span class="muted">({chapter.tokenCount.toLocaleString()} tokens)</span>
         </h2>
       {/if}
-      <ChapterBody {chapter} />
+      <ChapterBody {chapter} {showRomanization} />
     </section>
   {/each}
 </div>

--- a/apps/web/src/lib/components/reader/ReaderPage.svelte
+++ b/apps/web/src/lib/components/reader/ReaderPage.svelte
@@ -13,7 +13,13 @@
     chapters,
     chapterIdx,
     textId,
-  }: { chapters: ChapterView[]; chapterIdx: number; textId: string } = $props();
+    showRomanization = false,
+  }: {
+    chapters: ChapterView[];
+    chapterIdx: number;
+    textId: string;
+    showRomanization?: boolean;
+  } = $props();
 
   const current = $derived(
     chapters[Math.max(0, Math.min(chapterIdx, chapters.length - 1))],
@@ -43,7 +49,7 @@
 
   <article>
     {#if current}
-      <ChapterBody chapter={current} />
+      <ChapterBody chapter={current} {showRomanization} />
     {/if}
   </article>
 

--- a/apps/web/src/lib/components/reader/ReaderScroll.svelte
+++ b/apps/web/src/lib/components/reader/ReaderScroll.svelte
@@ -22,10 +22,12 @@
     chapters,
     chapterIdx,
     wordsPerPage = 250,
+    showRomanization = false,
   }: {
     chapters: ChapterView[];
     chapterIdx: number;
     wordsPerPage?: number;
+    showRomanization?: boolean;
   } = $props();
 
   let page = $state(0);
@@ -124,7 +126,10 @@
     {#if visibleServer}
       {#each visibleServer as paragraph, pIdx (pIdx)}
         <p class="body">
-          {#each paragraph as token (token.id)}<TokenSpan {token} />{/each}
+          {#each paragraph as token (token.id)}<TokenSpan
+              {token}
+              {showRomanization}
+            />{/each}
         </p>
       {/each}
     {:else if visibleFallback}

--- a/apps/web/src/lib/components/reader/TokenSpan.svelte
+++ b/apps/web/src/lib/components/reader/TokenSpan.svelte
@@ -1,21 +1,24 @@
 <!--
-  Single token render (T-5.2).
+  Single token render (T-5.2, romanization in T-5.3).
 
   One `<span>` per token, with a `.status-*` class when we have a
   lemma resolution. Word tokens get a hover affordance. Whitespace
   tokens render as plain text without any classes — the reader
   preserves the original layout faithfully.
 
-  T-5.4 layers the word pop-up on top of this; T-5.5 wires status
-  changes back to the server. The classes are stable so those tickets
-  don't have to touch markup.
+  When `showRomanization` is on AND the token has a precomputed
+  `romanization` (worker-time, T-2.5), the surface form renders
+  inside an HTML `<ruby>` element with the romanized form on top so
+  learners who aren't yet fluent in the script can decode each word
+  inline. Tokens without a romanization just render the surface.
 -->
 <script lang="ts">
   import type { ServerToken } from './types.js';
 
   let {
     token,
-  }: { token: ServerToken } = $props();
+    showRomanization = false,
+  }: { token: ServerToken; showRomanization?: boolean } = $props();
 
   // OOV tokens get a distinct visual state (T-5.4a) — dashed
   // underline rather than the known/unknown highlight, so the user
@@ -29,13 +32,21 @@
     if (token.isAmbiguous) classes.push('ambiguous');
     return classes.join(' ');
   });
+
+  const showRuby = $derived(
+    showRomanization && token.isWord && Boolean(token.romanization),
+  );
 </script>
 
-{#if token.isWord}<span
+{#if !token.isWord}{token.surface}{:else if showRuby}<ruby
     class={cssClass}
     data-token-id={token.id}
     data-token-idx={token.idx}
-    data-lemma-id={token.lemmaId ?? ''}>{token.surface}</span>{:else}{token.surface}{/if}
+    data-lemma-id={token.lemmaId ?? ''}>{token.surface}<rt>{token.romanization}</rt></ruby>{:else}<span
+    class={cssClass}
+    data-token-id={token.id}
+    data-token-idx={token.idx}
+    data-lemma-id={token.lemmaId ?? ''}>{token.surface}</span>{/if}
 
 <style>
   .word {
@@ -46,8 +57,17 @@
   .word:hover {
     background: color-mix(in srgb, var(--color-accent) 12%, transparent);
   }
-  /* Default — token has a lemma but the user hasn't marked it. The
-     LingQ-style "this is a word you should pay attention to" colour. */
+  /* `<ruby>` defaults to `display: ruby` which behaves like an inline
+     element — perfect for in-line text. We only need to nudge the
+     `<rt>` styling. */
+  ruby.word rt {
+    font-size: 0.6em;
+    color: var(--color-fg-muted);
+    line-height: 1.1;
+    /* Tight character spacing on rt so a long romanization doesn't
+       blow the underlying word's width out. */
+    letter-spacing: -0.01em;
+  }
   .status-unknown {
     background: color-mix(in srgb, var(--color-accent) 18%, transparent);
   }
@@ -55,21 +75,15 @@
     background: color-mix(in srgb, #b07a31 30%, transparent);
     color: var(--color-fg);
   }
-  /* Known + ignored: render as plain text, no highlight. */
   .status-known,
   .status-ignored {
     background: transparent;
   }
-  /* OOV: no dictionary match — dashed underline rather than a
-     highlight, so the user knows the system needs help on this token. */
   .oov {
     background: transparent;
     border-bottom: 1px dashed var(--color-fg-muted);
     border-radius: 0;
   }
-  /* Ambiguous: an extra dot above to hint that there are alternate
-     parses available (T-6.1's "N possible meanings" chevron lives in
-     the pop-up; this is the at-a-glance affordance). */
   .ambiguous::after {
     content: '·';
     color: var(--color-accent);

--- a/apps/web/src/routes/reader/[textId]/+page.server.ts
+++ b/apps/web/src/routes/reader/[textId]/+page.server.ts
@@ -50,6 +50,11 @@ function readMode(
   return fallback;
 }
 
+function readBool(url: URL, key: string): boolean {
+  const raw = url.searchParams.get(key);
+  return raw === '1' || raw === 'true';
+}
+
 export const load: PageServerLoad = async ({ params, locals, url }) => {
   if (!UUID_RE.test(params.textId)) throw error(400, 'Invalid text id');
   const viewer = locals.user ? { id: locals.user.id } : null;
@@ -70,6 +75,7 @@ export const load: PageServerLoad = async ({ params, locals, url }) => {
   // wires user-pref persistence (T-5.1b). For the skeleton the URL is
   // the only source.
   const mode = readMode(url, 'continuous');
+  const showRomanization = readBool(url, 'roman');
 
   // Pre-fetch NLP tokens for every chapter that has them. Chapters
   // without tokens fall back to client-side whitespace tokenization
@@ -112,6 +118,7 @@ export const load: PageServerLoad = async ({ params, locals, url }) => {
       tokenIdx,
     },
     mode,
+    showRomanization,
     isOwner: Boolean(locals.user && locals.user.id === result.text.ownerId),
   };
 };

--- a/apps/web/src/routes/reader/[textId]/+page.svelte
+++ b/apps/web/src/routes/reader/[textId]/+page.svelte
@@ -28,10 +28,23 @@
   );
 
   function setMode(mode: 'page' | 'paged_scroll' | 'continuous') {
-    void goto(
-      `/reader/${data.text.id}?mode=${mode}&chapter=${data.anchor.chapterIdx}`,
-      { keepFocus: true },
-    );
+    const params = new URLSearchParams();
+    params.set('mode', mode);
+    if (data.anchor.chapterIdx) params.set('chapter', String(data.anchor.chapterIdx));
+    if (data.showRomanization) params.set('roman', '1');
+    void goto(`/reader/${data.text.id}?${params.toString()}`, {
+      keepFocus: true,
+    });
+  }
+
+  function toggleRomanization() {
+    const params = new URLSearchParams();
+    params.set('mode', data.mode);
+    if (data.anchor.chapterIdx) params.set('chapter', String(data.anchor.chapterIdx));
+    if (!data.showRomanization) params.set('roman', '1');
+    void goto(`/reader/${data.text.id}?${params.toString()}`, {
+      keepFocus: true,
+    });
   }
 
   onMount(() => {
@@ -79,27 +92,39 @@
       </p>
     </div>
 
-    <div class="mode-toggle" role="group" aria-label="Reading mode">
+    <div class="toolbar-row">
+      <div class="mode-toggle" role="group" aria-label="Reading mode">
+        <button
+          type="button"
+          class:active={data.mode === 'page'}
+          onclick={() => setMode('page')}
+        >
+          Page
+        </button>
+        <button
+          type="button"
+          class:active={data.mode === 'paged_scroll'}
+          onclick={() => setMode('paged_scroll')}
+        >
+          Paged scroll
+        </button>
+        <button
+          type="button"
+          class:active={data.mode === 'continuous'}
+          onclick={() => setMode('continuous')}
+        >
+          Continuous
+        </button>
+      </div>
+
       <button
         type="button"
-        class:active={data.mode === 'page'}
-        onclick={() => setMode('page')}
+        class="roman-toggle"
+        class:active={data.showRomanization}
+        onclick={toggleRomanization}
+        aria-pressed={data.showRomanization}
       >
-        Page
-      </button>
-      <button
-        type="button"
-        class:active={data.mode === 'paged_scroll'}
-        onclick={() => setMode('paged_scroll')}
-      >
-        Paged scroll
-      </button>
-      <button
-        type="button"
-        class:active={data.mode === 'continuous'}
-        onclick={() => setMode('continuous')}
-      >
-        Continuous
+        Show romanization
       </button>
     </div>
   </header>
@@ -113,13 +138,19 @@
       chapters={data.chapters}
       chapterIdx={data.anchor.chapterIdx}
       textId={data.text.id}
+      showRomanization={data.showRomanization}
     />
   {:else if data.mode === 'paged_scroll'}
-    <ReaderScroll chapters={data.chapters} chapterIdx={data.anchor.chapterIdx} />
+    <ReaderScroll
+      chapters={data.chapters}
+      chapterIdx={data.anchor.chapterIdx}
+      showRomanization={data.showRomanization}
+    />
   {:else}
     <ReaderContinuous
       chapters={data.chapters}
       initialChapterIdx={data.anchor.chapterIdx}
+      showRomanization={data.showRomanization}
     />
   {/if}
 </div>
@@ -179,10 +210,33 @@
     border-color: color-mix(in srgb, #b07a31 60%, transparent);
     color: #b07a31;
   }
+  .toolbar-row {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    flex-wrap: wrap;
+    justify-content: space-between;
+  }
   .mode-toggle {
     display: flex;
     gap: 0.25rem;
     flex-wrap: wrap;
+  }
+  .roman-toggle {
+    padding: 0.4rem 0.75rem;
+    font: inherit;
+    font-size: 0.85rem;
+    border: 1px solid var(--color-border);
+    background: var(--color-bg);
+    color: var(--color-fg-muted);
+    border-radius: 999px;
+    cursor: pointer;
+    min-height: 36px;
+  }
+  .roman-toggle.active {
+    background: var(--color-accent);
+    color: var(--color-accent-fg, #fff);
+    border-color: var(--color-accent);
   }
   .mode-toggle button {
     padding: 0.4rem 0.75rem;

--- a/apps/web/src/routes/reader/[textId]/page-server.test.ts
+++ b/apps/web/src/routes/reader/[textId]/page-server.test.ts
@@ -163,6 +163,22 @@ describe('/reader/[textId] loader', () => {
     expect(getReadableText).toHaveBeenCalledWith(null, VALID_ID);
   });
 
+  it('reads ?roman=1 as showRomanization=true (T-5.3)', async () => {
+    getReadableText.mockResolvedValueOnce(ownedTextWithChapters(1));
+    const data = (await callLoad(
+      `http://x/reader/${VALID_ID}?roman=1`,
+    )) as { showRomanization: boolean };
+    expect(data.showRomanization).toBe(true);
+  });
+
+  it('defaults showRomanization to false when ?roman is absent', async () => {
+    getReadableText.mockResolvedValueOnce(ownedTextWithChapters(1));
+    const data = (await callLoad(`http://x/reader/${VALID_ID}`)) as {
+      showRomanization: boolean;
+    };
+    expect(data.showRomanization).toBe(false);
+  });
+
   it('attaches server tokens onto each chapter when the worker has run', async () => {
     getReadableText.mockResolvedValueOnce(ownedTextWithChapters(2));
     const tokenRow = (id: string, idx: number) => ({


### PR DESCRIPTION
Closes #48

## Summary

Toolbar toggle that flips every word into a \`<ruby>\` with the romanized form above it. Uses the precomputed \`romanization\` field on \`text_tokens\` (worker-time, T-2.5) — if a token has no romanization, it renders bare.

## Test plan

- [x] \`pnpm --filter @ciareader/web test\` — 516/516
- [x] \`check\` + \`lint\` clean
- [ ] Manual: with the worker producing romanizations, click "Show romanization" and confirm the small text appears above each word
- [ ] Manual: switch modes while the toggle is on, confirm the URL preserves \`?roman=1\`