### PR TITLE
T-5.9: reader chrome redesign

### DIFF
--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-theme="%cia.theme%">
+<html lang="en" data-theme="%cia.theme%" data-hl="background">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -11,6 +11,11 @@
       light-mode flash for dark-mode users. Reads the cookie written by
       the profile form and falls back to the OS preference. Mirrored by
       server-side rendering in hooks.server.ts so hydration matches.
+
+      `data-hl` controls reader word-status highlighting style
+      (background tint vs. underline). It's a reader-mode setting written
+      by T-5.1b's text-settings popover and persisted client-side; the
+      attribute is set here so first paint already has the right rules.
     -->
     <script>
       (function () {
@@ -18,15 +23,34 @@
           var match = document.cookie.match(/(?:^|; )cia_theme=([^;]+)/);
           var pref = match ? decodeURIComponent(match[1]) : 'system';
           var resolved =
-            pref === 'light' || pref === 'dark'
+            pref === 'light' || pref === 'dark' || pref === 'sepia'
               ? pref
               : window.matchMedia('(prefers-color-scheme: dark)').matches
                 ? 'dark'
                 : 'light';
           document.documentElement.setAttribute('data-theme', resolved);
+
+          var hlMatch = document.cookie.match(/(?:^|; )cia_hl=([^;]+)/);
+          var hlPref = hlMatch ? decodeURIComponent(hlMatch[1]) : 'background';
+          document.documentElement.setAttribute(
+            'data-hl',
+            hlPref === 'underline' ? 'underline' : 'background',
+          );
         } catch (_) {}
       })();
     </script>
+    <!--
+      CIAR design font stack (T-5.8). Inter / Source Serif 4 / JetBrains
+      Mono are global UI fonts; the script-specific Noto + Tiro families
+      back the reader body. Loaded via Google Fonts with display=swap so
+      first paint never blocks on a font response.
+    -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Source+Serif+4:ital,wght@0,400;0,500;0,600;1,400&family=Tiro+Devanagari+Hindi:ital@0;1&family=Noto+Serif+Devanagari:wght@400;500&family=Noto+Sans+Devanagari:wght@400;500&family=Noto+Serif+Bengali&family=Noto+Serif+Gujarati&family=Noto+Serif+Gurmukhi&family=Noto+Serif+Oriya&family=JetBrains+Mono:wght@400;500&display=swap"
+    />
     %sveltekit.head%
   </head>
   <body data-sveltekit-preload-data="hover">

