### PR TITLE
T-5.16: collapsible reader chrome for immersive reading

### DIFF
--- a/apps/web/src/lib/components/reader/immersive.test.ts
+++ b/apps/web/src/lib/components/reader/immersive.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  IMMERSIVE_ATTR,
+  IMMERSIVE_STORAGE_KEY,
+  isImmersiveAttributeSet,
+  readPersistedImmersive,
+  setImmersiveAttribute,
+  writePersistedImmersive,
+} from './immersive.js';
+
+beforeEach(() => {
+  sessionStorage.clear();
+  document.documentElement.removeAttribute(IMMERSIVE_ATTR);
+});
+
+afterEach(() => {
+  sessionStorage.clear();
+  document.documentElement.removeAttribute(IMMERSIVE_ATTR);
+});
+
+describe('immersive — sessionStorage helpers', () => {
+  it('readPersistedImmersive returns false when nothing is stored', () => {
+    expect(readPersistedImmersive()).toBe(false);
+  });
+
+  it('readPersistedImmersive returns true when sessionStorage has the flag', () => {
+    sessionStorage.setItem(IMMERSIVE_STORAGE_KEY, '1');
+    expect(readPersistedImmersive()).toBe(true);
+  });
+
+  it('writePersistedImmersive(true) writes the flag', () => {
+    writePersistedImmersive(true);
+    expect(sessionStorage.getItem(IMMERSIVE_STORAGE_KEY)).toBe('1');
+  });
+
+  it('writePersistedImmersive(false) removes the flag (so default reverts to off)', () => {
+    sessionStorage.setItem(IMMERSIVE_STORAGE_KEY, '1');
+    writePersistedImmersive(false);
+    expect(sessionStorage.getItem(IMMERSIVE_STORAGE_KEY)).toBeNull();
+  });
+
+  it('treats non-"1" values as off', () => {
+    sessionStorage.setItem(IMMERSIVE_STORAGE_KEY, 'true');
+    expect(readPersistedImmersive()).toBe(false);
+    sessionStorage.setItem(IMMERSIVE_STORAGE_KEY, '0');
+    expect(readPersistedImmersive()).toBe(false);
+  });
+});
+
+describe('immersive — DOM attribute helpers', () => {
+  it('setImmersiveAttribute(true) puts the flag on <html>', () => {
+    setImmersiveAttribute(true);
+    expect(document.documentElement.getAttribute(IMMERSIVE_ATTR)).toBe('1');
+    expect(isImmersiveAttributeSet()).toBe(true);
+  });
+
+  it('setImmersiveAttribute(false) clears the flag', () => {
+    setImmersiveAttribute(true);
+    setImmersiveAttribute(false);
+    expect(document.documentElement.hasAttribute(IMMERSIVE_ATTR)).toBe(false);
+    expect(isImmersiveAttributeSet()).toBe(false);
+  });
+
+  it('isImmersiveAttributeSet returns false when the attribute is absent', () => {
+    expect(isImmersiveAttributeSet()).toBe(false);
+  });
+});

