### PR TITLE
M2: Hindi schwa deletion + ē/ō fold in romanize.to_roman

### DIFF
--- a/services/nlp/app/pipelines/__init__.py
+++ b/services/nlp/app/pipelines/__init__.py
@@ -75,6 +75,7 @@ def get_pipeline(language_code: str) -> Pipeline:
             _PIPELINE_CACHE[pipeline_id] = StubPipeline(
                 script=descriptor.script,
                 roman_scheme=descriptor.default_romanization,
+                language=descriptor.code,
             )
         else:
             factory = _PIPELINE_FACTORIES.get(pipeline_id, StubPipeline)

--- a/services/nlp/app/pipelines/hindi.py
+++ b/services/nlp/app/pipelines/hindi.py
@@ -67,6 +67,10 @@ def build_hindi_pipeline() -> HindiPipeline:  # pragma: no cover
         nlp=nlp,
         script=desc.script,
         roman_scheme=desc.default_romanization,
+        # Language hint triggers the schwa-deletion path in
+        # :func:`app.romanize.to_roman` so reader output is "rām" not
+        # "rāma" for words like राम / कमल / भारत.
+        language=desc.code,
     )
 
 

--- a/services/nlp/app/pipelines/stanza_ud.py
+++ b/services/nlp/app/pipelines/stanza_ud.py
@@ -93,10 +93,18 @@ class StanzaUDPipeline(Pipeline):
         *,
         script: str | None = None,
         roman_scheme: str | None = None,
+        language: str | None = None,
     ) -> None:
         self._nlp = nlp
         self._script = script
         self._roman_scheme = roman_scheme
+        # Optional registry language code ("hi", "mr", "or"). Forwarded
+        # to ``to_roman`` so language-specific phonological rules
+        # (currently just Hindi schwa deletion + ē/ō fold) fire when
+        # the language hint is present. ``None`` keeps the legacy
+        # script-only behavior — callers without language context
+        # round-trip cleanly.
+        self._language = language
 
     def process(self, text: str) -> PipelineResult:
         doc = self._nlp(text)
@@ -187,6 +195,7 @@ class StanzaUDPipeline(Pipeline):
                 surface,
                 from_script=self._script,
                 to_scheme=self._roman_scheme,
+                language=self._language,
             )
         except UnsupportedScriptError:
             return None

--- a/services/nlp/app/pipelines/stub.py
+++ b/services/nlp/app/pipelines/stub.py
@@ -56,9 +56,14 @@ class StubPipeline(Pipeline):
         *,
         script: str | None = None,
         roman_scheme: str | None = None,
+        language: str | None = None,
     ) -> None:
         self._script = script
         self._roman_scheme = roman_scheme
+        # See :class:`StanzaUDPipeline` — language hint forwards to
+        # ``to_roman`` so the stub also produces schwa-deleted Hindi
+        # output when the dev/CI fallback path is in use.
+        self._language = language
 
     def process(self, text: str) -> PipelineResult:
         if not text:
@@ -93,6 +98,7 @@ class StubPipeline(Pipeline):
                 surface,
                 from_script=self._script,
                 to_scheme=self._roman_scheme,
+                language=self._language,
             )
         except UnsupportedScriptError:
             # The registry passed a script we don't yet have a

--- a/services/nlp/app/romanize.py
+++ b/services/nlp/app/romanize.py
@@ -27,12 +27,45 @@ land in a follow-up ticket (see docstring on :data:`SUPPORTED_SCHEMES`).
 Script + scheme tokens are the registry's canonical codes (ISO 15924
 script + the ``RomanizationScheme`` Literal). Calling code never
 touches ``sanscript``'s internal names.
