### PR TITLE
T-5.7: keyboard shortcuts (closes M5)

### DIFF
--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -51,6 +51,8 @@ export default [
         FileList: 'readonly',
         TextEncoder: 'readonly',
         TextDecoder: 'readonly',
+        // Reader keyboard handlers (T-5.7).
+        EventTarget: 'readonly',
       },
     },
   },

--- a/apps/web/src/lib/components/reader/ReaderPage.svelte
+++ b/apps/web/src/lib/components/reader/ReaderPage.svelte
@@ -34,7 +34,36 @@
       keepFocus: true,
     });
   }
+
+  // T-5.7: ←/→ flip pages. We listen on the window so the user
+  // doesn't have to first click the reader to focus it. Skip
+  // when typing in a form / textarea / contenteditable element so
+  // we don't hijack legitimate input.
+  function isTypingInsideElement(target: EventTarget | null): boolean {
+    if (!(target instanceof HTMLElement)) return false;
+    const tag = target.tagName;
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+    if (target.isContentEditable) return true;
+    return false;
+  }
+
+  function onKeydown(e: KeyboardEvent) {
+    if (e.metaKey || e.ctrlKey || e.altKey) return;
+    if (isTypingInsideElement(e.target)) return;
+    // Don't fight the popup — when it's mounted, it owns the
+    // keyboard. The popup itself stops Esc / k / l / i propagation.
+    if (document.querySelector('[data-testid="word-popup"]')) return;
+    if (e.key === 'ArrowLeft' && hasPrev) {
+      e.preventDefault();
+      go(chapterIdx - 1);
+    } else if (e.key === 'ArrowRight' && hasNext) {
+      e.preventDefault();
+      go(chapterIdx + 1);
+    }
+  }
 </script>
+
+<svelte:window onkeydown={onKeydown} />
 
 <div class="reader-page" data-mode="page">
   <header class="page-header">

--- a/apps/web/src/lib/components/reader/ReaderScroll.svelte
+++ b/apps/web/src/lib/components/reader/ReaderScroll.svelte
@@ -159,7 +159,31 @@
     next.set(lemmaId, status);
     statusOverrides = next;
   }
+
+  // T-5.7: ←/→ flip pages within the chapter.
+  function isTypingInsideElement(target: EventTarget | null): boolean {
+    if (!(target instanceof HTMLElement)) return false;
+    const tag = target.tagName;
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+    if (target.isContentEditable) return true;
+    return false;
+  }
+
+  function onKeydown(e: KeyboardEvent) {
+    if (e.metaKey || e.ctrlKey || e.altKey) return;
+    if (isTypingInsideElement(e.target)) return;
+    if (document.querySelector('[data-testid="word-popup"]')) return;
+    if (e.key === 'ArrowLeft' && hasPrev) {
+      e.preventDefault();
+      prev();
+    } else if (e.key === 'ArrowRight' && hasNext) {
+      e.preventDefault();
+      next();
+    }
+  }
 </script>
+
+<svelte:window onkeydown={onKeydown} />
 
 <div class="reader-scroll" data-mode="paged-scroll">
   <header class="page-header">

--- a/apps/web/src/lib/components/reader/WordPopup.svelte
+++ b/apps/web/src/lib/components/reader/WordPopup.svelte
@@ -132,6 +132,21 @@
     if (e.key === 'Escape') {
       e.preventDefault();
       onClose();
+      return;
+    }
+    if (!isOwner || !token.lemmaId) return;
+    // T-5.7: power-user shortcuts. Only fire when modifier-free so we
+    // don't fight the browser's own shortcuts (Cmd-K, Ctrl-L, etc.).
+    if (e.metaKey || e.ctrlKey || e.altKey) return;
+    if (e.key === 'k' || e.key === 'K') {
+      e.preventDefault();
+      void markStatus('known');
+    } else if (e.key === 'l' || e.key === 'L') {
+      e.preventDefault();
+      void markStatus('learning');
+    } else if (e.key === 'i' || e.key === 'I') {
+      e.preventDefault();
+      void markStatus('ignored');
     }
   }
 


### PR DESCRIPTION
Closes #53

## Summary

Power-user shortcuts on the reader. Closes **M5**.

- **Pop-up open**: \`k\` / \`l\` / \`i\` mark Known / Learning / Ignored (fires the same PATCH the buttons do).
- **Pop-up closed**: \`←\` / \`→\` flip pages in 'page' and 'paged-scroll' modes.
- Always skips on modifier keys, on form-input focus, and while the popup is mounted (the popup owns the keyboard).

## Test plan

- [x] \`pnpm --filter @ciareader/web test\` — 534/534
- [x] \`check\` + \`lint\` clean
- [ ] Manual: open the popup, press \`k\` → flips to Known, popup updates immediately
- [ ] Manual: close the popup, press \`→\` in page mode → next chapter
- [ ] Manual: focus a text input on the page (e.g. the upload form via the back button), press \`l\` → no shortcut fires