### PR TITLE
chore: add dev-native Makefile targets for hostside dev loop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev dev-down install install-nlp lint typecheck test test-coverage smoke clean
+.PHONY: dev dev-down install install-nlp lint typecheck test test-coverage smoke clean dev-native dev-native-services dev-native-down dev-native-db dev-native-nlp dev-native-web
 
 dev:
 	docker compose -f infra/docker-compose.yml up --build
@@ -36,3 +36,39 @@ clean:
 	rm -rf node_modules apps/*/node_modules packages/*/node_modules \
 	       apps/*/.svelte-kit apps/*/build \
 	       services/nlp/.venv services/nlp/.pytest_cache services/nlp/.ruff_cache
+
+# Native dev: data services in docker, web + nlp on the host. Use when
+# docker buildx can't reach pypi/npm registries (corp DNS, VPN, etc.).
+NATIVE_ENV = \
+	NLP_SERVICE_URL=http://localhost:8000 \
+	DATABASE_URL=postgres://ciareader:ciareader@localhost:5432/ciareader \
+	REDIS_URL=redis://localhost:6379 \
+	AUTH_SECRET=dev-only-secret-replace-in-prod-0000000000000000000000000000000 \
+	APP_BASE_URL=http://localhost:5173 \
+	SMTP_HOST=localhost \
+	SMTP_PORT=1025 \
+	SMTP_FROM=no-reply@ciareader.local
+
+dev-native: dev-native-services dev-native-db
+	@echo ""
+	@echo "Data services up + DB schema applied. Now in two terminals:"
+	@echo "  make dev-native-nlp   # FastAPI on :8000"
+	@echo "  make dev-native-web   # SvelteKit on :5173"
+	@echo ""
+	@echo "Web:     http://localhost:5173"
+	@echo "Mailpit: http://localhost:8025"
+
+dev-native-services:
+	docker compose -f infra/docker-compose.yml up -d postgres redis mailpit
+
+dev-native-down:
+	docker compose -f infra/docker-compose.yml stop postgres redis mailpit
+
+dev-native-db:
+	cd apps/web && $(NATIVE_ENV) pnpm exec drizzle-kit push --verbose
+
+dev-native-nlp:
+	cd services/nlp && PYTHONPATH=../../packages/shared-types/python:. .venv/bin/uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+
+dev-native-web:
+	cd apps/web && $(NATIVE_ENV) pnpm dev


### PR DESCRIPTION
## Summary

- Adds `make dev-native` and supporting targets so contributors can run the SvelteKit web app and FastAPI NLP service on the host while keeping Postgres, Redis, and Mailpit in Docker.
- Motivation: `make dev` (full Docker build) breaks when the buildx network can't reach pypi/npm — corp DNS, VPN, transient Docker Hub auth issues. The data-service images pull fine; only the *build* steps need outbound network. Splitting them out unblocks the dev loop without ditching Docker entirely.
- Env vars factored into a `NATIVE_ENV` Make variable shared between `dev-native-db` and `dev-native-web` so they can't drift. Values mirror `infra/docker-compose.yml`'s `web` service.

## Targets

| Target | What it does |
| --- | --- |
| `dev-native` | Composite: services + DB schema, then prints next-step instructions. |
| `dev-native-services` | `docker compose up -d postgres redis mailpit`. |
| `dev-native-down` | Stops those three. |
| `dev-native-db` | `drizzle-kit push` against `localhost:5432`. |
| `dev-native-nlp` | `uvicorn app.main:app --reload` from `services/nlp/.venv`. |
| `dev-native-web` | `pnpm dev` for the SvelteKit app. |

## Test plan

- [ ] `make -n dev-native` prints the expected recipe (verified).
- [ ] `make dev-native` brings up postgres/redis/mailpit and applies schema.
- [ ] `make dev-native-nlp` (separate terminal) — `/health` responds on :8000.
- [ ] `make dev-native-web` (separate terminal) — http://localhost:5173 loads.
- [ ] `make dev-native-down` stops the data services cleanly.

## Notes

- This is dev tooling only — no production code path. No Vitest/pytest coverage applies.
- Prereqs: `make install-nlp` once for the venv, and `pnpm install` for node modules.
- The default `make dev` (full Docker) is unchanged.