### PR TITLE
T-5.13: library redesign — card grid + cover gradients

### DIFF
--- a/apps/web/src/lib/components/library/cover.test.ts
+++ b/apps/web/src/lib/components/library/cover.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { COVERS, coverForId } from './cover.js';
+
+describe('coverForId', () => {
+  it('returns one of the seven design covers', () => {
+    expect(COVERS).toContain(coverForId('a'));
+    expect(COVERS).toContain(coverForId('a-very-long-uuid-style-text-id'));
+  });
+
+  it('is deterministic — the same id always picks the same cover', () => {
+    expect(coverForId('idgah')).toBe(coverForId('idgah'));
+    expect(coverForId('godaan')).toBe(coverForId('godaan'));
+  });
+
+  it('spreads across multiple covers (not all ids land on the same one)', () => {
+    const seen = new Set(
+      ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'].map(coverForId),
+    );
+    // 10 ids should land on at least 3 different covers — anything
+    // less suggests the hash is collapsing badly.
+    expect(seen.size).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/apps/web/src/lib/components/library/cover.ts
+++ b/apps/web/src/lib/components/library/cover.ts
@@ -1,0 +1,31 @@
+/**
+ * Library card cover-color picker (T-5.13).
+ *
+ * The CIAR design ships seven cover treatments — saffron, olive, rose,
+ * indigo, sepia, paper, plain — and each text gets a stable one based
+ * on its id so a user's library doesn't reshuffle colours across page
+ * loads. A simple FNV-1a-ish hash over the id codepoints is enough;
+ * we don't need cryptographic strength, just deterministic spread.
+ */
+
+export const COVERS = [
+  'saffron',
+  'olive',
+  'rose',
+  'indigo',
+  'sepia',
+  'paper',
+  'plain',
+] as const;
+export type Cover = (typeof COVERS)[number];
+
+export function coverForId(id: string): Cover {
+  let hash = 2166136261; // FNV-1a offset basis
+  for (let i = 0; i < id.length; i++) {
+    hash ^= id.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  // Coerce to non-negative before modulo.
+  const idx = (hash >>> 0) % COVERS.length;
+  return COVERS[idx]!;
+}

--- a/apps/web/src/routes/library/+page.svelte
+++ b/apps/web/src/routes/library/+page.svelte
@@ -1,4 +1,15 @@
+<!--
+  Library (T-4.5 → T-5.13).
+
+  The data flow is unchanged: tabs (Your / Shared / Official), language
+  filter, offset pagination. The CIAR design replaces the inline list
+  with a card grid — cover gradients picked deterministically per
+  text id (so a user's library doesn't reshuffle), kind tag (book vs
+  single — single for everything until M8 collections), status badge,
+  and a leading "Add a text" tile on the Your tab.
+-->
 <script lang="ts">
+  import { coverForId } from '$lib/components/library/cover.js';
   import type { PageData } from './$types';
 
   let { data }: { data: PageData } = $props();
@@ -25,8 +36,8 @@
   }
 
   const TABS = [
-    { id: 'your', label: 'Your texts', requiresAuth: true },
-    { id: 'shared', label: 'Shared with you', requiresAuth: true },
+    { id: 'your', label: 'Yours', requiresAuth: true },
+    { id: 'shared', label: 'Shared', requiresAuth: true },
     { id: 'official', label: 'Official', requiresAuth: false },
   ] as const;
 </script>
@@ -35,37 +46,40 @@
   <title>Library — CIA Reader</title>
 </svelte:head>
 
-<div class="page">
-  <header>
-    <h1>Library</h1>
-    <p class="sub">
-      {#if data.tab === 'your'}
-        Your imported texts.
-      {:else if data.tab === 'shared'}
-        Texts other users have shared with you.
-      {:else}
-        Curated texts for every learner.
-      {/if}
-    </p>
-  </header>
+<section class="content">
+  <header class="topbar">
+    <div>
+      <h1 class="title">Library</h1>
+      <p class="sub">
+        {#if data.tab === 'your'}
+          Your imported texts.
+        {:else if data.tab === 'shared'}
+          Texts other users have shared with you.
+        {:else}
+          Curated texts for every learner.
+        {/if}
+      </p>
+    </div>
 
-  <nav class="tabs" aria-label="Library tabs">
-    {#each TABS as t (t.id)}
-      {#if !t.requiresAuth || data.isAuthenticated}
-        <a
-          class:active={data.tab === t.id}
-          href={hrefWith({ tab: t.id, offset: null })}
-        >
-          {t.label}
-        </a>
-      {/if}
-    {/each}
-  </nav>
+    <nav class="status-tabs" aria-label="Library tabs">
+      {#each TABS as t (t.id)}
+        {#if !t.requiresAuth || data.isAuthenticated}
+          <a
+            class="status-tab"
+            data-active={data.tab === t.id ? '1' : '0'}
+            href={hrefWith({ tab: t.id, offset: null })}
+          >
+            {t.label}
+          </a>
+        {/if}
+      {/each}
+    </nav>
+  </header>
 
   <form method="get" class="filters">
     <input type="hidden" name="tab" value={data.tab} />
     <label>
-      Language
+      <span class="filter-label">Language</span>
       <select name="language">
         <option value="">All languages</option>
         {#each data.languages as lang (lang.code)}
@@ -75,36 +89,56 @@
         {/each}
       </select>
     </label>
-    <button type="submit">Filter</button>
+    <button type="submit" class="filter-go">Filter</button>
   </form>
+
+  <div class="lib-grid">
+    {#if data.tab === 'your' && data.isAuthenticated}
+      <a class="card upload-card" href="/upload">
+        <div class="upload-card-body">
+          <div class="big" aria-hidden="true">+</div>
+          <div class="label">Add a text or EPUB</div>
+          <div class="sub">.txt, .epub, .html, paste from clipboard</div>
+        </div>
+      </a>
+    {/if}
+
+    {#each data.page.cards as card (card.id)}
+      <a class="card lib-card" href={`/reader/${card.id}`}>
+        <div class={`lib-cover cover-${coverForId(card.id)}`}>
+          <div class="cover-title">{card.title}</div>
+          <div class="cover-chips">
+            <span class="chip status-{card.status}">{card.status}</span>
+            {#if card.visibility !== 'private'}
+              <span class="chip">{card.visibility}</span>
+            {/if}
+          </div>
+        </div>
+        <div class="body">
+          <div class="kind-row">
+            <span class="kind-tag">{card.sourceType}</span>
+            <span class="kind-meta">{card.language}</span>
+          </div>
+          <div class="title-dev">{card.title}</div>
+        </div>
+      </a>
+    {/each}
+  </div>
 
   {#if data.page.cards.length === 0}
     <p class="empty">
       {#if data.tab === 'your'}
-        You haven't uploaded any texts yet. <a href="/upload">Upload one →</a>
+        You haven't uploaded any texts yet — try the
+        <a href="/upload">+ Add a text</a> tile above.
       {:else if data.tab === 'shared'}
         No shared texts yet. Sharing lands in a future ticket.
       {:else}
         No official texts yet. Curators are working on it.
       {/if}
     </p>
-  {:else}
-    <ul class="cards">
-      {#each data.page.cards as card (card.id)}
-        <li>
-          <a class="card" href={`/reader/${card.id}`}>
-            <div class="card-title">{card.title}</div>
-            <div class="card-meta">
-              <span class="badge">{card.language}</span>
-              <span class="badge">{card.sourceType}</span>
-              <span class="badge status-{card.status}">{card.status}</span>
-              <span class="badge">{card.visibility}</span>
-            </div>
-          </a>
-        </li>
-      {/each}
-    </ul>
+  {/if}
 
+  {#if data.page.cards.length > 0}
     <nav class="pager" aria-label="Pagination">
       <span class="page-info">
         Page {pageNum} of {totalPages}
@@ -122,141 +156,328 @@
       </span>
     </nav>
   {/if}
-</div>
+</section>
 
 <style>
-  .page {
-    max-width: 50rem;
+  .content {
+    max-width: 72rem;
     margin: 0 auto;
-    padding: 1.5rem 1.25rem 3rem;
+    padding: 1.75rem 1.25rem 3rem;
   }
-  header h1 {
-    margin: 0 0 0.25rem;
-    font-size: 1.6rem;
+  @media (min-width: 768px) {
+    .content {
+      padding: 2.25rem 2rem 3.5rem;
+    }
   }
-  .sub {
-    color: var(--color-fg-muted);
-    margin: 0 0 1rem;
-    font-size: 0.9rem;
-  }
-  .tabs {
-    display: flex;
-    gap: 0.5rem;
-    flex-wrap: wrap;
-    border-bottom: 1px solid var(--color-border);
+  .topbar {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1rem;
+    align-items: end;
     margin-bottom: 1rem;
   }
-  .tabs a {
-    padding: 0.5rem 0.9rem;
-    color: var(--color-fg-muted);
-    text-decoration: none;
-    border-bottom: 2px solid transparent;
-    margin-bottom: -1px;
+  @media (min-width: 640px) {
+    .topbar {
+      grid-template-columns: 1fr auto;
+    }
   }
-  .tabs a.active {
-    color: var(--color-fg);
-    border-bottom-color: var(--color-accent);
+  .title {
+    font-family: var(--font-serif, var(--font-ui));
     font-weight: 600;
+    font-size: 1.4rem;
+    letter-spacing: -0.01em;
+    margin: 0;
+    color: var(--ink, var(--color-fg));
   }
+  .sub {
+    font-size: 0.78rem;
+    color: var(--ink-3, var(--color-fg-muted));
+    margin: 0.15rem 0 0;
+  }
+
+  /* Pill tabs (matches the design's status-tabs treatment used in
+     reader / words / settings). */
+  .status-tabs {
+    display: inline-flex;
+    gap: 4px;
+  }
+  .status-tab {
+    padding: 0.4rem 0.75rem;
+    border-radius: 7px;
+    font-family: var(--font-sans, var(--font-ui));
+    font-size: 0.78rem;
+    color: var(--ink-2, var(--color-fg-muted));
+    text-decoration: none;
+  }
+  .status-tab[data-active='1'] {
+    background: color-mix(
+      in oklch,
+      var(--ink, var(--color-fg)) 8%,
+      transparent
+    );
+    color: var(--ink, var(--color-fg));
+  }
+
   .filters {
     display: flex;
-    gap: 0.5rem;
     align-items: end;
+    gap: 0.5rem;
     margin-bottom: 1rem;
   }
   .filters label {
     flex: 1;
-    font-size: 0.85rem;
-    color: var(--color-fg-muted);
+    max-width: 18rem;
+  }
+  .filter-label {
+    display: block;
+    font-size: 0.62rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--ink-3, var(--color-fg-muted));
+    margin-bottom: 0.25rem;
   }
   .filters select {
     display: block;
     width: 100%;
-    margin-top: 0.25rem;
-    padding: 0.4rem 0.5rem;
+    padding: 0.45rem 0.65rem;
     font: inherit;
-    border: 1px solid var(--color-border);
-    border-radius: 6px;
-    background: var(--color-bg);
-    color: var(--color-fg);
-    min-height: 40px;
+    font-size: 0.85rem;
+    border: 1px solid var(--rule, var(--color-border));
+    border-radius: 8px;
+    background: var(--card, var(--color-bg));
+    color: var(--ink, var(--color-fg));
+    min-height: 36px;
   }
-  .filters button {
-    min-height: 40px;
-    padding: 0 1rem;
-    background: var(--color-accent);
-    color: var(--color-accent-fg, #fff);
-    border: 0;
-    border-radius: 6px;
+  .filter-go {
+    height: 36px;
+    padding: 0 0.85rem;
+    font-family: var(--font-sans, var(--font-ui));
+    font-size: 0.78rem;
+    background: var(--ink, var(--color-fg));
+    color: var(--paper, var(--color-bg));
+    border: 1px solid var(--ink, var(--color-fg));
+    border-radius: 8px;
     cursor: pointer;
   }
+
+  .lib-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 1rem;
+  }
+
+  .card {
+    background: var(--card, var(--color-bg));
+    border: 1px solid var(--card-edge, var(--color-border));
+    border-radius: 14px;
+    box-shadow: var(--shadow-1, 0 1px 2px rgba(0, 0, 0, 0.04));
+    color: inherit;
+    text-decoration: none;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    transition:
+      transform 150ms ease,
+      border-color 150ms ease,
+      box-shadow 150ms ease;
+  }
+  .card:hover {
+    transform: translateY(-2px);
+    border-color: color-mix(
+      in oklch,
+      var(--accent, var(--color-accent)) 40%,
+      var(--card-edge, var(--color-border))
+    );
+    box-shadow: var(--shadow-2, 0 8px 20px rgba(0, 0, 0, 0.08));
+  }
+
+  /* Cover gradients — one of seven, picked by hash(id). */
+  .lib-cover {
+    height: 140px;
+    position: relative;
+    overflow: hidden;
+    border-bottom: 1px solid var(--card-edge, var(--color-border));
+  }
+  .cover-title {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    text-align: center;
+    font-family: var(--font-serif-dev, var(--font-serif));
+    font-size: 1.6rem;
+    line-height: 1.05;
+    padding: 0.75rem;
+    color: var(--ink, var(--color-fg));
+  }
+  .cover-chips {
+    position: absolute;
+    top: 0.6rem;
+    right: 0.6rem;
+    display: flex;
+    gap: 0.3rem;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    height: 22px;
+    padding: 0 0.55rem;
+    border-radius: 999px;
+    font-size: 0.66rem;
+    background: color-mix(
+      in oklch,
+      var(--paper, var(--color-bg)) 80%,
+      transparent
+    );
+    color: var(--ink-2, var(--color-fg));
+    backdrop-filter: blur(4px);
+  }
+  .chip.status-ready {
+    background: var(--green-soft, color-mix(in srgb, #197a2f 20%, transparent));
+    color: var(--green, #197a2f);
+  }
+  .chip.status-failed {
+    background: var(--rose-soft, color-mix(in srgb, #b03131 20%, transparent));
+    color: var(--rose, #b03131);
+  }
+  .chip.status-processing,
+  .chip.status-pending {
+    background: var(--accent-soft, color-mix(in srgb, #b07a31 20%, transparent));
+    color: var(--accent-ink, #b07a31);
+  }
+
+  .cover-saffron {
+    background: radial-gradient(
+      140% 80% at 30% 20%,
+      oklch(0.86 0.12 75) 0%,
+      oklch(0.74 0.14 60) 100%
+    );
+  }
+  .cover-olive {
+    background: radial-gradient(
+      140% 80% at 30% 20%,
+      oklch(0.84 0.07 110) 0%,
+      oklch(0.65 0.1 130) 100%
+    );
+  }
+  .cover-rose {
+    background: radial-gradient(
+      140% 80% at 30% 20%,
+      oklch(0.86 0.07 25) 0%,
+      oklch(0.66 0.12 20) 100%
+    );
+  }
+  .cover-indigo {
+    background: radial-gradient(
+      140% 80% at 30% 20%,
+      oklch(0.78 0.06 270) 0%,
+      oklch(0.5 0.1 270) 100%
+    );
+    color: var(--paper, var(--color-bg));
+  }
+  .cover-indigo .cover-title {
+    color: var(--paper, var(--color-bg));
+  }
+  .cover-sepia {
+    background: radial-gradient(
+      140% 80% at 30% 20%,
+      oklch(0.86 0.05 80) 0%,
+      oklch(0.64 0.06 65) 100%
+    );
+  }
+  .cover-paper {
+    background: repeating-linear-gradient(
+      180deg,
+      var(--paper-2, #f7f1e2) 0 22px,
+      var(--paper, #fdfaf3) 22px 23px
+    );
+  }
+  .cover-plain {
+    background: var(--paper-2, #f7f1e2);
+  }
+
+  .body {
+    padding: 0.9rem 1rem 1rem;
+  }
+  .kind-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    margin-bottom: 0.4rem;
+  }
+  .kind-tag {
+    font-size: 0.62rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--ink-3, var(--color-fg-muted));
+    font-weight: 500;
+  }
+  .kind-meta {
+    font-size: 0.65rem;
+    color: var(--ink-3, var(--color-fg-muted));
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .title-dev {
+    font-family: var(--font-serif-dev, var(--font-serif));
+    font-size: 1.05rem;
+    line-height: 1.3;
+    color: var(--ink, var(--color-fg));
+  }
+
+  /* Upload tile — dashed-border invitation matching the design. */
+  .upload-card {
+    border-style: dashed;
+    border-width: 1.5px;
+    background: transparent;
+    min-height: 16rem;
+    display: grid;
+    place-items: center;
+    text-align: center;
+    color: var(--ink-3, var(--color-fg-muted));
+  }
+  .upload-card:hover {
+    color: var(--ink, var(--color-fg));
+    border-color: var(--accent, var(--color-accent));
+  }
+  .upload-card .big {
+    font-size: 1.85rem;
+    line-height: 1;
+    margin-bottom: 0.75rem;
+  }
+  .upload-card .label {
+    font-family: var(--font-sans, var(--font-ui));
+    font-size: 0.85rem;
+  }
+  .upload-card .sub {
+    font-size: 0.72rem;
+    color: var(--ink-4, var(--color-fg-subtle));
+    margin-top: 0.25rem;
+  }
+
   .empty {
-    color: var(--color-fg-muted);
+    color: var(--ink-3, var(--color-fg-muted));
     padding: 2rem 0;
     text-align: center;
   }
-  .cards {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-    display: grid;
-    gap: 0.75rem;
+  .empty a {
+    color: var(--accent-ink, var(--color-accent));
   }
-  .card {
-    display: block;
-    padding: 0.85rem 1rem;
-    border: 1px solid var(--color-border);
-    border-radius: 8px;
-    color: var(--color-fg);
-    text-decoration: none;
-    background: var(--color-bg);
-    transition: border-color 120ms ease;
-  }
-  .card:hover {
-    border-color: var(--color-accent);
-  }
-  .card-title {
-    font-size: 1.05rem;
-    font-weight: 600;
-    margin-bottom: 0.35rem;
-  }
-  .card-meta {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.4rem;
-  }
-  .badge {
-    font-size: 0.72rem;
-    padding: 0.05rem 0.45rem;
-    border-radius: 999px;
-    border: 1px solid var(--color-border);
-    background: var(--color-bg);
-    color: var(--color-fg-muted);
-  }
-  .status-ready {
-    border-color: color-mix(in srgb, #197a2f 60%, transparent);
-    color: #197a2f;
-  }
-  .status-failed {
-    border-color: color-mix(in srgb, #b03131 60%, transparent);
-    color: #b03131;
-  }
-  .status-processing,
-  .status-pending {
-    border-color: color-mix(in srgb, #b07a31 60%, transparent);
-    color: #b07a31;
-  }
+
   .pager {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-top: 1.5rem;
-    font-size: 0.9rem;
-    color: var(--color-fg-muted);
+    margin-top: 1.75rem;
+    font-size: 0.85rem;
+    color: var(--ink-3, var(--color-fg-muted));
   }
   .page-links a {
-    color: var(--color-accent);
+    color: var(--accent-ink, var(--color-accent));
     text-decoration: none;
-    margin-left: 0.75rem;
+    margin-left: 0.85rem;
   }
 </style>


### PR DESCRIPTION
## Summary

Restyle the library to match the CIAR design. Data flow unchanged — the tabs, language filter, and pagination still wire through the existing loader. Visual layer only.

### What changed
- **Card grid** with cover gradients (saffron / olive / rose / indigo / sepia / paper / plain). Each text gets a stable cover picked by `coverForId(id)` — an FNV-1a-ish hash so a user's library doesn't reshuffle across page loads.
- **Upload tile** (signed-in `your` tab only) leads as the first card. Routes to the existing `/upload` page; the design's modal flow is follow-up — an issue should track wrapping it in `<Modal>` (T-5.15) launched from this tile.
- **Card body** shows the source-type kind tag, language code, and the text title in `--font-serif-dev` so Devanagari / Odia titles render with the right family.
- **Status + visibility badges** sit on the cover so the card grid doesn't need a separate badge row.
- **Tabs** migrate from underline-style to the design's pill `status-tabs` treatment used elsewhere (reader, words, settings).

### Tests
- `cover.test.ts` (new) — 3 cases: returns one of the seven design covers, is deterministic, spreads across multiple covers (≥3 distinct for 10 ids).
- All 597 vitest pass · eslint + svelte-check 0/0.

### What's intentionally out
- **No upload-modal refactor** — `/upload` stays a page. Wrapping in `<Modal>` from T-5.15 + launching from the tile is a clean follow-up.
- **No coverage bar** (known/learning/unknown breakdown per text) — the design includes one but the data isn't denormalized today. Slated for a later ticket alongside T-10.2 ("Estimated-known % on cards").
- **No book/single distinction** — every text is `single` for now; book layout (with the spine + chapter-of-N meta line) lights up when M8 collections lands.

### Stack
Branched off `feat/t-5.12-home`. Once #167 → #169 → #170 → #171 → #174 → #175 merge, this rebases onto `main` cleanly.

Closes #163
Refs #42, #158