### PR TITLE
T-5.8: reader tokens + reading fonts

### DIFF
--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-theme="%cia.theme%">
+<html lang="en" data-theme="%cia.theme%" data-hl="background">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -11,6 +11,11 @@
       light-mode flash for dark-mode users. Reads the cookie written by
       the profile form and falls back to the OS preference. Mirrored by
       server-side rendering in hooks.server.ts so hydration matches.
+
+      `data-hl` controls reader word-status highlighting style
+      (background tint vs. underline). It's a reader-mode setting written
+      by T-5.1b's text-settings popover and persisted client-side; the
+      attribute is set here so first paint already has the right rules.
     -->
     <script>
       (function () {
@@ -18,15 +23,34 @@
           var match = document.cookie.match(/(?:^|; )cia_theme=([^;]+)/);
           var pref = match ? decodeURIComponent(match[1]) : 'system';
           var resolved =
-            pref === 'light' || pref === 'dark'
+            pref === 'light' || pref === 'dark' || pref === 'sepia'
               ? pref
               : window.matchMedia('(prefers-color-scheme: dark)').matches
                 ? 'dark'
                 : 'light';
           document.documentElement.setAttribute('data-theme', resolved);
+
+          var hlMatch = document.cookie.match(/(?:^|; )cia_hl=([^;]+)/);
+          var hlPref = hlMatch ? decodeURIComponent(hlMatch[1]) : 'background';
+          document.documentElement.setAttribute(
+            'data-hl',
+            hlPref === 'underline' ? 'underline' : 'background',
+          );
         } catch (_) {}
       })();
     </script>
+    <!--
+      CIAR design font stack (T-5.8). Inter / Source Serif 4 / JetBrains
+      Mono are global UI fonts; the script-specific Noto + Tiro families
+      back the reader body. Loaded via Google Fonts with display=swap so
+      first paint never blocks on a font response.
+    -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Source+Serif+4:ital,wght@0,400;0,500;0,600;1,400&family=Tiro+Devanagari+Hindi:ital@0;1&family=Noto+Serif+Devanagari:wght@400;500&family=Noto+Sans+Devanagari:wght@400;500&family=Noto+Serif+Bengali&family=Noto+Serif+Gujarati&family=Noto+Serif+Gurmukhi&family=Noto+Serif+Oriya&family=JetBrains+Mono:wght@400;500&display=swap"
+    />
     %sveltekit.head%
   </head>
   <body data-sveltekit-preload-data="hover">

