### PR TITLE
T-5.5: client-side known-words state with optimistic updates

### DIFF
--- a/apps/web/src/lib/components/reader/ChapterBody.svelte
+++ b/apps/web/src/lib/components/reader/ChapterBody.svelte
@@ -29,8 +29,26 @@
     isOwner?: boolean;
   } = $props();
 
+  // Local override map: lemmaId → user's most recent status. The
+  // popup's optimistic update writes through here so every other
+  // token tied to the same lemma flips its highlight in real time
+  // (the next page load reflects the same state via the loader).
+  let statusOverrides = $state(new Map<string, ServerToken['status']>());
+
+  // Apply any pending optimistic status flips to the token list
+  // before paragraph splitting so the .status-* classes update live.
+  const tokensWithOverrides = $derived.by(() => {
+    if (!chapter.tokens) return null;
+    if (statusOverrides.size === 0) return chapter.tokens;
+    return chapter.tokens.map((t) =>
+      t.lemmaId && statusOverrides.has(t.lemmaId)
+        ? { ...t, status: statusOverrides.get(t.lemmaId)! }
+        : t,
+    );
+  });
+
   const serverParagraphs = $derived(
-    chapter.tokens ? paragraphsOfServerTokens(chapter.tokens) : null,
+    tokensWithOverrides ? paragraphsOfServerTokens(tokensWithOverrides) : null,
   );
   const fallbackParagraphs = $derived(
     chapter.tokens ? null : paragraphsOfTokens(tokenize(chapter.body)),
@@ -38,8 +56,8 @@
 
   // Lookup helper — server tokens are keyed by id.
   const tokensById = $derived.by(() => {
-    if (!chapter.tokens) return new Map<string, ServerToken>();
-    return new Map(chapter.tokens.map((t) => [t.id, t]));
+    if (!tokensWithOverrides) return new Map<string, ServerToken>();
+    return new Map(tokensWithOverrides.map((t) => [t.id, t]));
   });
 
   let activeToken = $state<ServerToken | null>(null);
@@ -74,12 +92,15 @@
     activeRect = null;
   }
 
-  // T-5.5 wires this to the server. Today it's a no-op stub that just
-  // closes the popup so the click feels responsive — the actual
-  // status write lands one ticket later. We accept the status arg to
-  // keep the signature stable; t-5.5 will use it.
-  function onMarkStatus(/* status: 'learning' | 'known' | 'ignored' */) {
-    closePopup();
+  function onStatusChange(
+    lemmaId: string,
+    status: ServerToken['status'],
+  ) {
+    // Mutate the override map; the $derived chain re-runs so every
+    // other token tied to the same lemma flips its highlight too.
+    const next = new Map(statusOverrides);
+    next.set(lemmaId, status);
+    statusOverrides = next;
   }
 </script>
 
@@ -112,7 +133,7 @@
     anchorRect={activeRect}
     {isOwner}
     onClose={closePopup}
-    {onMarkStatus}
+    {onStatusChange}
   />
 {/if}
 

--- a/apps/web/src/lib/components/reader/ReaderScroll.svelte
+++ b/apps/web/src/lib/components/reader/ReaderScroll.svelte
@@ -152,6 +152,13 @@
     activeToken = null;
     activeRect = null;
   }
+
+  let statusOverrides = $state(new Map<string, ServerToken['status']>());
+  function onStatusChange(lemmaId: string, status: ServerToken['status']) {
+    const next = new Map(statusOverrides);
+    next.set(lemmaId, status);
+    statusOverrides = next;
+  }
 </script>
 
 <div class="reader-scroll" data-mode="paged-scroll">
@@ -202,6 +209,7 @@
     anchorRect={activeRect}
     {isOwner}
     onClose={closePopup}
+    {onStatusChange}
   />
 {/if}
 

--- a/apps/web/src/lib/components/reader/WordPopup.svelte
+++ b/apps/web/src/lib/components/reader/WordPopup.svelte
@@ -21,7 +21,7 @@
   accessibility pass can wire focus management without restructuring.
 -->
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onMount, untrack } from 'svelte';
   import type { ServerToken } from './types.js';
 
   type Provenance =
@@ -57,7 +57,7 @@
     anchorRect,
     isOwner,
     onClose,
