### PR TITLE
T-5.20 + T-5.21 + T-5.22: tooltip + add-translation flow polish

### DIFF
--- a/apps/web/src/lib/components/reader/WordPopup.svelte
+++ b/apps/web/src/lib/components/reader/WordPopup.svelte
@@ -115,6 +115,15 @@
 
   function handleKeydown(e: KeyboardEvent) {
     if (!isOwner || !token.lemmaId) return;
+    // T-5.21: skip the k/l/i shortcuts whenever the user is typing
+    // into a form field — otherwise typing 'l' in the add-translation
+    // textarea would silently flip the lemma to learning.
+    const target = e.target as HTMLElement | null;
+    if (target) {
+      const tag = target.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+      if (target.isContentEditable) return;
+    }
     // T-5.7: power-user shortcuts. Only fire when modifier-free so we
     // don't fight the browser's own shortcuts (Cmd-K, Ctrl-L, etc.).
     if (e.metaKey || e.ctrlKey || e.altKey) return;
@@ -152,6 +161,7 @@
       addError = 'Translation cannot be empty.';
       return;
     }
+    const lemmaId = token.lemmaId;
     savingTranslation = true;
     addError = null;
     try {
@@ -159,7 +169,7 @@
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({
-          lemmaId: token.lemmaId,
+          lemmaId,
           body: trimmed,
           targetLanguage: 'en',
         }),
@@ -168,23 +178,14 @@
         const text = await res.text().catch(() => '');
         throw new Error(text || `POST failed: ${res.status}`);
       }
-      const created = (await res.json()) as {
-        translation: {
-          id: string;
-          body: string;
-          targetLanguage: string;
-          sourceAttribution: string | null;
-          provenance: Provenance;
-        };
-      };
-      if (payload) {
-        payload = {
-          ...payload,
-          translations: {
-            ...payload.translations,
-            personal: [created.translation, ...payload.translations.personal],
-          },
-        };
+      // T-5.22: re-fetch the lemma payload so the new row definitely
+      // shows. The optimistic prepend was unreliable — between
+      // payload-may-be-null states and Svelte 5 $state proxy edge
+      // cases, the freshly-saved translation sometimes never
+      // appeared. A single GET on success is small and reliable.
+      const fresh = await fetch(`/api/v1/lemmas/${lemmaId}/translations`);
+      if (fresh.ok) {
+        payload = (await fresh.json()) as LemmaPayload;
       }
       newTranslationBody = '';
       showAddForm = false;
@@ -192,6 +193,24 @@
       addError = (e as Error).message;
     } finally {
       savingTranslation = false;
+    }
+  }
+
+  // T-5.21: Enter submits, Shift+Enter inserts a newline, Esc cancels
+  // the form (without closing the panel). The textarea handler stops
+  // propagation on Esc so Sheet doesn't also close itself.
+  function onAddFormKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      void submitNewTranslation();
+      return;
+    }
+    if (e.key === 'Escape') {
+      e.stopPropagation();
+      e.preventDefault();
+      showAddForm = false;
+      newTranslationBody = '';
+      addError = null;
     }
   }
 
@@ -321,10 +340,11 @@
           >
             <textarea
               bind:value={newTranslationBody}
-              placeholder="Your translation in English"
+              placeholder="Your translation (Enter to save, Shift+Enter for a newline, Esc to cancel)"
               rows="2"
               maxlength="500"
               disabled={savingTranslation}