--- a/apps/web/src/hooks.server.test.ts
+++ b/apps/web/src/hooks.server.test.ts
@@ -58,6 +58,10 @@ describe('resolveServerTheme', () => {
   it("defaults to 'light' when no source has an opinion", () => {
     expect(resolveServerTheme(makeEvent({}))).toBe('light');
   });
+
+  it("honors a 'sepia' cookie for logged-out visitors", () => {
+    expect(resolveServerTheme(makeEvent({ cookie: 'sepia' }))).toBe('sepia');
+  });
 });
 
 describe('handle — onboarding redirect', () => {

--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -1,7 +1,12 @@
 import { redirect, type Handle } from '@sveltejs/kit';
 import { resolveUser } from '$lib/server/auth/require-user.js';
 import { shouldRedirectToOnboarding } from '$lib/server/onboarding.js';
-import { THEME_COOKIE, isThemePreference, resolveTheme } from '$lib/theme/index.js';
+import {
+  THEME_COOKIE,
+  isThemePreference,
+  resolveTheme,
+  type ResolvedTheme,
+} from '$lib/theme/index.js';
 import { setJobDispatcher } from '$lib/server/texts/jobs.js';
 import { inProcessDispatcher } from '$lib/server/texts/in-process-dispatcher.js';
 
@@ -30,7 +35,7 @@ setJobDispatcher(inProcessDispatcher);
  *  4. Default to 'light' (light-mode systems without a cookie or hint won't
  *     flip when the client-side script runs).
  */
-export function resolveServerTheme(event: Parameters<Handle>[0]['event']): 'light' | 'dark' {
+export function resolveServerTheme(event: Parameters<Handle>[0]['event']): ResolvedTheme {
   const userPref = event.locals.user?.themePreference;
   const cookiePref = event.cookies.get(THEME_COOKIE);
   const preference = userPref ?? (isThemePreference(cookiePref) ? cookiePref : 'system');

--- a/apps/web/src/lib/styles/tokens.css
+++ b/apps/web/src/lib/styles/tokens.css
@@ -51,6 +51,97 @@
   /* Code */
   --color-code-bg: #f3f4f6;
   --color-code-fg: #111111;
+
+  /* CIAR design palette (Apr 2026 handoff).
+   * "Paper" / "ink" naming reflects the literary-reader positioning. The
+   * old `--color-*` tokens stay populated so unrenamed components keep
+   * working; new components consume these. */
+  --paper: #fdfaf3;
+  --paper-2: #f7f1e2;
+  --paper-3: #efe7d0;
+  --ink: #1f1a14;
+  --ink-2: #524a3d;
+  --ink-3: #877e6c;
+  --ink-4: #b3aa97;
+  --rule: #ece2c9;
+  --rule-2: #f3ebd6;
+  --card: #ffffff;
+  --card-edge: #ece2cc;
+
+  --accent: oklch(0.58 0.13 60); /* saffron */
+  --accent-soft: oklch(0.58 0.13 60 / 0.14);
+  --accent-ink: oklch(0.34 0.1 60);
+
+  --green: oklch(0.55 0.1 145);
+  --green-soft: oklch(0.55 0.1 145 / 0.14);
+  --rose: oklch(0.58 0.12 25);
+  --rose-soft: oklch(0.58 0.12 25 / 0.14);
+  --indigo: oklch(0.5 0.1 270);
+  --indigo-soft: oklch(0.5 0.1 270 / 0.14);
+
+  /* Word-status tints (background-highlight mode). Underline mode in T-5.9
+   * uses the accent hue at varying weights via the data-hl="underline" rules. */
+  --w-unknown-bg: transparent;
+  --w-l1-bg: oklch(0.92 0.07 80); /* very pale saffron */
+  --w-l2-bg: oklch(0.86 0.1 75);
+  --w-l3-bg: oklch(0.8 0.12 70);
+  --w-known-bg: transparent;
+  --w-ignored-bg: transparent;
+  --w-known-ink: var(--ink-3);
+  --w-ignored-ink: var(--ink-4);
+
+  --shadow-1:
+    0 1px 0 rgba(255, 255, 255, 0.5) inset, 0 1px 2px rgba(67, 47, 14, 0.06);
+  --shadow-2:
+    0 1px 0 rgba(255, 255, 255, 0.5) inset, 0 8px 24px rgba(67, 47, 14, 0.1);
+}
+
+[data-theme='sepia'] {
+  /* Surfaces */
+  --color-bg: #ead6b3;
+  --color-surface-1: #e1cb9f;
+  --color-surface-2: #d6bd8a;
+  --color-surface-3: #c9b083;
+  --color-overlay: rgba(42, 31, 16, 0.45);
+
+  /* Foreground */
+  --color-fg: #2a1f10;
+  --color-fg-muted: #4f3f25;
+  --color-fg-subtle: #7d6940;
+
+  --color-border: #c9b083;
+  --color-border-strong: #a8915e;
+
+  /* Sepia shares the saffron accent. */
+  --color-accent: oklch(0.58 0.13 60);
+  --color-accent-fg: #2a1f10;
+  --color-accent-hover: oklch(0.5 0.13 60);
+
+  --color-highlight-unknown: oklch(0.84 0.08 75);
+  --color-highlight-unknown-fg: #2a1f10;
+  --color-highlight-learning: oklch(0.76 0.12 70);
+  --color-highlight-learning-fg: #2a1f10;
+  --color-highlight-known: transparent;
+
+  --color-code-bg: #d6bd91;
+  --color-code-fg: #2a1f10;
+
+  /* CIAR design palette */
+  --paper: #ead6b3;
+  --paper-2: #e1cb9f;
+  --paper-3: #d6bd8a;
+  --ink: #2a1f10;
+  --ink-2: #4f3f25;
+  --ink-3: #7d6940;
+  --ink-4: #a8915e;
+  --rule: #c9b083;
+  --rule-2: #d6bd91;
+  --card: #f0dcb5;
+  --card-edge: #d2b884;
+
+  --w-l1-bg: oklch(0.84 0.08 75);
+  --w-l2-bg: oklch(0.76 0.12 70);
+  --w-l3-bg: oklch(0.68 0.13 65);
 }
 
 [data-theme='dark'] {
@@ -83,6 +174,32 @@
 
   --color-code-bg: #18181b;
   --color-code-fg: #f5f5f7;
+
+  /* CIAR design palette */
+  --paper: #161310;
+  --paper-2: #1d1916;
+  --paper-3: #25201b;
+  --ink: #f0e7d3;
+  --ink-2: #c9bfa9;
+  --ink-3: #897e6a;
+  --ink-4: #5d5547;
+  --rule: #2e2822;
+  --rule-2: #3a332b;
+  --card: #1a1714;
+  --card-edge: #2a241e;
+
+  --accent: oklch(0.78 0.13 70);
+  --accent-soft: oklch(0.78 0.13 70 / 0.18);
+  --accent-ink: oklch(0.86 0.11 70);
+
+  --w-l1-bg: oklch(0.3 0.05 70);
+  --w-l2-bg: oklch(0.38 0.08 68);
+  --w-l3-bg: oklch(0.46 0.11 65);
+
+  --shadow-1:
+    0 1px 0 rgba(255, 255, 255, 0.04) inset, 0 1px 2px rgba(0, 0, 0, 0.4);
+  --shadow-2:
+    0 1px 0 rgba(255, 255, 255, 0.04) inset, 0 12px 32px rgba(0, 0, 0, 0.55);
 }
 
 /* Typography, spacing, radii, shadows, motion — theme-invariant.
@@ -93,6 +210,18 @@
     system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
   --font-mono:
     'SF Mono', ui-monospace, 'Cascadia Code', Menlo, Consolas, 'Liberation Mono', monospace;
+
+  /* CIAR design typography (Apr 2026 handoff). Loaded via Google Fonts in
+   * app.html. The reader chooses --serif-dev for Devanagari body text and
+   * falls back through Noto for Bengali / Gujarati / Gurmukhi / Oriya in
+   * T-5.9. UI chrome uses --sans + --serif. */
+  --font-sans: 'Inter', ui-sans-serif, system-ui, -apple-system, sans-serif;
+  --font-serif: 'Source Serif 4', 'Iowan Old Style', 'Georgia', serif;
+  --font-serif-dev:
+    'Tiro Devanagari Hindi', 'Noto Serif Devanagari', 'Source Serif 4', serif;
+  --font-sans-dev: 'Noto Sans Devanagari', 'Inter', sans-serif;
+  --font-mono-display:
+    'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
 
   --font-size-xs: 0.75rem;
   --font-size-sm: 0.875rem;

--- a/apps/web/src/lib/styles/tokens.test.ts
+++ b/apps/web/src/lib/styles/tokens.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Token sanity tests. CSS-variable resolution isn't reliably testable in
+ * jsdom (custom properties are not always re-resolved on attribute change),
+ * so we read the source and assert that each theme block declares the keys
+ * that downstream components depend on. Cheap, fast, and catches accidental
+ * deletions during refactors.
+ */
+const tokens = readFileSync(
+  fileURLToPath(new URL('./tokens.css', import.meta.url)),
+  'utf-8',
+);
+
+function block(selector: string): string {
+  const start = tokens.indexOf(selector);
+  if (start === -1) throw new Error(`block ${selector} not found in tokens.css`);
+  const open = tokens.indexOf('{', start);
+  const close = tokens.indexOf('}', open);
+  return tokens.slice(open, close);
+}
+
+const lightBlock = block(":root,\n[data-theme='light']");
+const sepiaBlock = block("[data-theme='sepia']");
+const darkBlock = block("[data-theme='dark']");
+const rootInvariant = block(
+  '/* Typography, spacing, radii, shadows, motion — theme-invariant.',
+);
+
+describe('CIAR design palette', () => {
+  it.each([
+    ['light', lightBlock],
+    ['sepia', sepiaBlock],
+    ['dark', darkBlock],
+  ])('%s theme declares paper / ink / card / rule', (_name, b) => {
+    expect(b).toMatch(/--paper:\s/);
+    expect(b).toMatch(/--ink:\s/);
+    expect(b).toMatch(/--card:\s/);
+    expect(b).toMatch(/--rule:\s/);
+  });
+
+  it.each([
+    ['light', lightBlock],
+    ['sepia', sepiaBlock],
+    ['dark', darkBlock],
+  ])('%s theme declares word-status background tints (l1/l2/l3)', (_name, b) => {
+    expect(b).toMatch(/--w-l1-bg:\s/);
+    expect(b).toMatch(/--w-l2-bg:\s/);
+    expect(b).toMatch(/--w-l3-bg:\s/);
+  });
+
+  it('only the light theme defines the saffron accent + accent-soft pair (sepia + dark inherit)', () => {
+    expect(lightBlock).toMatch(/--accent:\s/);
+    expect(lightBlock).toMatch(/--accent-soft:\s/);
+    // Sepia inherits accent from :root,[data-theme='light']; dark overrides
+    // the accent for the dark palette.
+    expect(darkBlock).toMatch(/--accent:\s/);
+  });
+});
+
+describe('design typography tokens', () => {
+  it('declares the design font stack alongside the existing UI fonts', () => {
+    expect(rootInvariant).toMatch(/--font-sans:\s/);
+    expect(rootInvariant).toMatch(/--font-serif:\s/);
+    expect(rootInvariant).toMatch(/--font-serif-dev:\s/);
+    expect(rootInvariant).toMatch(/--font-sans-dev:\s/);
+    expect(rootInvariant).toMatch(/--font-mono-display:\s/);
+  });
+
+  it('preserves the legacy --font-ui / --font-mono tokens', () => {
+    expect(rootInvariant).toMatch(/--font-ui:\s/);
+    expect(rootInvariant).toMatch(/--font-mono:\s/);
+  });
+});

--- a/apps/web/src/lib/theme/index.test.ts
+++ b/apps/web/src/lib/theme/index.test.ts
@@ -21,13 +21,19 @@ describe('resolveTheme', () => {
     expect(resolveTheme('system', true)).toBe('dark');
     expect(resolveTheme('system', false)).toBe('light');
   });
+
+  it("returns 'sepia' when preference is 'sepia' regardless of system preference", () => {
+    expect(resolveTheme('sepia', true)).toBe('sepia');
+    expect(resolveTheme('sepia', false)).toBe('sepia');
+  });
 });
 
 describe('isThemePreference', () => {
-  it('accepts the three valid preference strings', () => {
+  it('accepts the four valid preference strings', () => {
     expect(isThemePreference('system')).toBe(true);
     expect(isThemePreference('light')).toBe(true);
     expect(isThemePreference('dark')).toBe(true);
+    expect(isThemePreference('sepia')).toBe(true);
   });
 
   it('rejects other values', () => {

--- a/apps/web/src/lib/theme/index.ts
+++ b/apps/web/src/lib/theme/index.ts
@@ -8,8 +8,8 @@
  * dark-mode users' first paint) and client-side onMount code (to react to
  * OS preference changes) can share it.
  */
-export type ThemePreference = 'system' | 'light' | 'dark';
-export type ResolvedTheme = 'light' | 'dark';
+export type ThemePreference = 'system' | 'light' | 'dark' | 'sepia';
+export type ResolvedTheme = 'light' | 'dark' | 'sepia';
 
 export function resolveTheme(
   preference: ThemePreference,
@@ -23,5 +23,5 @@ export const THEME_COOKIE = 'cia_theme';
 export const THEME_COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // 1 year
 
 export function isThemePreference(value: unknown): value is ThemePreference {
-  return value === 'system' || value === 'light' || value === 'dark';
+  return value === 'system' || value === 'light' || value === 'dark' || value === 'sepia';
 }


### PR DESCRIPTION
## Summary

Foundation for the M5 visual redesign (CIAR design handoff, Apr 2026). Adds the design's color + typography tokens, a sepia theme, and the `data-hl` highlight-style hook on `<html>`. Existing screens are untouched — the new tokens sit alongside the current `--color-*` family so reader / library / profile keep working until each screen's redesign ticket lands.

### What's in
- **`tokens.css`** — Paper/ink scale, saffron accent + soft variants, card + rule + shadow vars, word-status background tints (`--w-l1/2/3-bg`), and the design's font family vars (`--font-sans`, `--font-serif`, `--font-serif-dev`, `--font-sans-dev`, `--font-mono-display`). New `[data-theme='sepia']` block with the full sepia palette.
- **`theme/index.ts`** — `ThemePreference` and `ResolvedTheme` widened to include `'sepia'`. `isThemePreference` accepts `'sepia'`. `resolveTheme('sepia', _)` returns `'sepia'`.
- **`hooks.server.ts`** — `resolveServerTheme` return type now `ResolvedTheme` so it can pass `'sepia'` through to `data-theme`.
- **`app.html`** — Pre-paint script accepts `'sepia'` cookie values; reads a separate `cia_hl` cookie (default `background`) to set `data-hl="background|underline"`. Google Fonts loaded with `display=swap` (Inter, Source Serif 4, Tiro Devanagari Hindi, Noto Serif/Sans Devanagari, Noto Serif Bengali/Gujarati/Gurmukhi/Oriya, JetBrains Mono).

### What's intentionally out
- **DB schema unchanged.** The `theme_preference` Postgres enum still has `system | light | dark`. Sepia rides on the cookie. T-5.1b can decide whether to add `'sepia'` to the enum + migration when the reader's text-settings popover lands.
- **No screen restyling.** This ticket only ships tokens + fonts + theme plumbing. T-5.9 (reader chrome) is the first ticket that consumes the new tokens.
- **Font loading not yet lazy-per-script.** Loads the full design stack globally for now; per-language lazy-loading is in scope for T-5.1b's reader settings work.

### Tests
- `theme/index.test.ts` — sepia resolution + `isThemePreference('sepia')`.
- `hooks.server.test.ts` — `'sepia'` cookie passes through for logged-out visitors.
- `tokens.test.ts` (new) — every theme block declares paper/ink/card/rule + the word-status tint trio; design font tokens declared alongside the legacy `--font-ui` / `--font-mono` so nothing breaks.

571 tests pass · `svelte-check` clean (0 errors / 0 warnings).

Closes #158
Refs #42