### PR TITLE
T-5.11: app shell redesign — left rail + bottom nav

### DIFF
--- a/apps/web/src/lib/components/shell/AppShell.svelte
+++ b/apps/web/src/lib/components/shell/AppShell.svelte
@@ -1,6 +1,22 @@
+<!--
+  App shell (T-1.4 → T-5.11).
+
+  Desktop (>=960px): left rail with brand mark, sectioned nav, version
+  stamp + sign-out at the foot. Mobile (<960px): a thin top strip with
+  the brand + sign-out, plus a full-width bottom tab bar with icons +
+  labels. Each screen owns its own top bar — there is no global
+  full-width header on desktop, matching the CIAR design.
+-->
 <script lang="ts">
   import { page } from '$app/stores';
-  import { TABS, getActiveTabId, visibleTabs, type Tab } from './tabs.js';
+  import {
+    TABS,
+    getActiveTabId,
+    groupTabsBySection,
+    visibleTabs,
+    type Tab,
+    type TabIcon,
+  } from './tabs.js';
   import type { Snippet } from 'svelte';
 
   interface Props {
@@ -12,26 +28,74 @@
 
   const tabs = $derived<Tab[]>(visibleTabs(TABS, user !== null));
   const activeId = $derived(getActiveTabId($page.url.pathname, tabs));
+  const groups = $derived(groupTabsBySection(tabs));
+
+  // Inline-SVG glyphs match the CIAR design's atom set
+  // (see design-handoff/ciar/project/atoms.jsx). One viewBox + a list
+  // of paths keeps the markup small without pulling in an icon font.
+  const ICONS: Record<TabIcon, string[]> = {
+    home: ['M3 11.5L12 4l9 7.5', 'M5 10v9h14v-9'],
+    library: ['M4 5h4v14H4z', 'M10 5h4v14h-4z', 'M16 6l3.5 1-2.5 13L13.5 19'],
+    upload: ['M12 4v12', 'M7 9l5-5 5 5', 'M4 18v2h16v-2'],
+    profile: [
+      'M12 12a4 4 0 100-8 4 4 0 000 8z',
+      'M4 20a8 8 0 0116 0',
+    ],
+    signin: ['M11 8V5a2 2 0 012-2h6a2 2 0 012 2v14a2 2 0 01-2 2h-6a2 2 0 01-2-2v-3', 'M3 12h12', 'M9 8l-4 4 4 4'],
+  };
 </script>
 
 <div class="shell">
-  <header class="top-bar" aria-label="Primary">
+  <aside class="rail" aria-label="Primary navigation">
     <a class="brand" href="/" aria-label="CIA Reader home">
-      <span class="brand-mark">CIA</span>
-      <span class="brand-name">Reader</span>
+      <span class="brand-mark" aria-hidden="true">अ</span>
+      <span class="brand-text">
+        <span class="brand-name">CIAR</span>
+        <span class="brand-sub">Indo-Aryan Reader</span>
+      </span>
     </a>
-    <nav class="top-nav" aria-label="Primary navigation">
-      {#each tabs as tab (tab.id)}
-        <a
-          href={tab.href}
-          class="tab"
-          class:active={activeId === tab.id}
-          aria-current={activeId === tab.id ? 'page' : undefined}
-        >
-          {tab.label}
-        </a>
+
+    <nav class="nav" aria-label="Sections">
+      {#each groups as group (group.section ?? '_')}
+        {#if group.section}
+          <div class="nav-section">{group.section}</div>
+        {/if}
+        {#each group.tabs as tab (tab.id)}
+          <a
+            href={tab.href}
+            class="nav-item"
+            class:active={activeId === tab.id}
+            aria-current={activeId === tab.id ? 'page' : undefined}
+          >
+            {#if tab.icon}
+              <span class="nav-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" width="16" height="16">
+                  {#each ICONS[tab.icon] as d (d)}
+                    <path {d} />
+                  {/each}
+                </svg>
+              </span>
+            {/if}
+            <span>{tab.label}</span>
+          </a>
+        {/each}
       {/each}
     </nav>
+
+    <footer class="rail-foot">
+      <span class="version">v0.5 · alpha</span>
+      {#if user}
+        <form method="post" action="/logout" class="logout-form">
+          <button type="submit" class="logout">Sign out</button>
+        </form>
+      {/if}
+    </footer>
+  </aside>
+
+  <header class="top-strip" aria-label="Account">
+    <a class="brand-strip" href="/" aria-label="CIA Reader home">
+      <span class="brand-mark" aria-hidden="true">अ</span>
+    </a>
     {#if user}
       <span class="who" aria-label="Signed-in user">
         {user.displayName ?? user.email}
@@ -50,129 +114,289 @@
     {#each tabs as tab (tab.id)}
       <a
         href={tab.href}
-        class="tab"
+        class="bottom-tab"
         class:active={activeId === tab.id}
         aria-current={activeId === tab.id ? 'page' : undefined}
       >
-        {tab.label}
+        {#if tab.icon}
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" width="18" height="18">
+              {#each ICONS[tab.icon] as d (d)}
+                <path {d} />
+              {/each}
+            </svg>
+          </span>
+        {/if}
+        <span>{tab.label}</span>
       </a>
     {/each}
   </nav>
 </div>
 
 <style>
+  /* Desktop: rail + content. Mobile: top-strip + content + bottom-nav.
+     The shell uses the design's paper / ink / rule tokens with a
+     fallback to the legacy --color-* family so anything not yet
+     redesigned still looks coherent. */
   .shell {
     min-height: 100dvh;
-    display: flex;
-    flex-direction: column;
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-template-rows: auto 1fr auto;
+    grid-template-areas:
+      'top'
+      'content'
+      'bottom';
+    background: var(--paper, var(--color-bg));
+    color: var(--ink, var(--color-fg));
   }
-  .top-bar {
+  @media (min-width: 960px) {
+    .shell {
+      grid-template-columns: 232px 1fr;
+      grid-template-rows: 1fr;
+      grid-template-areas: 'rail content';
+    }
+  }
+
+  /* —— Top strip (mobile only) —— */
+  .top-strip {
+    grid-area: top;
     display: flex;
     align-items: center;
-    gap: var(--space-4);
-    padding: var(--space-3) var(--space-4);
-    border-bottom: 1px solid var(--color-border);
-    background: var(--color-surface-1);
-    position: sticky;
-    top: 0;
-    z-index: 10;
+    gap: 0.75rem;
+    padding: 0.6rem 0.9rem;
+    border-bottom: 1px solid var(--rule, var(--color-border));
+    background: color-mix(
+      in oklch,
+      var(--paper, var(--color-bg)) 88%,
+      var(--paper-2, transparent)
+    );
   }
-  .brand {
-    display: inline-flex;
-    align-items: baseline;
-    gap: var(--space-2);
-    text-decoration: none;
-    color: inherit;
-    font-weight: 700;
+  @media (min-width: 960px) {
+    .top-strip {
+      display: none;
+    }
   }
-  .brand-mark {
-    color: var(--color-accent);
-    letter-spacing: 0.04em;
-  }
-  .brand-name {
-    color: var(--color-fg);
-  }
-  .top-nav {
-    display: flex;
-    gap: var(--space-2);
-    flex: 1;
-    margin-left: var(--space-4);
+  .brand-strip .brand-mark {
+    width: 30px;
+    height: 30px;
   }
   .who {
-    color: var(--color-fg-muted);
-    font-size: var(--font-size-sm);
+    flex: 1;
+    color: var(--ink-3, var(--color-fg-muted));
+    font-size: 0.85rem;
     white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  /* —— Rail (desktop only) —— */
+  .rail {
+    grid-area: rail;
+    display: none;
+    flex-direction: column;
+    gap: 1.4rem;
+    padding: 1.4rem 1rem 1rem;
+    border-right: 1px solid var(--rule, var(--color-border));
+    background: color-mix(
+      in oklch,
+      var(--paper, var(--color-bg)) 88%,
+      var(--paper-2, transparent)
+    );
+    position: sticky;
+    top: 0;
+    height: 100dvh;
+  }
+  @media (min-width: 960px) {
+    .rail {
+      display: flex;
+    }
+  }
+  .brand {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0 0.25rem;
+    text-decoration: none;
+    color: inherit;
+  }
+  .brand-mark {
+    width: 28px;
+    height: 28px;
+    border-radius: 6px;
+    background: var(--ink, var(--color-fg));
+    color: var(--paper, var(--color-bg));
+    display: grid;
+    place-items: center;
+    font-family: var(--font-serif-dev, var(--font-serif));
+    font-size: 1.1rem;
+    line-height: 1;
+    padding-top: 2px;
+    flex-shrink: 0;
+  }
+  .brand-text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+    line-height: 1;
+  }
+  .brand-name {
+    font-family: var(--font-serif, var(--font-ui));
+    font-weight: 600;
+    font-size: 0.97rem;
+    letter-spacing: 0.01em;
+  }
+  .brand-sub {
+    font-family: var(--font-sans, var(--font-ui));
+    font-size: 0.66rem;
+    color: var(--ink-3, var(--color-fg-muted));
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  .nav {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+  }
+  .nav-section {
+    font-family: var(--font-sans, var(--font-ui));
+    font-size: 0.62rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--ink-4, var(--color-fg-subtle));
+    padding: 0.85rem 0.5rem 0.35rem;
+  }
+  .nav-item {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.45rem 0.6rem;
+    border-radius: 7px;
+    color: var(--ink-2, var(--color-fg-muted));
+    text-decoration: none;
+    font-family: var(--font-sans, var(--font-ui));
+    font-size: 0.84rem;
+  }
+  .nav-item:hover {
+    background: color-mix(in oklch, var(--ink, var(--color-fg)) 5%, transparent);
+    color: var(--ink, var(--color-fg));
+  }
+  .nav-item.active {
+    background: color-mix(in oklch, var(--ink, var(--color-fg)) 8%, transparent);
+    color: var(--ink, var(--color-fg));
+    font-weight: 500;
+  }
+  .nav-icon {
+    width: 16px;
+    height: 16px;
+    display: grid;
+    place-items: center;
+    color: var(--ink-3, var(--color-fg-muted));
+    flex-shrink: 0;
+  }
+  .nav-item.active .nav-icon {
+    color: var(--accent-ink, var(--color-accent));
+  }
+  .nav-icon svg {
+    stroke: currentColor;
+    fill: none;
+    stroke-width: 1.5;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  .rail-foot {
+    margin-top: auto;
+    padding: 0.7rem 0.5rem 0.25rem;
+    border-top: 1px solid var(--rule, var(--color-border));
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-family: var(--font-sans, var(--font-ui));
+    font-size: 0.72rem;
+    color: var(--ink-3, var(--color-fg-muted));
+  }
+  .version {
+    font-feature-settings: 'tnum';
   }
   .logout-form {
     margin: 0;
   }
   .logout {
     background: transparent;
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-md);
-    color: var(--color-fg-muted);
+    border: 1px solid var(--rule, var(--color-border));
+    border-radius: 6px;
+    color: var(--ink-3, var(--color-fg-muted));
     cursor: pointer;
     font: inherit;
-    font-size: var(--font-size-xs);
-    padding: var(--space-1) var(--space-2);
+    font-size: 0.7rem;
+    padding: 0.2rem 0.5rem;
   }
   .logout:hover {
-    color: var(--color-fg);
-  }
-  .tab {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    padding: var(--space-2) var(--space-3);
-    border-radius: var(--radius-md);
-    min-height: var(--touch-target);
-    color: var(--color-fg-muted);
-    text-decoration: none;
-    font-size: var(--font-size-sm);
-  }
-  .tab:hover {
-    color: var(--color-fg);
-    background: var(--color-surface-2);
-  }
-  .tab.active {
-    color: var(--color-accent);
-    background: var(--color-surface-2);
-    font-weight: 600;
-  }
-  .content {
-    flex: 1;
-    display: block;
-    padding-bottom: calc(var(--touch-target) + var(--space-6));
-  }
-  .bottom-nav {
-    display: none;
+    color: var(--ink, var(--color-fg));
   }
 
-  /* Mobile: hide the top nav links (brand + who stay), show the bottom tab bar. */
-  @media (max-width: 640px) {
-    .top-nav {
+  /* —— Main content —— */
+  .content {
+    grid-area: content;
+    display: block;
+    min-width: 0;
+  }
+  /* On mobile, leave room for the bottom nav so sticky reader-foot bars
+     and trailing content aren't hidden under it. */
+  @media (max-width: 959.98px) {
+    .content {
+      padding-bottom: calc(
+        var(--touch-target) * 1.4 + env(safe-area-inset-bottom, 0px)
+      );
+    }
+  }
+
+  /* —— Bottom tab bar (mobile only) —— */
+  .bottom-nav {
+    grid-area: bottom;
+    display: grid;
+    grid-auto-flow: column;
+    grid-auto-columns: 1fr;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: color-mix(
+      in oklch,
+      var(--paper, var(--color-bg)) 92%,
+      var(--paper-2, transparent)
+    );
+    border-top: 1px solid var(--rule, var(--color-border));
+    padding: 0.25rem 0.4rem;
+    padding-bottom: calc(0.25rem + env(safe-area-inset-bottom, 0px));
+    z-index: 10;
+  }
+  @media (min-width: 960px) {
+    .bottom-nav {
       display: none;
     }
-    .bottom-nav {
-      display: grid;
-      grid-auto-flow: column;
-      grid-auto-columns: 1fr;
-      position: fixed;
-      bottom: 0;
-      left: 0;
-      right: 0;
-      background: var(--color-surface-1);
-      border-top: 1px solid var(--color-border);
-      padding: var(--space-1) var(--space-2);
-      padding-bottom: calc(var(--space-1) + env(safe-area-inset-bottom, 0px));
-      z-index: 10;
-    }
-    .bottom-nav .tab {
-      padding: var(--space-2);
-      font-size: var(--font-size-xs);
-    }
-    .content {
-      padding-bottom: calc(var(--touch-target) * 1.5 + env(safe-area-inset-bottom, 0px));
-    }
+  }
+  .bottom-tab {
+    display: grid;
+    grid-template-rows: auto auto;
+    align-items: center;
+    justify-items: center;
+    gap: 0.15rem;
+    padding: 0.35rem 0.2rem;
+    color: var(--ink-3, var(--color-fg-muted));
+    text-decoration: none;
+    font-family: var(--font-sans, var(--font-ui));
+    font-size: 0.65rem;
+    border-radius: 8px;
+  }
+  .bottom-tab.active {
+    color: var(--accent-ink, var(--color-accent));
+  }
+  .bottom-tab .nav-icon {
+    color: inherit;
+    width: 18px;
+    height: 18px;
   }
 </style>

--- a/apps/web/src/lib/components/shell/tabs.test.ts
+++ b/apps/web/src/lib/components/shell/tabs.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { TABS, getActiveTabId, visibleTabs, type Tab } from './tabs.js';
+import {
+  TABS,
+  getActiveTabId,
+  groupTabsBySection,
+  visibleTabs,
+  type Tab,
+} from './tabs.js';
 
 describe('visibleTabs', () => {
   it('shows authenticated + any tabs to signed-in users', () => {
@@ -68,5 +74,40 @@ describe('getActiveTabId', () => {
     ];
     expect(getActiveTabId('/admin/reports', custom)).toBe('admin-reports');
     expect(getActiveTabId('/admin/something-else', custom)).toBe('admin');
+  });
+});
+
+describe('groupTabsBySection', () => {
+  it('places unsectioned tabs in their own bucket above the sectioned ones', () => {
+    const groups = groupTabsBySection(visibleTabs(TABS, true));
+    // home has no section, so it's first.
+    expect(groups[0]).toMatchObject({ section: null });
+    expect(groups[0]!.tabs.map((t) => t.id)).toEqual(['home']);
+  });
+
+  it('groups Read-section tabs (Library + Upload) together', () => {
+    const groups = groupTabsBySection(visibleTabs(TABS, true));
+    const read = groups.find((g) => g.section === 'Read');
+    expect(read).toBeDefined();
+    expect(read!.tabs.map((t) => t.id)).toEqual(['library', 'upload']);
+  });
+
+  it("groups Profile under 'You'", () => {
+    const groups = groupTabsBySection(visibleTabs(TABS, true));
+    const you = groups.find((g) => g.section === 'You');
+    expect(you!.tabs.map((t) => t.id)).toEqual(['profile']);
+  });
+
+  it('skips empty sections so signed-out users do not see a stray You header', () => {
+    const groups = groupTabsBySection(visibleTabs(TABS, false));
+    expect(groups.find((g) => g.section === 'You')).toBeUndefined();
+  });
+
+  it('preserves source order within a section', () => {
+    const custom: Tab[] = [
+      { id: 'b', label: 'B', href: '/b', auth: 'any', match: ['/b'], section: 'Read' },
+      { id: 'a', label: 'A', href: '/a', auth: 'any', match: ['/a'], section: 'Read' },
+    ];
+    expect(groupTabsBySection(custom)[0]!.tabs.map((t) => t.id)).toEqual(['b', 'a']);
   });
 });

--- a/apps/web/src/lib/components/shell/tabs.ts
+++ b/apps/web/src/lib/components/shell/tabs.ts
@@ -10,6 +10,20 @@
  */
 export type TabAuth = 'any' | 'authenticated' | 'anonymous';
 
+/** Icon names supported by the shell. New entries map to a glyph in
+ * `AppShell.svelte`'s icon switch. */
+export type TabIcon =
+  | 'home'
+  | 'library'
+  | 'upload'
+  | 'profile'
+  | 'signin';
+
+/** Section heading the tab clusters under in the desktop rail (T-5.11).
+ * `null` (the default) renders the tab outside any section, above the
+ * first grouped tab. */
+export type TabSection = 'Read' | 'Track' | 'You' | null;
+
 export interface Tab {
   id: string;
   label: string;
@@ -17,10 +31,12 @@ export interface Tab {
   auth: TabAuth;
   /** Used for highlighting; a tab is active if the current pathname starts with any of these. */
   match: string[];
+  icon?: TabIcon;
+  section?: TabSection;
 }
 
 export const TABS: readonly Tab[] = [
-  { id: 'home', label: 'Home', href: '/', auth: 'any', match: ['/'] },
+  { id: 'home', label: 'Home', href: '/', auth: 'any', match: ['/'], icon: 'home' },
   {
     id: 'library',
     label: 'Library',
@@ -29,6 +45,8 @@ export const TABS: readonly Tab[] = [
     // /reader/[textId] is reached by clicking a library card, so the
     // Library tab should stay highlighted while reading.
     match: ['/library', '/reader'],
+    icon: 'library',
+    section: 'Read',
   },
   {
     id: 'upload',
@@ -36,6 +54,8 @@ export const TABS: readonly Tab[] = [
     href: '/upload',
     auth: 'authenticated',
     match: ['/upload'],
+    icon: 'upload',
+    section: 'Read',
   },
   {
     id: 'profile',
@@ -43,8 +63,17 @@ export const TABS: readonly Tab[] = [
     href: '/profile',
     auth: 'authenticated',
     match: ['/profile'],
+    icon: 'profile',
+    section: 'You',
   },
-  { id: 'signin', label: 'Sign in', href: '/login', auth: 'anonymous', match: ['/login'] },
+  {
+    id: 'signin',
+    label: 'Sign in',
+    href: '/login',
+    auth: 'anonymous',
+    match: ['/login'],
+    icon: 'signin',
+  },
 ];
 
 export function visibleTabs(tabs: readonly Tab[], isAuthenticated: boolean): Tab[] {
@@ -68,4 +97,25 @@ export function getActiveTabId(pathname: string, tabs: readonly Tab[]): string |
     }
   }
   return best?.id ?? null;
+}
+
+/** Group visible tabs by their `section` for the desktop rail (T-5.11).
+ * Tabs with `section: null | undefined` go in the unsectioned bucket
+ * (rendered above the first sectioned group). Order within a section
+ * preserves the order in `tabs`. */
+export function groupTabsBySection(
+  tabs: readonly Tab[],
+): { section: TabSection; tabs: Tab[] }[] {
+  const order: TabSection[] = [null, 'Read', 'Track', 'You'];
+  const buckets = new Map<TabSection, Tab[]>();
+  for (const s of order) buckets.set(s, []);
+  for (const t of tabs) {
+    const s = t.section ?? null;
+    const bucket = buckets.get(s);
+    if (bucket) bucket.push(t);
+    else buckets.set(s, [t]);
+  }
+  return order
+    .map((section) => ({ section, tabs: buckets.get(section) ?? [] }))
+    .filter((g) => g.tabs.length > 0);
 }


### PR DESCRIPTION
## Summary

Replaces the global top-bar shell (T-1.4 era) with the CIAR design's two-mode layout — left rail on ≥960px, bottom tab bar on <960px. Each screen continues to render its own top bar in the content area (the reader's redesigned bar from T-5.9 sits cleanly under this).

### Desktop rail
- Brand mark `अ` + CIAR + "Indo-Aryan Reader" subtitle.
- Sectioned nav: home is unsectioned (above the first divider); Library + Upload sit under **Read**; Profile sits under **You**.
- Foot: `v0.5 · alpha` version stamp + sign-out button.

### Mobile
- Thin top strip with brand + signed-in user + sign-out (mobile users still need a way to log out — the bottom tab bar can't host a form button cleanly without crowding nav).
- Full-width bottom tab bar with inline-SVG icons + labels. Honors `env(safe-area-inset-bottom)` for iOS.

### Data model
`tabs.ts` gains two optional fields:
- `icon: TabIcon` — string id, mapped to inline SVG paths in `AppShell.svelte` (copied from `atoms.jsx` in the design handoff). Avoids pulling in an icon font.
- `section: TabSection` — `'Read' | 'Track' | 'You' | null`. `Track` is empty today; it'll fill in when T-10.6 (Words) and T-10.1 (Stats) land.

`groupTabsBySection()` is extracted alongside `visibleTabs` / `getActiveTabId` so the rail's grouping is unit-tested against the same single-source-of-truth.

### Tests
- `tabs.test.ts` adds 5 cases: unsectioned-bucket-first, Read grouping for signed-in users, You grouping, empty-section pruning for signed-out users (no stray "You" header), source-order preservation within a section.
- All 578 vitest pass · svelte-check 0/0.

### Stack
Branched off `feat/t-5.9-reader-chrome` so the rail's design tokens (paper / ink / rule) come from T-5.8. Once #167 (T-5.8) and #169 (T-5.9) merge, this PR's base will rebase to `main` cleanly.

Closes #161
Refs #42, #158