### PR TITLE
T-5.10: word hover tooltip + side panel split

### DIFF
--- a/apps/web/src/lib/components/reader/ChapterBody.svelte
+++ b/apps/web/src/lib/components/reader/ChapterBody.svelte
@@ -1,16 +1,21 @@
 <!--
-  Renders one chapter's body with the right tokenizer (T-5.2,
-  romanization in T-5.3, click-to-popup in T-5.4).
+  Renders one chapter's body (T-5.2, T-5.3, T-5.4, hover tooltip in T-5.10).
 
   Click handling lives here so the popup is mounted at most once per
   chapter render — wiring it on every TokenSpan would explode for
-  large chapters. We delegate via event-bubbling: a click anywhere on
-  this region is checked for `[data-token-id]` and an open-popup
-  intent is fired if it lands on a word.
+  large chapters. We delegate via event bubbling.
+
+  Two surfaces:
+    - Hover (mouseover): a lightweight WordTooltip that reads only
+      what's on the token row. Cheap; no fetch.
+    - Click: the full WordPopup side panel. Fetches translations,
+      offers status flips + add-translation form. Locks until the
+      user closes / picks another word.
 -->
 <script lang="ts">
   import TokenSpan from './TokenSpan.svelte';
   import WordPopup from './WordPopup.svelte';
+  import WordTooltip from './WordTooltip.svelte';
   import {
     paragraphsOfServerTokens,
     paragraphsOfTokens,
@@ -60,6 +65,9 @@
     return new Map(tokensWithOverrides.map((t) => [t.id, t]));
   });
 
+  // Click → side panel (locked until closed). Hover → tooltip
+  // (transient). Click and hover are independent so the side panel
+  // doesn't change as you graze other words with the cursor.
   let activeToken = $state<ServerToken | null>(null);
   let activeRect = $state<{
     top: number;
@@ -68,23 +76,85 @@
     right: number;
   } | null>(null);
 
