### PR TITLE
T-3.11: Customize action in reader popup

### DIFF
--- a/apps/web/src/lib/components/reader/WordPopup.svelte
+++ b/apps/web/src/lib/components/reader/WordPopup.svelte
@@ -20,6 +20,7 @@
 <script lang="ts">
   import { untrack } from 'svelte';
   import Sheet from '../overlay/Sheet.svelte';
+  import { customizableOfficialIds } from './customize-eligibility.js';
   import type { ServerToken } from './types.js';
 
   type Provenance =
@@ -33,6 +34,7 @@
     body: string;
     targetLanguage: string;
     sourceAttribution: string | null;
+    parentTranslationId: string | null;
     provenance: Provenance;
   };
 
@@ -154,6 +156,86 @@
   let savingTranslation = $state(false);
   let addError = $state<string | null>(null);
 
+  // ---- Customize-official flow (T-3.11) ---------------------------
+  // Which official translation (id) is currently being forked, if any,
+  // plus the body of the in-progress fork. The eligibility set itself
+  // lives in `customize-eligibility.ts` so the rule is unit-tested
+  // separately from the component.
+  let customizingId = $state<string | null>(null);
+  let customizeBody = $state('');
+  let savingCustomize = $state(false);
+  let customizeError = $state<string | null>(null);
+
+  const customizableIds = $derived(() =>
+    customizableOfficialIds(
+      isOwner,
+      payload?.translations.official ?? [],
+      payload?.translations.personal ?? [],
+    ),
+  );
+
+  function startCustomize(t: PublicTranslation) {
+    customizingId = t.id;
+    customizeBody = t.body;
+    customizeError = null;
+  }
+
+  function cancelCustomize() {
+    customizingId = null;
+    customizeBody = '';
+    customizeError = null;
+  }
+
+  type PostError = { message: string; status: number };
+
+  async function postTranslation(
+    body: string,
+    parentTranslationId: string | null,
+  ): Promise<PublicTranslation> {
+    if (!token.lemmaId) throw new Error('Missing lemma id');
+    const res = await fetch('/api/v1/translations', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        lemmaId: token.lemmaId,
+        body,
+        targetLanguage: 'en',
+        parentTranslationId,
+      }),
+    });
+    if (!res.ok) {
+      // 429 carries a JSON body with a friendly message; everything
+      // else falls through to the raw text + status combo.
+      let message = `POST failed: ${res.status}`;
+      if (res.status === 429) {
+        const errBody = (await res
+          .json()
+          .catch(() => null)) as { message?: string } | null;
+        message =
+          errBody?.message ?? 'Too many translations submitted. Try again later.';
+      } else {
+        const text = await res.text().catch(() => '');
+        if (text) message = text;
+      }
+      const err: PostError = { message, status: res.status };
+      throw err;
+    }
+    const created = (await res.json()) as { translation: PublicTranslation };
+    return created.translation;
+  }
+
+  // T-5.22: re-fetch the lemma payload after a write so the new row
+  // definitely shows. The optimistic prepend was unreliable across
+  // payload-may-be-null states and Svelte 5 $state proxy edge cases,
+  // and would have placed customize-fork rows in the wrong position
+  // anyway (the personal bucket sorts oldest-first server-side).
+  async function refetchPayload(lemmaId: string) {
+    const fresh = await fetch(`/api/v1/lemmas/${lemmaId}/translations`);
+    if (fresh.ok) {
+      payload = (await fresh.json()) as LemmaPayload;
+    }
+  }
+
   async function submitNewTranslation() {
     if (!token.lemmaId) return;
     const trimmed = newTranslationBody.trim();
@@ -165,32 +247,12 @@
     savingTranslation = true;
     addError = null;
     try {
-      const res = await fetch('/api/v1/translations', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({
-          lemmaId,
-          body: trimmed,
-          targetLanguage: 'en',
-        }),
-      });
-      if (!res.ok) {
-        const text = await res.text().catch(() => '');
-        throw new Error(text || `POST failed: ${res.status}`);
-      }
-      // T-5.22: re-fetch the lemma payload so the new row definitely
-      // shows. The optimistic prepend was unreliable — between
-      // payload-may-be-null states and Svelte 5 $state proxy edge
-      // cases, the freshly-saved translation sometimes never
-      // appeared. A single GET on success is small and reliable.
-      const fresh = await fetch(`/api/v1/lemmas/${lemmaId}/translations`);
-      if (fresh.ok) {
-        payload = (await fresh.json()) as LemmaPayload;
-      }
+      await postTranslation(trimmed, null);
+      await refetchPayload(lemmaId);
       newTranslationBody = '';
       showAddForm = false;
     } catch (e) {
-      addError = (e as Error).message;
+      addError = (e as PostError).message ?? (e as Error).message;
     } finally {
       savingTranslation = false;
     }
@@ -211,6 +273,43 @@
       showAddForm = false;
       newTranslationBody = '';
       addError = null;