-    onMarkStatus,
+    onStatusChange,
   }: {
     token: ServerToken;
     /** DOMRect of the clicked token's bounding box, used to anchor
@@ -65,14 +65,26 @@
     anchorRect: { top: number; left: number; bottom: number; right: number };
     isOwner: boolean;
     onClose: () => void;
-    /** T-5.5 wires this to PATCH /api/v1/known-lemmas; T-5.4 just
-     *  emits the intent. */
-    onMarkStatus?: (status: 'learning' | 'known' | 'ignored') => void;
+    /** Called after a successful PATCH so the parent can update its
+     *  in-memory token list (rerunning the loader would lose scroll
+     *  position). */
+    onStatusChange?: (
+      lemmaId: string,
+      status: 'unknown' | 'learning' | 'known' | 'ignored',
+    ) => void;
   } = $props();
 
   let payload = $state<LemmaPayload | null>(null);
   let loadError = $state<string | null>(null);
   let showAlternates = $state(false);
+  // Optimistic mirror of the token's status — flips immediately when
+  // the user picks Learning / Known / Ignored, then reverts if the
+  // server write fails. Initialised once via untrack so Svelte 5
+  // doesn't flag the prop read.
+  let optimisticStatus = $state<'unknown' | 'learning' | 'known' | 'ignored'>(
+    untrack(() => token.status),
+  );
+  let writeError = $state<string | null>(null);
 
   // Position state — set after mount once we know our own size.
   let popupEl: HTMLElement | null = $state(null);
@@ -142,6 +154,33 @@
     const entries = Object.entries(features);
     if (entries.length === 0) return '';
     return entries.map(([k, v]) => `${k}: ${v}`).join(' · ');
+  }
+
+  async function markStatus(
+    status: 'unknown' | 'learning' | 'known' | 'ignored',
+  ) {
+    if (!token.lemmaId) return;
+    const lemmaId = token.lemmaId;
+    const previous = optimisticStatus;
+    // Optimistic flip — the user sees the change before the wire
+    // settles.
+    optimisticStatus = status;
+    writeError = null;
+    try {
+      const res = await fetch(`/api/v1/me/known-lemmas/${lemmaId}`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ status }),
+      });
+      if (!res.ok) {
+        throw new Error(`PATCH failed: ${res.status}`);
+      }
+      onStatusChange?.(lemmaId, status);
+    } catch (e) {
+      // Revert on failure so the user knows something went wrong.
+      optimisticStatus = previous;
+      writeError = (e as Error).message;
+    }
   }
 </script>
 
@@ -214,26 +253,29 @@
     <div class="status-row" role="group" aria-label="Mark status">
       <button
         type="button"
-        class:active={token.status === 'learning'}
-        onclick={() => onMarkStatus?.('learning')}
+        class:active={optimisticStatus === 'learning'}
+        onclick={() => markStatus('learning')}
       >
         Learning
       </button>
       <button
         type="button"
-        class:active={token.status === 'known'}
-        onclick={() => onMarkStatus?.('known')}
+        class:active={optimisticStatus === 'known'}
+        onclick={() => markStatus('known')}
       >
         Known
       </button>
       <button
         type="button"
-        class:active={token.status === 'ignored'}
-        onclick={() => onMarkStatus?.('ignored')}
+        class:active={optimisticStatus === 'ignored'}
+        onclick={() => markStatus('ignored')}
       >
         Ignored
       </button>
     </div>
