### PR TITLE
T-5.12: home screen redesign

### DIFF
--- a/apps/web/src/routes/+page.server.ts
+++ b/apps/web/src/routes/+page.server.ts
@@ -1,5 +1,26 @@
+/**
+ * Home loader (T-5.12).
+ *
+ * Used to be a diagnostic dashboard; the redesign turns it into the
+ * language-pick landing. Loads:
+ *   - SUPPORTED_LANGUAGE_CODES + LANGUAGES descriptors (always)
+ *   - Per-user known-word counts from `user_languages.knownWordsCountCache`
+ *     when a user is signed in. The cache is refreshed by the
+ *     known-lemmas write path (T-5.5) so this read is a single
+ *     primary-key lookup per language with no GROUP BY.
+ *   - NLP health passthrough — kept in the loader so /debug or future
+ *     status surfaces can read it without a second request.
+ */
+import { eq } from 'drizzle-orm';
+
+import { db } from '$lib/server/db/index.js';
+import { userLanguages } from '$lib/server/db/schema.js';
 import { nlpClient } from '$lib/server/nlp-client.js';
-import { SUPPORTED_LANGUAGE_CODES, LANGUAGES } from '@ciareader/shared-types';
+import {
+  LANGUAGES,
+  SUPPORTED_LANGUAGE_CODES,
+  type LanguageCode,
+} from '@ciareader/shared-types';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ locals }) => {
@@ -13,6 +34,20 @@ export const load: PageServerLoad = async ({ locals }) => {
     console.error('NLP health check failed:', err);
   }
 
+  const knownByLanguage: Partial<Record<LanguageCode, number>> = {};
+  if (locals.user) {
+    const rows = await db
+      .select({
+        language: userLanguages.language,
+        knownWordsCountCache: userLanguages.knownWordsCountCache,
+      })
+      .from(userLanguages)
+      .where(eq(userLanguages.userId, locals.user.id));
+    for (const r of rows) {
+      knownByLanguage[r.language as LanguageCode] = r.knownWordsCountCache;
+    }
+  }
+
   return {
     nlpStatus,
     nlpLanguages,
@@ -21,6 +56,7 @@ export const load: PageServerLoad = async ({ locals }) => {
       displayName: LANGUAGES[code].displayName,
       nativeName: LANGUAGES[code].nativeName,
       script: LANGUAGES[code].script,
+      known: knownByLanguage[code] ?? 0,
     })),
     user: locals.user
       ? {

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -1,110 +1,168 @@
+<!--
+  Home (T-5.12).
+
+  Replaces the M0 diagnostic dashboard with the CIAR design's
+  language-pick landing: hero copy + a card grid where each card
+  shows a supported language's native + Roman name, script, and the
+  signed-in user's known-word count for that language. Clicking a
+  card jumps to the library filtered to that language.
+-->
 <script lang="ts">
   import type { PageData } from './$types';
+
   let { data }: { data: PageData } = $props();
 </script>
 
-<div class="page">
-  <h1>CIA Reader</h1>
-  <p class="sub">Comparative Indo-Aryan — a LingQ-style reader for Hindi, Marathi, and Odia.</p>
+<svelte:head>
+  <title>CIA Reader — Read in Indo-Aryan languages</title>
+</svelte:head>
 
-  <section>
-    <h2>Stack status</h2>
-    <ul class="status">
-      <li>
-        Web <span class="ok">up</span>
-      </li>
-      <li>
-        NLP service
-        {#if data.nlpStatus === 'ok'}
-          <span class="ok">up</span>
-        {:else}
-          <span class="down">down</span>
+<section class="content">
+  <h1 class="home-hero">
+    Read in your <em>own time.</em>
+  </h1>
+  <p class="home-sub">
+    Pick a language to begin. Your progress, known-words list, and per-language
+    settings are kept separately for each script.
+  </p>
+
+  <div class="lang-grid">
+    {#each data.languages as L (L.code)}
+      <a
+        class="lang-card card"
+        href={`/library?language=${L.code}`}
+        aria-label={`Open the ${L.displayName} library`}
+      >
+        <div class="lc-native">{L.nativeName}</div>
+        <div class="lc-en">{L.displayName}</div>
+        <div class="lc-meta">{L.script}</div>
+        {#if data.user}
+          <div class="lc-stats">
+            <div class="lc-stat">
+              <div class="n">{L.known.toLocaleString()}</div>
+              <div class="l">Known</div>
+            </div>
+          </div>
         {/if}
-      </li>
-    </ul>
-  </section>
+      </a>
+    {/each}
+  </div>
 
-  <section>
-    <h2>Supported languages</h2>
-    <ul class="langs">
-      {#each data.languages as lang}
-        <li>
-          <span class="native">{lang.nativeName}</span>
-          <span class="muted">({lang.displayName} — {lang.script})</span>
-        </li>
-      {/each}
-    </ul>
-  </section>
-
-  <section>
-    <h2>You</h2>
-    {#if data.user}
-      <p>
-        Signed in as <strong>{data.user.displayName ?? data.user.email}</strong>
-        <span class="muted">({data.user.role})</span>
-        — <a href="/profile">Profile</a>
-      </p>
-    {:else}
-      <p class="muted">Not signed in. Use <code>/api/v1/auth/register</code> or <code>/api/v1/auth/login</code>.</p>
-    {/if}
-  </section>
-
-  <section>
-    <h2>Smoke test</h2>
-    <p>
-      <a href="/api/v1/smoke">GET /api/v1/smoke</a> — end-to-end web → NLP round-trip.
+  {#if !data.user}
+    <p class="home-cta">
+      <a href="/login">Sign in</a> to track known words across each language.
     </p>
-  </section>
-</div>
+  {/if}
+</section>
 
 <style>
-  .page {
-    max-width: 48rem;
+  .content {
+    max-width: 64rem;
+    padding: 2rem 1.25rem 3rem;
     margin: 0 auto;
-    padding: 2rem 1.25rem;
   }
-  h1 {
-    margin: 0 0 0.25rem;
+  @media (min-width: 768px) {
+    .content {
+      padding: 3rem 2rem 4rem;
+    }
+  }
+  .home-hero {
+    font-family: var(--font-serif, var(--font-ui));
     font-size: 2rem;
+    line-height: 1.1;
+    letter-spacing: -0.02em;
+    color: var(--ink, var(--color-fg));
+    font-weight: 400;
+    margin: 0 0 0.5rem;
   }
-  h2 {
-    font-size: 1.1rem;
-    margin: 1.75rem 0 0.5rem;
-    color: var(--color-fg-muted);
-    font-weight: 600;
-    text-transform: uppercase;
+  @media (min-width: 768px) {
+    .home-hero {
+      font-size: 2.5rem;
+    }
+  }
+  .home-hero em {
+    font-style: italic;
+    color: var(--accent-ink, var(--color-accent));
+  }
+  .home-sub {
+    font-size: 0.95rem;
+    color: var(--ink-3, var(--color-fg-muted));
+    max-width: 36rem;
+    margin: 0 0 1.75rem;
+    line-height: 1.5;
+  }
+  .lang-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 0.85rem;
+  }
+  .card {
+    background: var(--card, var(--color-bg));
+    border: 1px solid var(--card-edge, var(--color-border));
+    border-radius: 14px;
+    box-shadow: var(--shadow-1, 0 1px 2px rgba(0, 0, 0, 0.04));
+  }
+  .lang-card {
+    padding: 1.25rem 1.25rem 1.1rem;
+    cursor: pointer;
+    transition:
+      border-color 150ms ease,
+      transform 150ms ease;
+    text-decoration: none;
+    color: inherit;
+    display: block;
+  }
+  .lang-card:hover {
+    border-color: color-mix(
+      in oklch,
+      var(--accent, var(--color-accent)) 50%,
+      var(--card-edge, var(--color-border))
+    );
+    transform: translateY(-1px);
+  }
+  .lc-native {
+    font-family: var(--font-serif-dev, var(--font-serif));
+    font-size: 1.85rem;
+    line-height: 1.1;
+    color: var(--ink, var(--color-fg));
+    margin-bottom: 0.35rem;
+  }
+  .lc-en {
+    font-family: var(--font-serif, var(--font-ui));
+    font-size: 0.85rem;
+    color: var(--ink-2, var(--color-fg));
+  }
+  .lc-meta {
+    font-size: 0.66rem;
+    color: var(--ink-4, var(--color-fg-subtle));
     letter-spacing: 0.04em;
+    margin-top: 0.15rem;
+    text-transform: uppercase;
   }
-  .sub {
-    margin: 0 0 1.5rem;
-    color: var(--color-fg-muted);
+  .lc-stats {
+    margin-top: 1rem;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0.5rem;
+    font-feature-settings: 'tnum';
   }
-  ul {
-    list-style: none;
-    padding: 0;
-    margin: 0;
+  .lc-stat .n {
+    font-family: var(--font-serif, var(--font-ui));
+    font-size: 1.05rem;
+    color: var(--ink, var(--color-fg));
   }
-  .status li,
-  .langs li {
-    padding: 0.5rem 0;
-    border-bottom: 1px solid var(--color-border);
+  .lc-stat .l {
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--ink-3, var(--color-fg-muted));
   }
-  .ok {
-    color: var(--color-success);
-    font-weight: 600;
+  .home-cta {
+    margin-top: 1.75rem;
+    color: var(--ink-3, var(--color-fg-muted));
+    font-size: 0.9rem;
   }
-  .down {
-    color: var(--color-danger);
-    font-weight: 600;
-  }
-  .muted {
-    color: var(--color-fg-muted);
-  }
-  .native {
-    font-size: 1.15rem;
-    margin-right: 0.5rem;
-  }
-  a {
-    color: var(--color-accent);
+  .home-cta a {
+    color: var(--accent-ink, var(--color-accent));
   }
 </style>

--- a/apps/web/src/routes/page-server.test.ts
+++ b/apps/web/src/routes/page-server.test.ts
@@ -11,9 +11,30 @@ vi.mock('$lib/server/nlp-client.js', () => ({
   },
 }));
 
+// Mock the userLanguages query — the home loader now reads
+// `knownWordsCountCache` per language for signed-in users (T-5.12).
+const knownRows = vi.fn<
+  () => Promise<Array<{ language: string; knownWordsCountCache: number }>>
+>();
+vi.mock('$lib/server/db/index.js', () => ({
+  db: {
+    select() {
+      return {
+        from() {
+          return {
+            where: () => knownRows(),
+          };
+        },
+      };
+    },
+  },
+}));
+
 describe('root +page.server.ts load', () => {
   beforeEach(() => {
     health.mockReset();
+    knownRows.mockReset();
+    knownRows.mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -54,5 +75,32 @@ describe('root +page.server.ts load', () => {
     const data = await callLoad({});
     expect(data.nlpStatus).toBe('down');
     expect(data.nlpLanguages).toEqual([]);
+  });
+
+  it('returns 0 known per language for signed-out visitors without querying user_languages', async () => {
+    health.mockResolvedValue({ status: 'ok', languages: [] });
+    const data = await callLoad({});
+    expect(knownRows).not.toHaveBeenCalled();
+    for (const l of data.languages) {
+      expect(l.known).toBe(0);
+    }
+  });
+
+  it('merges per-user knownWordsCountCache values onto the language list', async () => {
+    health.mockResolvedValue({ status: 'ok', languages: [] });
+    knownRows.mockResolvedValue([
+      { language: 'hi', knownWordsCountCache: 1247 },
+      { language: 'mr', knownWordsCountCache: 421 },
+    ]);
+    const data = await callLoad({
+      user: { id: 'u1', email: 'a@b.c', displayName: 'Alex', role: 'user' },
+    });
+    const hi = data.languages.find((l: { code: string }) => l.code === 'hi');
+    const mr = data.languages.find((l: { code: string }) => l.code === 'mr');
+    const or = data.languages.find((l: { code: string }) => l.code === 'or');
+    expect(hi?.known).toBe(1247);
+    expect(mr?.known).toBe(421);
+    // Languages without a row default to 0.
+    expect(or?.known).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

Replaces the M0 diagnostic dashboard at `/` with the CIAR design's language-pick landing.

### Surface
- **Hero**: "Read in your *own time.*" + a short subtitle explaining the per-language separation model.
- **Language grid**: one card per supported language (Hi / Mr / Or). Cards show native name (`--font-serif-dev`), English display name, ISO 15924 script code, and — for signed-in users — the cached known-words count from `user_languages.knownWordsCountCache`. Clicking a card jumps to `/library?language=<code>`.
- **Signed-out CTA**: single "Sign in" link inviting the user to track known words.

### Loader
- Adds a single-shot `userLanguages` lookup keyed by `userId`. Reads `knownWordsCountCache` (kept fresh by T-5.5's status writes), so it's one PK lookup per user — no GROUP BY.
- Anonymous visitors skip the query entirely; defaults to 0 known.
- NLP health passthrough kept for future `/debug` surfaces; not rendered on home anymore.

### What's intentionally out
- **No "Continue where you left off" row** — the design includes it but it needs a `text_progress` join (`text_id` × `pct_read < 100` ordered by `updated_at` desc). Slated for a follow-up so this PR stays focused on the landing.
- **No "Learning" count** on cards — only the cached known count is denormalized today. Adding a learning-count cache is a `user_known_lemmas` write-path concern; T-10.1 (per-language stats page) is the natural home for that work.

### Tests
- `page-server.test.ts` now mocks the `userLanguages` query. Two new cases: signed-out doesn't query (`expect(knownRows).not.toHaveBeenCalled()`); signed-in merges per-language counts (Hi=1247, Mr=421, Or=0 — the "no row" default). Existing NLP-status tests preserved.
- All 594 vitest pass · svelte-check 0/0.

### Stack
Branched off `feat/t-5.10-tooltip-side-panel`. Once #167 → #169 → #170 → #171 → #174 merge, this rebases onto `main` cleanly.

Closes #162
Refs #42, #158