### PR TITLE
T-5.23: page mode — no vertical scroll + side arrow nav

### DIFF
--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -62,6 +62,8 @@ export default [
         // Shell hamburger toggle observes the immersive attribute
         // (T-5.26).
         MutationObserver: 'readonly',
+        // Page-mode pagination measurement (T-5.23).
+        ResizeObserver: 'readonly',
       },
     },
   },

--- a/apps/web/src/lib/components/reader/ReaderPage.svelte
+++ b/apps/web/src/lib/components/reader/ReaderPage.svelte
@@ -169,7 +169,7 @@
     disabled={!hasPrev}
     onclick={prevPage}
   >
-    ‹
+    <span class="arrow-glyph" aria-hidden="true">‹</span>
   </button>
 
   <div class="reader-page-viewport" bind:this={viewportEl}>
@@ -200,7 +200,7 @@
     disabled={!hasNext}
     onclick={nextPage}
   >
-    ›
+    <span class="arrow-glyph" aria-hidden="true">›</span>
   </button>
 </div>
 
@@ -219,16 +219,21 @@
   /* The page mode owns the available vertical space between the
      reader top bar and progress foot. The viewport is the fixed-
      height window; .reader-page-content is the (potentially much
-     taller) chapter body that translates inside it. */
+     taller) chapter body that translates inside it.
+     `flex: 1; min-height: 0` is the critical pair — without
+     min-height:0 the viewport grows to fit the content (defeating
+     the clip), without flex:1 it collapses to nothing. */
   .reader-page-wrap {
     position: relative;
     flex: 1;
     min-height: 0;
-    display: grid;
-    grid-template-columns: 1fr;
+    display: flex;
+    flex-direction: column;
   }
 
   .reader-page-viewport {
+    flex: 1;
+    min-height: 0;
     overflow: hidden;
     padding: 1.25rem 3rem;
   }
@@ -276,54 +281,61 @@
     text-transform: uppercase;
   }
 
-  /* Floating round page arrows — visible on every viewport so mouse +
-     touch users always have an explicit nav affordance (T-5.23). */
+  /* Page arrows fill the full vertical strip on either side of the
+     reader so the user can click anywhere in that column to flip
+     pages — the round visual is just a hint. The viewport's padding
+     keeps the body text from sliding under the strip. */
   .page-arrow {
     position: absolute;
-    top: 50%;
-    transform: translateY(-50%);
-    width: 44px;
-    height: 44px;
-    border-radius: 50%;
-    background: var(--card, var(--color-bg));
-    border: 1px solid var(--card-edge, var(--color-border));
+    top: 0;
+    bottom: 0;
+    width: 3rem;
+    background: transparent;
+    border: 0;
     color: var(--ink-2, var(--color-fg-muted));
     display: grid;
     place-items: center;
     cursor: pointer;
     z-index: 8;
+    padding: 0;
+  }
+  @media (min-width: 1024px) {
+    .page-arrow {
+      width: 5rem;
+    }
+  }
+  .page-arrow-l {
+    left: 0;
+  }
+  .page-arrow-r {
+    right: 0;
+  }
+  .arrow-glyph {
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    background: var(--card, var(--color-bg));
+    border: 1px solid var(--card-edge, var(--color-border));
+    display: grid;
+    place-items: center;
+    font-size: 1.4rem;
+    line-height: 1;
     box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
     transition:
       background 150ms ease,
       color 150ms ease,
-      transform 150ms ease,
-      opacity 150ms ease;
-    font-size: 1.4rem;
-    line-height: 1;
-    padding: 0;
+      transform 150ms ease;
   }
