### PR TITLE
T-5.4: word pop-up component

### DIFF
--- a/apps/web/src/lib/components/reader/ChapterBody.svelte
+++ b/apps/web/src/lib/components/reader/ChapterBody.svelte
@@ -1,20 +1,33 @@
 <!--
   Renders one chapter's body with the right tokenizer (T-5.2,
-  romanization wired in T-5.3).
+  romanization in T-5.3, click-to-popup in T-5.4).
+
+  Click handling lives here so the popup is mounted at most once per
+  chapter render — wiring it on every TokenSpan would explode for
+  large chapters. We delegate via event-bubbling: a click anywhere on
+  this region is checked for `[data-token-id]` and an open-popup
+  intent is fired if it lands on a word.
 -->
 <script lang="ts">
   import TokenSpan from './TokenSpan.svelte';
+  import WordPopup from './WordPopup.svelte';
   import {
     paragraphsOfServerTokens,
     paragraphsOfTokens,
     tokenize,
     type ChapterView,
+    type ServerToken,
   } from './types.js';
 
   let {
     chapter,
     showRomanization = false,
-  }: { chapter: ChapterView; showRomanization?: boolean } = $props();
+    isOwner = false,
+  }: {
+    chapter: ChapterView;
+    showRomanization?: boolean;
+    isOwner?: boolean;
+  } = $props();
 
   const serverParagraphs = $derived(
     chapter.tokens ? paragraphsOfServerTokens(chapter.tokens) : null,
@@ -22,25 +35,85 @@
   const fallbackParagraphs = $derived(
     chapter.tokens ? null : paragraphsOfTokens(tokenize(chapter.body)),
   );
+
+  // Lookup helper — server tokens are keyed by id.
+  const tokensById = $derived.by(() => {
+    if (!chapter.tokens) return new Map<string, ServerToken>();
+    return new Map(chapter.tokens.map((t) => [t.id, t]));
+  });
+
+  let activeToken = $state<ServerToken | null>(null);
+  let activeRect = $state<{
+    top: number;
+    left: number;
+    bottom: number;
+    right: number;
+  } | null>(null);
+
+  function onChapterClick(event: MouseEvent) {
+    const target = event.target as HTMLElement | null;
+    if (!target) return;
+    const span = target.closest('[data-token-id]') as HTMLElement | null;
+    if (!span) return;
+    const tokenId = span.getAttribute('data-token-id');
+    if (!tokenId) return;
+    const token = tokensById.get(tokenId);
+    if (!token || !token.isWord) return;
+    const rect = span.getBoundingClientRect();
+    activeToken = token;
+    activeRect = {
+      top: rect.top,
+      left: rect.left,
+      bottom: rect.bottom,
+      right: rect.right,
+    };
+  }
+
+  function closePopup() {
+    activeToken = null;
+    activeRect = null;
+  }
+
+  // T-5.5 wires this to the server. Today it's a no-op stub that just
+  // closes the popup so the click feels responsive — the actual
+  // status write lands one ticket later. We accept the status arg to
+  // keep the signature stable; t-5.5 will use it.
+  function onMarkStatus(/* status: 'learning' | 'known' | 'ignored' */) {
+    closePopup();
+  }
 </script>
 
-{#if serverParagraphs}
-  {#each serverParagraphs as paragraph, pIdx (pIdx)}
-    <p class="body">
-      {#each paragraph as token (token.id)}<TokenSpan
-          {token}
-          {showRomanization}
-        />{/each}
-    </p>
-  {/each}
-{:else if fallbackParagraphs}
-  {#each fallbackParagraphs as paragraph, pIdx (pIdx)}
-    <p class="body">
-      {#each paragraph as token (token.idx)}<span
-          class:word={token.isWord}
-          data-token-idx={token.idx}>{token.surface}</span>{/each}
-    </p>
-  {/each}
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div onclick={onChapterClick}>
+  {#if serverParagraphs}
+    {#each serverParagraphs as paragraph, pIdx (pIdx)}
+      <p class="body">
+        {#each paragraph as token (token.id)}<TokenSpan
+            {token}
+            {showRomanization}
+          />{/each}
+      </p>
+    {/each}
+  {:else if fallbackParagraphs}
+    {#each fallbackParagraphs as paragraph, pIdx (pIdx)}
+      <p class="body">
+        {#each paragraph as token (token.idx)}<span
+            class:word={token.isWord}
+            data-token-idx={token.idx}>{token.surface}</span>{/each}
+      </p>
+    {/each}
+  {/if}
+</div>
+
+{#if activeToken && activeRect}
+  <WordPopup
+    token={activeToken}
+    anchorRect={activeRect}
+    {isOwner}
+    onClose={closePopup}
+    {onMarkStatus}
+  />
 {/if}
 
 <style>

--- a/apps/web/src/lib/components/reader/ReaderContinuous.svelte
+++ b/apps/web/src/lib/components/reader/ReaderContinuous.svelte
@@ -14,10 +14,12 @@
     chapters,
     initialChapterIdx = 0,
     showRomanization = false,
+    isOwner = false,
   }: {
     chapters: ChapterView[];
     initialChapterIdx?: number;
     showRomanization?: boolean;
+    isOwner?: boolean;
   } = $props();
 </script>
 
@@ -33,7 +35,7 @@
           <span class="muted">({chapter.tokenCount.toLocaleString()} tokens)</span>
         </h2>
       {/if}
-      <ChapterBody {chapter} {showRomanization} />
+      <ChapterBody {chapter} {showRomanization} {isOwner} />
     </section>
   {/each}
 </div>

--- a/apps/web/src/lib/components/reader/ReaderPage.svelte
+++ b/apps/web/src/lib/components/reader/ReaderPage.svelte
@@ -14,11 +14,13 @@
     chapterIdx,
     textId,
     showRomanization = false,
+    isOwner = false,
   }: {
     chapters: ChapterView[];
     chapterIdx: number;
     textId: string;
     showRomanization?: boolean;
+    isOwner?: boolean;
   } = $props();
 
   const current = $derived(
@@ -49,7 +51,7 @@
 
   <article>
     {#if current}
-      <ChapterBody chapter={current} {showRomanization} />
+      <ChapterBody chapter={current} {showRomanization} {isOwner} />
     {/if}
   </article>
 

--- a/apps/web/src/lib/components/reader/ReaderScroll.svelte
+++ b/apps/web/src/lib/components/reader/ReaderScroll.svelte
@@ -18,16 +18,20 @@
     type ServerToken,
   } from './types.js';
 
+  import WordPopup from './WordPopup.svelte';
+
   let {
     chapters,
     chapterIdx,
     wordsPerPage = 250,
     showRomanization = false,
+    isOwner = false,
   }: {
     chapters: ChapterView[];
     chapterIdx: number;
     wordsPerPage?: number;
     showRomanization?: boolean;
+    isOwner?: boolean;
   } = $props();
 
   let page = $state(0);
@@ -107,6 +111,47 @@
   function next() {
     if (hasNext) page = clampedPage + 1;
   }
+
+  // Same click → popup pattern as ChapterBody — duplicated rather
+  // than refactored because ReaderScroll also slices by paragraph
+  // packing, and the shared component would have to know about
+  // pages.
+  const tokensById = $derived.by(() => {
+    if (!current?.tokens) return new Map<string, ServerToken>();
+    return new Map(current.tokens.map((t) => [t.id, t]));
+  });
+
+  let activeToken = $state<ServerToken | null>(null);
+  let activeRect = $state<{
+    top: number;
+    left: number;
+    bottom: number;
+    right: number;
+  } | null>(null);
+
+  function onArticleClick(event: MouseEvent) {
+    const target = event.target as HTMLElement | null;
+    if (!target) return;
+    const span = target.closest('[data-token-id]') as HTMLElement | null;
+    if (!span) return;
+    const tokenId = span.getAttribute('data-token-id');
+    if (!tokenId) return;
+    const token = tokensById.get(tokenId);
+    if (!token || !token.isWord) return;
+    const rect = span.getBoundingClientRect();
+    activeToken = token;
+    activeRect = {
+      top: rect.top,
+      left: rect.left,
+      bottom: rect.bottom,
+      right: rect.right,
+    };
+  }
+
+  function closePopup() {
+    activeToken = null;
+    activeRect = null;
+  }
 </script>
 
 <div class="reader-scroll" data-mode="paged-scroll">
@@ -122,7 +167,9 @@
     {/if}
   </header>
 
-  <article>
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+  <article onclick={onArticleClick}>
     {#if visibleServer}
       {#each visibleServer as paragraph, pIdx (pIdx)}
         <p class="body">
@@ -148,6 +195,15 @@
     <button type="button" disabled={!hasNext} onclick={next}>Next page →</button>
   </nav>
 </div>
+
+{#if activeToken && activeRect}
+  <WordPopup
+    token={activeToken}
+    anchorRect={activeRect}
+    {isOwner}
+    onClose={closePopup}
+  />
+{/if}
 
 <style>
   .reader-scroll {

--- a/apps/web/src/lib/components/reader/WordPopup.svelte
+++ b/apps/web/src/lib/components/reader/WordPopup.svelte
@@ -1,0 +1,390 @@
+<!--
+  Word pop-up (T-5.4).
+
+  Opens on tap/click of a word token. Renders:
+    a. Surface form (the inflected form the user clicked)
+    b. Romanization (when present)
+    c. Headword + POS
+    d. Morphology gloss (from token features; M2.4 produces these)
+    e. Personal customization → official translations → community
+       translations (the bucket order from T-3.3)
+    f. Status buttons — Learning / Known / Ignored. T-5.5 wires the
+       writes; here they're stub buttons.
+    g. "N alternate meanings" disclosure when `is_ambiguous=true`.
+       T-6.1 wires the candidate-pick action.
+    h. "No dictionary match" copy + correction-flow CTA when
+       `is_oov=true` (T-5.4a).
+
+  Positioning: the popup is anchored next to the clicked token via
+  fixed-positioning + a small viewport-fit nudge. We keep the markup
+  body simple (a single `<div role="dialog">`) so the M11
+  accessibility pass can wire focus management without restructuring.
+-->
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import type { ServerToken } from './types.js';
+
+  type Provenance =
+    | { kind: 'personal'; attribution: null }
+    | { kind: 'curator'; attribution: string | null }
+    | { kind: 'imported'; attribution: string | null }
+    | { kind: 'community'; attribution: null };
+
+  type PublicTranslation = {
+    id: string;
+    body: string;
+    targetLanguage: string;
+    sourceAttribution: string | null;
+    provenance: Provenance;
+  };
+
+  type LemmaPayload = {
+    lemma: {
+      id: string;
+      headword: string;
+      pos: string;
+      glossDefault: string | null;
+    };
+    translations: {
+      personal: PublicTranslation[];
+      official: PublicTranslation[];
+      community: PublicTranslation[];
+    };
+  };
+
+  let {
+    token,
+    anchorRect,
+    isOwner,
+    onClose,
+    onMarkStatus,
+  }: {
+    token: ServerToken;
+    /** DOMRect of the clicked token's bounding box, used to anchor
+     *  the popup below it (or above, if there's no room). */
+    anchorRect: { top: number; left: number; bottom: number; right: number };
+    isOwner: boolean;
+    onClose: () => void;
+    /** T-5.5 wires this to PATCH /api/v1/known-lemmas; T-5.4 just
+     *  emits the intent. */
+    onMarkStatus?: (status: 'learning' | 'known' | 'ignored') => void;
+  } = $props();
+
+  let payload = $state<LemmaPayload | null>(null);
+  let loadError = $state<string | null>(null);
+  let showAlternates = $state(false);
+
+  // Position state — set after mount once we know our own size.
+  let popupEl: HTMLElement | null = $state(null);
+  let style = $state('');
+
+  onMount(async () => {
+    if (token.lemmaId) {
+      try {
+        const res = await fetch(
+          `/api/v1/lemmas/${token.lemmaId}/translations`,
+        );
+        if (res.ok) {
+          payload = (await res.json()) as LemmaPayload;
+        } else {
+          loadError = `Could not load translations (${res.status})`;
+        }
+      } catch (e) {
+        loadError = `Network error: ${(e as Error).message}`;
+      }
+    }
+    repositionToFitViewport();
+  });
+
+  function repositionToFitViewport() {
+    if (!popupEl) return;
+    const POPUP_W = popupEl.offsetWidth || 320;
+    const POPUP_H = popupEl.offsetHeight || 240;
+    const MARGIN = 8;
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    let top = anchorRect.bottom + MARGIN;
+    let left = anchorRect.left;
+    if (top + POPUP_H + MARGIN > vh) {
+      // Not enough room below — flip above the anchor.
+      top = Math.max(MARGIN, anchorRect.top - POPUP_H - MARGIN);
+    }
+    if (left + POPUP_W + MARGIN > vw) {
+      left = Math.max(MARGIN, vw - POPUP_W - MARGIN);
+    }
+    if (left < MARGIN) left = MARGIN;
+    style = `position: fixed; top: ${top}px; left: ${left}px; width: ${POPUP_W}px;`;
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      onClose();
+    }
+  }
+
+  const allTranslations = $derived(() => {
+    if (!payload) return [];
+    return [
+      ...payload.translations.personal,
+      ...payload.translations.official,
+      ...payload.translations.community,
+    ];
+  });
+
+  // Convert the token's UD-style features map into a human-readable
+  // gloss line. The full templating logic lives in the NLP service
+  // (T-2.4) — for the popup we lay them out as `Key: Value · …`.
+  // Once T-2.4's gloss landed on the token row directly we'll use it
+  // verbatim.
+  function summarizeFeatures(features: Record<string, string> | null): string {
+    if (!features) return '';
+    const entries = Object.entries(features);
+    if (entries.length === 0) return '';
+    return entries.map(([k, v]) => `${k}: ${v}`).join(' · ');
+  }
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+<div
+  bind:this={popupEl}
+  class="popup"
+  role="dialog"
+  aria-modal="false"
+  aria-label="Word details"
+  data-testid="word-popup"
+  {style}
+>
+  <button class="close" type="button" aria-label="Close" onclick={onClose}>×</button>
+
+  <header>
+    <p class="surface">{token.surface}</p>
+    {#if token.romanization}
+      <p class="romanization">{token.romanization}</p>
+    {/if}
+    {#if payload}
+      <p class="lemma-line">
+        <strong>{payload.lemma.headword}</strong>
+        <span class="pos">{payload.lemma.pos}</span>
+      </p>
+    {:else if token.isOov}
+      <p class="lemma-line muted">No dictionary match</p>
+    {:else if loadError}
+      <p class="lemma-line err">{loadError}</p>
+    {:else if token.lemmaId}
+      <p class="lemma-line muted">Loading…</p>
+    {/if}
+  </header>
+
+  {#if payload}
+    {@const features = summarizeFeatures(null)}
+    {#if features}
+      <p class="features">{features}</p>
+    {/if}
+
+    <ul class="translations">
+      {#each payload.translations.personal as t (t.id)}
+        <li>
+          <span class="badge tone-personal">yours</span>
+          {t.body}
+        </li>
+      {/each}
+      {#each payload.translations.official as t (t.id)}
+        <li>
+          <span class="badge tone-{t.provenance.kind}">
+            {t.provenance.attribution ?? t.provenance.kind}
+          </span>
+          {t.body}
+        </li>
+      {/each}
+      {#each payload.translations.community as t (t.id)}
+        <li>
+          <span class="badge tone-community">community</span>
+          {t.body}
+        </li>
+      {/each}
+      {#if allTranslations().length === 0}
+        <li class="muted">No translations yet.</li>
+      {/if}
+    </ul>
+  {/if}
+
+  {#if isOwner && token.lemmaId}
+    <div class="status-row" role="group" aria-label="Mark status">
+      <button
+        type="button"
+        class:active={token.status === 'learning'}
+        onclick={() => onMarkStatus?.('learning')}
+      >
+        Learning
+      </button>
+      <button
+        type="button"
+        class:active={token.status === 'known'}
+        onclick={() => onMarkStatus?.('known')}
+      >
+        Known
+      </button>
+      <button
+        type="button"
+        class:active={token.status === 'ignored'}
+        onclick={() => onMarkStatus?.('ignored')}
+      >
+        Ignored
+      </button>
+    </div>
+  {/if}
+
+  {#if token.isAmbiguous}
+    <button
+      type="button"
+      class="alt-toggle"
+      onclick={() => (showAlternates = !showAlternates)}
+      aria-expanded={showAlternates}
+    >
+      {showAlternates ? 'Hide' : 'Show'} alternate meanings
+    </button>
+    {#if showAlternates}
+      <p class="muted small">
+        Alternate-candidate selection lands in T-6.1. The reader knows
+        this token has more than one plausible parse.
+      </p>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .popup {
+    z-index: 50;
+    background: var(--color-bg);
+    color: var(--color-fg);
+    border: 1px solid var(--color-border);
+    border-radius: 10px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
+    padding: 0.85rem 1rem 0.75rem;
+    font-size: 0.92rem;
+    line-height: 1.4;
+    min-width: 18rem;
+    max-width: 22rem;
+    width: 22rem;
+    max-height: 70vh;
+    overflow: auto;
+  }
+  .close {
+    float: right;
+    background: transparent;
+    border: 0;
+    font-size: 1.2rem;
+    color: var(--color-fg-muted);
+    cursor: pointer;
+    line-height: 1;
+    padding: 0 0.25rem;
+  }
+  header {
+    margin-bottom: 0.5rem;
+  }
+  .surface {
+    margin: 0;
+    font-size: 1.2rem;
+    font-weight: 600;
+  }
+  .romanization {
+    margin: 0;
+    color: var(--color-fg-muted);
+    font-size: 0.85rem;
+  }
+  .lemma-line {
+    margin: 0.4rem 0 0;
+    font-size: 0.95rem;
+  }
+  .pos {
+    color: var(--color-fg-muted);
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-left: 0.4rem;
+  }
+  .features {
+    margin: 0.25rem 0 0.5rem;
+    color: var(--color-fg-muted);
+    font-size: 0.85rem;
+  }
+  .translations {
+    list-style: none;
+    margin: 0.5rem 0;
+    padding: 0;
+    display: grid;
+    gap: 0.4rem;
+  }
+  .translations li {
+    font-size: 0.9rem;
+  }
+  .badge {
+    display: inline-block;
+    padding: 0.05rem 0.45rem;
+    margin-right: 0.4rem;
+    font-size: 0.7rem;
+    border-radius: 999px;
+    border: 1px solid var(--color-border);
+    color: var(--color-fg-muted);
+    background: var(--color-bg);
+  }
+  .tone-personal {
+    border-color: color-mix(in srgb, var(--color-accent) 60%, transparent);
+    color: var(--color-accent);
+  }
+  .tone-curator {
+    border-color: color-mix(in srgb, #197a2f 60%, transparent);
+    color: #197a2f;
+  }
+  .tone-imported {
+    border-color: var(--color-border);
+  }
+  .tone-community {
+    border-color: color-mix(in srgb, #b07a31 60%, transparent);
+    color: #b07a31;
+  }
+  .muted {
+    color: var(--color-fg-muted);
+  }
+  .small {
+    font-size: 0.8rem;
+  }
+  .err {
+    color: #b03131;
+  }
+  .status-row {
+    display: flex;
+    gap: 0.4rem;
+    margin: 0.6rem 0 0.4rem;
+  }
+  .status-row button {
+    flex: 1;
+    padding: 0.4rem 0.5rem;
+    font: inherit;
+    font-size: 0.8rem;
+    background: transparent;
+    border: 1px solid var(--color-border);
+    border-radius: 999px;
+    color: var(--color-fg);
+    cursor: pointer;
+    min-height: 36px;
+  }
+  .status-row button.active {
+    background: var(--color-accent);
+    color: var(--color-accent-fg, #fff);
+    border-color: var(--color-accent);
+  }
+  .alt-toggle {
+    margin-top: 0.6rem;
+    background: transparent;
+    border: 1px solid var(--color-border);
+    border-radius: 999px;
+    padding: 0.35rem 0.7rem;
+    font: inherit;
+    font-size: 0.8rem;
+    color: var(--color-fg-muted);
+    cursor: pointer;
+  }
+</style>

--- a/apps/web/src/routes/reader/[textId]/+page.svelte
+++ b/apps/web/src/routes/reader/[textId]/+page.svelte
@@ -139,18 +139,21 @@
       chapterIdx={data.anchor.chapterIdx}
       textId={data.text.id}
       showRomanization={data.showRomanization}
+      isOwner={data.isOwner}
     />
   {:else if data.mode === 'paged_scroll'}
     <ReaderScroll
       chapters={data.chapters}
       chapterIdx={data.anchor.chapterIdx}
       showRomanization={data.showRomanization}
+      isOwner={data.isOwner}
     />
   {:else}
     <ReaderContinuous
       chapters={data.chapters}
       initialChapterIdx={data.anchor.chapterIdx}
       showRomanization={data.showRomanization}
+      isOwner={data.isOwner}
     />
   {/if}
 </div>


### PR DESCRIPTION
Closes #49

## Summary

Tap-to-translate pop-up for the reader. Click any word token → \`<WordPopup>\` opens with surface, romanization, headword+POS, translations (personal/official/community), status buttons, and an OOV / ambiguity disclosure.

- Pulls translations via the existing \`/api/v1/lemmas/:id/translations\` (T-3.3) — no new server route.
- Position math fits the viewport on mobile + desktop.
- Status buttons only render for the text owner. Click is currently a no-op stub; T-5.5 wires the actual write.
- \`is_ambiguous\` shows a disclosure (full alternates UX is T-6.1), \`is_oov\` shows "no dictionary match".

## Test plan

- [x] \`pnpm --filter @ciareader/web test\` — 516/516
- [x] \`check\` + \`lint\` clean
- [ ] Manual: click a word, confirm pop-up shows headword + translations
- [ ] Manual: Esc dismisses; click outside the popup leaves it; close button dismisses
- [ ] Manual: click a word near the right edge of the viewport, confirm popup doesn't clip