### PR TITLE
T-5.24 + T-5.27: scroll-mode side arrows + reader close button

### DIFF
--- a/apps/web/src/lib/components/reader/ReaderScroll.svelte
+++ b/apps/web/src/lib/components/reader/ReaderScroll.svelte
@@ -186,45 +186,62 @@
 <svelte:window onkeydown={onKeydown} />
 
 <div class="reader-scroll" data-mode="paged-scroll">
-  <header class="page-header">
-    {#if current}
-      <h2>
-        {current.title ?? `Chapter ${current.idx + 1}`}
-      </h2>
-      <p class="muted">
-        Page {clampedPage + 1} of {pageCount}
-        · {wordsPerPage.toLocaleString()} words/page
-      </p>
-    {/if}
-  </header>
+  <button
+    type="button"
+    class="page-arrow page-arrow-l"
+    aria-label="Previous page"
+    disabled={!hasPrev}
+    onclick={prev}
+  >
+    ‹
+  </button>
 
-  <!-- svelte-ignore a11y_click_events_have_key_events -->
-  <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-  <article onclick={onArticleClick}>
-    {#if visibleServer}
-      {#each visibleServer as paragraph, pIdx (pIdx)}
-        <p class="body">
-          {#each paragraph as token (token.id)}<TokenSpan
-              {token}
-              {showRomanization}
-            />{/each}
+  <div class="reader-scroll-inner">
+    <header class="page-header">
+      {#if current}
+        <h2>
+          {current.title ?? `Chapter ${current.idx + 1}`}
+        </h2>
+        <p class="muted">
+          Page {clampedPage + 1} of {pageCount}
+          · {wordsPerPage.toLocaleString()} words/page
         </p>
-      {/each}
-    {:else if visibleFallback}
-      {#each visibleFallback as paragraph, pIdx (pIdx)}
-        <p class="body">
-          {#each paragraph as token (token.idx)}<span
-              class:word={token.isWord}
-              data-token-idx={token.idx}>{token.surface}</span>{/each}
-        </p>
-      {/each}
-    {/if}
-  </article>
+      {/if}
+    </header>
 
-  <nav class="pager" aria-label="Page navigation">
-    <button type="button" disabled={!hasPrev} onclick={prev}>← Previous page</button>
-    <button type="button" disabled={!hasNext} onclick={next}>Next page →</button>
-  </nav>
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
+    <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+    <article onclick={onArticleClick}>
+      {#if visibleServer}
+        {#each visibleServer as paragraph, pIdx (pIdx)}
+          <p class="body">
+            {#each paragraph as token (token.id)}<TokenSpan
+                {token}
+                {showRomanization}
+              />{/each}
+          </p>
+        {/each}
+      {:else if visibleFallback}
+        {#each visibleFallback as paragraph, pIdx (pIdx)}
+          <p class="body">
+            {#each paragraph as token (token.idx)}<span
+                class:word={token.isWord}
+                data-token-idx={token.idx}>{token.surface}</span>{/each}
+          </p>
+        {/each}
+      {/if}
+    </article>
+  </div>
+
+  <button
+    type="button"
+    class="page-arrow page-arrow-r"
+    aria-label="Next page"
+    disabled={!hasNext}
+    onclick={next}
+  >
+    ›
+  </button>
 </div>
 
 {#if activeToken && activeRect}
@@ -238,27 +255,61 @@
 {/if}
 
 <style>
+  /* T-5.24: scroll mode now uses the same floating round arrows as
+     page mode (T-5.9) so mouse + touch users always have a click
+     target. The text column itself flows naturally — the user can
+     still scroll within a page. */
   .reader-scroll {
-    max-width: 38rem;
+    position: relative;
+    flex: 1;
+    min-height: 0;
+    padding: 0;
+  }
+  .reader-scroll-inner {
+    max-width: 40rem;
     margin: 0 auto;
-    padding: 1rem 1.25rem 4rem;
+    padding: 1.25rem 3rem 2rem;
+  }
+  @media (min-width: 1024px) {
+    .reader-scroll-inner {
+      padding: 2rem 5rem 2.5rem;
+    }
   }
   .page-header h2 {
-    font-size: 1.2rem;
-    margin: 0 0 0.25rem;
+    font-family: var(--font-serif-dev, var(--font-serif));
+    font-size: 1.05rem;
+    color: var(--ink-3, var(--color-fg-muted));
+    letter-spacing: 0.04em;
+    border-bottom: 1px solid var(--rule, var(--color-border));
+    padding-bottom: 0.85rem;
+    margin: 0 0 0.5rem;
+    font-weight: 400;
   }
   .muted {
-    color: var(--color-fg-muted);
-    font-size: 0.85rem;
+    color: var(--ink-3, var(--color-fg-muted));
+    font-size: 0.78rem;
     margin: 0 0 1rem;
+    font-family: var(--font-mono-display, var(--font-mono));
+    font-feature-settings: 'tnum';
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
   }
   article {
     min-height: 50vh;
+    font-family: var(--font-serif-dev, var(--font-serif));
+    font-size: 1.1rem;
+    line-height: 2;
+    color: var(--ink, var(--color-fg));
+    word-spacing: 0.03em;
+    text-wrap: pretty;
+  }
+  @media (min-width: 768px) {
+    article {
+      font-size: 1.25rem;
+    }
   }
   .body {
     margin: 0 0 1rem;
-    line-height: 1.75;
-    font-size: 1.05rem;
   }
   .word {
     cursor: pointer;
@@ -268,24 +319,53 @@
   .word:hover {
     background: color-mix(in srgb, var(--color-accent) 12%, transparent);
   }
-  .pager {
-    display: flex;
-    justify-content: space-between;
-    margin-top: 2rem;
-    gap: 0.75rem;
-  }
-  .pager button {
-    flex: 1;
-    min-height: 44px;
-    padding: 0 1rem;
-    background: var(--color-accent);
-    color: var(--color-accent-fg, #fff);
-    border: 0;
-    border-radius: 6px;
+
+  /* Floating round page arrows — same treatment as ReaderPage. */
+  .page-arrow {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    background: var(--card, var(--color-bg));
+    border: 1px solid var(--card-edge, var(--color-border));
+    color: var(--ink-2, var(--color-fg-muted));
+    display: grid;
+    place-items: center;
     cursor: pointer;
+    z-index: 8;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
+    transition:
+      background 150ms ease,
+      color 150ms ease,
+      transform 150ms ease,
+      opacity 150ms ease;
+    font-size: 1.4rem;
+    line-height: 1;
+    padding: 0;
   }
-  .pager button[disabled] {
-    opacity: 0.4;
+  .page-arrow-l {
+    left: 0.5rem;
+  }
+  .page-arrow-r {
+    right: 0.5rem;
+  }
+  @media (min-width: 1024px) {
+    .page-arrow-l {
+      left: 1rem;
+    }
+    .page-arrow-r {
+      right: 1rem;
+    }
+  }
+  .page-arrow:hover:not(:disabled) {
+    background: var(--accent-soft, var(--color-accent));
+    color: var(--accent-ink, var(--color-accent-fg, #fff));
+    transform: translateY(-50%) scale(1.05);
+  }
+  .page-arrow:disabled {
+    opacity: 0.25;
     cursor: not-allowed;
   }
 </style>

--- a/apps/web/src/routes/reader/[textId]/+page.svelte
+++ b/apps/web/src/routes/reader/[textId]/+page.svelte
@@ -194,7 +194,12 @@
 
 <div class="reader">
   <header class="reader-top">
-    <a class="crumb" href="/library" aria-label="Back to library">← Library</a>
+    <a class="reader-close" href="/library" aria-label="Close reader" title="Close reader">
+      <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true">
+        <path d="M6 6l12 12" />
+        <path d="M18 6L6 18" />
+      </svg>
+    </a>
     <div class="reader-meta">
       <h1 class="t">{data.text.title}</h1>
       <p class="a">
@@ -331,16 +336,29 @@
       padding: 1rem 1.75rem;
     }
   }
-  .crumb {
-    font-family: var(--font-sans, var(--font-ui));
-    font-size: 0.78rem;
+  /* T-5.27: small × close button replacing the "← Library" crumb. */
+  .reader-close {
+    width: 32px;
+    height: 32px;
+    display: grid;
+    place-items: center;
     color: var(--ink-3, var(--color-fg-muted));
     text-decoration: none;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
+    border: 1px solid transparent;
+    border-radius: 8px;
+    transition:
+      background 150ms ease,
+      color 150ms ease,
+      border-color 150ms ease;
   }
-  .crumb:hover {
-    color: var(--accent-ink, var(--color-accent));
+  .reader-close:hover {
+    color: var(--ink, var(--color-fg));
+    background: color-mix(
+      in oklch,
+      var(--ink, var(--color-fg)) 6%,
+      transparent
+    );
+    border-color: var(--rule, var(--color-border));
   }
   .reader-meta {
     min-width: 0;


### PR DESCRIPTION
## Summary

Two small reader-chrome polish changes folded into one PR.

### T-5.24 — Scroll mode side arrows
- `ReaderScroll` wraps its inner content in `.reader-scroll-inner` and adds the same floating round arrow buttons used by `ReaderPage` (T-5.9). Mouse + touch users now have a click target; keyboard ←/→ keeps working.
- Drops the in-flow "← Previous page / Next page →" buttons at the bottom — the side arrows make them redundant.
- Restyled the article body to use `--font-serif-dev`, line-height 2, and paper tokens so all three modes share the literary-reader treatment.

### T-5.27 — × close button replacing "← Library"
- The reader top bar's textual breadcrumb is now a 32×32 icon button with an × glyph and `aria-label="Close reader"`. Hover tints the background and outlines the button. `href="/library"` so middle-click and Cmd-click still open in a new tab.

### Tests
All 631 vitest pass · eslint + svelte-check 0/0. No new behavioral logic — pure chrome.

### Stack
Branched off `feat/t-5.23-page-mode-paginate` so the page-mode pagination changes don't conflict with this scroll-mode restyle. Once #198 lands, this rebases onto `main` cleanly.

Closes #190 · Closes #200
Refs #42, #161