-  function onChapterClick(event: MouseEvent) {
-    const target = event.target as HTMLElement | null;
-    if (!target) return;
+  let hoverToken = $state<ServerToken | null>(null);
+  let hoverRect = $state<{
+    top: number;
+    left: number;
+    bottom: number;
+    right: number;
+    width: number;
+    height: number;
+  } | null>(null);
+
+  function findToken(target: HTMLElement | null): {
+    token: ServerToken;
+    el: HTMLElement;
+  } | null {
+    if (!target) return null;
     const span = target.closest('[data-token-id]') as HTMLElement | null;
-    if (!span) return;
+    if (!span) return null;
     const tokenId = span.getAttribute('data-token-id');
-    if (!tokenId) return;
+    if (!tokenId) return null;
     const token = tokensById.get(tokenId);
-    if (!token || !token.isWord) return;
-    const rect = span.getBoundingClientRect();
-    activeToken = token;
+    if (!token || !token.isWord) return null;
+    return { token, el: span };
+  }
+
+  function onChapterClick(event: MouseEvent) {
+    const found = findToken(event.target as HTMLElement);
+    if (!found) return;
+    const rect = found.el.getBoundingClientRect();
+    activeToken = found.token;
     activeRect = {
       top: rect.top,
       left: rect.left,
       bottom: rect.bottom,
       right: rect.right,
     };
+    // Hide the hover tooltip so it doesn't double up with the panel.
+    hoverToken = null;
+    hoverRect = null;
+  }
+
+  // Accepts both MouseEvent (mouseover) and FocusEvent (focusin) so
+  // the tooltip surfaces for pointer hovers AND keyboard tabbing.
+  function showHoverTooltip(event: Event) {
+    const found = findToken(event.target as HTMLElement);
+    if (!found) {
+      hoverToken = null;
+      hoverRect = null;
+      return;
+    }
+    // Skip the tooltip when the side panel is locked on the same
+    // word — redundant.
+    if (activeToken && activeToken.id === found.token.id) {
+      hoverToken = null;
+      hoverRect = null;
+      return;
+    }
+    const rect = found.el.getBoundingClientRect();
+    hoverToken = found.token;
+    hoverRect = {
+      top: rect.top,
+      left: rect.left,
+      bottom: rect.bottom,
+      right: rect.right,
+      width: rect.width,
+      height: rect.height,
+    };
+  }
+
+  function hideHoverTooltip(event: Event) {
+    // Only clear if the cursor / focus genuinely leaves the chapter
+    // region — moving between two adjacent words shouldn't flicker
+    // the tooltip off and on.
+    const related =
+      'relatedTarget' in event ? (event.relatedTarget as HTMLElement | null) : null;
+    if (related && (event.currentTarget as HTMLElement).contains(related)) {
+      return;
+    }
+    hoverToken = null;
+    hoverRect = null;
   }
 
   function closePopup() {
@@ -104,9 +174,20 @@
   }
 </script>
 
+<!-- The hover tooltip is decorative chrome — keyboard / focus users get
+     the full side panel via Enter on a focused word. mouseover/mouseout
+     are paired with focusin/focusout (the bubbling versions of focus /
+     blur) so the tooltip also appears for keyboard navigation. -->
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <!-- svelte-ignore a11y_no_static_element_interactions -->
-<div onclick={onChapterClick}>
+<!-- svelte-ignore a11y_mouse_events_have_key_events -->
+<div
+  onclick={onChapterClick}
+  onmouseover={showHoverTooltip}
+  onmouseout={hideHoverTooltip}
+  onfocusin={showHoverTooltip}
+  onfocusout={hideHoverTooltip}
+>
   {#if serverParagraphs}
     {#each serverParagraphs as paragraph, pIdx (pIdx)}
       <p class="body">
@@ -126,6 +207,10 @@
     {/each}
   {/if}
 </div>
+
+{#if hoverToken && hoverRect}
+  <WordTooltip token={hoverToken} anchorRect={hoverRect} />
+{/if}
 
 {#if activeToken && activeRect}
   <WordPopup

--- a/apps/web/src/lib/components/reader/WordPopup.svelte
+++ b/apps/web/src/lib/components/reader/WordPopup.svelte
@@ -1,27 +1,25 @@
 <!--
-  Word pop-up (T-5.4).
+  Word side panel (T-5.4 → T-5.10).
 
-  Opens on tap/click of a word token. Renders:
-    a. Surface form (the inflected form the user clicked)
-    b. Romanization (when present)
-    c. Headword + POS
-    d. Morphology gloss (from token features; M2.4 produces these)
-    e. Personal customization → official translations → community
-       translations (the bucket order from T-3.3)
-    f. Status buttons — Learning / Known / Ignored. T-5.5 wires the
-       writes; here they're stub buttons.
-    g. "N alternate meanings" disclosure when `is_ambiguous=true`.
-       T-6.1 wires the candidate-pick action.
-    h. "No dictionary match" copy + correction-flow CTA when
-       `is_oov=true` (T-5.4a).
+  Opens on tap/click of a word. Renders inside a <Sheet> so it slides
+  up from the bottom on <960px and in from the right on >=960px,
+  matching the CIAR design's reader side-panel.
 
-  Positioning: the popup is anchored next to the clicked token via
-  fixed-positioning + a small viewport-fit nudge. We keep the markup
-  body simple (a single `<div role="dialog">`) so the M11
-  accessibility pass can wire focus management without restructuring.
+  Content (unchanged from T-5.4):
+    a. Surface form + romanization + headword + POS
+    b. Personal → official → community translations (T-3.3 ordering)
+    c. "+ Add my translation" form (T-3.2)
+    d. Status buttons — Learning / Known / Ignored (T-5.5)
+    e. "N alternate meanings" disclosure when is_ambiguous=true
+       (T-6.1 wires the candidate-pick action)
+    f. "No dictionary match" copy when is_oov=true (T-5.4a)
+
+  Keyboard: Sheet handles Esc + focus trap. We keep k/l/i status
+  shortcuts so the existing keyboard-first flow (T-5.7) still works.
 -->
 <script lang="ts">
   import { untrack } from 'svelte';
+  import Sheet from '../overlay/Sheet.svelte';
   import type { ServerToken } from './types.js';
 
   type Provenance =
@@ -52,22 +50,19 @@
     };
   };
 
+  // anchorRect is accepted but unused — anchor positioning was used
+  // before T-5.10 switched to Sheet. Kept on the prop signature for
+  // backward compat with callers that still pass it.
   let {
     token,
-    anchorRect,
     isOwner,
     onClose,
     onStatusChange,
   }: {
     token: ServerToken;
-    /** DOMRect of the clicked token's bounding box, used to anchor
-     *  the popup below it (or above, if there's no room). */
-    anchorRect: { top: number; left: number; bottom: number; right: number };
+    anchorRect?: { top: number; left: number; bottom: number; right: number };
     isOwner: boolean;
     onClose: () => void;
-    /** Called after a successful PATCH so the parent can update its
-     *  in-memory token list (rerunning the loader would lose scroll
-     *  position). */
     onStatusChange?: (
       lemmaId: string,
       status: 'unknown' | 'learning' | 'known' | 'ignored',
@@ -81,46 +76,12 @@
     untrack(() => token.status),
   );
   let writeError = $state<string | null>(null);
-  let popupEl: HTMLElement | null = $state(null);
-
-  // Compute an initial positioned style synchronously so the popup
-  // appears at the click site on the very first paint — without it,
-  // the popup briefly renders inline before onMount's reposition
-  // call moves it to fixed coordinates.
-  function computeStyle(rect: typeof anchorRect, measured?: HTMLElement | null): string {
-    const POPUP_W = measured?.offsetWidth || 320;
-    const POPUP_H = measured?.offsetHeight || 240;
-    const MARGIN = 8;
-    const vw = typeof window !== 'undefined' ? window.innerWidth : 1024;
-    const vh = typeof window !== 'undefined' ? window.innerHeight : 768;
-    let top = rect.bottom + MARGIN;
-    let left = rect.left;
-    if (top + POPUP_H + MARGIN > vh) {
-      top = Math.max(MARGIN, rect.top - POPUP_H - MARGIN);
-    }
-    if (left + POPUP_W + MARGIN > vw) {
-      left = Math.max(MARGIN, vw - POPUP_W - MARGIN);
-    }
-    if (left < MARGIN) left = MARGIN;
-    return `position: fixed; top: ${top}px; left: ${left}px; width: ${POPUP_W}px;`;
-  }
-
-  // Position is a `$derived` of the anchor + measured popup, so it
-  // recalculates whenever the token changes (parent passes a new
-  // anchorRect) or the popup grows after content loads. The
-  // `payload`/`loadError` deps make sure measurement re-runs after
-  // the fetch resolves.
-  const style = $derived.by(() => {
-    void payload;
-    void loadError;
-    return computeStyle(anchorRect, popupEl);
-  });
 
   // Re-fetch translations whenever the token prop changes. `$effect`
   // runs the body each time `token` (and thus `token.id` / `lemmaId`)
   // changes — which happens when the parent rebinds the popup to a
-  // different word — so navigating word-to-word loads the new
-  // entry instead of leaving the old one stuck.
+  // different word — so navigating word-to-word loads the new entry
+  // instead of leaving the old one stuck.
   $effect(() => {
     const t = token;
     optimisticStatus = t.status;
@@ -153,11 +114,6 @@
   });
 
   function handleKeydown(e: KeyboardEvent) {
-    if (e.key === 'Escape') {
-      e.preventDefault();
-      onClose();
-      return;
-    }
     if (!isOwner || !token.lemmaId) return;
     // T-5.7: power-user shortcuts. Only fire when modifier-free so we
     // don't fight the browser's own shortcuts (Cmd-K, Ctrl-L, etc.).
@@ -183,23 +139,7 @@
     ];
   });
 
-  // Convert the token's UD-style features map into a human-readable
-  // gloss line. The full templating logic lives in the NLP service
-  // (T-2.4) — for the popup we lay them out as `Key: Value · …`.
-  // Once T-2.4's gloss landed on the token row directly we'll use it
-  // verbatim.
-  function summarizeFeatures(features: Record<string, string> | null): string {
-    if (!features) return '';
-    const entries = Object.entries(features);
-    if (entries.length === 0) return '';
-    return entries.map(([k, v]) => `${k}: ${v}`).join(' · ');
-  }
-
   // ---- Add-translation flow ---------------------------------------
-  // Lets the reader stash their own definition for any token whose
-  // lemma is in the dictionary. Backed by POST /api/v1/translations
-  // (T-3.2). The new row lands in the `personal` bucket on the next
-  // render so the user sees it pinned to the top of the popup.
   let showAddForm = $state(false);
   let newTranslationBody = $state('');
   let savingTranslation = $state(false);
@@ -237,8 +177,6 @@
           provenance: Provenance;
         };
       };