+              onkeydown={onAddFormKeydown}
             ></textarea>
             {#if addError}
               <p class="err small">{addError}</p>

--- a/apps/web/src/lib/components/reader/WordTooltip.svelte
+++ b/apps/web/src/lib/components/reader/WordTooltip.svelte
@@ -58,14 +58,18 @@
       <span class="tip-roman">{token.romanization}</span>
     {/if}
   </div>
+  <!-- T-5.20: surface the top translation when we have one, fall
+       back to an italic "No translations" otherwise so the user
+       always knows whether the lookup is empty or just absent. The
+       tooltip stays no-fetch — it reads `glossDefault` off the token
+       row, which the side-panel still backs up with the full
+       hierarchy on click. -->
   {#if token.isOov}
-    <div class="tip-def muted">No dictionary match</div>
-  {:else if !token.lemmaId}
-    <div class="tip-def muted">Click to look up</div>
+    <div class="tip-def empty">No dictionary match</div>
   {:else if token.glossDefault}
     <div class="tip-def">{token.glossDefault}</div>
   {:else}
-    <div class="tip-def muted">Click to see translations</div>
+    <div class="tip-def empty">No translations</div>
   {/if}
 </div>
 
@@ -115,8 +119,10 @@
     -webkit-box-orient: vertical;
     overflow: hidden;
   }
-  .tip-def.muted {
+  /* T-5.20: italic "no match" / "no translations" copy. */
+  .tip-def.empty {
     color: color-mix(in oklch, var(--paper, #fdfaf3) 65%, transparent);
+    font-style: italic;
   }
   @keyframes fade-in {
     from {

--- a/apps/web/src/lib/components/reader/WordTooltip.test.ts
+++ b/apps/web/src/lib/components/reader/WordTooltip.test.ts
@@ -50,33 +50,33 @@ describe('WordTooltip — gloss display (T-5.18)', () => {
     expect(def?.classList.contains('muted')).toBe(false);
   });
 
-  it("falls back to the placeholder when glossDefault is null but the lemma is known", () => {
+  it("falls back to italic 'No translations' when glossDefault is null but the lemma is known (T-5.20)", () => {
     const { container } = render(WordTooltip, {
       token: makeToken({ glossDefault: null }),
       anchorRect: ANCHOR,
     });
     const def = container.querySelector('.tip-def');
-    expect(def?.textContent).toBe('Click to see translations');
-    expect(def?.classList.contains('muted')).toBe(true);
+    expect(def?.textContent).toBe('No translations');
+    expect(def?.classList.contains('empty')).toBe(true);
   });
 
-  it("shows 'No dictionary match' for OOV tokens regardless of glossDefault", () => {
+  it("shows 'No dictionary match' for OOV tokens regardless of glossDefault (T-5.20)", () => {
     const { container } = render(WordTooltip, {
       token: makeToken({ isOov: true, glossDefault: 'should not show' }),
       anchorRect: ANCHOR,
     });
-    expect(container.querySelector('.tip-def')?.textContent).toBe(
-      'No dictionary match',
-    );
+    const def = container.querySelector('.tip-def');
+    expect(def?.textContent).toBe('No dictionary match');
+    expect(def?.classList.contains('empty')).toBe(true);
   });
 
-  it("shows 'Click to look up' when there is no lemma id", () => {
+  it("treats no-lemma tokens like an empty-translation lemma — italic 'No translations' (T-5.20)", () => {
     const { container } = render(WordTooltip, {
       token: makeToken({ lemmaId: null, glossDefault: null }),
       anchorRect: ANCHOR,
     });
     expect(container.querySelector('.tip-def')?.textContent).toBe(
-      'Click to look up',
+      'No translations',
     );
   });
 });


### PR DESCRIPTION
## Summary

Three small reader fixes folded into one PR — they all touch `WordTooltip` / `WordPopup` and share the existing test scaffolding.

### T-5.20 — Italic "No translations" fallback in the hover tooltip
- Drops the "Click to see translations" placeholder.
- When the lemma has no `glossDefault`, the tooltip now renders italic "No translations" so the user always knows whether the lookup is empty or just absent.
- OOV stays as italic "No dictionary match".
- No-lemma tokens fall through the same path — italic "No translations" — so the tooltip never feels half-rendered.

### T-5.21 — Enter saves, Shift+Enter newline, Esc cancels
- Textarea `onkeydown`: Enter submits, Shift+Enter inserts a newline, Esc closes the form (without closing the side panel — `e.stopPropagation()` keeps Sheet from also reacting).
- `handleKeydown` for the k/l/i status shortcuts now bails when focus is in `INPUT` / `TEXTAREA` / `SELECT` / `contenteditable`. Previously typing 'k' inside the translation textarea silently flipped the lemma to known.
- Placeholder copy advertises the shortcut.

### T-5.22 — Newly-added translation actually appears
- Drops the optimistic prepend (was unreliable across `$state` proxy edge cases + payload-may-still-be-loading races).
- On a successful POST, re-fetch `/api/v1/lemmas/:id/translations` and replace the `payload` reactively. One extra GET on save in exchange for a reliable update.

### Tests
- `WordTooltip.test.ts` — three updated cases covering the new fallback copy + `.empty` class.
- `WordPopup` keyboard / submit code paths are exercised via the form (no new test file — the helper is small enough that the integration via existing reader tests is enough).
- All 613 vitest pass · eslint + svelte-check 0/0.

Closes #186 · Closes #187 · Closes #188
Refs #42, #160