### PR TITLE
T-5.17: don't blur the reader text when the side panel is open

### DIFF
--- a/apps/web/src/lib/components/overlay/Sheet.svelte
+++ b/apps/web/src/lib/components/overlay/Sheet.svelte
@@ -23,6 +23,11 @@
     width?: number;
     /** Sheet maximum height as a CSS length on <960px (bottom mode). */
     maxHeight?: string;
+    /** When `false`, the backdrop captures clicks (so clicking outside
+     *  still closes the sheet) but stays transparent — no dim, no
+     *  blur. The reader's word side-panel uses this so the surrounding
+     *  paragraph remains readable while a word is locked (T-5.17). */
+    dimmed?: boolean;
     children?: Snippet;
   }
 
@@ -32,6 +37,7 @@
     title = '',
     width = 380,
     maxHeight = '85dvh',
+    dimmed = true,
     children,
   }: Props = $props();
 
@@ -73,6 +79,7 @@
 {#if open}
   <div
     class="sheet-back"
+    class:dimmed
     role="presentation"
     onclick={onBackdropClick}
     onkeydown={onKeydown}
@@ -110,10 +117,18 @@
   .sheet-back {
     position: fixed;
     inset: 0;
-    background: rgba(20, 16, 10, 0.42);
     z-index: 40;
+    /* Default: transparent — only sheets that opt in via dimmed=true
+     * paint the scrim. Click capture works either way. */
+  }
+  .sheet-back.dimmed {
+    background: rgba(20, 16, 10, 0.42);
     backdrop-filter: blur(4px);
   }
+  /* The bottom sheet on narrow viewports occludes the lower part of
+   * the page even when `dimmed=false`. We still want a subtle
+   * separation so the panel doesn't visually blend into the reader.
+   * The sheet's own .sheet shadow handles that. */
   .sheet {
     position: absolute;
     background: var(--paper, var(--color-bg));

--- a/apps/web/src/lib/components/overlay/Sheet.test.ts
+++ b/apps/web/src/lib/components/overlay/Sheet.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render } from '@testing-library/svelte';
+
+import Sheet from './Sheet.svelte';
+import { __resetScrollLockForTests } from './scroll-lock.js';
+
+beforeEach(() => {
+  __resetScrollLockForTests();
+  // jsdom doesn't implement scrollTo; the lock-scroll release branch
+  // would otherwise pollute stderr.
+  vi.stubGlobal('scrollTo', vi.fn());
+});
+
+afterEach(() => {
+  // Tear down the previous test's mount so .sheet-back queries don't
+  // pick up a leftover element on the next render.
+  cleanup();
+  vi.unstubAllGlobals();
+  __resetScrollLockForTests();
+});
+
+describe('Sheet — dimmed prop (T-5.17)', () => {
+  it('paints a dimmed scrim by default', () => {
+    const { container } = render(Sheet, { open: true, onClose: () => {} });
+    const back = container.querySelector('.sheet-back');
+    expect(back).not.toBeNull();
+    expect(back!.classList.contains('dimmed')).toBe(true);
+  });
+
+  it('omits the .dimmed class when dimmed={false} so the reader text stays readable', () => {
+    const { container } = render(Sheet, {
+      open: true,
+      onClose: () => {},
+      dimmed: false,
+    });
+    const back = container.querySelector('.sheet-back');
+    expect(back).not.toBeNull();
+    expect(back!.classList.contains('dimmed')).toBe(false);
+  });
+
+  it('keeps the backdrop element so click-outside-to-close still works when dimmed=false', async () => {
+    let closed = 0;
+    const { container } = render(Sheet, {
+      open: true,
+      dimmed: false,
+      onClose: () => {
+        closed += 1;
+      },
+    });
+    const back = container.querySelector('.sheet-back') as HTMLElement;
+    await fireEvent.click(back);
+    expect(closed).toBe(1);
+  });
+});

--- a/apps/web/src/lib/components/reader/WordPopup.svelte
+++ b/apps/web/src/lib/components/reader/WordPopup.svelte
@@ -222,7 +222,9 @@
 
 <svelte:window onkeydown={handleKeydown} />
 
-<Sheet open={true} onClose={onClose} title="">
+<!-- T-5.17: dimmed=false so the reader paragraph remains readable
+     while a word is locked in the panel. -->
+<Sheet open={true} onClose={onClose} title="" dimmed={false}>
   <div data-testid="word-popup">
     <header class="sp-head">
       <h2 class="sp-word">{token.surface}</h2>

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -11,6 +11,13 @@ import { defineConfig } from 'vitest/config';
  */
 export default defineConfig({
   plugins: [sveltekit()],
+  resolve: {
+    // Tell vitest's resolver to pick the browser export of `svelte`
+    // when running under jsdom — otherwise `mount()` etc. resolve to
+    // the SSR build and throw `lifecycle_function_unavailable`. Only
+    // affects tests; the app build picks conditions normally.
+    conditions: process.env.VITEST ? ['browser'] : [],
+  },
   test: {
     environment: 'jsdom',
     globals: false,


### PR DESCRIPTION
## Summary

The T-5.10 reader side panel rendered inside `<Sheet>` blurred the surrounding paragraph because Sheet's default backdrop applies `rgba(...)` + `backdrop-filter: blur(4px)`. Readers want to keep glancing at the sentence while a word is locked in the panel.

### What changed
- **`Sheet.svelte`** gains a `dimmed: boolean = true` prop. When `false`, the `.sheet-back` element keeps capturing clicks (click-outside still closes) but stays transparent — no scrim, no blur. The `.dimmed` class wraps the backdrop styles, so other consumers (lang picker, future modals) keep their dim by default.
- **`WordPopup.svelte`** passes `dimmed={false}` so the reader paragraph remains fully readable behind the right-side panel / bottom sheet.

### Test infrastructure
`vitest.config.ts` now sets `resolve.conditions = ['browser']` when `VITEST` is in the env. Svelte 5's `mount()` was resolving to the SSR build under Node and throwing `lifecycle_function_unavailable` — this picks the client build so we can actually render components in jsdom tests. Cheap fix, no impact on the app build.

### Tests
- `Sheet.test.ts` (new) — 3 cases: default paints the `.dimmed` scrim; `dimmed={false}` omits it; click-outside-to-close still fires when undimmed.
- All 600 vitest pass · eslint + svelte-check 0/0.

Closes #177
Refs #42, #160, #165