### PR TITLE
T-5.19: home page robustness fix

### DIFF
--- a/apps/web/src/routes/+page.server.ts
+++ b/apps/web/src/routes/+page.server.ts
@@ -34,17 +34,25 @@ export const load: PageServerLoad = async ({ locals }) => {
     console.error('NLP health check failed:', err);
   }
 
+  // Per-language known-words cache. Wrapped in try/catch so a database
+  // hiccup or a schema regression in this single read can't take the
+  // whole landing page offline (T-5.19) — we'd rather render the
+  // language grid with zero counts than 500 the home route.
   const knownByLanguage: Partial<Record<LanguageCode, number>> = {};
-  if (locals.user) {
-    const rows = await db
-      .select({
-        language: userLanguages.language,
-        knownWordsCountCache: userLanguages.knownWordsCountCache,
-      })
-      .from(userLanguages)
-      .where(eq(userLanguages.userId, locals.user.id));
-    for (const r of rows) {
-      knownByLanguage[r.language as LanguageCode] = r.knownWordsCountCache;
+  if (locals.user?.id) {
+    try {
+      const rows = await db
+        .select({
+          language: userLanguages.language,
+          knownWordsCountCache: userLanguages.knownWordsCountCache,
+        })
+        .from(userLanguages)
+        .where(eq(userLanguages.userId, locals.user.id));
+      for (const r of rows) {
+        knownByLanguage[r.language as LanguageCode] = r.knownWordsCountCache;
+      }
+    } catch (err) {
+      console.error('home: user_languages query failed:', err);
     }
   }
 

--- a/apps/web/src/routes/page-server.test.ts
+++ b/apps/web/src/routes/page-server.test.ts
@@ -103,4 +103,24 @@ describe('root +page.server.ts load', () => {
     // Languages without a row default to 0.
     expect(or?.known).toBe(0);
   });
+
+  it("renders with zero counts (not a 500) when the user_languages query throws (T-5.19)", async () => {
+    health.mockResolvedValue({ status: 'ok', languages: [] });
+    knownRows.mockRejectedValue(new Error('db down'));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const data = await callLoad({
+      user: { id: 'u1', email: 'a@b.c', displayName: 'Alex', role: 'user' },
+    });
+    expect(data.languages.every((l: { known: number }) => l.known === 0)).toBe(true);
+  });
+
+  it('skips the user_languages query when locals.user has no id (defensive guard)', async () => {
+    health.mockResolvedValue({ status: 'ok', languages: [] });
+    await callLoad({
+      // intentionally malformed user record — should not crash, should
+      // not call the query.
+      user: { email: 'a@b.c', displayName: null, role: 'user' },
+    });
+    expect(knownRows).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

T-5.12 added a `SELECT … FROM user_languages WHERE user_id = $1` to the home loader. If that query throws (DB hiccup, transient connection issue, schema regression, malformed `locals.user`), the whole landing page returns 500. The user reported the home page no longer loads.

### Fix
- Wrap the user_languages SELECT in `try/catch`. On failure, `console.error` and fall back to zero counts on every language card. The grid still renders.
- Defensive guard: only run the query when `locals.user?.id` is present. A malformed user record shouldn't crash the home page either.

### Tests
- `page-server.test.ts` — 2 new cases: (a) `knownRows.mockRejectedValue(...)` → page renders with all `known: 0` (no thrown error), (b) `locals.user` without an `id` → query is never called.
- All 615 vitest pass · eslint + svelte-check 0/0.

### Follow-up
The catch is defensive — there's still an underlying error to chase if the home page was actually 500'ing in production. Once we have the runtime stack from the deployed environment, we can fix the root cause (probably a Drizzle / postgres-js / column-name mismatch). For now this PR keeps the page reachable so users aren't blocked.

Closes #185
Refs #42