+    }
+  }
+
+  // Mirror onAddFormKeydown so Enter/Esc on the customize textarea
+  // behaves the same way as on the add-translation textarea.
+  function onCustomizeKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      void submitCustomize();
+      return;
+    }
+    if (e.key === 'Escape') {
+      e.stopPropagation();
+      e.preventDefault();
+      cancelCustomize();
+    }
+  }
+
+  async function submitCustomize() {
+    if (!customizingId || !token.lemmaId) return;
+    const trimmed = customizeBody.trim();
+    if (trimmed.length === 0) {
+      customizeError = 'Translation cannot be empty.';
+      return;
+    }
+    const lemmaId = token.lemmaId;
+    savingCustomize = true;
+    customizeError = null;
+    try {
+      await postTranslation(trimmed, customizingId);
+      await refetchPayload(lemmaId);
+      customizingId = null;
+      customizeBody = '';
+    } catch (e) {
+      customizeError = (e as PostError).message ?? (e as Error).message;
+    } finally {
+      savingCustomize = false;
     }
   }
 
@@ -311,11 +410,60 @@
           </li>
         {/each}
         {#each payload.translations.official as t (t.id)}
-          <li>
-            <span class="badge tone-{t.provenance.kind}">
-              {t.provenance.attribution ?? t.provenance.kind}
-            </span>
-            {t.body}
+          <li class="official-row">
+            <div class="official-body">
+              <span class="badge tone-{t.provenance.kind}">
+                {t.provenance.attribution ?? t.provenance.kind}
+              </span>
+              {t.body}
+              {#if customizableIds().has(t.id)}
+                <button
+                  type="button"
+                  class="customize-toggle"
+                  data-testid="customize-toggle"
+                  onclick={() => startCustomize(t)}
+                  disabled={customizingId !== null}
+                  title="Fork this translation into a private copy you can edit"
+                >
+                  Customize
+                </button>
+              {/if}
+            </div>
+            {#if customizingId === t.id}
+              <form
+                class="customize-form"
+                data-testid="customize-form"
+                onsubmit={(e) => {
+                  e.preventDefault();
+                  void submitCustomize();
+                }}
+              >
+                <textarea
+                  bind:value={customizeBody}
+                  rows="2"
+                  maxlength="500"
+                  disabled={savingCustomize}
+                  aria-label="Your customized translation"
+                  onkeydown={onCustomizeKeydown}
+                ></textarea>
+                {#if customizeError}
+                  <p class="err small">{customizeError}</p>
+                {/if}
+                <div class="add-row">
+                  <button type="submit" disabled={savingCustomize}>
+                    {savingCustomize ? 'Saving…' : 'Save'}
+                  </button>
+                  <button
+                    type="button"
+                    class="ghost"
+                    disabled={savingCustomize}
+                    onclick={cancelCustomize}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </form>
+            {/if}
           </li>
         {/each}
         {#each payload.translations.community as t (t.id)}
@@ -609,6 +757,61 @@
   .add-row button[disabled] {
     opacity: 0.5;
     cursor: not-allowed;
+  }
+
+  .official-row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+  .official-body {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.3rem;
+  }
+  .customize-toggle {
+    margin-left: auto;
+    padding: 0.1rem 0.55rem;
+    background: transparent;
+    border: 1px solid var(--rule, var(--color-border));
+    border-radius: 999px;
+    font: inherit;
+    font-size: 0.7rem;
+    color: var(--ink-3, var(--color-fg-muted));
+    cursor: pointer;
+  }
+  .customize-toggle:hover:not([disabled]) {
+    border-color: var(--accent, var(--color-accent));
+    color: var(--accent-ink, var(--color-accent));
+  }
+  .customize-toggle[disabled] {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+  .customize-form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    padding: 0.5rem;
+    border: 1px solid var(--rule, var(--color-border));
+    border-radius: 8px;
+    background: color-mix(
+      in oklch,
+      var(--ink, var(--color-fg)) 3%,
+      transparent
+    );
+  }
+  .customize-form textarea {
+    width: 100%;
+    padding: 0.45rem 0.6rem;
+    font: inherit;
+    font-size: 0.85rem;
+    border: 1px solid var(--rule, var(--color-border));
+    border-radius: 6px;
+    background: var(--card, var(--color-bg));
+    color: var(--ink, var(--color-fg));
+    resize: vertical;
   }
 
   .alt-toggle {

--- a/apps/web/src/lib/components/reader/customize-eligibility.test.ts
+++ b/apps/web/src/lib/components/reader/customize-eligibility.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import { customizableOfficialIds } from './customize-eligibility.js';
+
+describe('customizableOfficialIds (T-3.11)', () => {
+  const officials = [{ id: 'o1' }, { id: 'o2' }, { id: 'o3' }];
+
+  it('returns the empty set when the viewer is not the owner', () => {
+    const result = customizableOfficialIds(false, officials, []);
+    expect(result.size).toBe(0);
+  });
+
+  it('returns every official when the personal bucket is empty', () => {
+    const result = customizableOfficialIds(true, officials, []);
+    expect([...result].sort()).toEqual(['o1', 'o2', 'o3']);
+  });
+
+  it('excludes officials that the viewer has already forked', () => {
+    const personal = [{ parentTranslationId: 'o2' }];
+    const result = customizableOfficialIds(true, officials, personal);
+    expect([...result].sort()).toEqual(['o1', 'o3']);
+  });
+
+  it('ignores personal translations with no parent (fresh community submissions)', () => {
+    const personal = [
+      { parentTranslationId: null },
+      { parentTranslationId: 'o1' },
+    ];
+    const result = customizableOfficialIds(true, officials, personal);
+    expect([...result].sort()).toEqual(['o2', 'o3']);
+  });
+
+  it('handles parents pointing at an unknown official without breaking', () => {
+    // Could happen if a curator soft-hid the official the user previously
+    // forked — the fork's parent_translation_id still points at the now-
+    // invisible row. We just do the straightforward set-difference and
+    // return only officials currently visible.
+    const personal = [{ parentTranslationId: 'o-deleted' }];
+    const result = customizableOfficialIds(true, officials, personal);
+    expect([...result].sort()).toEqual(['o1', 'o2', 'o3']);
+  });
+
+  it('returns a fresh Set on every call (not a shared reference)', () => {
+    const a = customizableOfficialIds(true, officials, []);
+    const b = customizableOfficialIds(true, officials, []);
+    expect(a).not.toBe(b);
+    a.delete('o1');
+    expect(b.has('o1')).toBe(true);
+  });
+});

--- a/apps/web/src/lib/components/reader/customize-eligibility.ts
+++ b/apps/web/src/lib/components/reader/customize-eligibility.ts
@@ -1,0 +1,47 @@
+/**
+ * Reader-popup customize-action eligibility (T-3.11 → completes T-3.5).
+ *
+ * The pop-up shows a "Customize" button on each official translation row.
+ * Clicking it forks that official into a personal translation via
+ * `POST /api/v1/translations` with `parentTranslationId`. The wire and the
+ * server-side validation already exist (T-3.2 / T-3.5 schema work) — this
+ * helper just decides which officials should expose the button.
+ *
+ * Extracted to a pure module so the rule is unit-testable without booting
+ * the Svelte component. Vitest excludes `.svelte` files from coverage; the
+ * eligibility predicate is the only branch worth covering and it lives
+ * here.
+ */
+
+type OfficialTranslation = {
+  id: string;
+};
+
+type PersonalTranslation = {
+  parentTranslationId: string | null;
+};
+
+/**
+ * Return the set of official-translation ids that the viewer is allowed
+ * to fork right now. Empty when the viewer is not the owner. Excludes
+ * any official that the viewer has already customized (i.e. their
+ * personal bucket already contains a row with `parentTranslationId`
+ * pointing at it) — re-customizing the same official would just create
+ * a redundant fork.
+ */
+export function customizableOfficialIds(
+  isOwner: boolean,
+  officials: ReadonlyArray<OfficialTranslation>,
+  personal: ReadonlyArray<PersonalTranslation>,
+): Set<string> {
+  if (!isOwner) return new Set();
+  const alreadyForked = new Set<string>();
+  for (const p of personal) {
+    if (p.parentTranslationId) alreadyForked.add(p.parentTranslationId);
+  }
+  const eligible = new Set<string>();
+  for (const o of officials) {
+    if (!alreadyForked.has(o.id)) eligible.add(o.id);
+  }
+  return eligible;
+}


### PR DESCRIPTION
## Summary

Adds the user-facing half of T-3.5: a per-row **Customize** button on each official translation that forks it into an editable personal copy via `POST /api/v1/translations` with `parentTranslationId`. The schema and server-side validation already exist — this is purely the popup UI plus a small eligibility predicate.

- New `customize-eligibility.ts` exports `customizableOfficialIds()` — pure predicate, 6 unit tests cover the visibility rule (empty when not owner, hides officials already forked, ignores parentless personals, etc.).
- `WordPopup.svelte` renders a Customize pill at the right edge of each eligible official; clicking opens an inline `<form>` pre-filled with that translation's body. On submit, the new personal row is prepended (the personal bucket is already first in `bucketTranslations()`, so no extra retrieval work).
- Refactored `submitNewTranslation` and the new customize flow to share a `postTranslation()` helper. The shared helper handles the 429 path — a rate-limited fork now surfaces the server's friendly message instead of the raw HTTP error string.
- Hides the Customize button for officials the viewer has already customized (the personal fork's `parent_translation_id` matches), so re-customizing the same official can't create redundant rows.

## Test plan

- [x] `pnpm test` — 78 files / 603 tests pass, including the new `customize-eligibility.test.ts`
- [x] `pnpm check` — 0 errors / 0 warnings
- [x] `pnpm lint` — clean
- [x] `pnpm build` — clean
- [ ] Manual smoke in a browser: click Customize on an imported translation, edit, save, see the personal copy at top with `yours` badge; refresh and confirm the Customize button is hidden on the now-forked official; trigger 429 and confirm the friendly toast.

Closes #194. Refs #30.