### PR TITLE
T-5.14: settings page redesign

### DIFF
--- a/apps/web/src/routes/profile/+page.svelte
+++ b/apps/web/src/routes/profile/+page.svelte
@@ -1,3 +1,11 @@
+<!--
+  Profile / settings (T-1.2 → T-5.14).
+
+  CIAR design's sectioned layout: each section has a heading + subtitle
+  on the left and the actual controls on the right. On <768px the
+  two columns stack. The form actions and validation flow are
+  unchanged from T-1.2 — this PR only restyles.
+-->
 <script lang="ts">
   import { enhance } from '$app/forms';
   import type { ActionData, PageData } from './$types';
@@ -19,212 +27,336 @@
 </script>
 
 <svelte:head>
-  <title>Profile — CIA Reader</title>
+  <title>Settings — CIA Reader</title>
 </svelte:head>
 
-<div class="page">
-  <h1>Profile</h1>
+<section class="content">
+  <header class="topbar">
+    <div>
+      <h1 class="title">Settings</h1>
+      <p class="sub">Account + per-language reading preferences.</p>
+    </div>
+  </header>
 
-  <section>
-    <h2>Account</h2>
-    <form method="POST" action="?/updateProfile" use:enhance>
-      <label>
-        <span>Email</span>
-        <input type="email" value={data.user.email} readonly aria-readonly="true" />
-      </label>
-      <label>
-        <span>Display name</span>
-        <input
-          type="text"
-          name="displayName"
-          value={data.user.displayName ?? ''}
-          maxlength="80"
-          placeholder="How should we address you?"
-        />
-      </label>
-      <fieldset>
-        <legend>Theme</legend>
-        {#each ['system', 'light', 'dark'] as theme}
-          <label class="radio">
-            <input
-              type="radio"
-              name="themePreference"
-              value={theme}
-              checked={data.user.themePreference === theme}
-            />
-            <span class="capitalize">{theme}</span>
-          </label>
-        {/each}
-      </fieldset>
-      <button type="submit">Save account</button>
-      {#if form && form.section === 'profile' && form.ok}
-        <p class="ok" role="status">Saved.</p>
-      {:else if form && form.section === 'profile' && !form.ok}
-        <p class="err" role="alert">{form.message}</p>
-      {/if}
-    </form>
-  </section>
-
-  <section>
-    <h2>Languages</h2>
-    <p class="muted">
-      Per-language reading preferences. These defaults take effect the first time you open a
-      text in that language.
-    </p>
-    {#each data.languages as lang}
-      <form method="POST" action="?/updateLanguage" use:enhance class="lang-form">
-        <header>
-          <h3>
-            <span class="native">{lang.nativeName}</span>
-            <span class="muted">({lang.displayName} — {lang.script})</span>
-          </h3>
-          {#if lang.isDefault}
-            <span class="muted small">Using defaults</span>
+  <div class="card">
+    <section class="settings-section">
+      <div class="settings-h-col">
+        <h2 class="settings-h">Account</h2>
+        <p class="settings-sub">Used across all languages.</p>
+      </div>
+      <form method="POST" action="?/updateProfile" use:enhance class="form-col">
+        <label class="field">
+          <span class="field-label">Email</span>
+          <input
+            type="email"
+            value={data.user.email}
+            readonly
+            aria-readonly="true"
+          />
+        </label>
+        <label class="field">
+          <span class="field-label">Display name</span>
+          <input
+            type="text"
+            name="displayName"
+            value={data.user.displayName ?? ''}
+            maxlength="80"
+            placeholder="How should we address you?"
+          />
+        </label>
+        <fieldset class="field">
+          <legend class="field-label">Theme</legend>
+          <div class="radio-row">
+            {#each ['system', 'light', 'dark'] as theme (theme)}
+              <label class="radio">
+                <input
+                  type="radio"
+                  name="themePreference"
+                  value={theme}
+                  checked={data.user.themePreference === theme}
+                />
+                <span class="capitalize">{theme}</span>
+              </label>
+            {/each}
+          </div>
+        </fieldset>
+        <div class="form-actions">
+          <button type="submit" class="btn">Save account</button>
+          {#if form && form.section === 'profile' && form.ok}
+            <span class="ok" role="status">Saved.</span>
+          {:else if form && form.section === 'profile' && !form.ok}
+            <span class="err" role="alert">{form.message}</span>
           {/if}
-        </header>
-        <input type="hidden" name="code" value={lang.code} />
-        <label>
-          <span>Script preference</span>
-          <select name="scriptPreference">
-            {#each ['native', 'native_with_romanization', 'romanization_only'] as pref}
-              <option value={pref} selected={lang.scriptPreference === pref}>
-                {SCRIPT_PREF_LABELS[pref]}
-              </option>
-            {/each}
-          </select>
-        </label>
-        <label>
-          <span>Romanization scheme</span>
-          <select name="romanizationScheme">
-            {#each lang.supportedRomanizations as scheme}
-              <option value={scheme} selected={lang.romanizationScheme === scheme}>
-                {ROMAN_LABELS[scheme] ?? scheme}
-              </option>
-            {/each}
-          </select>
-        </label>
-        <button type="submit">Save {lang.displayName}</button>
-        {#if form && form.section === 'language' && form.code === lang.code && form.ok}
-          <p class="ok" role="status">Saved.</p>
-        {:else if form && form.section === 'language' && form.code === lang.code && !form.ok}
-          <p class="err" role="alert">{form.message}</p>
-        {/if}
+        </div>
       </form>
-    {/each}
-  </section>
-</div>
+    </section>
+
+    <section class="settings-section">
+      <div class="settings-h-col">
+        <h2 class="settings-h">Languages</h2>
+        <p class="settings-sub">
+          Per-language reading defaults. These take effect the first time you
+          open a text in that language.
+        </p>
+      </div>
+      <div class="form-col">
+        {#each data.languages as lang (lang.code)}
+          <form
+            method="POST"
+            action="?/updateLanguage"
+            use:enhance
+            class="lang-form"
+          >
+            <header class="lang-form-h">
+              <div>
+                <span class="native">{lang.nativeName}</span>
+                <span class="muted small">
+                  {lang.displayName} · {lang.script}
+                </span>
+              </div>
+              {#if lang.isDefault}
+                <span class="muted small">Using defaults</span>
+              {/if}
+            </header>
+            <input type="hidden" name="code" value={lang.code} />
+            <label class="field">
+              <span class="field-label">Script preference</span>
+              <select name="scriptPreference">
+                {#each ['native', 'native_with_romanization', 'romanization_only'] as pref (pref)}
+                  <option value={pref} selected={lang.scriptPreference === pref}>
+                    {SCRIPT_PREF_LABELS[pref]}
+                  </option>
+                {/each}
+              </select>
+            </label>
+            <label class="field">
+              <span class="field-label">Romanization scheme</span>
+              <select name="romanizationScheme">
+                {#each lang.supportedRomanizations as scheme (scheme)}
+                  <option
+                    value={scheme}
+                    selected={lang.romanizationScheme === scheme}
+                  >
+                    {ROMAN_LABELS[scheme] ?? scheme}
+                  </option>
+                {/each}
+              </select>
+            </label>
+            <div class="form-actions">
+              <button type="submit" class="btn secondary">
+                Save {lang.displayName}
+              </button>
+              {#if form && form.section === 'language' && form.code === lang.code && form.ok}
+                <span class="ok" role="status">Saved.</span>
+              {:else if form && form.section === 'language' && form.code === lang.code && !form.ok}
+                <span class="err" role="alert">{form.message}</span>
+              {/if}
+            </div>
+          </form>
+        {/each}
+      </div>
+    </section>
+  </div>
+</section>
 
 <style>
-  .page {
-    max-width: 48rem;
+  .content {
+    max-width: 64rem;
     margin: 0 auto;
-    padding: 2rem 1.25rem;
+    padding: 1.75rem 1.25rem 3rem;
   }
-  h1 {
-    margin: 0 0 1rem;
+  @media (min-width: 768px) {
+    .content {
+      padding: 2.25rem 2rem 3.5rem;
+    }
   }
-  h2 {
-    font-size: 1.1rem;
-    margin: 1.75rem 0 0.5rem;
-    color: var(--color-fg-muted);
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
+  .topbar {
+    margin-bottom: 1.25rem;
   }
-  h3 {
-    font-size: 1rem;
+  .title {
+    font-family: var(--font-serif, var(--font-ui));
+    font-weight: 600;
+    font-size: 1.4rem;
+    letter-spacing: -0.01em;
     margin: 0;
+    color: var(--ink, var(--color-fg));
   }
-  section {
-    border-top: 1px solid var(--color-border);
-    padding-top: 1rem;
+  .sub {
+    font-size: 0.78rem;
+    color: var(--ink-3, var(--color-fg-muted));
+    margin: 0.15rem 0 0;
   }
-  form {
+
+  .card {
+    background: var(--card, var(--color-bg));
+    border: 1px solid var(--card-edge, var(--color-border));
+    border-radius: 14px;
+    box-shadow: var(--shadow-1, 0 1px 2px rgba(0, 0, 0, 0.04));
+    overflow: hidden;
+  }
+
+  .settings-section {
+    padding: 1.25rem 1.4rem;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1rem;
+    align-items: start;
+    border-top: 1px solid var(--rule-2, var(--color-border));
+  }
+  .settings-section:first-child {
+    border-top: 0;
+  }
+  @media (min-width: 768px) {
+    .settings-section {
+      grid-template-columns: 220px 1fr;
+      gap: 1.5rem;
+      padding: 1.25rem 1.4rem;
+    }
+  }
+  .settings-h {
+    font-family: var(--font-serif, var(--font-ui));
+    font-weight: 500;
+    font-size: 1rem;
+    color: var(--ink, var(--color-fg));
+    margin: 0 0 0.25rem;
+  }
+  .settings-sub {
+    font-size: 0.78rem;
+    color: var(--ink-3, var(--color-fg-muted));
+    margin: 0;
+    line-height: 1.4;
+  }
+
+  .form-col {
     display: flex;
     flex-direction: column;
-    gap: 0.75rem;
-    max-width: 32rem;
+    gap: 0.85rem;
   }
   .lang-form {
-    border: 1px solid var(--color-border);
-    border-radius: 8px;
-    padding: 1rem;
-    margin: 0.75rem 0;
+    border: 1px solid var(--rule, var(--color-border));
+    border-radius: 9px;
+    padding: 0.85rem 1rem;
+    background: color-mix(
+      in oklch,
+      var(--paper, var(--color-bg)) 92%,
+      transparent
+    );
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
   }
-  .lang-form header {
+  .lang-form-h {
     display: flex;
     justify-content: space-between;
     align-items: baseline;
-    margin-bottom: 0.5rem;
+    gap: 0.5rem;
   }
-  label {
+  .native {
+    font-family: var(--font-serif-dev, var(--font-serif));
+    font-size: 1.1rem;
+    margin-right: 0.3rem;
+    color: var(--ink, var(--color-fg));
+  }
+
+  .field {
     display: flex;
     flex-direction: column;
-    gap: 0.25rem;
-    font-size: 0.9rem;
+    gap: 0.3rem;
+    border: 0;
+    padding: 0;
+    margin: 0;
   }
-  label.radio {
-    flex-direction: row;
-    align-items: center;
-    gap: 0.4rem;
-    font-size: 1rem;
-    padding: 0.35rem 0;
-  }
-  fieldset {
-    border: 1px solid var(--color-border);
-    border-radius: 6px;
-    padding: 0.5rem 0.75rem;
-  }
-  legend {
-    padding: 0 0.4rem;
-    color: var(--color-fg-muted);
-    font-size: 0.85rem;
+  .field-label {
+    font-family: var(--font-sans, var(--font-ui));
+    font-size: 0.62rem;
     text-transform: uppercase;
-    letter-spacing: 0.04em;
+    letter-spacing: 0.08em;
+    color: var(--ink-3, var(--color-fg-muted));
   }
   input[type='text'],
   input[type='email'],
   select {
-    padding: 0.55rem 0.75rem;
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-md);
-    background: var(--color-bg);
-    color: var(--color-fg);
+    padding: 0.55rem 0.7rem;
+    border: 1px solid var(--rule, var(--color-border));
+    border-radius: 8px;
+    background: var(--card, var(--color-bg));
+    color: var(--ink, var(--color-fg));
     font: inherit;
-    min-height: var(--touch-target);
+    font-size: 0.85rem;
+    min-height: var(--touch-target, 44px);
+  }
+  input[type='text']:focus,
+  input[type='email']:focus,
+  select:focus {
+    outline: 2px solid var(--accent, var(--color-accent));
+    outline-offset: 1px;
   }
   input[readonly] {
-    color: var(--color-fg-muted);
+    color: var(--ink-3, var(--color-fg-muted));
+    background: color-mix(
+      in oklch,
+      var(--paper, var(--color-bg)) 90%,
+      transparent
+    );
   }
-  button {
-    align-self: flex-start;
-    padding: 0.6rem 1rem;
-    background: var(--color-accent);
-    color: var(--color-accent-fg);
-    border: none;
-    border-radius: var(--radius-md);
+
+  .radio-row {
+    display: flex;
+    gap: 0.85rem;
+    flex-wrap: wrap;
+  }
+  .radio {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.85rem;
+    color: var(--ink, var(--color-fg));
+    padding: 0.35rem 0;
     cursor: pointer;
-    font: inherit;
-    min-height: var(--touch-target);
   }
+  .radio input {
+    accent-color: var(--accent, var(--color-accent));
+  }
+
+  .btn {
+    height: var(--touch-target, 44px);
+    padding: 0 1rem;
+    background: var(--ink, var(--color-fg));
+    color: var(--paper, var(--color-bg));
+    border: 1px solid var(--ink, var(--color-fg));
+    border-radius: 8px;
+    font-family: var(--font-sans, var(--font-ui));
+    font-size: 0.82rem;
+    font-weight: 500;
+    cursor: pointer;
+  }
+  .btn.secondary {
+    background: transparent;
+    color: var(--ink-2, var(--color-fg));
+    border-color: var(--rule, var(--color-border));
+  }
+  .form-actions {
+    display: flex;
+    gap: 0.75rem;
+    align-items: center;
+    margin-top: 0.5rem;
+  }
+
   .muted {
-    color: var(--color-fg-muted);
+    color: var(--ink-3, var(--color-fg-muted));
   }
   .small {
-    font-size: 0.8rem;
+    font-size: 0.78rem;
   }
-  .native {
-    font-size: 1.1rem;
-    margin-right: 0.3rem;
+  .ok {
+    color: var(--green, var(--color-success));
+    font-size: 0.85rem;
+  }
+  .err {
+    color: var(--rose, var(--color-danger));
+    font-size: 0.85rem;
   }
   .capitalize {
     text-transform: capitalize;
-  }
-  .ok {
-    color: var(--color-success);
-    margin: 0;
-  }
-  .err {
-    color: var(--color-danger);
-    margin: 0;
   }
 </style>


### PR DESCRIPTION
## Summary

Restyle `/profile` to match the CIAR design's sectioned settings layout. **Form actions, validation, and backend wiring untouched** — every input field name + action route is identical to T-1.2.

### Surface
- Page-level **Settings** header with title + subtitle, then a single card holding every section.
- Sectioned layout: each section renders the heading + helper copy in a 220px left column and the controls on the right. Stacks vertically below 768px so mobile shows section header above controls.
- Field labels migrate to the design's small-caps treatment (`--font-sans`, 0.62rem, letter-spacing, `--ink-3` muted).
- Theme radio group renders inline (system / light / dark).
- Per-language forms each render in their own bordered sub-card with the native name in `--font-serif-dev`, the `displayName · script` as muted small text, and "Save Hindi" etc. as secondary buttons.
- Primary/secondary buttons follow the design (primary = `--ink` on `--paper`, secondary = transparent on `--rule`).

### What's intentionally out
- **No scope toggle** (Global / Per-language). The design has one but our existing flat layout already lays out both groups vertically and is simpler. Adding the toggle is a follow-up if we add many more global settings.
- **No new sections** (no "Reading defaults", no "Dictionary sources", no "Data" with export/delete). Those are surfaces in the design but the data isn't all wired today; they'll land alongside their respective epics (T-10.3 Vocabulary export, T-1.b sources reordering).

### Tests
All 597 vitest pass · eslint + svelte-check 0/0. The existing `profile-server.test.ts` covers the loader + actions; this PR doesn't touch either.

### Stack
Branched off `feat/t-5.13-library`. Once #167 → #169 → #170 → #171 → #174 → #175 → #176 merge, this rebases onto `main` cleanly.

Closes #164
Refs #42, #158