+
+Hindi schwa deletion
+====================
+
+Hindi drops the Devanagari inherent schwa in most positions
+(राम → ``rām``, कमल → ``kamal``, भारत → ``bhārat``), and the schemes
+sanscript ships from a Sanskrit baseline don't model that — sanscript
+alone produces ``rāma``, ``kamala``, ``bhārata``. Marathi and Odia
+retain the schwa, so the bug is Hindi-specific.
+
+When :func:`to_roman` is called with ``language="hi"`` we route the
+Devanagari input through aksharamukha's ``RemoveSchwaHindi`` pre-rule,
+which emits the same Devanagari with explicit viramas where the schwa
+should be silent (e.g. कमला → कम्ला). That schwa-deleted Devanagari is
+then handed to sanscript like any other input, so every supported
+scheme (ISO / IAST / ITRANS / Velthuis) picks up the deletion
+uniformly — we don't depend on aksharamukha's romanization output.
+
+A second Hindi-specific quirk: ISO 15919 distinguishes ``ē/ō`` (long)
+from ``e/o`` (short). Hindi merged that distinction phonologically —
+there is only one /e/ and one /o/ — but sanscript still emits
+``ē/ō`` because the underlying Devanagari े/ो are mechanically the
+"long" forms. For ``language="hi"`` + ``to_scheme="iso15919"`` we
+fold ``ē → e`` and ``ō → o`` after transliteration so the output
+matches reader expectations. Marathi and Odia keep the macrons — they
+genuinely use the length distinction.
+
+The ``language`` kwarg is opt-in. Callers without language context
+(round-trip dictionary tooling, the script-aware editor's reverse
+``to_native`` direction) keep getting raw sanscript output, which
+is reversible. Schwa-deleted Hindi output is intentionally lossy —
+``rām`` doesn't round-trip back to राम — so it's display-only.
 """
 
 from __future__ import annotations
 
 import unicodedata
 
+from aksharamukha import transliterate as _aksharamukha
 from indic_transliteration import sanscript
 
 # Script codes (ISO 15924) → the sanscript scheme name. The registry
@@ -102,12 +135,42 @@ def _resolve_scheme(name: str) -> str:
         return _SCHEME_TO_SANSCRIPT[name]
     except KeyError as e:
         raise UnsupportedSchemeError(
-            f"Romanization scheme {name!r} not implemented; "
-            f"supported: {sorted(SUPPORTED_SCHEMES)}"
+            f"Romanization scheme {name!r} not implemented; supported: {sorted(SUPPORTED_SCHEMES)}"
         ) from e
 
 
-def to_roman(text: str, *, from_script: str, to_scheme: str) -> str:
+def _hindi_schwa_delete(devanagari: str) -> str:
+    """Apply aksharamukha's ``RemoveSchwaHindi`` to a Devanagari string.
+
+    Returns the same string with explicit viramas where the inherent
+    schwa should be silent. This is a Devanagari→Devanagari transform —
+    the actual romanization is still done by sanscript. Wrapped behind
+    a function so callers (and tests) don't import aksharamukha
+    directly and so the dependency is easy to swap if a better Hindi
+    schwa-deletion model lands later.
+    """
+    return _aksharamukha.process(
+        "Devanagari",
+        "Devanagari",
+        devanagari,
+        pre_options=["RemoveSchwaHindi"],
+    )
+
+
+# Hindi merges the ISO 15919 ē/ō length distinction into a single
+# /e/ and /o/. After sanscript emits ISO output we fold the macron
+# variants down to plain e/o for the Hindi display layer. Marathi and
+# Odia genuinely use the length distinction and skip this fold.
+_HINDI_ISO_FOLD = str.maketrans({"ē": "e", "ō": "o", "Ē": "E", "Ō": "O"})
+
+
+def to_roman(
+    text: str,
+    *,
+    from_script: str,
+    to_scheme: str,
+    language: str | None = None,
+) -> str:
     """Transliterate native-script text into a romanization scheme.
 
     The input is NFC-normalized defensively — the /process HTTP layer
@@ -115,13 +178,27 @@ def to_roman(text: str, *, from_script: str, to_scheme: str) -> str:
     dictionary-import code call this module directly, and a
     mis-normalized surface shouldn't produce a mis-romanized output.
     Empty string in, empty string out — a no-op rather than an error.