+    {#if writeError}
+      <p class="err small">Could not save: {writeError}</p>
+    {/if}
   {/if}
 
   {#if token.isAmbiguous}

--- a/apps/web/src/lib/server/texts/tokens.ts
+++ b/apps/web/src/lib/server/texts/tokens.ts
@@ -147,3 +147,107 @@ export async function listKnownLemmas(
 // Re-export `inArray` so callers can build composite predicates
 // without importing drizzle directly when needed.
 export { inArray };
+
+// -----------------------------------------------------------------------
+// setKnownLemmaStatus (T-5.5)
+// -----------------------------------------------------------------------
+
+/**
+ * Upsert the user's known-status for a lemma. The reader's pop-up
+ * (T-5.4) wires its Learning / Known / Ignored buttons through this.
+ * Recomputes the per-language known-count cache on
+ * `user_languages.known_words_count_cache` so the stats card on the
+ * profile page is correct without a full scan.
+ *
+ * Returns the new status row.
+ */
+export async function setKnownLemmaStatus(args: {
+  userId: string;
+  lemmaId: string;
+  status: 'unknown' | 'learning' | 'known' | 'ignored';
+  now?: Date;
+}): Promise<UserKnownLemma> {
+  const now = args.now ?? new Date();
+
+  // Look up the lemma to find its language — needed for the per-
+  // language cache update. A missing lemma is a 404; the caller
+  // converts the thrown error.
+  const [lemma] = await db
+    .select({ id: schema.lemmas.id, language: schema.lemmas.language })
+    .from(schema.lemmas)
+    .where(eq(schema.lemmas.id, args.lemmaId))
+    .limit(1);
+  if (!lemma) {
+    throw new Error(`Lemma ${args.lemmaId} not found`);
+  }
+  const language = (lemma as { language: 'hi' | 'mr' | 'or' }).language;
+
+  // Upsert. We can't use Drizzle's onConflictDoUpdate with a composite
+  // PK across all our drivers without a lot of ceremony — the simpler
+  // path is to read the existing row and conditionally INSERT or
+  // UPDATE.
+  const existing = (await db
+    .select()
+    .from(schema.userKnownLemmas)
+    .where(eq(schema.userKnownLemmas.userId, args.userId))) as UserKnownLemma[];
+  const row = existing.find((r) => r.lemmaId === args.lemmaId);
+
+  let result: UserKnownLemma;
+  if (row) {
+    const [updated] = (await db
+      .update(schema.userKnownLemmas)
+      .set({ status: args.status, updatedAt: now })
+      .where(
+        // Composite PK condition.
+        (await import('drizzle-orm')).and(
+          eq(schema.userKnownLemmas.userId, args.userId),
+          eq(schema.userKnownLemmas.lemmaId, args.lemmaId),
+        )!,
+      )
+      .returning()) as UserKnownLemma[];
+    if (!updated) throw new Error('Failed to update user_known_lemmas');
+    result = updated;
+  } else {
+    const [inserted] = (await db
+      .insert(schema.userKnownLemmas)
+      .values({
+        userId: args.userId,
+        lemmaId: args.lemmaId,
+        status: args.status,
+        updatedAt: now,
+      })
+      .returning()) as UserKnownLemma[];
+    if (!inserted) throw new Error('Failed to insert user_known_lemmas');
+    result = inserted;
+  }
+
+  // Recompute the cache for this user × language. Counted as the
+  // number of rows with status='known' for the lemmas in that
+  // language.
+  const allKnown = (await db
+    .select({
+      lemmaId: schema.userKnownLemmas.lemmaId,
+      language: schema.lemmas.language,
+    })
+    .from(schema.userKnownLemmas)
+    .innerJoin(schema.lemmas, eq(schema.lemmas.id, schema.userKnownLemmas.lemmaId))
+    .where(
+      (await import('drizzle-orm')).and(
+        eq(schema.userKnownLemmas.userId, args.userId),
+        eq(schema.userKnownLemmas.status, 'known'),
+        eq(schema.lemmas.language, language),
+      )!,
+    )) as Array<{ lemmaId: string; language: string }>;
+  const knownCount = allKnown.length;
+  await db
+    .update(schema.userLanguages)
+    .set({ knownWordsCountCache: knownCount })
+    .where(
+      (await import('drizzle-orm')).and(
+        eq(schema.userLanguages.userId, args.userId),
+        eq(schema.userLanguages.language, language),
+      )!,
+    );
+
+  return result;
+}

--- a/apps/web/src/routes/api/v1/me/known-lemmas/[lemmaId]/+server.ts
+++ b/apps/web/src/routes/api/v1/me/known-lemmas/[lemmaId]/+server.ts
@@ -1,0 +1,62 @@
+/**
+ * PATCH /api/v1/me/known-lemmas/:lemmaId (T-5.5).
+ *
+ * Upsert the caller's known-status for a lemma. The reader pop-up's
+ * Learning / Known / Ignored buttons (T-5.4) call this with the
+ * status value the user picked.
+ *
+ * Body: `{ status: 'unknown' | 'learning' | 'known' | 'ignored' }`.
+ * Response: 200 with the updated row + the user's new known-words
+ * count for the affected language so the stats card can update
+ * without a separate fetch.
+ */
+import { error, json } from '@sveltejs/kit';
+import { z } from 'zod';
+
+import { requireUser } from '$lib/server/auth/require-user.js';
+import { setKnownLemmaStatus } from '$lib/server/texts/tokens.js';
+import type { RequestHandler } from './$types';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const body = z.object({
+  status: z.enum(['unknown', 'learning', 'known', 'ignored']),
+});
+
+export const PATCH: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  const lemmaId = event.params.lemmaId;
+  if (!lemmaId || !UUID_RE.test(lemmaId)) throw error(400, 'Invalid lemma id');
+
+  let parsed: { status: 'unknown' | 'learning' | 'known' | 'ignored' };
+  try {
+    const json_body = await event.request.json();
+    const result = body.safeParse(json_body);
+    if (!result.success) throw error(400, 'Invalid body');
+    parsed = result.data;
+  } catch (e) {
+    if (e && typeof e === 'object' && 'status' in e) throw e;
+    throw error(400, 'Invalid JSON body');
+  }
+
+  try {
+    const row = await setKnownLemmaStatus({
+      userId: user.id,
+      lemmaId,
+      status: parsed.status,
+    });
+    return json({
+      knownLemma: {
+        userId: row.userId,
+        lemmaId: row.lemmaId,
+        status: row.status,
+        updatedAt: row.updatedAt,
+      },
+    });
+  } catch (err) {
+    if ((err as Error).message?.includes('not found')) {
+      throw error(404, (err as Error).message);
+    }
+    throw err;
+  }
+};

--- a/apps/web/src/routes/api/v1/me/known-lemmas/[lemmaId]/known-lemmas-server.test.ts
+++ b/apps/web/src/routes/api/v1/me/known-lemmas/[lemmaId]/known-lemmas-server.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const setKnownLemmaStatus = vi.fn();
+const requireUser = vi.fn();
+
+vi.mock('$lib/server/texts/tokens.js', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/texts/tokens.js')>(
+    '$lib/server/texts/tokens.js',
+  );
+  return {
+    ...actual,
+    setKnownLemmaStatus: (...a: unknown[]) => setKnownLemmaStatus(...a),
+  };
+});
+
+vi.mock('$lib/server/auth/require-user.js', () => ({
+  requireUser: (...a: unknown[]) => requireUser(...a),
+}));
+
+type PatchFn = (typeof import('./+server.js'))['PATCH'];
+
+const VALID_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const USER = { id: 'user-1', role: 'user' as const };
+
+async function callPatch(
+  body: unknown,
+  lemmaId = VALID_ID,
+  user: typeof USER | null = USER,
+) {
+  if (user) {
+    requireUser.mockResolvedValueOnce(user);
+  } else {
+    requireUser.mockImplementationOnce(() => {
+      throw { status: 401 };
+    });
+  }
+  const { PATCH } = await import('./+server.js');
+  const event = {
+    params: { lemmaId },
+    request: new Request(`http://x/api/v1/me/known-lemmas/${lemmaId}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: typeof body === 'string' ? body : JSON.stringify(body),
+    }),
+  } as unknown as Parameters<PatchFn>[0];
+  try {
+    return await PATCH(event);
+  } catch (e) {
+    return e as { status: number };
+  }
+}
+
+beforeEach(() => {
+  setKnownLemmaStatus.mockReset();
+  requireUser.mockReset();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('PATCH /api/v1/me/known-lemmas/:lemmaId', () => {
+  it('updates the status and returns the row', async () => {
+    setKnownLemmaStatus.mockResolvedValueOnce({
+      userId: USER.id,
+      lemmaId: VALID_ID,
+      status: 'known',
+      updatedAt: new Date('2026-04-27T00:00:00Z'),
+    });
+    const res = (await callPatch({ status: 'known' })) as Response;
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.knownLemma.status).toBe('known');
+    expect(setKnownLemmaStatus).toHaveBeenCalledWith({
+      userId: USER.id,
+      lemmaId: VALID_ID,
+      status: 'known',
+    });
+  });
+
+  it('rejects an unsupported status with 400', async () => {
+    const res = (await callPatch({ status: 'maybe' })) as { status: number };
+    expect(res.status).toBe(400);
+    expect(setKnownLemmaStatus).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing body with 400', async () => {
+    const res = (await callPatch({})) as { status: number };
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects an invalid lemma uuid with 400', async () => {
+    const res = (await callPatch({ status: 'known' }, 'not-a-uuid')) as {
+      status: number;
+    };
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when the service reports the lemma is missing', async () => {
+    setKnownLemmaStatus.mockRejectedValueOnce(
+      new Error('Lemma abc not found'),
+    );
+    const res = (await callPatch({ status: 'known' })) as { status: number };
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const res = (await callPatch({ status: 'known' }, VALID_ID, null)) as {
+      status: number;
+    };
+    expect(res.status).toBe(401);
+    expect(setKnownLemmaStatus).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #51

## Summary

Wires the pop-up's status buttons to the server and flips local state optimistically. New \`PATCH /api/v1/me/known-lemmas/:lemmaId\` upserts the user's known-status for a lemma and recomputes the per-language \`known_words_count_cache\` so the profile stats stay in sync without a re-scan.

The pop-up's \`onStatusChange\` callback drops a local override into ChapterBody / ReaderScroll's status map — every other matching token flips its highlight in real time, without reloading the chapter.

## Test plan

- [x] \`pnpm --filter @ciareader/web test\` — 522/522 (8 new)
- [x] \`check\` + \`lint\` clean
- [ ] Manual: click "Known" on a word with multiple occurrences; confirm every matching token loses the highlight
- [ ] Manual: kill the server mid-click; confirm the optimistic flip reverts and an error message appears