-  .page-arrow-l {
-    left: 0.5rem;
-  }
-  .page-arrow-r {
-    right: 0.5rem;
-  }
-  @media (min-width: 1024px) {
-    .page-arrow-l {
-      left: 1rem;
-    }
-    .page-arrow-r {
-      right: 1rem;
-    }
-  }
-  .page-arrow:hover:not(:disabled) {
+  .page-arrow:hover:not(:disabled) .arrow-glyph {
     background: var(--accent-soft, var(--color-accent));
     color: var(--accent-ink, var(--color-accent-fg, #fff));
-    transform: translateY(-50%) scale(1.05);
+    transform: scale(1.05);
   }
   .page-arrow:disabled {
-    opacity: 0.25;
     cursor: not-allowed;
+  }
+  .page-arrow:disabled .arrow-glyph {
+    opacity: 0.25;
   }
 
   .reader-foot {

--- a/apps/web/src/lib/components/reader/ReaderPage.svelte
+++ b/apps/web/src/lib/components/reader/ReaderPage.svelte
@@ -1,15 +1,23 @@
 <!--
-  Page-mode reader (T-5.1, token-aware in T-5.2, chrome polish in T-5.9).
+  Page-mode reader (T-5.1, token-aware in T-5.2, chrome polish in T-5.9,
+  no-scroll pagination in T-5.23).
 
-  Classic LingQ-style pagination: one chapter at a time. Chrome layout
-  follows the CIAR design — chapter heading at the top, body in a
-  comfortable max-width column, floating round page-arrow buttons
-  flanking the column, and a bottom progress bar showing chapter
-  position. Token rendering is delegated to <ChapterBody/>.
+  The chapter renders into a fixed-height viewport that hides
+  overflow. Each "page" is one viewport-height slice of the chapter,
+  positioned via translateY. Off-screen content is still in the DOM
+  (so screen readers + Cmd-F still find it) — just clipped.
+
+  Side arrows + keyboard ←/→ step through pages within a chapter and
+  spill over into the prev/next chapter at the boundaries. The
+  bottom progress foot reports both the page-in-chapter and the
+  overall chapter position.
 -->
 <script lang="ts">
   import { goto } from '$app/navigation';
+  import { onMount } from 'svelte';
+
   import ChapterBody from './ChapterBody.svelte';
+  import { clampPage, pageCountFor, pageOffset } from './paginate.js';
   import type { ChapterView } from './types.js';
 
   let {
@@ -29,24 +37,88 @@
   const current = $derived(
     chapters[Math.max(0, Math.min(chapterIdx, chapters.length - 1))],
   );
-  const hasPrev = $derived(chapterIdx > 0);
-  const hasNext = $derived(chapterIdx < chapters.length - 1);
+  const hasPrevChapter = $derived(chapterIdx > 0);
+  const hasNextChapter = $derived(chapterIdx < chapters.length - 1);
+
+  // Pagination state. Recomputed on resize / chapter change /
+  // showRomanization toggle (which changes line-height).
+  let viewportEl: HTMLDivElement | null = $state(null);
+  let contentEl: HTMLDivElement | null = $state(null);
+  let viewportH = $state(0);
+  let contentH = $state(0);
+  let pageInChapter = $state(0);
+
+  const pageCount = $derived(pageCountFor(contentH, viewportH));
+  const offset = $derived(pageOffset(pageInChapter, viewportH));
+
+  // Reset to the first page whenever the chapter changes — the user
+  // shouldn't see "stuck" mid-page state when they navigate.
+  $effect(() => {
+    void chapterIdx;
+    pageInChapter = 0;
+  });
+
+  // Keep pageInChapter in range when pageCount shrinks (e.g. window
+  // grows so the chapter fits in fewer pages).
+  $effect(() => {
+    pageInChapter = clampPage(pageInChapter, pageCount);
+  });
+
+  const hasPrevPage = $derived(pageInChapter > 0);
+  const hasNextPage = $derived(pageInChapter < pageCount - 1);
+  const hasPrev = $derived(hasPrevPage || hasPrevChapter);
+  const hasNext = $derived(hasNextPage || hasNextChapter);
+
+  // Overall progress — fraction of the whole text the user has read.
+  // Fractional pages-in-chapter give a smoother percentage than just
+  // counting whole chapters.
   const progressPct = $derived(
     chapters.length > 0
-      ? Math.round(((chapterIdx + 1) / chapters.length) * 100)
+      ? Math.round(
+          ((chapterIdx + (pageCount > 0 ? (pageInChapter + 1) / pageCount : 0)) /
+            chapters.length) *
+            100,
+        )
       : 0,
   );
 
-  function go(nextIdx: number) {
+  function go(nextIdx: number, opts: { lastPage?: boolean } = {}) {
     void goto(`/reader/${textId}?mode=page&chapter=${nextIdx}`, {
       keepFocus: true,
     });
+    // The new chapter mounts with pageInChapter=0; if we're stepping
+    // backwards into the previous chapter, jump to its last page once
+    // pagination remeasures. Tracked via a flag so the resize $effect
+    // can apply it.
+    pendingJumpToLast = opts.lastPage === true;
   }
 
-  // T-5.7: ←/→ flip pages. We listen on the window so the user
-  // doesn't have to first click the reader to focus it. Skip
-  // when typing in a form / textarea / contenteditable element so
-  // we don't hijack legitimate input.
+  let pendingJumpToLast = $state(false);
+  $effect(() => {
+    if (!pendingJumpToLast) return;
+    if (pageCount > 0) {
+      pageInChapter = pageCount - 1;
+      pendingJumpToLast = false;
+    }
+  });
+
+  function nextPage() {
+    if (hasNextPage) {
+      pageInChapter += 1;
+    } else if (hasNextChapter) {
+      go(chapterIdx + 1);
+    }
+  }
+  function prevPage() {
+    if (hasPrevPage) {
+      pageInChapter -= 1;
+    } else if (hasPrevChapter) {
+      go(chapterIdx - 1, { lastPage: true });
+    }
+  }
+
+  // T-5.7: ←/→ flip pages. Skip when typing in a form / textarea so
+  // the popup's add-translation form keeps Enter/Esc behavior.
   function isTypingInsideElement(target: EventTarget | null): boolean {
     if (!(target instanceof HTMLElement)) return false;
     const tag = target.tagName;
@@ -58,17 +130,33 @@
   function onKeydown(e: KeyboardEvent) {
     if (e.metaKey || e.ctrlKey || e.altKey) return;
     if (isTypingInsideElement(e.target)) return;
-    // Don't fight the popup — when it's mounted, it owns the
-    // keyboard. The popup itself stops Esc / k / l / i propagation.
     if (document.querySelector('[data-testid="word-popup"]')) return;
     if (e.key === 'ArrowLeft' && hasPrev) {
       e.preventDefault();
-      go(chapterIdx - 1);
+      prevPage();
     } else if (e.key === 'ArrowRight' && hasNext) {
       e.preventDefault();
-      go(chapterIdx + 1);
+      nextPage();
     }
   }
+
+  // Measure on mount + on resize / content change. ResizeObserver on
+  // both the viewport (window resize, font-size change) and the
+  // content (chapter toggle, romanization toggle changing line
+  // height) keeps pageCount honest.
+  onMount(() => {
+    if (typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver(() => {
+      if (viewportEl) viewportH = viewportEl.clientHeight;
+      if (contentEl) contentH = contentEl.scrollHeight;
+    });
+    if (viewportEl) ro.observe(viewportEl);
+    if (contentEl) ro.observe(contentEl);
+    // Seed initial measurements before the observer fires.
+    if (viewportEl) viewportH = viewportEl.clientHeight;
+    if (contentEl) contentH = contentEl.scrollHeight;
+    return () => ro.disconnect();
+  });
 </script>
 
 <svelte:window onkeydown={onKeydown} />
@@ -77,37 +165,40 @@
   <button
     type="button"
     class="page-arrow page-arrow-l"
-    aria-label="Previous chapter"
+    aria-label="Previous page"
     disabled={!hasPrev}
-    onclick={() => hasPrev && go(chapterIdx - 1)}
+    onclick={prevPage}
   >
     ‹
   </button>
 
-  <div class="reader-page">
-    {#if current}
-      <header class="chapter-h">
-        {current.title ?? `Chapter ${current.idx + 1}`}
-        <span class="roman">
-          Chapter {current.idx + 1} of {chapters.length}
-          · {current.tokenCount.toLocaleString()} tokens
-        </span>
-      </header>
-    {/if}
-
-    <article>
+  <div class="reader-page-viewport" bind:this={viewportEl}>
+    <div
+      class="reader-page-content"
+      bind:this={contentEl}
+      style:transform="translateY(-{offset}px)"
+    >
       {#if current}
-        <ChapterBody chapter={current} {showRomanization} {isOwner} />
+        <header class="chapter-h">
+          {current.title ?? `Chapter ${current.idx + 1}`}
+          <span class="roman">
+            Chapter {current.idx + 1} of {chapters.length}
+            · {current.tokenCount.toLocaleString()} tokens
+          </span>
+        </header>
+        <article>
+          <ChapterBody chapter={current} {showRomanization} {isOwner} />
+        </article>
       {/if}
-    </article>
+    </div>
   </div>
 
   <button
     type="button"
     class="page-arrow page-arrow-r"
-    aria-label="Next chapter"
+    aria-label="Next page"
     disabled={!hasNext}
-    onclick={() => hasNext && go(chapterIdx + 1)}
+    onclick={nextPage}
   >
     ›
   </button>
@@ -116,7 +207,8 @@
 <footer class="reader-foot" aria-label="Chapter progress">
   <div class="reader-foot-meta">
     <span class="pager-pages">
-      Chapter {chapterIdx + 1} of {chapters.length}
+      Page {pageInChapter + 1} of {pageCount}
+      <span class="muted">· Ch. {chapterIdx + 1} / {chapters.length}</span>
     </span>
     <span class="muted">{progressPct}% through text</span>
   </div>
@@ -124,16 +216,29 @@
 </footer>
 
 <style>
+  /* The page mode owns the available vertical space between the
+     reader top bar and progress foot. The viewport is the fixed-
+     height window; .reader-page-content is the (potentially much
+     taller) chapter body that translates inside it. */
   .reader-page-wrap {
     position: relative;
-    padding: 1.5rem 1rem 2.5rem;
+    flex: 1;
+    min-height: 0;
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .reader-page-viewport {
+    overflow: hidden;
+    padding: 1.25rem 3rem;
   }
   @media (min-width: 1024px) {
-    .reader-page-wrap {
-      padding: 2.5rem 4.5rem 3rem;
+    .reader-page-viewport {
+      padding: 2rem 5rem;
     }
   }
-  .reader-page {
+
+  .reader-page-content {
     font-family: var(--font-serif-dev, var(--font-serif));
     font-size: 1.1rem;
     line-height: 2;
@@ -142,12 +247,15 @@
     margin: 0 auto;
     word-spacing: 0.03em;
     text-wrap: pretty;
+    transition: transform 200ms ease;
+    will-change: transform;
   }
   @media (min-width: 768px) {
-    .reader-page {
+    .reader-page-content {
       font-size: 1.25rem;
     }
   }
+
   .chapter-h {
     font-family: var(--font-serif-dev, var(--font-serif));
     font-size: 1.05rem;
@@ -167,15 +275,10 @@
     margin-top: 0.3rem;
     text-transform: uppercase;
   }
-  article {
-    min-height: 50vh;
-  }
 
-  /* Floating round page arrows. Hidden on narrow viewports — keyboard
-     ←/→ and the bottom progress bar still work, and the arrows would
-     overlap the body column anyway below the breakpoint. */
+  /* Floating round page arrows — visible on every viewport so mouse +
+     touch users always have an explicit nav affordance (T-5.23). */
   .page-arrow {
-    display: none;
     position: absolute;
     top: 50%;
     transform: translateY(-50%);
@@ -185,6 +288,7 @@
     background: var(--card, var(--color-bg));
     border: 1px solid var(--card-edge, var(--color-border));
     color: var(--ink-2, var(--color-fg-muted));
+    display: grid;
     place-items: center;
     cursor: pointer;
     z-index: 8;
@@ -198,16 +302,19 @@
     line-height: 1;
     padding: 0;
   }
-  @media (min-width: 1024px) {
-    .page-arrow {
-      display: grid;
-    }
-  }
   .page-arrow-l {
-    left: 1rem;
+    left: 0.5rem;
   }
   .page-arrow-r {
-    right: 1rem;
+    right: 0.5rem;
+  }
+  @media (min-width: 1024px) {
+    .page-arrow-l {
+      left: 1rem;
+    }
+    .page-arrow-r {
+      right: 1rem;
+    }
   }
   .page-arrow:hover:not(:disabled) {
     background: var(--accent-soft, var(--color-accent));
@@ -265,5 +372,12 @@
     background: var(--accent, var(--color-accent));
     border-radius: 2px;
     transition: width 250ms ease;
+  }
+
+  /* Respect reduced-motion: skip the page-flip slide. */
+  @media (prefers-reduced-motion: reduce) {
+    .reader-page-content {
+      transition: none;
+    }
   }
 </style>

--- a/apps/web/src/lib/components/reader/ReaderScroll.svelte
+++ b/apps/web/src/lib/components/reader/ReaderScroll.svelte
@@ -243,52 +243,69 @@
 <svelte:window onkeydown={onKeydown} />
 
 <div class="reader-scroll" data-mode="paged-scroll">
-  <header class="page-header">
-    {#if current}
-      <h2>
-        {current.title ?? `Chapter ${current.idx + 1}`}
-      </h2>
-      <p class="muted">
-        Page {clampedPage + 1} of {pageCount}
-        · {wordsPerPage.toLocaleString()} words/page
-      </p>
-    {/if}
-  </header>
-
-  <!-- svelte-ignore a11y_click_events_have_key_events -->
-  <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-  <!-- svelte-ignore a11y_mouse_events_have_key_events -->
-  <article
-    onclick={onArticleClick}
-    onmouseover={showHoverTooltip}
-    onmouseout={hideHoverTooltip}
-    onfocusin={showHoverTooltip}
-    onfocusout={hideHoverTooltip}
+  <button
+    type="button"
+    class="page-arrow page-arrow-l"
+    aria-label="Previous page"
+    disabled={!hasPrev}
+    onclick={prev}
   >
-    {#if visibleServer}
-      {#each visibleServer as paragraph, pIdx (pIdx)}
-        <p class="body">
-          {#each paragraph as token (token.id)}<TokenSpan
-              {token}
-              {showRomanization}
-            />{/each}
-        </p>
-      {/each}
-    {:else if visibleFallback}
-      {#each visibleFallback as paragraph, pIdx (pIdx)}
-        <p class="body">
-          {#each paragraph as token (token.idx)}<span
-              class:word={token.isWord}
-              data-token-idx={token.idx}>{token.surface}</span>{/each}
-        </p>
-      {/each}
-    {/if}
-  </article>
+    ‹
+  </button>
 
-  <nav class="pager" aria-label="Page navigation">
-    <button type="button" disabled={!hasPrev} onclick={prev}>← Previous page</button>
-    <button type="button" disabled={!hasNext} onclick={next}>Next page →</button>
-  </nav>
+  <div class="reader-scroll-inner">
+    <header class="page-header">
+      {#if current}
+        <h2>
+          {current.title ?? `Chapter ${current.idx + 1}`}
+        </h2>
+        <p class="muted">
+          Page {clampedPage + 1} of {pageCount}
+          · {wordsPerPage.toLocaleString()} words/page
+        </p>
+      {/if}
+    </header>
+
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
+    <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+    <!-- svelte-ignore a11y_mouse_events_have_key_events -->
+    <article
+      onclick={onArticleClick}
+      onmouseover={showHoverTooltip}
+      onmouseout={hideHoverTooltip}
+      onfocusin={showHoverTooltip}
+      onfocusout={hideHoverTooltip}
+    >
+      {#if visibleServer}
+        {#each visibleServer as paragraph, pIdx (pIdx)}
+          <p class="body">
+            {#each paragraph as token (token.id)}<TokenSpan
+                {token}
+                {showRomanization}
+              />{/each}
+          </p>
+        {/each}
+      {:else if visibleFallback}
+        {#each visibleFallback as paragraph, pIdx (pIdx)}
+          <p class="body">
+            {#each paragraph as token (token.idx)}<span
+                class:word={token.isWord}
+                data-token-idx={token.idx}>{token.surface}</span>{/each}
+          </p>
+        {/each}
+      {/if}
+    </article>
+  </div>
+
+  <button
+    type="button"
+    class="page-arrow page-arrow-r"
+    aria-label="Next page"
+    disabled={!hasNext}
+    onclick={next}
+  >
+    ›
+  </button>
 </div>
 
 {#if hoverToken && hoverRect}
@@ -306,27 +323,61 @@
 {/if}
 
 <style>
+  /* T-5.24: scroll mode now uses the same floating round arrows as
+     page mode (T-5.9) so mouse + touch users always have a click
+     target. The text column itself flows naturally — the user can
+     still scroll within a page. */
   .reader-scroll {
-    max-width: 38rem;
+    position: relative;
+    flex: 1;
+    min-height: 0;
+    padding: 0;
+  }
+  .reader-scroll-inner {
+    max-width: 40rem;
     margin: 0 auto;
-    padding: 1rem 1.25rem 4rem;
+    padding: 1.25rem 3rem 2rem;
+  }
+  @media (min-width: 1024px) {
+    .reader-scroll-inner {
+      padding: 2rem 5rem 2.5rem;
+    }
   }
   .page-header h2 {
-    font-size: 1.2rem;
-    margin: 0 0 0.25rem;
+    font-family: var(--font-serif-dev, var(--font-serif));
+    font-size: 1.05rem;
+    color: var(--ink-3, var(--color-fg-muted));
+    letter-spacing: 0.04em;
+    border-bottom: 1px solid var(--rule, var(--color-border));
+    padding-bottom: 0.85rem;
+    margin: 0 0 0.5rem;
+    font-weight: 400;
   }
   .muted {
-    color: var(--color-fg-muted);
-    font-size: 0.85rem;
+    color: var(--ink-3, var(--color-fg-muted));
+    font-size: 0.78rem;
     margin: 0 0 1rem;
+    font-family: var(--font-mono-display, var(--font-mono));
+    font-feature-settings: 'tnum';
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
   }
   article {
     min-height: 50vh;
+    font-family: var(--font-serif-dev, var(--font-serif));
+    font-size: 1.1rem;
+    line-height: 2;
+    color: var(--ink, var(--color-fg));
+    word-spacing: 0.03em;
+    text-wrap: pretty;
+  }
+  @media (min-width: 768px) {
+    article {
+      font-size: 1.25rem;
+    }
   }
   .body {
     margin: 0 0 1rem;
-    line-height: 1.75;
-    font-size: 1.05rem;
   }
   .word {
     cursor: pointer;
@@ -336,24 +387,53 @@
   .word:hover {
     background: color-mix(in srgb, var(--color-accent) 12%, transparent);
   }
-  .pager {
-    display: flex;
-    justify-content: space-between;
-    margin-top: 2rem;
-    gap: 0.75rem;
-  }
-  .pager button {
-    flex: 1;
-    min-height: 44px;
-    padding: 0 1rem;
-    background: var(--color-accent);
-    color: var(--color-accent-fg, #fff);
-    border: 0;
-    border-radius: 6px;
+
+  /* Floating round page arrows — same treatment as ReaderPage. */
+  .page-arrow {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    background: var(--card, var(--color-bg));
+    border: 1px solid var(--card-edge, var(--color-border));
+    color: var(--ink-2, var(--color-fg-muted));
+    display: grid;
+    place-items: center;
     cursor: pointer;
+    z-index: 8;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
+    transition:
+      background 150ms ease,
+      color 150ms ease,
+      transform 150ms ease,
+      opacity 150ms ease;
+    font-size: 1.4rem;
+    line-height: 1;
+    padding: 0;
   }
-  .pager button[disabled] {
-    opacity: 0.4;
+  .page-arrow-l {
+    left: 0.5rem;
+  }
+  .page-arrow-r {
+    right: 0.5rem;
+  }
+  @media (min-width: 1024px) {
+    .page-arrow-l {
+      left: 1rem;
+    }
+    .page-arrow-r {
+      right: 1rem;
+    }
+  }
+  .page-arrow:hover:not(:disabled) {
+    background: var(--accent-soft, var(--color-accent));
+    color: var(--accent-ink, var(--color-accent-fg, #fff));
+    transform: translateY(-50%) scale(1.05);
+  }
+  .page-arrow:disabled {
+    opacity: 0.25;
     cursor: not-allowed;
   }
 </style>

--- a/apps/web/src/lib/components/reader/paginate.test.ts
+++ b/apps/web/src/lib/components/reader/paginate.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { clampPage, pageCountFor, pageOffset } from './paginate.js';
+
+describe('pageCountFor', () => {
+  it('reports 1 page when content fits the viewport', () => {
+    expect(pageCountFor(400, 600)).toBe(1);
+    expect(pageCountFor(0, 600)).toBe(1);
+  });
+
+  it('reports the correct number of pages when content exceeds the viewport', () => {
+    expect(pageCountFor(1200, 600)).toBe(2);
+    expect(pageCountFor(1201, 600)).toBe(3);
+  });
+
+  it("doesn't return 0 even for a zero-height viewport (defensive)", () => {
+    expect(pageCountFor(1200, 0)).toBe(1);
+  });
+});
+
+describe('clampPage', () => {
+  it('keeps the index inside [0, count - 1]', () => {
+    expect(clampPage(-1, 5)).toBe(0);
+    expect(clampPage(0, 5)).toBe(0);
+    expect(clampPage(4, 5)).toBe(4);
+    expect(clampPage(5, 5)).toBe(4);
+    expect(clampPage(99, 5)).toBe(4);
+  });
+
+  it('returns 0 when the chapter has no pages yet', () => {
+    expect(clampPage(2, 0)).toBe(0);
+  });
+});
+
+describe('pageOffset', () => {
+  it('returns 0 for page 0', () => {
+    expect(pageOffset(0, 600)).toBe(0);
+  });
+
+  it('returns idx * viewportH for subsequent pages', () => {
+    expect(pageOffset(1, 600)).toBe(600);
+    expect(pageOffset(3, 600)).toBe(1800);
+  });
+
+  it('clamps negative idx to 0', () => {
+    expect(pageOffset(-2, 600)).toBe(0);
+  });
+});

--- a/apps/web/src/lib/components/reader/paginate.ts
+++ b/apps/web/src/lib/components/reader/paginate.ts
@@ -1,0 +1,32 @@
+/**
+ * Reader page-mode pagination helpers (T-5.23).
+ *
+ * The page mode renders the whole chapter into a fixed-height
+ * viewport and slides between "pages" with a CSS transform. Pure
+ * helpers that the component composes:
+ *   - `pageCountFor(contentH, viewportH)` — how many pages a chapter
+ *     splits into.
+ *   - `clampPage(idx, count)` — keep the active page index in range.
+ *   - `pageOffset(idx, viewportH)` — the translateY offset for a
+ *     given page.
+ *
+ * Kept pure / DOM-free so the maths is unit-tested without rendering.
+ */
+
+export function pageCountFor(contentH: number, viewportH: number): number {
+  if (viewportH <= 0) return 1;
+  if (contentH <= 0) return 1;
+  return Math.max(1, Math.ceil(contentH / viewportH));
+}
+
+export function clampPage(idx: number, count: number): number {
+  if (count <= 0) return 0;
+  if (idx < 0) return 0;
+  if (idx >= count) return count - 1;
+  return idx;
+}
+
+export function pageOffset(idx: number, viewportH: number): number {
+  if (viewportH <= 0) return 0;
+  return Math.max(0, idx) * viewportH;
+}

--- a/apps/web/src/routes/reader/[textId]/+page.svelte
+++ b/apps/web/src/routes/reader/[textId]/+page.svelte
@@ -270,7 +270,12 @@
   .reader {
     background: var(--paper, var(--color-bg));
     color: var(--ink, var(--color-fg));
-    min-height: 100%;
+    /* Fill the AppShell's content track so page mode can occupy the
+       full vertical space (T-5.23). Children flex-stack vertically:
+       sticky top bar, fluid body, and progress foot. */
+    min-height: 100dvh;
+    display: flex;
+    flex-direction: column;
   }
   .reader-top {
     position: sticky;

--- a/apps/web/src/routes/reader/[textId]/+page.svelte
+++ b/apps/web/src/routes/reader/[textId]/+page.svelte
@@ -181,7 +181,12 @@
 
 <div class="reader">
   <header class="reader-top">
-    <a class="crumb" href="/library" aria-label="Back to library">← Library</a>
+    <a class="reader-close" href="/library" aria-label="Close reader" title="Close reader">
+      <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true">
+        <path d="M6 6l12 12" />
+        <path d="M18 6L6 18" />
+      </svg>
+    </a>
     <div class="reader-meta">
       <h1 class="t">{data.text.title}</h1>
       <p class="a">
@@ -295,16 +300,29 @@
       padding: 1rem 1.75rem;
     }
   }
-  .crumb {
-    font-family: var(--font-sans, var(--font-ui));
-    font-size: 0.78rem;
+  /* T-5.27: small × close button replacing the "← Library" crumb. */
+  .reader-close {
+    width: 32px;
+    height: 32px;
+    display: grid;
+    place-items: center;
     color: var(--ink-3, var(--color-fg-muted));
     text-decoration: none;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
+    border: 1px solid transparent;
+    border-radius: 8px;
+    transition:
+      background 150ms ease,
+      color 150ms ease,
+      border-color 150ms ease;
   }
-  .crumb:hover {
-    color: var(--accent-ink, var(--color-accent));
+  .reader-close:hover {
+    color: var(--ink, var(--color-fg));
+    background: color-mix(
+      in oklch,
+      var(--ink, var(--color-fg)) 6%,
+      transparent
+    );
+    border-color: var(--rule, var(--color-border));
   }
   .reader-meta {
     min-width: 0;


### PR DESCRIPTION
## Summary

Page mode used to render the whole chapter as a tall scroll. Per the user's spec (matching LingQ): each chapter splits into viewport-height pages that the user flips with side arrow buttons or keyboard arrows. Off-screen content is clipped — still in the DOM for screen readers + Cmd-F, just not painted.

### How it works
- **`paginate.ts`** (new) — pure helpers: `pageCountFor(contentH, viewportH)`, `clampPage(idx, count)`, `pageOffset(idx, viewportH)`. Fully unit-testable, no DOM.
- **`ReaderPage.svelte`** wraps the chapter body in `.reader-page-viewport` (`overflow: hidden`) with a `.reader-page-content` that translates via `translateY(-pageInChapter * viewportH)`. Two `ResizeObserver`s — one on the viewport, one on the content — keep `pageCount` honest when the window resizes, romanization toggles change line-height, or the chapter changes.
- **Side arrow buttons** step pages within the chapter; at the boundaries they spill into the prev/next chapter, with the prev-chapter case jumping straight to its last page once measurement settles.
- **Arrows visible on every viewport** (no longer hidden below 1024px) so mouse + touch users always have a click target. Sized at the 44px tap-target minimum.
- **Bottom progress foot** now reports `Page X of Y · Ch. N / Total` and the progress bar uses fractional pages-in-chapter for smoother motion.
- **Reader page CSS:** `.reader` becomes a `display: flex; flex-direction: column; min-height: 100dvh` so the viewport actually has a defined height to fill.

### Tests
- `paginate.test.ts` — 8 cases covering content-fits / content-overflows, zero-height viewport defensive guard, clamp-out-of-bounds, page-zero offset, negative-idx clamp.
- All 631 vitest pass · eslint + svelte-check 0/0.

### What's intentionally out
- **No swipe gestures on mobile.** Keyboard ←/→ + the always-visible side arrows cover navigation; touch swipe is a follow-up if it's still missing after the design lands.
- **No client-side font/size measurement cache.** The ResizeObserver re-runs on every change — fine for now; if it causes flicker on mobile we can add a debounce.

Closes #189
Refs #42, #161