-      // Optimistically prepend the new row to the personal bucket
-      // so the user sees it without re-fetching.
       if (payload) {
         payload = {
           ...payload,
@@ -263,8 +201,6 @@
     if (!token.lemmaId) return;
     const lemmaId = token.lemmaId;
     const previous = optimisticStatus;
-    // Optimistic flip — the user sees the change before the wire
-    // settles.
     optimisticStatus = status;
     writeError = null;
     try {
@@ -278,7 +214,6 @@
       }
       onStatusChange?.(lemmaId, status);
     } catch (e) {
-      // Revert on failure so the user knows something went wrong.
       optimisticStatus = previous;
       writeError = (e as Error).message;
     }
@@ -287,331 +222,345 @@
 
 <svelte:window onkeydown={handleKeydown} />
 
-<div
-  bind:this={popupEl}
-  class="popup"
-  role="dialog"
-  aria-modal="false"
-  aria-label="Word details"
-  data-testid="word-popup"
-  {style}
->
-  <button class="close" type="button" aria-label="Close" onclick={onClose}>×</button>
-
-  <header>
-    <p class="surface">{token.surface}</p>
-    {#if token.romanization}
-      <p class="romanization">{token.romanization}</p>
-    {/if}
-    {#if payload}
-      <p class="lemma-line">
-        <strong>{payload.lemma.headword}</strong>
-        <span class="pos">{payload.lemma.pos}</span>
-      </p>
-    {:else if token.isOov}
-      <p class="lemma-line muted">No dictionary match</p>
-    {:else if loadError}
-      <p class="lemma-line err">{loadError}</p>
-    {:else if token.lemmaId}
-      <p class="lemma-line muted">Loading…</p>
-    {/if}
-  </header>
-
-  {#if payload}
-    {@const features = summarizeFeatures(null)}
-    {#if features}
-      <p class="features">{features}</p>
-    {/if}
-
-    <ul class="translations">
-      {#each payload.translations.personal as t (t.id)}
-        <li>
-          <span class="badge tone-personal">yours</span>
-          {t.body}
-        </li>
-      {/each}
-      {#each payload.translations.official as t (t.id)}
-        <li>
-          <span class="badge tone-{t.provenance.kind}">
-            {t.provenance.attribution ?? t.provenance.kind}
-          </span>
-          {t.body}
-        </li>
-      {/each}
-      {#each payload.translations.community as t (t.id)}
-        <li>
-          <span class="badge tone-community">community</span>
-          {t.body}
-        </li>
-      {/each}
-      {#if allTranslations().length === 0}
-        <li class="muted">No translations yet.</li>
+<Sheet open={true} onClose={onClose} title="">
+  <div data-testid="word-popup">
+    <header class="sp-head">
+      <h2 class="sp-word">{token.surface}</h2>
+      {#if token.romanization}
+        <p class="sp-roman">{token.romanization}</p>
       {/if}
-    </ul>
+      {#if payload}
+        <p class="sp-row">
+          <span class="k">Lemma</span>
+          <span class="v">{payload.lemma.headword}</span>
+        </p>
+        <p class="sp-row">
+          <span class="k">Part of speech</span>
+          <span class="v">{payload.lemma.pos}</span>
+        </p>
+      {:else if token.isOov}
+        <p class="muted">No dictionary match</p>
+      {:else if loadError}
+        <p class="err">{loadError}</p>
+      {:else if token.lemmaId}
+        <p class="muted">Loading…</p>
+      {/if}
+    </header>
 
-    {#if isOwner}
-      {#if showAddForm}
-        <form
-          class="add-form"
-          onsubmit={(e) => {
-            e.preventDefault();
-            void submitNewTranslation();
-          }}
-        >
-          <textarea
-            bind:value={newTranslationBody}
-            placeholder="Your translation in English"
-            rows="2"
-            maxlength="500"
-            disabled={savingTranslation}
-          ></textarea>
-          {#if addError}
-            <p class="err small">{addError}</p>
-          {/if}
-          <div class="add-row">
-            <button type="submit" disabled={savingTranslation}>
-              {savingTranslation ? 'Saving…' : 'Save'}
-            </button>
-            <button
-              type="button"
-              class="ghost"
-              disabled={savingTranslation}
-              onclick={() => {
-                showAddForm = false;
-                newTranslationBody = '';
-                addError = null;
-              }}
-            >
-              Cancel
-            </button>
-          </div>
-        </form>
-      {:else}
+    {#if isOwner && token.lemmaId}
+      <div class="sp-status" role="group" aria-label="Mark status">
         <button
           type="button"
-          class="add-toggle"
-          onclick={() => {
-            showAddForm = true;
-          }}
+          data-active={optimisticStatus === 'learning' ? '1' : '0'}
+          onclick={() => markStatus('learning')}
         >
-          + Add my translation
+          Learning
         </button>
+        <button
+          type="button"
+          data-active={optimisticStatus === 'known' ? '1' : '0'}
+          onclick={() => markStatus('known')}
+        >
+          Known
+        </button>
+        <button
+          type="button"
+          data-active={optimisticStatus === 'ignored' ? '1' : '0'}
+          onclick={() => markStatus('ignored')}
+        >
+          Ignored
+        </button>
+      </div>
+      {#if writeError}
+        <p class="err small">Could not save: {writeError}</p>
       {/if}
     {/if}
-  {/if}
 
-  {#if isOwner && token.lemmaId}
-    <div class="status-row" role="group" aria-label="Mark status">
-      <button
-        type="button"
-        class:active={optimisticStatus === 'learning'}
-        onclick={() => markStatus('learning')}
-      >
-        Learning
-      </button>
-      <button
-        type="button"
-        class:active={optimisticStatus === 'known'}
-        onclick={() => markStatus('known')}
-      >
-        Known
-      </button>
-      <button
-        type="button"
-        class:active={optimisticStatus === 'ignored'}
-        onclick={() => markStatus('ignored')}
-      >
-        Ignored
-      </button>
-    </div>
-    {#if writeError}
-      <p class="err small">Could not save: {writeError}</p>
-    {/if}
-  {/if}
+    {#if payload}
+      <h3 class="sp-section-h">
+        Translations
+        <span class="muted">{allTranslations().length}</span>
+      </h3>
 
-  {#if token.isAmbiguous}
-    <button
-      type="button"
-      class="alt-toggle"
-      onclick={() => (showAlternates = !showAlternates)}
-      aria-expanded={showAlternates}
-    >
-      {showAlternates ? 'Hide' : 'Show'} alternate meanings
-    </button>
-    {#if showAlternates}
-      <p class="muted small">
-        Alternate-candidate selection lands in T-6.1. The reader knows
-        this token has more than one plausible parse.
-      </p>
+      <ul class="translations">
+        {#each payload.translations.personal as t (t.id)}
+          <li>
+            <span class="badge tone-personal">yours</span>
+            {t.body}
+          </li>
+        {/each}
+        {#each payload.translations.official as t (t.id)}
+          <li>
+            <span class="badge tone-{t.provenance.kind}">
+              {t.provenance.attribution ?? t.provenance.kind}
+            </span>
+            {t.body}
+          </li>
+        {/each}
+        {#each payload.translations.community as t (t.id)}
+          <li>
+            <span class="badge tone-community">community</span>
+            {t.body}
+          </li>
+        {/each}
+        {#if allTranslations().length === 0}
+          <li class="muted">No translations yet.</li>
+        {/if}
+      </ul>
+
+      {#if isOwner}
+        {#if showAddForm}
+          <form
+            class="add-form"
+            onsubmit={(e) => {
+              e.preventDefault();
+              void submitNewTranslation();
+            }}
+          >
+            <textarea
+              bind:value={newTranslationBody}
+              placeholder="Your translation in English"
+              rows="2"
+              maxlength="500"
+              disabled={savingTranslation}
+            ></textarea>
+            {#if addError}
+              <p class="err small">{addError}</p>
+            {/if}
+            <div class="add-row">
+              <button type="submit" disabled={savingTranslation}>
+                {savingTranslation ? 'Saving…' : 'Save'}
+              </button>
+              <button
+                type="button"
+                class="ghost"
+                disabled={savingTranslation}
+                onclick={() => {
+                  showAddForm = false;
+                  newTranslationBody = '';
+                  addError = null;
+                }}
+              >
+                Cancel
+              </button>
+            </div>
+          </form>
+        {:else}
+          <button
+            type="button"
+            class="add-toggle"
+            onclick={() => {
+              showAddForm = true;
+            }}
+          >
+            + Add my translation
+          </button>
+        {/if}
+      {/if}
     {/if}
-  {/if}
-</div>
+
+    {#if token.isAmbiguous}
+      <button
+        type="button"
+        class="alt-toggle"
+        onclick={() => (showAlternates = !showAlternates)}
+        aria-expanded={showAlternates}
+      >
+        {showAlternates ? 'Hide' : 'Show'} alternate meanings
+      </button>
+      {#if showAlternates}
+        <p class="muted small">
+          Alternate-candidate selection lands in T-6.1. The reader knows
+          this token has more than one plausible parse.
+        </p>
+      {/if}
+    {/if}
+  </div>
+</Sheet>
 
 <style>
-  .popup {
-    z-index: 50;
-    background: var(--color-bg);
-    color: var(--color-fg);
-    border: 1px solid var(--color-border);
-    border-radius: 10px;
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
-    padding: 0.85rem 1rem 0.75rem;
-    font-size: 0.92rem;
-    line-height: 1.4;
-    min-width: 18rem;
-    max-width: 22rem;
-    width: 22rem;
-    max-height: 70vh;
-    overflow: auto;
+  .sp-head {
+    margin-bottom: 0.85rem;
   }
-  .close {
-    float: right;
-    background: transparent;
-    border: 0;
-    font-size: 1.2rem;
-    color: var(--color-fg-muted);
-    cursor: pointer;
-    line-height: 1;
-    padding: 0 0.25rem;
+  .sp-word {
+    margin: 0 0 0.25rem;
+    font-family: var(--font-serif-dev, var(--font-serif));
+    font-size: 1.85rem;
+    line-height: 1.1;
+    color: var(--ink, var(--color-fg));
   }
-  header {
-    margin-bottom: 0.5rem;
+  .sp-roman {
+    margin: 0 0 0.85rem;
+    font-family: var(--font-mono-display, var(--font-mono));
+    font-size: 0.78rem;
+    color: var(--ink-3, var(--color-fg-muted));
   }
-  .surface {
+  .sp-row {
+    display: flex;
+    align-items: baseline;
+    gap: 0.6rem;
+    padding: 0.5rem 0;
     margin: 0;
-    font-size: 1.2rem;
-    font-weight: 600;
+    border-top: 1px solid var(--rule-2, var(--color-border));
   }
-  .romanization {
-    margin: 0;
-    color: var(--color-fg-muted);
-    font-size: 0.85rem;
-  }
-  .lemma-line {
-    margin: 0.4rem 0 0;
-    font-size: 0.95rem;
-  }
-  .pos {
-    color: var(--color-fg-muted);
-    font-size: 0.8rem;
+  .sp-row .k {
+    width: 92px;
+    flex-shrink: 0;
+    font-size: 0.66rem;
+    letter-spacing: 0.08em;
     text-transform: uppercase;
-    letter-spacing: 0.04em;
-    margin-left: 0.4rem;
+    color: var(--ink-3, var(--color-fg-muted));
   }
-  .features {
-    margin: 0.25rem 0 0.5rem;
-    color: var(--color-fg-muted);
+  .sp-row .v {
+    flex: 1;
+    color: var(--ink, var(--color-fg));
     font-size: 0.85rem;
   }
+
+  .sp-status {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 4px;
+    margin: 0.6rem 0 0.85rem;
+    background: color-mix(
+      in oklch,
+      var(--ink, var(--color-fg)) 5%,
+      transparent
+    );
+    padding: 3px;
+    border-radius: 9px;
+  }
+  .sp-status button {
+    height: 30px;
+    border: 0;
+    background: transparent;
+    border-radius: 7px;
+    font: inherit;
+    font-size: 0.78rem;
+    font-weight: 500;
+    color: var(--ink-2, var(--color-fg-muted));
+    display: grid;
+    place-items: center;
+    cursor: pointer;
+  }
+  .sp-status button:hover {
+    background: color-mix(
+      in oklch,
+      var(--ink, var(--color-fg)) 5%,
+      transparent
+    );
+  }
+  .sp-status button[data-active='1'] {
+    background: var(--card, var(--color-bg));
+    color: var(--ink, var(--color-fg));
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+  }
+
+  .sp-section-h {
+    font-size: 0.66rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--ink-3, var(--color-fg-muted));
+    margin: 1rem 0 0.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-weight: 500;
+  }
+
   .translations {
     list-style: none;
-    margin: 0.5rem 0;
+    margin: 0;
     padding: 0;
     display: grid;
-    gap: 0.4rem;
+    gap: 0.5rem;
   }
   .translations li {
-    font-size: 0.9rem;
+    font-size: 0.88rem;
+    line-height: 1.4;
+    color: var(--ink, var(--color-fg));
   }
   .badge {
     display: inline-block;
-    padding: 0.05rem 0.45rem;
+    padding: 0.1rem 0.5rem;
     margin-right: 0.4rem;
-    font-size: 0.7rem;
+    font-size: 0.66rem;
     border-radius: 999px;
-    border: 1px solid var(--color-border);
-    color: var(--color-fg-muted);
-    background: var(--color-bg);
+    border: 1px solid var(--rule, var(--color-border));
+    color: var(--ink-3, var(--color-fg-muted));
+    background: var(--card, var(--color-bg));
   }
   .tone-personal {
-    border-color: color-mix(in srgb, var(--color-accent) 60%, transparent);
-    color: var(--color-accent);
+    border-color: color-mix(
+      in oklch,
+      var(--accent, var(--color-accent)) 60%,
+      transparent
+    );
+    color: var(--accent-ink, var(--color-accent));
   }
   .tone-curator {
-    border-color: color-mix(in srgb, #197a2f 60%, transparent);
-    color: #197a2f;
+    border-color: color-mix(
+      in oklch,
+      var(--green, #197a2f) 60%,
+      transparent
+    );
+    color: var(--green, #197a2f);
   }
   .tone-imported {
-    border-color: var(--color-border);
+    border-color: var(--rule, var(--color-border));
   }
   .tone-community {
-    border-color: color-mix(in srgb, #b07a31 60%, transparent);
-    color: #b07a31;
+    border-color: color-mix(
+      in oklch,
+      var(--accent, var(--color-accent)) 40%,
+      transparent
+    );
+    color: var(--ink-3, var(--color-fg-muted));
   }
+
   .muted {
-    color: var(--color-fg-muted);
+    color: var(--ink-3, var(--color-fg-muted));
   }
   .small {
-    font-size: 0.8rem;
+    font-size: 0.75rem;
   }
   .err {
-    color: #b03131;
+    color: var(--rose, #b03131);
   }
-  .status-row {
-    display: flex;
-    gap: 0.4rem;
-    margin: 0.6rem 0 0.4rem;
-  }
-  .status-row button {
-    flex: 1;
-    padding: 0.4rem 0.5rem;
-    font: inherit;
-    font-size: 0.8rem;
-    background: transparent;
-    border: 1px solid var(--color-border);
-    border-radius: 999px;
-    color: var(--color-fg);
-    cursor: pointer;
-    min-height: 36px;
-  }
-  .status-row button.active {
-    background: var(--color-accent);
-    color: var(--color-accent-fg, #fff);
-    border-color: var(--color-accent);
-  }
-  .alt-toggle {
-    margin-top: 0.6rem;
-    background: transparent;
-    border: 1px solid var(--color-border);
-    border-radius: 999px;
-    padding: 0.35rem 0.7rem;
-    font: inherit;
-    font-size: 0.8rem;
-    color: var(--color-fg-muted);
-    cursor: pointer;
-  }
+
   .add-toggle {
-    margin-top: 0.5rem;
-    background: transparent;
-    border: 1px dashed var(--color-border);
-    border-radius: 6px;
-    padding: 0.4rem 0.7rem;
-    font: inherit;
-    font-size: 0.8rem;
-    color: var(--color-accent);
-    cursor: pointer;
+    margin-top: 0.6rem;
     width: 100%;
-    text-align: left;
+    padding: 0.5rem 0.7rem;
+    background: transparent;
+    border: 1px dashed var(--rule, var(--color-border));
+    border-radius: 8px;
+    color: var(--ink-3, var(--color-fg-muted));
+    font: inherit;
+    font-size: 0.78rem;
+    cursor: pointer;
+    text-align: center;
   }
   .add-toggle:hover {
-    border-color: var(--color-accent);
-    background: color-mix(in srgb, var(--color-accent) 6%, transparent);
+    border-color: var(--accent, var(--color-accent));
+    color: var(--accent-ink, var(--color-accent));
+    border-style: solid;
   }
   .add-form {
-    margin-top: 0.5rem;
+    margin-top: 0.6rem;
     display: flex;
     flex-direction: column;
     gap: 0.4rem;
   }
   .add-form textarea {
     width: 100%;
-    padding: 0.5rem 0.6rem;
+    padding: 0.55rem 0.7rem;
     font: inherit;
-    font-size: 0.9rem;
-    border: 1px solid var(--color-border);
-    border-radius: 6px;
-    background: var(--color-bg);
-    color: var(--color-fg);
+    font-size: 0.85rem;
+    border: 1px solid var(--rule, var(--color-border));
+    border-radius: 8px;
+    background: var(--card, var(--color-bg));
+    color: var(--ink, var(--color-fg));
     resize: vertical;
   }
   .add-row {
@@ -620,23 +569,35 @@
   }
   .add-row button {
     flex: 1;
-    padding: 0.4rem 0.6rem;
+    padding: 0.5rem 0.6rem;
     font: inherit;
-    font-size: 0.85rem;
-    background: var(--color-accent);
-    color: var(--color-accent-fg, #fff);
-    border: 0;
-    border-radius: 6px;
+    font-size: 0.82rem;
+    background: var(--ink, var(--color-fg));
+    color: var(--paper, var(--color-bg));
+    border: 1px solid var(--ink, var(--color-fg));
+    border-radius: 8px;
     cursor: pointer;
     min-height: 36px;
   }
   .add-row button.ghost {
     background: transparent;
-    color: var(--color-fg);
-    border: 1px solid var(--color-border);
+    color: var(--ink, var(--color-fg));
+    border: 1px solid var(--rule, var(--color-border));
   }
   .add-row button[disabled] {
     opacity: 0.5;
     cursor: not-allowed;
+  }
+
+  .alt-toggle {
+    margin-top: 0.85rem;
+    background: transparent;
+    border: 1px solid var(--rule, var(--color-border));
+    border-radius: 999px;
+    padding: 0.4rem 0.85rem;
+    font: inherit;
+    font-size: 0.78rem;
+    color: var(--ink-3, var(--color-fg-muted));
+    cursor: pointer;
   }
 </style>

--- a/apps/web/src/lib/components/reader/WordTooltip.svelte
+++ b/apps/web/src/lib/components/reader/WordTooltip.svelte
@@ -1,0 +1,122 @@
+<!--
+  Hover tooltip (T-5.10).
+
+  Lightweight read-only popover that follows the cursor on word
+  hover. Shows the surface form, romanization (when present), and
+  the lemma's gloss/definition if it's already on the token row. No
+  fetch — this surface stays cheap so hovering through a paragraph
+  doesn't trigger N network calls. Click on the same word opens the
+  full side panel (WordPopup), which does fetch.
+-->
+<script lang="ts">
+  import type { ServerToken } from './types.js';
+  import { placeTooltip, type AnchorRect } from './tooltip-position.js';
+
+  interface Props {
+    token: ServerToken;
+    anchorRect: AnchorRect;
+  }
+
+  let { token, anchorRect }: Props = $props();
+
+  let tipEl = $state<HTMLDivElement | null>(null);
+  let measured = $state<{ w: number; h: number } | null>(null);
+
+  // Placement is derived from the anchor + measured dimensions so it
+  // re-runs whenever the parent rebinds the tooltip to a new word.
+  // Defaults seed the first paint near the word; the $effect below
+  // refines once we measure for real.
+  const placement = $derived.by(() => {
+    const w = measured?.w ?? 240;
+    const h = measured?.h ?? 80;
+    return placeTooltip(anchorRect, w, h, {
+      width: typeof window !== 'undefined' ? window.innerWidth : 1024,
+      height: typeof window !== 'undefined' ? window.innerHeight : 768,
+    });
+  });
+
+  $effect(() => {
+    if (!tipEl) return;
+    measured = {
+      w: tipEl.offsetWidth || 240,
+      h: tipEl.offsetHeight || 80,
+    };
+  });
+</script>
+
+<div
+  bind:this={tipEl}
+  class="tip"
+  role="tooltip"
+  aria-hidden="false"
+  style:top="{placement.top}px"
+  style:left="{placement.left}px"
+>
+  <div class="tip-head">
+    <span class="tip-w">{token.surface}</span>
+    {#if token.romanization}
+      <span class="tip-roman">{token.romanization}</span>
+    {/if}
+  </div>
+  {#if token.isOov}
+    <div class="tip-def muted">No dictionary match</div>
+  {:else if !token.lemmaId}
+    <div class="tip-def muted">Click to look up</div>
+  {:else}
+    <div class="tip-def muted">Click to see translations</div>
+  {/if}
+</div>
+
+<style>
+  .tip {
+    position: fixed;
+    z-index: 30;
+    background: var(--ink, #1f1a14);
+    color: var(--paper, #fdfaf3);
+    border-radius: 8px;
+    padding: 0.55rem 0.75rem;
+    font-size: 0.78rem;
+    font-family: var(--font-sans, system-ui, sans-serif);
+    max-width: 280px;
+    pointer-events: none;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.22);
+    line-height: 1.4;
+    animation: fade-in 120ms ease-out;
+  }
+  .tip-head {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    margin-bottom: 0.25rem;
+    flex-wrap: wrap;
+  }
+  .tip-w {
+    font-family: var(--font-serif-dev, var(--font-serif, serif));
+    font-size: 1rem;
+    line-height: 1.1;
+  }
+  .tip-roman {
+    font-family: var(--font-mono-display, var(--font-mono, monospace));
+    font-size: 0.7rem;
+    color: color-mix(in oklch, var(--paper, #fdfaf3) 70%, transparent);
+    flex-shrink: 0;
+  }
+  .tip-def.muted {
+    color: color-mix(in oklch, var(--paper, #fdfaf3) 65%, transparent);
+  }
+  @keyframes fade-in {
+    from {
+      opacity: 0;
+      transform: translateY(2px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .tip {
+      animation: none;
+    }
+  }
+</style>

--- a/apps/web/src/lib/components/reader/tooltip-position.test.ts
+++ b/apps/web/src/lib/components/reader/tooltip-position.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { placeTooltip, type AnchorRect } from './tooltip-position.js';
+
+function rect(top: number, left: number, width = 60, height = 24): AnchorRect {
+  return { top, left, width, height, bottom: top + height, right: left + width };
+}
+
+const VP = { width: 1024, height: 768 };
+
+describe('placeTooltip', () => {
+  it('centers the tooltip above the anchor word when there is room', () => {
+    const placement = placeTooltip(rect(200, 400), 200, 80, VP);
+    expect(placement.flipped).toBe(false);
+    expect(placement.top).toBe(200 - 80 - 8); // above with 8px margin
+    // Center: anchor at 400 + 30 = 430; tooltip half-width 100 → left=330.
+    expect(placement.left).toBe(330);
+  });
+
+  it('flips below when the anchor is too close to the top', () => {
+    const placement = placeTooltip(rect(4, 400), 200, 80, VP);
+    expect(placement.flipped).toBe(true);
+    expect(placement.top).toBe(4 + 24 + 8);
+  });
+
+  it('clamps to the left margin when the centered tooltip would overflow left', () => {
+    const placement = placeTooltip(rect(200, 4), 200, 80, VP);
+    expect(placement.left).toBe(8);
+  });
+
+  it('clamps to the right margin when the centered tooltip would overflow right', () => {
+    const placement = placeTooltip(rect(200, 1000), 200, 80, VP);
+    expect(placement.left).toBe(VP.width - 8 - 200);
+  });
+
+  it('falls back to bottom-clamped placement when the tooltip cannot fit above OR below', () => {
+    // Tiny viewport, tall tooltip — only the clamp branch wins.
+    const tinyVp = { width: 320, height: 100 };
+    const placement = placeTooltip(rect(10, 100, 40, 20), 200, 200, tinyVp);
+    expect(placement.flipped).toBe(true);
+    expect(placement.top).toBe(8); // clamped to top margin since neither above nor below fits
+  });
+});

--- a/apps/web/src/lib/components/reader/tooltip-position.ts
+++ b/apps/web/src/lib/components/reader/tooltip-position.ts
@@ -1,0 +1,55 @@
+/**
+ * Hover-tooltip positioning helper (T-5.10).
+ *
+ * The reader's hover tooltip appears above the focused word, centered
+ * horizontally. If the word sits too close to the viewport edges we
+ * flip the tooltip below or clamp it to a margin so it stays
+ * fully visible. Pure function — no DOM access — so positioning is
+ * unit-tested without rendering the component.
+ */
+
+export interface AnchorRect {
+  top: number;
+  left: number;
+  bottom: number;
+  right: number;
+  width: number;
+  height: number;
+}
+
+export interface TooltipPlacement {
+  top: number;
+  left: number;
+  /** Hint for the caller to flip the arrow if it draws one. */
+  flipped: boolean;
+}
+
+const MARGIN = 8;
+
+export function placeTooltip(
+  anchor: AnchorRect,
+  tipWidth: number,
+  tipHeight: number,
+  viewport: { width: number; height: number },
+): TooltipPlacement {
+  const center = anchor.left + anchor.width / 2;
+  let left = center - tipWidth / 2;
+  if (left < MARGIN) left = MARGIN;
+  if (left + tipWidth > viewport.width - MARGIN) {
+    left = viewport.width - MARGIN - tipWidth;
+  }
+
+  // Prefer above. If above clips, fall through to below.
+  let top = anchor.top - tipHeight - MARGIN;
+  let flipped = false;
+  if (top < MARGIN) {
+    top = anchor.bottom + MARGIN;
+    flipped = true;
+    // If below also clips, clamp to bottom margin.
+    if (top + tipHeight > viewport.height - MARGIN) {
+      top = Math.max(MARGIN, viewport.height - MARGIN - tipHeight);
+    }
+  }
+
+  return { top, left, flipped };
+}

--- a/apps/web/src/routes/+page.server.ts
+++ b/apps/web/src/routes/+page.server.ts
@@ -1,5 +1,26 @@
+/**
+ * Home loader (T-5.12).
+ *
+ * Used to be a diagnostic dashboard; the redesign turns it into the
+ * language-pick landing. Loads:
+ *   - SUPPORTED_LANGUAGE_CODES + LANGUAGES descriptors (always)
+ *   - Per-user known-word counts from `user_languages.knownWordsCountCache`
+ *     when a user is signed in. The cache is refreshed by the
+ *     known-lemmas write path (T-5.5) so this read is a single
+ *     primary-key lookup per language with no GROUP BY.
+ *   - NLP health passthrough — kept in the loader so /debug or future
+ *     status surfaces can read it without a second request.
+ */
+import { eq } from 'drizzle-orm';
+
+import { db } from '$lib/server/db/index.js';
+import { userLanguages } from '$lib/server/db/schema.js';
 import { nlpClient } from '$lib/server/nlp-client.js';
-import { SUPPORTED_LANGUAGE_CODES, LANGUAGES } from '@ciareader/shared-types';
+import {
+  LANGUAGES,
+  SUPPORTED_LANGUAGE_CODES,
+  type LanguageCode,
+} from '@ciareader/shared-types';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ locals }) => {
@@ -13,6 +34,20 @@ export const load: PageServerLoad = async ({ locals }) => {
     console.error('NLP health check failed:', err);
   }
 
+  const knownByLanguage: Partial<Record<LanguageCode, number>> = {};
+  if (locals.user) {
+    const rows = await db
+      .select({
+        language: userLanguages.language,
+        knownWordsCountCache: userLanguages.knownWordsCountCache,
+      })
+      .from(userLanguages)
+      .where(eq(userLanguages.userId, locals.user.id));
+    for (const r of rows) {
+      knownByLanguage[r.language as LanguageCode] = r.knownWordsCountCache;
+    }
+  }
+
   return {
     nlpStatus,
     nlpLanguages,
@@ -21,6 +56,7 @@ export const load: PageServerLoad = async ({ locals }) => {
       displayName: LANGUAGES[code].displayName,
       nativeName: LANGUAGES[code].nativeName,
       script: LANGUAGES[code].script,
+      known: knownByLanguage[code] ?? 0,
     })),
     user: locals.user
       ? {

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -1,110 +1,168 @@
+<!--
+  Home (T-5.12).
+
+  Replaces the M0 diagnostic dashboard with the CIAR design's
+  language-pick landing: hero copy + a card grid where each card
+  shows a supported language's native + Roman name, script, and the
+  signed-in user's known-word count for that language. Clicking a
+  card jumps to the library filtered to that language.
+-->
 <script lang="ts">
   import type { PageData } from './$types';
+
   let { data }: { data: PageData } = $props();
 </script>
 
-<div class="page">
-  <h1>CIA Reader</h1>
-  <p class="sub">Comparative Indo-Aryan — a LingQ-style reader for Hindi, Marathi, and Odia.</p>
+<svelte:head>
+  <title>CIA Reader — Read in Indo-Aryan languages</title>
+</svelte:head>
 
-  <section>
-    <h2>Stack status</h2>
-    <ul class="status">
-      <li>
-        Web <span class="ok">up</span>
-      </li>
-      <li>
-        NLP service
-        {#if data.nlpStatus === 'ok'}
-          <span class="ok">up</span>
-        {:else}
-          <span class="down">down</span>
+<section class="content">
+  <h1 class="home-hero">
+    Read in your <em>own time.</em>
+  </h1>
+  <p class="home-sub">
+    Pick a language to begin. Your progress, known-words list, and per-language
+    settings are kept separately for each script.
+  </p>
+
+  <div class="lang-grid">
+    {#each data.languages as L (L.code)}
+      <a
+        class="lang-card card"
+        href={`/library?language=${L.code}`}
+        aria-label={`Open the ${L.displayName} library`}
+      >
+        <div class="lc-native">{L.nativeName}</div>
+        <div class="lc-en">{L.displayName}</div>
+        <div class="lc-meta">{L.script}</div>
+        {#if data.user}
+          <div class="lc-stats">
+            <div class="lc-stat">
+              <div class="n">{L.known.toLocaleString()}</div>
+              <div class="l">Known</div>
+            </div>
+          </div>
         {/if}
-      </li>
-    </ul>
-  </section>
+      </a>
+    {/each}
+  </div>
 
-  <section>
-    <h2>Supported languages</h2>
-    <ul class="langs">
-      {#each data.languages as lang}
-        <li>
-          <span class="native">{lang.nativeName}</span>
-          <span class="muted">({lang.displayName} — {lang.script})</span>
-        </li>
-      {/each}
-    </ul>
-  </section>
-
-  <section>
-    <h2>You</h2>
-    {#if data.user}
-      <p>
-        Signed in as <strong>{data.user.displayName ?? data.user.email}</strong>
-        <span class="muted">({data.user.role})</span>
-        — <a href="/profile">Profile</a>
-      </p>
-    {:else}
-      <p class="muted">Not signed in. Use <code>/api/v1/auth/register</code> or <code>/api/v1/auth/login</code>.</p>
-    {/if}
-  </section>
-
-  <section>
-    <h2>Smoke test</h2>
-    <p>
-      <a href="/api/v1/smoke">GET /api/v1/smoke</a> — end-to-end web → NLP round-trip.
+  {#if !data.user}
+    <p class="home-cta">
+      <a href="/login">Sign in</a> to track known words across each language.
     </p>
-  </section>
-</div>
+  {/if}
+</section>
 
 <style>
-  .page {
-    max-width: 48rem;
+  .content {
+    max-width: 64rem;
+    padding: 2rem 1.25rem 3rem;
     margin: 0 auto;
-    padding: 2rem 1.25rem;
   }
-  h1 {
-    margin: 0 0 0.25rem;
+  @media (min-width: 768px) {
+    .content {
+      padding: 3rem 2rem 4rem;
+    }
+  }
+  .home-hero {
+    font-family: var(--font-serif, var(--font-ui));
     font-size: 2rem;
+    line-height: 1.1;
+    letter-spacing: -0.02em;
+    color: var(--ink, var(--color-fg));
+    font-weight: 400;
+    margin: 0 0 0.5rem;
   }
-  h2 {
-    font-size: 1.1rem;
-    margin: 1.75rem 0 0.5rem;
-    color: var(--color-fg-muted);
-    font-weight: 600;
-    text-transform: uppercase;
+  @media (min-width: 768px) {
+    .home-hero {
+      font-size: 2.5rem;
+    }
+  }
+  .home-hero em {
+    font-style: italic;
+    color: var(--accent-ink, var(--color-accent));
+  }
+  .home-sub {
+    font-size: 0.95rem;
+    color: var(--ink-3, var(--color-fg-muted));
+    max-width: 36rem;
+    margin: 0 0 1.75rem;
+    line-height: 1.5;
+  }
+  .lang-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 0.85rem;
+  }
+  .card {
+    background: var(--card, var(--color-bg));
+    border: 1px solid var(--card-edge, var(--color-border));
+    border-radius: 14px;
+    box-shadow: var(--shadow-1, 0 1px 2px rgba(0, 0, 0, 0.04));
+  }
+  .lang-card {
+    padding: 1.25rem 1.25rem 1.1rem;
+    cursor: pointer;
+    transition:
+      border-color 150ms ease,
+      transform 150ms ease;
+    text-decoration: none;
+    color: inherit;
+    display: block;
+  }
+  .lang-card:hover {
+    border-color: color-mix(
+      in oklch,
+      var(--accent, var(--color-accent)) 50%,
+      var(--card-edge, var(--color-border))
+    );
+    transform: translateY(-1px);
+  }
+  .lc-native {
+    font-family: var(--font-serif-dev, var(--font-serif));
+    font-size: 1.85rem;
+    line-height: 1.1;
+    color: var(--ink, var(--color-fg));
+    margin-bottom: 0.35rem;
+  }
+  .lc-en {
+    font-family: var(--font-serif, var(--font-ui));
+    font-size: 0.85rem;
+    color: var(--ink-2, var(--color-fg));
+  }
+  .lc-meta {
+    font-size: 0.66rem;
+    color: var(--ink-4, var(--color-fg-subtle));
     letter-spacing: 0.04em;
+    margin-top: 0.15rem;
+    text-transform: uppercase;
   }
-  .sub {
-    margin: 0 0 1.5rem;
-    color: var(--color-fg-muted);
+  .lc-stats {
+    margin-top: 1rem;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0.5rem;
+    font-feature-settings: 'tnum';
   }
-  ul {
-    list-style: none;
-    padding: 0;
-    margin: 0;
+  .lc-stat .n {
+    font-family: var(--font-serif, var(--font-ui));
+    font-size: 1.05rem;
+    color: var(--ink, var(--color-fg));
   }
-  .status li,
-  .langs li {
-    padding: 0.5rem 0;
-    border-bottom: 1px solid var(--color-border);
+  .lc-stat .l {
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--ink-3, var(--color-fg-muted));
   }
-  .ok {
-    color: var(--color-success);
-    font-weight: 600;
+  .home-cta {
+    margin-top: 1.75rem;
+    color: var(--ink-3, var(--color-fg-muted));
+    font-size: 0.9rem;
   }
-  .down {
-    color: var(--color-danger);
-    font-weight: 600;
-  }
-  .muted {
-    color: var(--color-fg-muted);
-  }
-  .native {
-    font-size: 1.15rem;
-    margin-right: 0.5rem;
-  }
-  a {
-    color: var(--color-accent);
+  .home-cta a {
+    color: var(--accent-ink, var(--color-accent));
   }
 </style>

--- a/apps/web/src/routes/page-server.test.ts
+++ b/apps/web/src/routes/page-server.test.ts
@@ -11,9 +11,30 @@ vi.mock('$lib/server/nlp-client.js', () => ({
   },
 }));
 
+// Mock the userLanguages query — the home loader now reads
+// `knownWordsCountCache` per language for signed-in users (T-5.12).
+const knownRows = vi.fn<
+  () => Promise<Array<{ language: string; knownWordsCountCache: number }>>
+>();
+vi.mock('$lib/server/db/index.js', () => ({
+  db: {
+    select() {
+      return {
+        from() {
+          return {
+            where: () => knownRows(),
+          };
+        },
+      };
+    },
+  },
+}));
+
 describe('root +page.server.ts load', () => {
   beforeEach(() => {
     health.mockReset();
+    knownRows.mockReset();
+    knownRows.mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -54,5 +75,32 @@ describe('root +page.server.ts load', () => {
     const data = await callLoad({});
     expect(data.nlpStatus).toBe('down');
     expect(data.nlpLanguages).toEqual([]);
+  });
+
+  it('returns 0 known per language for signed-out visitors without querying user_languages', async () => {
+    health.mockResolvedValue({ status: 'ok', languages: [] });
+    const data = await callLoad({});
+    expect(knownRows).not.toHaveBeenCalled();
+    for (const l of data.languages) {
+      expect(l.known).toBe(0);
+    }
+  });
+
+  it('merges per-user knownWordsCountCache values onto the language list', async () => {
+    health.mockResolvedValue({ status: 'ok', languages: [] });
+    knownRows.mockResolvedValue([
+      { language: 'hi', knownWordsCountCache: 1247 },
+      { language: 'mr', knownWordsCountCache: 421 },
+    ]);
+    const data = await callLoad({
+      user: { id: 'u1', email: 'a@b.c', displayName: 'Alex', role: 'user' },
+    });
+    const hi = data.languages.find((l: { code: string }) => l.code === 'hi');
+    const mr = data.languages.find((l: { code: string }) => l.code === 'mr');
+    const or = data.languages.find((l: { code: string }) => l.code === 'or');
+    expect(hi?.known).toBe(1247);
+    expect(mr?.known).toBe(421);
+    // Languages without a row default to 0.
+    expect(or?.known).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

Splits the existing word popup into two surfaces, matching the CIAR design's reader interaction model.

### 1. Hover tooltip (`WordTooltip.svelte`)
Lightweight, follows the cursor on word hover. Reads only what's already on the token row (surface, romanization, OOV-vs-lemma'd state). **No fetch** — hovering through a paragraph never triggers N network calls. Position computed by the new pure `placeTooltip()` helper that clamps to viewport edges and flips above→below when the anchor is too close to the top.

### 2. Side panel (`WordPopup.svelte` — content unchanged, render layer rebuilt)
Opens on click. Now renders inside `<Sheet>` (T-5.15) so it slides up from the bottom on <960px and in from the right on ≥960px. Sheet handles focus trap, Esc, scroll lock — the bespoke fixed-positioning math is gone.

Content is preserved: status row, lemma row, translations bucket order (personal → official → community), "+ Add my translation" form, alternate-meanings disclosure. The `anchorRect` prop stays on the signature for backward compat but is now unused.

### ChapterBody wiring
- `mouseover` / `mouseout` for the tooltip
- `focusin` / `focusout` for keyboard navigation (the bubbling siblings of `focus` / `blur`)
- `click` for the side panel
- Tooltip auto-hides when the side panel locks on the same word so they don't double up

### Tests
- `tooltip-position.test.ts` — 5 cases: center-above, flip-below near top, clamp-left + clamp-right, tiny-viewport fallback (neither above nor below fits → top-margin clamp).
- All 592 vitest pass · svelte-check 0/0.

### Stack
Branched off `feat/t-5.15-modal-sheet` to consume the new Sheet primitive. The k/l/i status keyboard shortcuts (T-5.7) keep working.

Closes #160
Refs #42, #158, #165