--- a/apps/web/src/hooks.server.test.ts
+++ b/apps/web/src/hooks.server.test.ts
@@ -58,6 +58,10 @@ describe('resolveServerTheme', () => {
   it("defaults to 'light' when no source has an opinion", () => {
     expect(resolveServerTheme(makeEvent({}))).toBe('light');
   });
+
+  it("honors a 'sepia' cookie for logged-out visitors", () => {
+    expect(resolveServerTheme(makeEvent({ cookie: 'sepia' }))).toBe('sepia');
+  });
 });
 
 describe('handle — onboarding redirect', () => {

--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -1,7 +1,12 @@
 import { redirect, type Handle } from '@sveltejs/kit';
 import { resolveUser } from '$lib/server/auth/require-user.js';
 import { shouldRedirectToOnboarding } from '$lib/server/onboarding.js';
-import { THEME_COOKIE, isThemePreference, resolveTheme } from '$lib/theme/index.js';
+import {
+  THEME_COOKIE,
+  isThemePreference,
+  resolveTheme,
+  type ResolvedTheme,
+} from '$lib/theme/index.js';
 import { setJobDispatcher } from '$lib/server/texts/jobs.js';
 import { inProcessDispatcher } from '$lib/server/texts/in-process-dispatcher.js';
 
@@ -30,7 +35,7 @@ setJobDispatcher(inProcessDispatcher);
  *  4. Default to 'light' (light-mode systems without a cookie or hint won't
  *     flip when the client-side script runs).
  */
-export function resolveServerTheme(event: Parameters<Handle>[0]['event']): 'light' | 'dark' {
+export function resolveServerTheme(event: Parameters<Handle>[0]['event']): ResolvedTheme {
   const userPref = event.locals.user?.themePreference;
   const cookiePref = event.cookies.get(THEME_COOKIE);
   const preference = userPref ?? (isThemePreference(cookiePref) ? cookiePref : 'system');

--- a/apps/web/src/lib/components/reader/ReaderPage.svelte
+++ b/apps/web/src/lib/components/reader/ReaderPage.svelte
@@ -1,8 +1,11 @@
 <!--
-  Page-mode reader (T-5.1, token-aware in T-5.2).
+  Page-mode reader (T-5.1, token-aware in T-5.2, chrome polish in T-5.9).
 
-  Classic LingQ-style pagination: one chapter at a time with prev/next
-  buttons. Token rendering is delegated to <ChapterBody/>.
+  Classic LingQ-style pagination: one chapter at a time. Chrome layout
+  follows the CIAR design — chapter heading at the top, body in a
+  comfortable max-width column, floating round page-arrow buttons
+  flanking the column, and a bottom progress bar showing chapter
+  position. Token rendering is delegated to <ChapterBody/>.
 -->
 <script lang="ts">
   import { goto } from '$app/navigation';
@@ -28,6 +31,11 @@
   );
   const hasPrev = $derived(chapterIdx > 0);
   const hasNext = $derived(chapterIdx < chapters.length - 1);
+  const progressPct = $derived(
+    chapters.length > 0
+      ? Math.round(((chapterIdx + 1) / chapters.length) * 100)
+      : 0,
+  );
 
   function go(nextIdx: number) {
     void goto(`/reader/${textId}?mode=page&chapter=${nextIdx}`, {
@@ -65,71 +73,197 @@
 
 <svelte:window onkeydown={onKeydown} />
 
-<div class="reader-page" data-mode="page">
-  <header class="page-header">
+<div class="reader-page-wrap" data-mode="page">
+  <button
+    type="button"
+    class="page-arrow page-arrow-l"
+    aria-label="Previous chapter"
+    disabled={!hasPrev}
+    onclick={() => hasPrev && go(chapterIdx - 1)}
+  >
+    ‹
+  </button>
+
+  <div class="reader-page">
     {#if current}
-      <h2>
+      <header class="chapter-h">
         {current.title ?? `Chapter ${current.idx + 1}`}
-      </h2>
-      <p class="muted">
-        Chapter {current.idx + 1} of {chapters.length}
-        · {current.tokenCount.toLocaleString()} tokens
-      </p>
+        <span class="roman">
+          Chapter {current.idx + 1} of {chapters.length}
+          · {current.tokenCount.toLocaleString()} tokens
+        </span>
+      </header>
     {/if}
-  </header>
 
-  <article>
-    {#if current}
-      <ChapterBody chapter={current} {showRomanization} {isOwner} />
-    {/if}
-  </article>
+    <article>
+      {#if current}
+        <ChapterBody chapter={current} {showRomanization} {isOwner} />
+      {/if}
+    </article>
+  </div>
 
-  <nav class="pager" aria-label="Chapter navigation">
-    <button type="button" disabled={!hasPrev} onclick={() => go(chapterIdx - 1)}>
-      ← Previous chapter
-    </button>
-    <button type="button" disabled={!hasNext} onclick={() => go(chapterIdx + 1)}>
-      Next chapter →
-    </button>
-  </nav>
+  <button
+    type="button"
+    class="page-arrow page-arrow-r"
+    aria-label="Next chapter"
+    disabled={!hasNext}
+    onclick={() => hasNext && go(chapterIdx + 1)}
+  >
+    ›
+  </button>
 </div>
 
+<footer class="reader-foot" aria-label="Chapter progress">
+  <div class="reader-foot-meta">
+    <span class="pager-pages">
+      Chapter {chapterIdx + 1} of {chapters.length}
+    </span>
+    <span class="muted">{progressPct}% through text</span>
+  </div>
+  <div class="reader-foot-bar"><i style="width: {progressPct}%"></i></div>
+</footer>
+
 <style>
+  .reader-page-wrap {
+    position: relative;
+    padding: 1.5rem 1rem 2.5rem;
+  }
+  @media (min-width: 1024px) {
+    .reader-page-wrap {
+      padding: 2.5rem 4.5rem 3rem;
+    }
+  }
   .reader-page {
-    max-width: 38rem;
+    font-family: var(--font-serif-dev, var(--font-serif));
+    font-size: 1.1rem;
+    line-height: 2;
+    color: var(--ink, var(--color-fg));
+    max-width: 40rem;
     margin: 0 auto;
-    padding: 1rem 1.25rem 4rem;
+    word-spacing: 0.03em;
+    text-wrap: pretty;
   }
-  .page-header h2 {
-    font-size: 1.2rem;
-    margin: 0 0 0.25rem;
+  @media (min-width: 768px) {
+    .reader-page {
+      font-size: 1.25rem;
+    }
   }
-  .muted {
-    color: var(--color-fg-muted);
-    font-size: 0.85rem;
-    margin: 0 0 1rem;
+  .chapter-h {
+    font-family: var(--font-serif-dev, var(--font-serif));
+    font-size: 1.05rem;
+    color: var(--ink-3, var(--color-fg-muted));
+    letter-spacing: 0.04em;
+    border-bottom: 1px solid var(--rule, var(--color-border));
+    padding-bottom: 0.875rem;
+    margin: 0 0 1.75rem;
+    font-weight: 400;
+  }
+  .chapter-h .roman {
+    display: block;
+    font-family: var(--font-mono-display, var(--font-mono));
+    font-size: 0.7rem;
+    color: var(--ink-4, var(--color-fg-subtle));
+    letter-spacing: 0.04em;
+    margin-top: 0.3rem;
+    text-transform: uppercase;
   }
   article {
     min-height: 50vh;
   }
-  .pager {
-    display: flex;
-    justify-content: space-between;
-    margin-top: 2rem;
-    gap: 0.75rem;
-  }
-  .pager button {
-    flex: 1;
-    min-height: 44px;
-    padding: 0 1rem;
-    background: var(--color-accent);
-    color: var(--color-accent-fg, #fff);
-    border: 0;
-    border-radius: 6px;
+
+  /* Floating round page arrows. Hidden on narrow viewports — keyboard
+     ←/→ and the bottom progress bar still work, and the arrows would
+     overlap the body column anyway below the breakpoint. */
+  .page-arrow {
+    display: none;
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    background: var(--card, var(--color-bg));
+    border: 1px solid var(--card-edge, var(--color-border));
+    color: var(--ink-2, var(--color-fg-muted));
+    place-items: center;
     cursor: pointer;
+    z-index: 8;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
+    transition:
+      background 150ms ease,
+      color 150ms ease,
+      transform 150ms ease,
+      opacity 150ms ease;
+    font-size: 1.4rem;
+    line-height: 1;
+    padding: 0;
   }
-  .pager button[disabled] {
-    opacity: 0.4;
+  @media (min-width: 1024px) {
+    .page-arrow {
+      display: grid;
+    }
+  }
+  .page-arrow-l {
+    left: 1rem;
+  }
+  .page-arrow-r {
+    right: 1rem;
+  }
+  .page-arrow:hover:not(:disabled) {
+    background: var(--accent-soft, var(--color-accent));
+    color: var(--accent-ink, var(--color-accent-fg, #fff));
+    transform: translateY(-50%) scale(1.05);
+  }
+  .page-arrow:disabled {
+    opacity: 0.25;
     cursor: not-allowed;
+  }
+
+  .reader-foot {
+    border-top: 1px solid var(--rule, var(--color-border));
+    background: color-mix(
+      in oklch,
+      var(--paper, var(--color-bg)) 88%,
+      var(--paper-2, transparent)
+    );
+    padding: 0.6rem 1.25rem 0.75rem;
+    position: sticky;
+    bottom: 0;
+  }
+  @media (min-width: 768px) {
+    .reader-foot {
+      padding: 0.75rem 1.75rem 0.9rem;
+    }
+  }
+  .reader-foot-meta {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    font-size: 0.72rem;
+    color: var(--ink-3, var(--color-fg-muted));
+    margin-bottom: 0.4rem;
+  }
+  .pager-pages {
+    font-family: var(--font-mono-display, var(--font-mono));
+    font-feature-settings: 'tnum';
+    letter-spacing: 0.04em;
+    color: var(--ink-2, var(--color-fg));
+  }
+  .muted {
+    color: var(--ink-3, var(--color-fg-muted));
+  }
+  .reader-foot-bar {
+    height: 3px;
+    background: color-mix(in oklch, var(--ink, var(--color-fg)) 8%, transparent);
+    border-radius: 2px;
+    position: relative;
+    overflow: hidden;
+  }
+  .reader-foot-bar > i {
+    position: absolute;
+    inset: 0 auto 0 0;
+    background: var(--accent, var(--color-accent));
+    border-radius: 2px;
+    transition: width 250ms ease;
   }
 </style>

--- a/apps/web/src/lib/components/reader/TokenSpan.svelte
+++ b/apps/web/src/lib/components/reader/TokenSpan.svelte
@@ -1,19 +1,20 @@
 <!--
-  Single token render (T-5.2, romanization in T-5.3).
+  Single token render (T-5.2, romanization in T-5.3, status modes in T-5.9).
 
-  One `<span>` per token, with a `.status-*` class when we have a
-  lemma resolution. Word tokens get a hover affordance. Whitespace
-  tokens render as plain text without any classes — the reader
-  preserves the original layout faithfully.
+  One `<span>` per token, with a numeric `data-s` attribute when we
+  have a lemma resolution. The colored highlight rules live in
+  `tokens.css` and are switched between background-tint and underline
+  modes via `data-hl` on `<html>`. Whitespace tokens render as plain
+  text without any classes.
 
   When `showRomanization` is on AND the token has a precomputed
   `romanization` (worker-time, T-2.5), the surface form renders
   inside an HTML `<ruby>` element with the romanized form on top so
   learners who aren't yet fluent in the script can decode each word
-  inline. Tokens without a romanization just render the surface.
+  inline.
 -->
 <script lang="ts">
-  import type { ServerToken } from './types.js';
+  import { statusToCode, type ServerToken } from './types.js';
 
   let {
     token,
@@ -28,10 +29,16 @@
     if (!token.isWord) return '';
     const classes: string[] = ['word'];
     if (token.isOov) classes.push('oov');
-    else classes.push(`status-${token.status}`);
     if (token.isAmbiguous) classes.push('ambiguous');
     return classes.join(' ');
   });
+
+  // OOV tokens are categorically pre-status; the design dashes them
+  // and skips the colored tint regardless of `data-hl`. We omit
+  // data-s on those so the highlight rules never match.
+  const dataS = $derived(
+    token.isWord && !token.isOov ? statusToCode(token.status) : undefined,
+  );
 
   const showRuby = $derived(
     showRomanization && token.isWord && Boolean(token.romanization),
@@ -42,42 +49,34 @@
     class={cssClass}
     data-token-id={token.id}
     data-token-idx={token.idx}
-    data-lemma-id={token.lemmaId ?? ''}>{token.surface}<rt>{token.romanization}</rt></ruby>{:else}<span
+    data-lemma-id={token.lemmaId ?? ''}
+    data-s={dataS}>{token.surface}<rt>{token.romanization}</rt></ruby>{:else}<span
     class={cssClass}
     data-token-id={token.id}
     data-token-idx={token.idx}
-    data-lemma-id={token.lemmaId ?? ''}>{token.surface}</span>{/if}
+    data-lemma-id={token.lemmaId ?? ''}
+    data-s={dataS}>{token.surface}</span>{/if}
 
 <style>
   .word {
     cursor: pointer;
     border-radius: 3px;
-    transition: background 80ms ease;
+    padding: 0 1.5px;
+    transition: background 120ms ease;
   }
   .word:hover {
-    background: color-mix(in srgb, var(--color-accent) 12%, transparent);
+    background: color-mix(in oklch, var(--accent) 28%, transparent);
   }
   /* `<ruby>` defaults to `display: ruby` which behaves like an inline
      element — perfect for in-line text. We only need to nudge the
      `<rt>` styling. */
   ruby.word rt {
     font-size: 0.6em;
-    color: var(--color-fg-muted);
+    color: var(--ink-3, var(--color-fg-muted));
     line-height: 1.1;
     /* Tight character spacing on rt so a long romanization doesn't
        blow the underlying word's width out. */
     letter-spacing: -0.01em;
-  }
-  .status-unknown {
-    background: color-mix(in srgb, var(--color-accent) 18%, transparent);
-  }
-  .status-learning {
-    background: color-mix(in srgb, #b07a31 30%, transparent);
-    color: var(--color-fg);
-  }
-  .status-known,
-  .status-ignored {
-    background: transparent;
   }
   .oov {
     background: transparent;
@@ -86,7 +85,7 @@
   }
   .ambiguous::after {
     content: '·';
-    color: var(--color-accent);
+    color: var(--accent, var(--color-accent));
     margin-left: 0.05em;
     vertical-align: super;
     font-size: 0.7em;

--- a/apps/web/src/lib/components/reader/types.test.ts
+++ b/apps/web/src/lib/components/reader/types.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { paragraphsOfTokens, tokenize } from './types.js';
+import { STATUS_TO_CODE, paragraphsOfTokens, statusToCode, tokenize } from './types.js';
 
 describe('tokenize', () => {
   it('splits on word boundaries while preserving whitespace + punctuation', () => {
@@ -54,5 +54,23 @@ describe('paragraphsOfTokens', () => {
   it('skips empty paragraphs from runs of blank lines', () => {
     const tokens = tokenize('one\n\n\n\ntwo');
     expect(paragraphsOfTokens(tokens)).toHaveLength(2);
+  });
+});
+
+describe('statusToCode', () => {
+  it('maps every ServerToken status to a stable numeric code', () => {
+    expect(statusToCode('unknown')).toBe('0');
+    expect(statusToCode('learning')).toBe('2');
+    expect(statusToCode('known')).toBe('4');
+    expect(statusToCode('ignored')).toBe('5');
+  });
+
+  it('exposes the same mapping as a constant for callers that prefer the table', () => {
+    expect(STATUS_TO_CODE).toEqual({
+      unknown: '0',
+      learning: '2',
+      known: '4',
+      ignored: '5',
+    });
   });
 });

--- a/apps/web/src/lib/components/reader/types.ts
+++ b/apps/web/src/lib/components/reader/types.ts
@@ -34,6 +34,28 @@ export type ChapterView = {
 export type ReaderLayoutMode = 'page' | 'paged_scroll' | 'continuous';
 
 /**
+ * Numeric status code emitted as `data-s` on each rendered word so the
+ * design's highlight CSS (background-tint vs. underline modes, see
+ * `tokens.css`) can target the right tint without the markup needing to
+ * know about saffron OKLCH math. The numbers are stable: `0=new` for an
+ * unknown lemma the user hasn't categorized, `2=L2` is where we map our
+ * single "learning" bucket today, `4=known`, `5=ignored`. `1` and `3`
+ * are reserved for L1 / L3 once we split the learning bucket.
+ */
+export type StatusCode = '0' | '1' | '2' | '3' | '4' | '5';
+export const STATUS_TO_CODE: Readonly<Record<ServerToken['status'], StatusCode>> =
+  {
+    unknown: '0',
+    learning: '2',
+    known: '4',
+    ignored: '5',
+  } as const;
+
+export function statusToCode(status: ServerToken['status']): StatusCode {
+  return STATUS_TO_CODE[status];
+}
+
+/**
  * Cheap whitespace tokenizer for the placeholder render path. M5's
  * later tickets replace this with token rows from the NLP worker
  * (T-2.6) — at that point the reader pulls token spans straight from

--- a/apps/web/src/lib/styles/tokens.css
+++ b/apps/web/src/lib/styles/tokens.css
@@ -318,3 +318,61 @@ code {
     transition-duration: 0.01ms !important;
   }
 }
+
+/* —— Reader word-status highlight modes (T-5.9) ————————————————
+ * Each rendered word carries `data-s="0"` (new) … `"5"` (ignored) from
+ * TokenSpan. The highlight style is global, switched by `data-hl` on
+ * `<html>`: background-tint by default, underline when the user picks
+ * the underline style in the reader settings popover (T-5.1b). The
+ * scoped `.word` rules in TokenSpan handle hover + cursor + OOV — these
+ * rules only paint the status colour. */
+html[data-hl='background'] .word[data-s='0'] {
+  background: transparent;
+  box-shadow: inset 0 -1px 0 var(--accent);
+}
+html[data-hl='background'] .word[data-s='1'] {
+  background: var(--w-l1-bg);
+}
+html[data-hl='background'] .word[data-s='2'] {
+  background: var(--w-l2-bg);
+}
+html[data-hl='background'] .word[data-s='3'] {
+  background: var(--w-l3-bg);
+}
+html[data-hl='background'] .word[data-s='4'] {
+  color: var(--w-known-ink);
+}
+html[data-hl='background'] .word[data-s='5'] {
+  color: var(--w-ignored-ink);
+  text-decoration: line-through;
+  text-decoration-color: var(--ink-4);
+  text-decoration-thickness: 0.5px;
+}
+
+html[data-hl='underline'] .word[data-s='0'] {
+  background: transparent;
+  box-shadow: inset 0 -1.5px 0 var(--accent);
+}
+html[data-hl='underline'] .word[data-s='1'] {
+  background: transparent;
+  box-shadow: inset 0 -1.5px 0 oklch(0.78 0.1 80);
+}
+html[data-hl='underline'] .word[data-s='2'] {
+  background: transparent;
+  box-shadow: inset 0 -2px 0 oklch(0.7 0.13 75);
+}
+html[data-hl='underline'] .word[data-s='3'] {
+  background: transparent;
+  box-shadow: inset 0 -2.5px 0 oklch(0.62 0.15 70);
+}
+html[data-hl='underline'] .word[data-s='4'] {
+  box-shadow: none;
+  color: var(--w-known-ink);
+}
+html[data-hl='underline'] .word[data-s='5'] {
+  box-shadow: none;
+  color: var(--w-ignored-ink);
+  text-decoration: line-through;
+  text-decoration-color: var(--ink-4);
+  text-decoration-thickness: 0.5px;
+}

--- a/apps/web/src/lib/styles/tokens.css
+++ b/apps/web/src/lib/styles/tokens.css
@@ -51,6 +51,97 @@
   /* Code */
   --color-code-bg: #f3f4f6;
   --color-code-fg: #111111;
+
+  /* CIAR design palette (Apr 2026 handoff).
+   * "Paper" / "ink" naming reflects the literary-reader positioning. The
+   * old `--color-*` tokens stay populated so unrenamed components keep
+   * working; new components consume these. */
+  --paper: #fdfaf3;
+  --paper-2: #f7f1e2;
+  --paper-3: #efe7d0;
+  --ink: #1f1a14;
+  --ink-2: #524a3d;
+  --ink-3: #877e6c;
+  --ink-4: #b3aa97;
+  --rule: #ece2c9;
+  --rule-2: #f3ebd6;
+  --card: #ffffff;
+  --card-edge: #ece2cc;
+
+  --accent: oklch(0.58 0.13 60); /* saffron */
+  --accent-soft: oklch(0.58 0.13 60 / 0.14);
+  --accent-ink: oklch(0.34 0.1 60);
+
+  --green: oklch(0.55 0.1 145);
+  --green-soft: oklch(0.55 0.1 145 / 0.14);
+  --rose: oklch(0.58 0.12 25);
+  --rose-soft: oklch(0.58 0.12 25 / 0.14);
+  --indigo: oklch(0.5 0.1 270);
+  --indigo-soft: oklch(0.5 0.1 270 / 0.14);
+
+  /* Word-status tints (background-highlight mode). Underline mode in T-5.9
+   * uses the accent hue at varying weights via the data-hl="underline" rules. */
+  --w-unknown-bg: transparent;
+  --w-l1-bg: oklch(0.92 0.07 80); /* very pale saffron */
+  --w-l2-bg: oklch(0.86 0.1 75);
+  --w-l3-bg: oklch(0.8 0.12 70);
+  --w-known-bg: transparent;
+  --w-ignored-bg: transparent;
+  --w-known-ink: var(--ink-3);
+  --w-ignored-ink: var(--ink-4);
+
+  --shadow-1:
+    0 1px 0 rgba(255, 255, 255, 0.5) inset, 0 1px 2px rgba(67, 47, 14, 0.06);
+  --shadow-2:
+    0 1px 0 rgba(255, 255, 255, 0.5) inset, 0 8px 24px rgba(67, 47, 14, 0.1);
+}
+
+[data-theme='sepia'] {
+  /* Surfaces */
+  --color-bg: #ead6b3;
+  --color-surface-1: #e1cb9f;
+  --color-surface-2: #d6bd8a;
+  --color-surface-3: #c9b083;
+  --color-overlay: rgba(42, 31, 16, 0.45);
+
+  /* Foreground */
+  --color-fg: #2a1f10;
+  --color-fg-muted: #4f3f25;
+  --color-fg-subtle: #7d6940;
+
+  --color-border: #c9b083;
+  --color-border-strong: #a8915e;
+
+  /* Sepia shares the saffron accent. */
+  --color-accent: oklch(0.58 0.13 60);
+  --color-accent-fg: #2a1f10;
+  --color-accent-hover: oklch(0.5 0.13 60);
+
+  --color-highlight-unknown: oklch(0.84 0.08 75);
+  --color-highlight-unknown-fg: #2a1f10;
+  --color-highlight-learning: oklch(0.76 0.12 70);
+  --color-highlight-learning-fg: #2a1f10;
+  --color-highlight-known: transparent;
+
+  --color-code-bg: #d6bd91;
+  --color-code-fg: #2a1f10;
+
+  /* CIAR design palette */
+  --paper: #ead6b3;
+  --paper-2: #e1cb9f;
+  --paper-3: #d6bd8a;
+  --ink: #2a1f10;
+  --ink-2: #4f3f25;
+  --ink-3: #7d6940;
+  --ink-4: #a8915e;
+  --rule: #c9b083;
+  --rule-2: #d6bd91;
+  --card: #f0dcb5;
+  --card-edge: #d2b884;
+
+  --w-l1-bg: oklch(0.84 0.08 75);
+  --w-l2-bg: oklch(0.76 0.12 70);
+  --w-l3-bg: oklch(0.68 0.13 65);
 }
 
 [data-theme='dark'] {
@@ -83,6 +174,32 @@
 
   --color-code-bg: #18181b;
   --color-code-fg: #f5f5f7;
+
+  /* CIAR design palette */
+  --paper: #161310;
+  --paper-2: #1d1916;
+  --paper-3: #25201b;
+  --ink: #f0e7d3;
+  --ink-2: #c9bfa9;
+  --ink-3: #897e6a;
+  --ink-4: #5d5547;
+  --rule: #2e2822;
+  --rule-2: #3a332b;
+  --card: #1a1714;
+  --card-edge: #2a241e;
+
+  --accent: oklch(0.78 0.13 70);
+  --accent-soft: oklch(0.78 0.13 70 / 0.18);
+  --accent-ink: oklch(0.86 0.11 70);
+
+  --w-l1-bg: oklch(0.3 0.05 70);
+  --w-l2-bg: oklch(0.38 0.08 68);
+  --w-l3-bg: oklch(0.46 0.11 65);
+
+  --shadow-1:
+    0 1px 0 rgba(255, 255, 255, 0.04) inset, 0 1px 2px rgba(0, 0, 0, 0.4);
+  --shadow-2:
+    0 1px 0 rgba(255, 255, 255, 0.04) inset, 0 12px 32px rgba(0, 0, 0, 0.55);
 }
 
 /* Typography, spacing, radii, shadows, motion — theme-invariant.
@@ -93,6 +210,18 @@
     system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
   --font-mono:
     'SF Mono', ui-monospace, 'Cascadia Code', Menlo, Consolas, 'Liberation Mono', monospace;
+
+  /* CIAR design typography (Apr 2026 handoff). Loaded via Google Fonts in
+   * app.html. The reader chooses --serif-dev for Devanagari body text and
+   * falls back through Noto for Bengali / Gujarati / Gurmukhi / Oriya in
+   * T-5.9. UI chrome uses --sans + --serif. */
+  --font-sans: 'Inter', ui-sans-serif, system-ui, -apple-system, sans-serif;
+  --font-serif: 'Source Serif 4', 'Iowan Old Style', 'Georgia', serif;
+  --font-serif-dev:
+    'Tiro Devanagari Hindi', 'Noto Serif Devanagari', 'Source Serif 4', serif;
+  --font-sans-dev: 'Noto Sans Devanagari', 'Inter', sans-serif;
+  --font-mono-display:
+    'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
 
   --font-size-xs: 0.75rem;
   --font-size-sm: 0.875rem;

--- a/apps/web/src/lib/styles/tokens.test.ts
+++ b/apps/web/src/lib/styles/tokens.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Token sanity tests. CSS-variable resolution isn't reliably testable in
+ * jsdom (custom properties are not always re-resolved on attribute change),
+ * so we read the source and assert that each theme block declares the keys
+ * that downstream components depend on. Cheap, fast, and catches accidental
+ * deletions during refactors.
+ */
+const tokens = readFileSync(
+  fileURLToPath(new URL('./tokens.css', import.meta.url)),
+  'utf-8',
+);
+
+function block(selector: string): string {
+  const start = tokens.indexOf(selector);
+  if (start === -1) throw new Error(`block ${selector} not found in tokens.css`);
+  const open = tokens.indexOf('{', start);
+  const close = tokens.indexOf('}', open);
+  return tokens.slice(open, close);
+}
+
+const lightBlock = block(":root,\n[data-theme='light']");
+const sepiaBlock = block("[data-theme='sepia']");
+const darkBlock = block("[data-theme='dark']");
+const rootInvariant = block(
+  '/* Typography, spacing, radii, shadows, motion — theme-invariant.',
+);
+
+describe('CIAR design palette', () => {
+  it.each([
+    ['light', lightBlock],
+    ['sepia', sepiaBlock],
+    ['dark', darkBlock],
+  ])('%s theme declares paper / ink / card / rule', (_name, b) => {
+    expect(b).toMatch(/--paper:\s/);
+    expect(b).toMatch(/--ink:\s/);
+    expect(b).toMatch(/--card:\s/);
+    expect(b).toMatch(/--rule:\s/);
+  });
+
+  it.each([
+    ['light', lightBlock],
+    ['sepia', sepiaBlock],
+    ['dark', darkBlock],
+  ])('%s theme declares word-status background tints (l1/l2/l3)', (_name, b) => {
+    expect(b).toMatch(/--w-l1-bg:\s/);
+    expect(b).toMatch(/--w-l2-bg:\s/);
+    expect(b).toMatch(/--w-l3-bg:\s/);
+  });
+
+  it('only the light theme defines the saffron accent + accent-soft pair (sepia + dark inherit)', () => {
+    expect(lightBlock).toMatch(/--accent:\s/);
+    expect(lightBlock).toMatch(/--accent-soft:\s/);
+    // Sepia inherits accent from :root,[data-theme='light']; dark overrides
+    // the accent for the dark palette.
+    expect(darkBlock).toMatch(/--accent:\s/);
+  });
+});
+
+describe('design typography tokens', () => {
+  it('declares the design font stack alongside the existing UI fonts', () => {
+    expect(rootInvariant).toMatch(/--font-sans:\s/);
+    expect(rootInvariant).toMatch(/--font-serif:\s/);
+    expect(rootInvariant).toMatch(/--font-serif-dev:\s/);
+    expect(rootInvariant).toMatch(/--font-sans-dev:\s/);
+    expect(rootInvariant).toMatch(/--font-mono-display:\s/);
+  });
+
+  it('preserves the legacy --font-ui / --font-mono tokens', () => {
+    expect(rootInvariant).toMatch(/--font-ui:\s/);
+    expect(rootInvariant).toMatch(/--font-mono:\s/);
+  });
+});

--- a/apps/web/src/lib/theme/index.test.ts
+++ b/apps/web/src/lib/theme/index.test.ts
@@ -21,13 +21,19 @@ describe('resolveTheme', () => {
     expect(resolveTheme('system', true)).toBe('dark');
     expect(resolveTheme('system', false)).toBe('light');
   });
+
+  it("returns 'sepia' when preference is 'sepia' regardless of system preference", () => {
+    expect(resolveTheme('sepia', true)).toBe('sepia');
+    expect(resolveTheme('sepia', false)).toBe('sepia');
+  });
 });
 
 describe('isThemePreference', () => {
-  it('accepts the three valid preference strings', () => {
+  it('accepts the four valid preference strings', () => {
     expect(isThemePreference('system')).toBe(true);
     expect(isThemePreference('light')).toBe(true);
     expect(isThemePreference('dark')).toBe(true);
+    expect(isThemePreference('sepia')).toBe(true);
   });
 
   it('rejects other values', () => {

--- a/apps/web/src/lib/theme/index.ts
+++ b/apps/web/src/lib/theme/index.ts
@@ -8,8 +8,8 @@
  * dark-mode users' first paint) and client-side onMount code (to react to
  * OS preference changes) can share it.
  */
-export type ThemePreference = 'system' | 'light' | 'dark';
-export type ResolvedTheme = 'light' | 'dark';
+export type ThemePreference = 'system' | 'light' | 'dark' | 'sepia';
+export type ResolvedTheme = 'light' | 'dark' | 'sepia';
 
 export function resolveTheme(
   preference: ThemePreference,
@@ -23,5 +23,5 @@ export const THEME_COOKIE = 'cia_theme';
 export const THEME_COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // 1 year
 
 export function isThemePreference(value: unknown): value is ThemePreference {
-  return value === 'system' || value === 'light' || value === 'dark';
+  return value === 'system' || value === 'light' || value === 'dark' || value === 'sepia';
 }

--- a/apps/web/src/routes/reader/[textId]/+page.svelte
+++ b/apps/web/src/routes/reader/[textId]/+page.svelte
@@ -153,39 +153,36 @@
 </svelte:head>
 
 <div class="reader">
-  <header class="toolbar">
-    <p class="crumb">
-      <a href="/library">← Library</a>
-    </p>
-    <div class="title-row">
-      <h1>{data.text.title}</h1>
-      <p class="meta">
+  <header class="reader-top">
+    <a class="crumb" href="/library" aria-label="Back to library">← Library</a>
+    <div class="reader-meta">
+      <h1 class="t">{data.text.title}</h1>
+      <p class="a">
         <span class="badge">{data.text.language}</span>
-        <span class="badge">{data.text.sourceType}</span>
         <span class="badge status-{liveStatus}">{statusLabel}</span>
         <span class="badge">{data.text.visibility}</span>
       </p>
     </div>
 
-    <div class="toolbar-row">
-      <div class="mode-toggle" role="group" aria-label="Reading mode">
+    <div class="reader-tools">
+      <div class="mode-switch" role="group" aria-label="Reading mode">
         <button
           type="button"
-          class:active={data.mode === 'page'}
+          data-active={data.mode === 'page' ? '1' : '0'}
           onclick={() => setMode('page')}
         >
           Page
         </button>
         <button
           type="button"
-          class:active={data.mode === 'paged_scroll'}
+          data-active={data.mode === 'paged_scroll' ? '1' : '0'}
           onclick={() => setMode('paged_scroll')}
         >
-          Paged scroll
+          Scroll
         </button>
         <button
           type="button"
-          class:active={data.mode === 'continuous'}
+          data-active={data.mode === 'continuous' ? '1' : '0'}
           onclick={() => setMode('continuous')}
         >
           Continuous
@@ -195,11 +192,12 @@
       <button
         type="button"
         class="roman-toggle"
-        class:active={showRomanization}
+        data-active={showRomanization ? '1' : '0'}
         onclick={toggleRomanization}
         aria-pressed={showRomanization}
+        title="Toggle romanization"
       >
-        Show romanization
+        Aa
       </button>
     </div>
   </header>
@@ -234,107 +232,139 @@
 </div>
 
 <style>
+  /* CIAR design reader chrome (T-5.9). Paper background + serif title.
+     Stacks on small viewports; mode-switch + romanization sit on the
+     right at >=640px. */
   .reader {
-    --reader-toolbar-bg: var(--color-bg);
+    background: var(--paper, var(--color-bg));
+    color: var(--ink, var(--color-fg));
+    min-height: 100%;
   }
-  .toolbar {
+  .reader-top {
     position: sticky;
     top: 0;
-    z-index: 10;
-    background: var(--reader-toolbar-bg);
-    border-bottom: 1px solid var(--color-border);
-    padding: 0.75rem 1.25rem 0.85rem;
+    z-index: 5;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0.5rem 1rem;
+    padding: 0.85rem 1.25rem 0.9rem;
+    background: color-mix(in oklch, var(--paper, var(--color-bg)) 86%, var(--paper-2, transparent));
+    border-bottom: 1px solid var(--rule, var(--color-border));
+  }
+  @media (min-width: 640px) {
+    .reader-top {
+      grid-template-columns: auto 1fr auto;
+      align-items: center;
+      padding: 1rem 1.75rem;
+    }
   }
   .crumb {
-    margin: 0 0 0.4rem;
-    font-size: 0.85rem;
+    font-family: var(--font-sans, var(--font-ui));
+    font-size: 0.78rem;
+    color: var(--ink-3, var(--color-fg-muted));
+    text-decoration: none;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
   }
-  .crumb a {
-    color: var(--color-accent);
+  .crumb:hover {
+    color: var(--accent-ink, var(--color-accent));
   }
-  .title-row {
-    margin-bottom: 0.6rem;
+  .reader-meta {
+    min-width: 0;
   }
-  .title-row h1 {
-    margin: 0 0 0.25rem;
-    font-size: 1.25rem;
-  }
-  .meta {
+  .reader-meta .t {
     margin: 0;
+    font-family: var(--font-serif-dev, var(--font-serif));
+    font-size: 1.125rem;
+    font-weight: 500;
+    color: var(--ink, var(--color-fg));
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .reader-meta .a {
+    margin: 0.15rem 0 0;
     display: flex;
-    gap: 0.4rem;
     flex-wrap: wrap;
-    font-size: 0.85rem;
-    color: var(--color-fg-muted);
+    gap: 0.3rem;
+    font-family: var(--font-sans, var(--font-ui));
+    font-size: 0.78rem;
+    color: var(--ink-3, var(--color-fg-muted));
   }
   .badge {
-    font-size: 0.72rem;
-    padding: 0.05rem 0.45rem;
+    display: inline-flex;
+    align-items: center;
+    height: 22px;
+    padding: 0 0.6rem;
     border-radius: 999px;
-    border: 1px solid var(--color-border);
-    background: var(--color-bg);
-    color: var(--color-fg-muted);
+    background: color-mix(in oklch, var(--ink, var(--color-fg)) 6%, transparent);
+    color: var(--ink-2, var(--color-fg-muted));
+    font-size: 0.7rem;
+    letter-spacing: 0.01em;
   }
   .status-ready {
-    border-color: color-mix(in srgb, #197a2f 60%, transparent);
-    color: #197a2f;
+    background: var(--green-soft, color-mix(in srgb, #197a2f 12%, transparent));
+    color: var(--green, #197a2f);
   }
   .status-failed {
-    border-color: color-mix(in srgb, #b03131 60%, transparent);
-    color: #b03131;
+    background: var(--rose-soft, color-mix(in srgb, #b03131 12%, transparent));
+    color: var(--rose, #b03131);
   }
   .status-processing,
   .status-pending {
-    border-color: color-mix(in srgb, #b07a31 60%, transparent);
-    color: #b07a31;
+    background: var(--accent-soft, color-mix(in srgb, #b07a31 12%, transparent));
+    color: var(--accent-ink, #b07a31);
   }
-  .toolbar-row {
+  .reader-tools {
     display: flex;
-    gap: 0.5rem;
     align-items: center;
+    gap: 0.5rem;
     flex-wrap: wrap;
-    justify-content: space-between;
   }
-  .mode-toggle {
-    display: flex;
-    gap: 0.25rem;
-    flex-wrap: wrap;
+  .mode-switch {
+    display: inline-flex;
+    background: color-mix(in oklch, var(--ink, var(--color-fg)) 5%, transparent);
+    border-radius: 8px;
+    padding: 2px;
+    gap: 2px;
+  }
+  .mode-switch button {
+    height: 28px;
+    padding: 0 0.7rem;
+    font: inherit;
+    font-size: 0.78rem;
+    color: var(--ink-2, var(--color-fg-muted));
+    background: transparent;
+    border: 0;
+    border-radius: 6px;
+    cursor: pointer;
+  }
+  .mode-switch button[data-active='1'] {
+    background: var(--card, var(--color-bg));
+    color: var(--ink, var(--color-fg));
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
   }
   .roman-toggle {
-    padding: 0.4rem 0.75rem;
-    font: inherit;
+    width: 32px;
+    height: 32px;
+    display: grid;
+    place-items: center;
+    border: 1px solid var(--rule, var(--color-border));
+    border-radius: 8px;
+    background: transparent;
+    color: var(--ink-2, var(--color-fg-muted));
+    font-family: var(--font-serif, serif);
     font-size: 0.85rem;
-    border: 1px solid var(--color-border);
-    background: var(--color-bg);
-    color: var(--color-fg-muted);
-    border-radius: 999px;
     cursor: pointer;
-    min-height: 36px;
   }
-  .roman-toggle.active {
-    background: var(--color-accent);
-    color: var(--color-accent-fg, #fff);
-    border-color: var(--color-accent);
-  }
-  .mode-toggle button {
-    padding: 0.4rem 0.75rem;
-    font: inherit;
-    font-size: 0.85rem;
-    border: 1px solid var(--color-border);
-    background: var(--color-bg);
-    color: var(--color-fg);
-    border-radius: 999px;
-    cursor: pointer;
-    min-height: 36px;
-  }
-  .mode-toggle button.active {
-    background: var(--color-accent);
-    color: var(--color-accent-fg, #fff);
-    border-color: var(--color-accent);
+  .roman-toggle[data-active='1'] {
+    background: var(--accent-soft, var(--color-accent));
+    border-color: var(--accent, var(--color-accent));
+    color: var(--accent-ink, var(--color-accent-fg, #fff));
   }
   .err {
-    color: #b03131;
-    background: color-mix(in srgb, #b03131 8%, transparent);
+    color: var(--rose, #b03131);
+    background: var(--rose-soft, color-mix(in srgb, #b03131 8%, transparent));
     border: 1px solid color-mix(in srgb, #b03131 30%, transparent);
     border-radius: 8px;
     padding: 0.75rem 1rem;


### PR DESCRIPTION
## Summary

Visual layer of the CIAR design's reader page. No data flow, status logic, or routing changes — just chrome.

### What changed
- **Top bar (`+page.svelte`)** — paper-warm background, serif-dev title, mode pill (Page / Scroll / Continuous), `Aa` romanization toggle. Stacks vertically on mobile; rearranges to title-plus-tools at ≥640px.
- **`ReaderPage.svelte`** — body wraps in a 40rem serif-dev column with line-height 2. Chapter heading is muted with a slot for a romanized subtitle (currently shows chapter-of-N; the romanization data lands in a follow-up). Floating round page-arrows appear at ≥1024px (keyboard `←/→` already covers narrower viewports). Sticky bottom `reader-foot` with chapter progress percent + animated bar.
- **`TokenSpan.svelte`** — now emits `data-s='0'..'5'` per word. Existing scoped `.status-*` rules (which painted the highlight) deleted; the colored treatment moved to `tokens.css` under `html[data-hl='background'|'underline'] .word[data-s='...']`. T-5.1b's reader popover can switch highlight style by flipping the `data-hl` attribute.
- **`types.ts`** — `STATUS_TO_CODE` / `statusToCode()` map the existing 4-status model to the design's 6-slot numbering: `unknown→0`, `learning→2`, `known→4`, `ignored→5`. `1` and `3` reserved for when we split the learning bucket.

### What's intentionally out
- **No L1/L2/L3 split.** The data model still has a single `learning` status; this PR maps it to slot 2 (the design's "main" learning hue). Splitting is a data-layer change for a separate ticket.
- **No mobile page-arrows.** Below 1024px keyboard `←/→` and the bottom progress bar are the navigation primitives; arrow buttons would crowd the body column. T-5.10's mobile sheet design will revisit.
- **OOV + ambiguous treatments unchanged** — both still scoped to `TokenSpan.svelte` since they're orthogonal to the user-status highlight.

### Tests
- `types.test.ts` adds 2 tests asserting the status-to-code mapping (table form + helper form). Catches accidental renumbering — the data-s codes are written into many CSS rules.
- All 573 vitest pass · svelte-check 0/0.

Closes #159
Refs #42, #158