--- a/apps/web/src/lib/components/reader/immersive.ts
+++ b/apps/web/src/lib/components/reader/immersive.ts
@@ -1,0 +1,54 @@
+/**
+ * Immersive reading mode (T-5.16).
+ *
+ * When the reader hides its chrome — the app shell rail on desktop,
+ * the bottom tab bar on mobile, and the mobile top-strip — the
+ * page sets `data-reader-immersive="1"` on `<html>`. AppShell.svelte's
+ * CSS responds to that attribute. The flag is persisted in
+ * `sessionStorage` so paging or chapter clicks within a reader visit
+ * keep the chrome hidden, but it does NOT survive tab close (you
+ * always start a fresh visit with the chrome showing).
+ *
+ * The helpers are pure DOM/storage so they're testable under jsdom
+ * without rendering a Svelte component.
+ */
+
+export const IMMERSIVE_ATTR = 'data-reader-immersive';
+export const IMMERSIVE_STORAGE_KEY = 'cia_reader_immersive';
+
+/** Read the persisted immersive preference for this tab. Returns
+ *  false in non-browser environments (SSR). */
+export function readPersistedImmersive(): boolean {
+  if (typeof sessionStorage === 'undefined') return false;
+  try {
+    return sessionStorage.getItem(IMMERSIVE_STORAGE_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+/** Write the immersive preference for this tab. */
+export function writePersistedImmersive(on: boolean): void {
+  if (typeof sessionStorage === 'undefined') return;
+  try {
+    if (on) sessionStorage.setItem(IMMERSIVE_STORAGE_KEY, '1');
+    else sessionStorage.removeItem(IMMERSIVE_STORAGE_KEY);
+  } catch {
+    // Storage may be unavailable (private browsing on Safari, etc.) —
+    // fall through silently. The attribute on <html> is still the
+    // active source of truth for the current page paint.
+  }
+}
+
+/** Apply the immersive flag to `<html>` so the shell's CSS responds. */
+export function setImmersiveAttribute(on: boolean): void {
+  if (typeof document === 'undefined') return;
+  if (on) document.documentElement.setAttribute(IMMERSIVE_ATTR, '1');
+  else document.documentElement.removeAttribute(IMMERSIVE_ATTR);
+}
+
+/** Read the current attribute state. */
+export function isImmersiveAttributeSet(): boolean {
+  if (typeof document === 'undefined') return false;
+  return document.documentElement.getAttribute(IMMERSIVE_ATTR) === '1';
+}

--- a/apps/web/src/lib/components/shell/AppShell.svelte
+++ b/apps/web/src/lib/components/shell/AppShell.svelte
@@ -399,4 +399,24 @@
     width: 18px;
     height: 18px;
   }
+
+  /* —— Immersive mode (T-5.16) ————————————————————————
+   * The reader page sets `data-reader-immersive="1"` on <html> when
+   * the user opts into a full-viewport reading view. We hide the
+   * shell's own chrome and let the reader content occupy the whole
+   * grid track. The reader's own top bar / progress foot stay
+   * visible — only cross-screen navigation chrome collapses. */
+  :global(html[data-reader-immersive='1']) .rail,
+  :global(html[data-reader-immersive='1']) .top-strip,
+  :global(html[data-reader-immersive='1']) .bottom-nav {
+    display: none;
+  }
+  :global(html[data-reader-immersive='1']) .shell {
+    grid-template-columns: 1fr;
+    grid-template-areas: 'content';
+  }
+  :global(html[data-reader-immersive='1']) .content {
+    /* Bottom nav is gone — drop the safe-area padding too. */
+    padding-bottom: 0;
+  }
 </style>

--- a/apps/web/src/routes/reader/[textId]/+page.svelte
+++ b/apps/web/src/routes/reader/[textId]/+page.svelte
@@ -6,9 +6,26 @@
   import ReaderPage from '$lib/components/reader/ReaderPage.svelte';
   import ReaderScroll from '$lib/components/reader/ReaderScroll.svelte';
   import { ProgressWriter } from '$lib/components/reader/progress-client.js';
+  import {
+    readPersistedImmersive,
+    setImmersiveAttribute,
+    writePersistedImmersive,
+  } from '$lib/components/reader/immersive.js';
   import type { PageData } from './$types';
 
   let { data }: { data: PageData } = $props();
+
+  // T-5.16: Immersive mode hides the AppShell rail / bottom-nav so
+  // the reader takes the full viewport. State persists in
+  // sessionStorage for this tab — paging stays immersive — but does
+  // not survive tab close. Cleaned up on unmount so other routes
+  // never inherit the hidden chrome.
+  let immersive = $state(false);
+  function toggleImmersive() {
+    immersive = !immersive;
+    setImmersiveAttribute(immersive);
+    writePersistedImmersive(immersive);
+  }
 
   // Live status mirrors data.text.status; flips when the polling loop
   // hits a terminal state (T-4.4).
@@ -72,6 +89,23 @@
   onMount(() => {
     liveStatus = data.text.status;
 
+    // T-5.16: hydrate immersive mode from sessionStorage so paging
+    // within a reader visit keeps the chrome hidden. Tab close clears
+    // it. Listen for Esc to exit immersive (and only when the side
+    // panel isn't open — the popup owns Esc when it's mounted).
+    immersive = readPersistedImmersive();
+    setImmersiveAttribute(immersive);
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      if (!immersive) return;
+      if (document.querySelector('[data-testid="word-popup"]')) return;
+      e.preventDefault();
+      immersive = false;
+      setImmersiveAttribute(false);
+      writePersistedImmersive(false);
+    };
+    window.addEventListener('keydown', onKey);
+
     // Status polling — owners only.
     let cleanupPoll: (() => void) | null = null;
     if (data.isOwner && shouldPoll(liveStatus)) {
@@ -122,6 +156,12 @@
 
     return () => {
       cleanupPoll?.();
+      window.removeEventListener('keydown', onKey);
+      // T-5.16: clear the attribute when the reader unmounts so other
+      // routes (Library / Words / Settings) never inherit hidden
+      // chrome. The sessionStorage flag stays so re-opening a text in
+      // the same tab restores the user's preference.
+      setImmersiveAttribute(false);
       if (beforeUnloadHandler)
         window.removeEventListener('beforeunload', beforeUnloadHandler);
       void progressWriter?.flush();
@@ -198,6 +238,34 @@
         title="Toggle romanization"
       >
         Aa
+      </button>
+
+      <button
+        type="button"
+        class="immersive-toggle"
+        data-active={immersive ? '1' : '0'}
+        onclick={toggleImmersive}
+        aria-pressed={immersive}
+        title={immersive
+          ? 'Exit immersive reading (Esc)'
+          : 'Hide app chrome for immersive reading'}
+        aria-label={immersive ? 'Exit immersive reading' : 'Enter immersive reading'}
+      >
+        {#if immersive}
+          <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M9 4v5H4" />
+            <path d="M15 4v5h5" />
+            <path d="M9 20v-5H4" />
+            <path d="M15 20v-5h5" />
+          </svg>
+        {:else}
+          <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M4 9V4h5" />
+            <path d="M20 9V4h-5" />
+            <path d="M4 15v5h5" />
+            <path d="M20 15v5h-5" />
+          </svg>
+        {/if}
       </button>
     </div>
   </header>
@@ -358,6 +426,25 @@
     cursor: pointer;
   }
   .roman-toggle[data-active='1'] {
+    background: var(--accent-soft, var(--color-accent));
+    border-color: var(--accent, var(--color-accent));
+    color: var(--accent-ink, var(--color-accent-fg, #fff));
+  }
+  .immersive-toggle {
+    width: 32px;
+    height: 32px;
+    display: grid;
+    place-items: center;
+    border: 1px solid var(--rule, var(--color-border));
+    border-radius: 8px;
+    background: transparent;
+    color: var(--ink-2, var(--color-fg-muted));
+    cursor: pointer;
+  }
+  .immersive-toggle:hover {
+    color: var(--ink, var(--color-fg));
+  }
+  .immersive-toggle[data-active='1'] {
     background: var(--accent-soft, var(--color-accent));
     border-color: var(--accent, var(--color-accent));
     color: var(--accent-ink, var(--color-accent-fg, #fff));


### PR DESCRIPTION
## Summary

A toggle in the reader top bar hides the AppShell rail (desktop) + top-strip + bottom-nav (mobile), so a reader can occupy the full viewport. The reader's own top bar + bottom progress foot stay visible — only cross-screen navigation chrome collapses.

### How it works
- **`immersive.ts`** (new) wraps the `data-reader-immersive` attribute on `<html>` + the `cia_reader_immersive` sessionStorage key with pure DOM helpers. No Svelte runtime — fully unit-testable under jsdom.
- **Reader `+page.svelte`** hydrates the attribute from sessionStorage on mount, listens for `Esc` to exit (skips when the side panel owns Esc — uses the existing `[data-testid="word-popup"]` lookup), and clears the attribute on unmount so other routes never inherit hidden chrome. The sessionStorage flag stays so re-opening a text in the same tab restores the user's preference.
- **Reader top bar** gains a pill button next to the romanization `Aa` toggle: shrink-icon when chrome is showing, expand-icon when immersive. `aria-pressed` reflects state; `title` doubles as the Esc-exit hint.
- **`AppShell.svelte`** adds three `:global()` rules under `html[data-reader-immersive='1']` that flip `.rail` / `.top-strip` / `.bottom-nav` to `display: none` and collapse the grid to a single content track.

### Persistence model
| event | sessionStorage | attribute |
|---|---|---|
| toggle on | `'1'` | `'1'` |
| toggle off / Esc | removed | removed |
| paging within reader | unchanged | unchanged |
| navigate away from /reader | unchanged | removed on unmount |
| return to a reader page | read on mount | re-applied on mount |
| tab close | cleared by browser | — |

### Tests
- `immersive.test.ts` (new) — 8 cases: sessionStorage round-trip, non-`'1'` values treated as off, write-false removes the key, attribute getter / setter / clear.
- All 605 vitest pass · eslint + svelte-check 0/0.

Closes #173
Refs #42, #161