+
+    ``language`` is an opt-in hint that lets callers trigger
+    language-specific phonological rules — currently just Hindi schwa
+    deletion + ISO ē/ō → e/o fold (see module docstring). Pass the
+    registry's language code (``"hi"``, ``"mr"``, ``"or"``) when the
+    output is for *display*; leave it unset when the output must
+    round-trip back through :func:`to_native`.
     """
     if not text:
         return ""
     normalized = unicodedata.normalize("NFC", text)
+    if language == "hi" and from_script == "Deva":
+        # Schwa-delete on the Devanagari side, then let sanscript handle
+        # the actual romanization for whichever scheme was requested.
+        normalized = _hindi_schwa_delete(normalized)
     src = _resolve_script(from_script)
     dst = _resolve_scheme(to_scheme)
-    return sanscript.transliterate(normalized, src, dst)
+    out = sanscript.transliterate(normalized, src, dst)
+    if language == "hi" and to_scheme == "iso15919":
+        out = out.translate(_HINDI_ISO_FOLD)
+    return out
 
 
 def to_native(text: str, *, target_script: str, from_scheme: str) -> str:

--- a/services/nlp/pyproject.toml
+++ b/services/nlp/pyproject.toml
@@ -12,6 +12,12 @@ dependencies = [
   # from the script-aware editor (T-6.2a). Kept as a base dep rather
   # than under [models] so CI exercises it directly.
   "indic-transliteration>=2.3.68",
+  # Aksharamukha is used only for Hindi schwa-deletion preprocessing
+  # (Devanagari → schwa-deleted Devanagari, virama-marked); the actual
+  # romanization is then handled by indic-transliteration as for every
+  # other language. We don't depend on aksharamukha's romanization
+  # output schemes — only on its `RemoveSchwaHindi` source-side rule.
+  "aksharamukha>=2.3",
   # Python-native Redis job queue for async NLP work (T-2.6). The
   # worker process imports RedisSettings at module load; keep it in
   # base deps so tests that import app.worker don't need [models].

--- a/services/nlp/tests/test_romanize.py
+++ b/services/nlp/tests/test_romanize.py
@@ -62,6 +62,86 @@ def test_to_roman_empty_is_empty():
     assert romanize.to_roman("", from_script="Deva", to_scheme="iast") == ""
 
 
+# ---- Hindi-specific: schwa deletion + ē/ō → e/o fold ----
+#
+# These exercise the ``language="hi"`` opt-in path documented in the
+# module. Without the kwarg sanscript alone produces "rāma" / "kamala"
+# / "bhārata" — correct for Sanskrit, wrong for Hindi.
+
+
+@pytest.mark.parametrize(
+    "native,expected_iso",
+    [
+        ("राम", "rām"),  # final schwa deleted
+        ("कमल", "kamal"),  # final schwa deleted
+        ("भारत", "bhārat"),  # medial schwa kept, final deleted
+        ("कमला", "kamlā"),  # medial schwa deleted, long ā preserved
+        ("धर्म", "dharm"),  # consonant cluster, final deleted
+        ("पुस्तक", "pustak"),  # final deleted, NFC-stable
+    ],
+)
+def test_hindi_schwa_deletion_iso(native: str, expected_iso: str):
+    out = romanize.to_roman(native, from_script="Deva", to_scheme="iso15919", language="hi")
+    assert out == expected_iso
+
+
+def test_hindi_schwa_deletion_applies_to_iast_too():
+    # Schwa deletion is a phonological fact about Hindi, so it must
+    # apply regardless of which roman scheme is requested. IAST
+    # output should also drop the trailing schwa.
+    iast = romanize.to_roman("राम", from_script="Deva", to_scheme="iast", language="hi")
+    assert iast == "rām"
+
+
+def test_hindi_iso_folds_long_e_to_short_e():
+    # बोलना → "bolna"; without the fold sanscript emits "bōl…" because
+    # ISO 15919 mechanically marks े as the long ē. Hindi has only
+    # one /e/, so the fold is the right output.
+    out = romanize.to_roman("बोलता", from_script="Deva", to_scheme="iso15919", language="hi")
+    assert "ē" not in out
+    assert "ō" not in out
+    assert out == "boltā"
+
+
+def test_hindi_fold_does_not_apply_to_iast():
+    # IAST already uses bare e/o (no length distinction in the scheme),
+    # so the fold is a no-op there but worth pinning to catch
+    # regressions if the scheme tables shift.
+    out = romanize.to_roman("बोलता", from_script="Deva", to_scheme="iast", language="hi")
+    assert out == "boltā"
+
+
+def test_marathi_keeps_inherent_schwa_with_language_hint():
+    # Marathi retains the final schwa (राम → "rāma"). Passing
+    # ``language="mr"`` must NOT trigger schwa deletion — that's a
+    # Hindi-only rule.
+    out = romanize.to_roman("राम", from_script="Deva", to_scheme="iso15919", language="mr")
+    assert out == "rāma"
+
+
+def test_marathi_keeps_long_e_macron():
+    # Marathi genuinely uses the e/ē length distinction, so the ē→e
+    # fold must NOT apply for ``language="mr"``.
+    out = romanize.to_roman("हे", from_script="Deva", to_scheme="iso15919", language="mr")
+    assert "ē" in out
+
+
+def test_default_language_keeps_legacy_sanscript_behavior():
+    # Without ``language=``, callers (the to_native round-trip path,
+    # dictionary tooling) must keep getting raw sanscript output so
+    # round-trip remains lossless.
+    out = romanize.to_roman("राम", from_script="Deva", to_scheme="iso15919")
+    assert out == "rāma"
+
+
+def test_hindi_language_hint_is_noop_for_orya():
+    # The schwa-deletion path is gated on ``from_script="Deva"`` —
+    # Odia text with a stray ``language="hi"`` (a caller bug) must
+    # not get mangled by Devanagari-specific preprocessing.
+    out = romanize.to_roman("ନମସ୍କାର", from_script="Orya", to_scheme="iast", language="hi")
+    assert out == "namaskāra"
+
+
 # ---- to_native (romanization scheme → native script) ----
 
 
@@ -140,8 +220,7 @@ def test_round_trip_preserves_native(native: str, script: str, scheme: str):
     roman = romanize.to_roman(native, from_script=script, to_scheme=scheme)
     back = romanize.to_native(roman, target_script=script, from_scheme=scheme)
     assert back == unicodedata.normalize("NFC", native), (
-        f"round-trip broken for {native!r} via {scheme}: "
-        f"{native!r} -> {roman!r} -> {back!r}"
+        f"round-trip broken for {native!r} via {scheme}: {native!r} -> {roman!r} -> {back!r}"
     )
 
 


### PR DESCRIPTION
## Summary

- The romanization layer (T-2.5) was producing Sanskritic output for Hindi: राम → \`rāma\`, कमल → \`kamala\`, भारत → \`bhārata\`. sanscript alone has no Hindi-specific phonology, so trailing inherent schwas survive transliteration even though Hindi drops them.
- Adds an **opt-in** \`language\` kwarg to \`to_roman\`. When \`language=\"hi\"\` and the input is Devanagari, we run aksharamukha's \`RemoveSchwaHindi\` on the Devanagari side (Devanagari → schwa-deleted Devanagari with explicit viramas) and hand the result to sanscript like any other input. Every supported scheme picks up the deletion uniformly — we don't depend on aksharamukha's own romanization output.
- Also folds \`ē → e\` / \`ō → o\` for \`language=\"hi\"\` + \`to_scheme=\"iso15919\"\`. Hindi merged the ISO 15919 vowel-length distinction phonologically; Marathi and Odia kept it, so the fold is Hindi-only.
- Wired through \`StanzaUDPipeline\` / \`StubPipeline\` so the Hindi factory passes \`language=\"hi\"\` automatically; Marathi and Odia behavior is unchanged.

## Output before / after (Hindi)

| input | before (sanscript only) | after (\`language=\"hi\"\`) |
|-------|-------------------------|---------------------------|
| राम   | \`rāma\`                  | \`rām\`                     |
| कमल   | \`kamala\`                | \`kamal\`                   |
| भारत  | \`bhārata\`               | \`bhārat\`                  |
| कमला  | \`kamalā\`                | \`kamlā\` (medial schwa dropped, length kept) |
| धर्म  | \`dharma\`                | \`dharm\`                   |
| बोलता | \`bōltā\`                 | \`boltā\` (ē/ō fold for ISO) |

Marathi (\`language=\"mr\"\`) and Odia (\`language=\"or\"\`) outputs are unchanged: राम → \`rāma\`, ଓଡ଼ିଆ → \`ōṛiā\`. The fold and schwa rules are gated on Hindi.

## Why this design

The \`language\` kwarg is **opt-in** and one-way:

- Round-trip callers (the script-aware editor's \`to_native\` direction, dictionary tooling, the existing parametric round-trip test) don't pass \`language\` and keep getting raw sanscript output, which is reversible.
- Schwa-deleted Hindi output is intentionally lossy (\`rām\` doesn't round-trip back to राम), so it's display-only.

Aksharamukha is used only as a Devanagari→Devanagari preprocessor for the schwa rule. We do not depend on its romanization tables, which keeps every scheme (ISO / IAST / ITRANS / Velthuis) consistently produced by sanscript.

## Test plan

- [x] \`pytest\` in \`services/nlp\` — 181 passed, 100% coverage on \`app/romanize.py\`, total coverage 94%
- [x] \`ruff check\` clean
- [x] New tests cover: Hindi ISO schwa deletion (राम/कमल/भारत/कमला/धर्म/पुस्तक), Hindi IAST schwa deletion, Hindi ē/ō fold, Marathi keeps schwa, Marathi keeps ē macron, default \`language=None\` keeps legacy sanscript output, Odia ignores stray \`language=\"hi\"\`
- [x] Existing round-trip parametrized tests still green (don't pass \`language\`, so unaffected)
- [x] Hindi pipeline factory now wired with \`language=\"hi\"\`; Marathi / Odia factories unchanged

Refs #21 (T-2.5 — Romanization + transliteration utilities).