### PR TITLE
T-5.18: show the lemma gloss in the hover tooltip

### DIFF
--- a/apps/web/src/lib/components/reader/WordTooltip.svelte
+++ b/apps/web/src/lib/components/reader/WordTooltip.svelte
@@ -19,7 +19,7 @@
 
   let { token, anchorRect }: Props = $props();
 
-  let tipEl = $state<HTMLDivElement | null>(null);
+  let tipEl: HTMLDivElement | null = $state(null);
   let measured = $state<{ w: number; h: number } | null>(null);
 
   // Placement is derived from the anchor + measured dimensions so it
@@ -62,6 +62,8 @@
     <div class="tip-def muted">No dictionary match</div>
   {:else if !token.lemmaId}
     <div class="tip-def muted">Click to look up</div>
+  {:else if token.glossDefault}
+    <div class="tip-def">{token.glossDefault}</div>
   {:else}
     <div class="tip-def muted">Click to see translations</div>
   {/if}
@@ -100,6 +102,18 @@
     font-size: 0.7rem;
     color: color-mix(in oklch, var(--paper, #fdfaf3) 70%, transparent);
     flex-shrink: 0;
+  }
+  .tip-def {
+    color: color-mix(in oklch, var(--paper, #fdfaf3) 88%, transparent);
+    font-size: 0.78rem;
+    line-height: 1.35;
+    /* Long glosses (e.g. multi-meaning lemmas) get clamped to two
+     * lines — the side panel still shows the full text on click. */
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
   }
   .tip-def.muted {
     color: color-mix(in oklch, var(--paper, #fdfaf3) 65%, transparent);

--- a/apps/web/src/lib/components/reader/WordTooltip.test.ts
+++ b/apps/web/src/lib/components/reader/WordTooltip.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { cleanup, render } from '@testing-library/svelte';
+
+import WordTooltip from './WordTooltip.svelte';
+import type { ServerToken } from './types.js';
+import type { AnchorRect } from './tooltip-position.js';
+
+const ANCHOR: AnchorRect = {
+  top: 200,
+  left: 400,
+  bottom: 224,
+  right: 460,
+  width: 60,
+  height: 24,
+};
+
+function makeToken(overrides: Partial<ServerToken> = {}): ServerToken {
+  return {
+    id: 't1',
+    idx: 0,
+    surface: 'प्रभात',
+    isWord: true,
+    isAmbiguous: false,
+    isOov: false,
+    lemmaId: 'lem-1',
+    romanization: 'prabhāt',
+    glossDefault: null,
+    status: 'unknown',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  // Reset DOM between tests so multiple renders don't pile up
+  // .tip elements that confuse querySelector.
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('WordTooltip — gloss display (T-5.18)', () => {
+  it("shows the lemma's glossDefault when present", () => {
+    const { container } = render(WordTooltip, {
+      token: makeToken({ glossDefault: 'morning, dawn' }),
+      anchorRect: ANCHOR,
+    });
+    const def = container.querySelector('.tip-def');
+    expect(def?.textContent).toBe('morning, dawn');
+    expect(def?.classList.contains('muted')).toBe(false);
+  });
+
+  it("falls back to the placeholder when glossDefault is null but the lemma is known", () => {
+    const { container } = render(WordTooltip, {
+      token: makeToken({ glossDefault: null }),
+      anchorRect: ANCHOR,
+    });
+    const def = container.querySelector('.tip-def');
+    expect(def?.textContent).toBe('Click to see translations');
+    expect(def?.classList.contains('muted')).toBe(true);
+  });
+
+  it("shows 'No dictionary match' for OOV tokens regardless of glossDefault", () => {
+    const { container } = render(WordTooltip, {
+      token: makeToken({ isOov: true, glossDefault: 'should not show' }),
+      anchorRect: ANCHOR,
+    });
+    expect(container.querySelector('.tip-def')?.textContent).toBe(
+      'No dictionary match',
+    );
+  });
+
+  it("shows 'Click to look up' when there is no lemma id", () => {
+    const { container } = render(WordTooltip, {
+      token: makeToken({ lemmaId: null, glossDefault: null }),
+      anchorRect: ANCHOR,
+    });
+    expect(container.querySelector('.tip-def')?.textContent).toBe(
+      'Click to look up',
+    );
+  });
+});

--- a/apps/web/src/lib/components/reader/types.ts
+++ b/apps/web/src/lib/components/reader/types.ts
@@ -19,6 +19,9 @@ export type ServerToken = {
   isOov: boolean;
   lemmaId: string | null;
   romanization: string | null;
+  /** Canonical short gloss for the lemma — surfaced in the hover
+   *  tooltip (T-5.18). Null when there's no lemma or no gloss yet. */
+  glossDefault: string | null;
   status: 'known' | 'learning' | 'ignored' | 'unknown';
 };
 

--- a/apps/web/src/lib/server/texts/tokens.test.ts
+++ b/apps/web/src/lib/server/texts/tokens.test.ts
@@ -36,6 +36,10 @@ vi.mock('../db/index.js', () => ({
       lemmaId: 'user_known_lemmas.lemma_id',
       status: 'user_known_lemmas.status',
     },
+    lemmas: {
+      id: 'lemmas.id',
+      glossDefault: 'lemmas.gloss_default',
+    },
   },
 }));
 
@@ -79,6 +83,7 @@ describe('loadChapterTokens', () => {
   it('returns tokens with status=unknown when the viewer has no known-lemma rows', async () => {
     stage([tokenRow({ id: 't1', idx: 0 }), tokenRow({ id: 't2', idx: 1 })]);
     stage([]); // user_known_lemmas → empty
+    stage([]); // lemmas (gloss lookup) → empty
     const result = await loadChapterTokens('chap-1', 'user-1');
     expect(result).not.toBeNull();
     expect(result!.every((t) => t.status === 'unknown')).toBe(true);
@@ -94,6 +99,7 @@ describe('loadChapterTokens', () => {
       { userId: 'user-1', lemmaId: 'lem-known', status: 'known' },
       { userId: 'user-1', lemmaId: 'lem-learning', status: 'learning' },
     ]);
+    stage([]); // lemmas (gloss lookup) — none on file for these lemmas
     const result = await loadChapterTokens('chap-1', 'user-1');
     expect(result).toEqual([
       expect.objectContaining({ id: 't1', status: 'known' }),
@@ -102,13 +108,34 @@ describe('loadChapterTokens', () => {
     ]);
   });
 
-  it('handles anonymous viewers (no second SELECT, every status=unknown)', async () => {
+  it('attaches glossDefault from the lemmas table for the hover tooltip (T-5.18)', async () => {
+    stage([
+      tokenRow({ id: 't1', idx: 0, lemmaId: 'lem-a' }),
+      tokenRow({ id: 't2', idx: 1, lemmaId: 'lem-b' }),
+      tokenRow({ id: 't3', idx: 2, lemmaId: null, isWord: false, surface: ' ' }),
+    ]);
+    stage([]); // user_known_lemmas
+    stage([
+      { id: 'lem-a', glossDefault: 'morning' },
+      { id: 'lem-b', glossDefault: null },
+    ]);
+    const result = await loadChapterTokens('chap-1', 'user-1');
+    expect(result![0]).toMatchObject({ id: 't1', glossDefault: 'morning' });
+    // Lemma row exists but the gloss column is null — should pass through.
+    expect(result![1]).toMatchObject({ id: 't2', glossDefault: null });
+    // Whitespace token has no lemma id; glossDefault defaults to null.
+    expect(result![2]).toMatchObject({ id: 't3', glossDefault: null });
+  });
+
+  it('handles anonymous viewers (no user_known_lemmas SELECT, every status=unknown)', async () => {
     stage([tokenRow({ id: 't1', idx: 0 })]);
+    stage([]); // lemmas (gloss lookup) — only this second SELECT runs
     const result = await loadChapterTokens('chap-1', null);
     expect(result).not.toBeNull();
     expect(result![0]!.status).toBe('unknown');
-    // Only ONE SELECT — the user_known_lemmas query was skipped.
-    expect(selectFn).toHaveBeenCalledTimes(1);
+    // Two SELECTs total — the user_known_lemmas query was skipped, but
+    // the lemmas-for-gloss query still runs.
+    expect(selectFn).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/apps/web/src/lib/server/texts/tokens.ts
+++ b/apps/web/src/lib/server/texts/tokens.ts
@@ -25,6 +25,11 @@ export type RenderedToken = {
   isOov: boolean;
   lemmaId: string | null;
   romanization: string | null;
+  /** Canonical short gloss for the lemma — surfaced in the hover
+   *  tooltip (T-5.18) so a reader can scan a paragraph without
+   *  locking the side panel. Null when the lemma has no glossDefault
+   *  on file, or when the token has no lemma id (whitespace, OOV). */
+  glossDefault: string | null;
   status: 'known' | 'learning' | 'ignored' | 'unknown';
 };
 
@@ -73,6 +78,26 @@ export async function loadChapterTokens(
     }
   }
 
+  // T-5.18: pull each lemma's `glossDefault` so the hover tooltip can
+  // surface a brief definition without a per-hover fetch. Cheap — a
+  // single SELECT against an indexed primary key.
+  const glossByLemma = new Map<string, string | null>();
+  if (lemmaIds.length > 0) {
+    const lemmaRows = (await db
+      .select({
+        id: schema.lemmas.id,
+        glossDefault: schema.lemmas.glossDefault,
+      })
+      .from(schema.lemmas)
+      .where(inArray(schema.lemmas.id, lemmaIds))) as Array<{
+      id: string;
+      glossDefault: string | null;
+    }>;
+    for (const r of lemmaRows) {
+      glossByLemma.set(r.id, r.glossDefault);
+    }
+  }
+
   return tokens.map((t) => {
     const status: RenderedToken['status'] =
       t.lemmaId && statusByLemma.has(t.lemmaId)
@@ -87,6 +112,7 @@ export async function loadChapterTokens(
       isOov: t.isOov,
       lemmaId: t.lemmaId,
       romanization: t.romanization,
+      glossDefault: t.lemmaId ? glossByLemma.get(t.lemmaId) ?? null : null,
       status,
     };
   });

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -11,6 +11,13 @@ import { defineConfig } from 'vitest/config';
  */
 export default defineConfig({
   plugins: [sveltekit()],
+  resolve: {
+    // Tell vitest's resolver to pick the browser export of `svelte`
+    // when running under jsdom — otherwise `mount()` etc. resolve to
+    // the SSR build and throw `lifecycle_function_unavailable`. Only
+    // affects tests; the app build picks conditions normally.
+    conditions: process.env.VITEST ? ['browser'] : [],
+  },
   test: {
     environment: 'jsdom',
     globals: false,


### PR DESCRIPTION
## Summary

The T-5.10 hover tooltip showed only the surface + romanization + a "Click to see translations" placeholder. This PR surfaces the lemma's canonical short gloss inline so a reader can scan a paragraph without locking the side panel for every word.

### Server
- **`loadChapterTokens`** gains a single `SELECT lemmas.id, lemmas.gloss_default FROM lemmas WHERE id = ANY($1)` against the indexed PK to pull `glossDefault` for the lemma ids in the chapter.
- One extra round-trip per chapter load — shared across every token, not per-hover. Anonymous viewers also incur it (still cheap, no GROUP BY).
- `RenderedToken` adds `glossDefault: string | null`.

### Client
- `ServerToken` (lib/components/reader/types.ts) adds the matching field.
- `WordTooltip` renders the gloss when present; falls back to the existing placeholder copy when null. Long glosses clamp to two lines via `-webkit-line-clamp` so the tooltip stays compact; the side panel still shows the full text on click.

### Test infrastructure
`vitest.config.ts` adds the same `resolve.conditions = ['browser']` fix #182 introduces, so component tests can mount under jsdom (Svelte 5's `mount()` defaults to the SSR build under Node and throws). Will collide cleanly if #182 lands first.

### Tests
- **`tokens.test.ts`** — new case asserting `glossDefault` is attached for lemmas with a row, null when the row's gloss is null, null when the token has no lemma id. Existing cases were updated to stage an additional empty result for the lemma lookup.
- **`WordTooltip.test.ts`** (new) — 4 cases: gloss displays when present, placeholder when null, OOV copy overrides any gloss, no-lemma copy when `lemmaId` is null.
- All 602 vitest pass · eslint + svelte-check 0/0.

Closes #178
Refs #42, #160