### PR TITLE
T-5.26: hamburger rail-toggle on the AppShell

### DIFF
--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -59,6 +59,9 @@ export default [
         TextDecoder: 'readonly',
         // Reader keyboard handlers (T-5.7).
         EventTarget: 'readonly',
+        // Shell hamburger toggle observes the immersive attribute
+        // (T-5.26).
+        MutationObserver: 'readonly',
       },
     },
   },

--- a/apps/web/src/lib/components/shell/AppShell.svelte
+++ b/apps/web/src/lib/components/shell/AppShell.svelte
@@ -9,6 +9,7 @@
 -->
 <script lang="ts">
   import { page } from '$app/stores';
+  import { onMount } from 'svelte';
   import {
     TABS,
     getActiveTabId,
@@ -17,6 +18,12 @@
     type Tab,
     type TabIcon,
   } from './tabs.js';
+  import {
+    isImmersiveAttributeSet,
+    readPersistedImmersive,
+    setImmersiveAttribute,
+    writePersistedImmersive,
+  } from '../reader/immersive.js';
   import type { Snippet } from 'svelte';
 
   interface Props {
@@ -29,6 +36,34 @@
   const tabs = $derived<Tab[]>(visibleTabs(TABS, user !== null));
   const activeId = $derived(getActiveTabId($page.url.pathname, tabs));
   const groups = $derived(groupTabsBySection(tabs));
+
+  // T-5.26: hamburger toggle for the rail / shell chrome. Reuses the
+  // same `data-reader-immersive` attribute + `cia_reader_immersive`
+  // sessionStorage key from T-5.16 so the existing CSS keeps working
+  // — only the button location and icon change. Bootstrap on mount
+  // so a refresh keeps the user's preference.
+  let collapsed = $state(false);
+  onMount(() => {
+    collapsed = readPersistedImmersive();
+    setImmersiveAttribute(collapsed);
+    // Reflect any external attribute mutation (e.g. the reader page's
+    // Esc handler clearing immersive on exit) back into our local
+    // state so the button glyph stays in sync.
+    const obs = new MutationObserver(() => {
+      const next = isImmersiveAttributeSet();
+      if (next !== collapsed) collapsed = next;
+    });
+    obs.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['data-reader-immersive'],
+    });
+    return () => obs.disconnect();
+  });
+  function toggleCollapsed() {
+    collapsed = !collapsed;
+    setImmersiveAttribute(collapsed);
+    writePersistedImmersive(collapsed);
+  }
 
   // Inline-SVG glyphs match the CIAR design's atom set
   // (see design-handoff/ciar/project/atoms.jsx). One viewBox + a list
@@ -45,6 +80,33 @@
     signin: ['M11 8V5a2 2 0 012-2h6a2 2 0 012 2v14a2 2 0 01-2 2h-6a2 2 0 01-2-2v-3', 'M3 12h12', 'M9 8l-4 4 4 4'],
   };
 </script>
+
+<!-- T-5.26: hamburger button toggles the rail / shell chrome.
+     Positioned fixed so it stays clickable when the rail itself is
+     hidden — clicking it again brings the chrome back. -->
+<button
+  type="button"
+  class="rail-toggle"
+  aria-label={collapsed ? 'Show navigation' : 'Hide navigation'}
+  aria-pressed={collapsed}
+  title={collapsed ? 'Show navigation' : 'Hide navigation'}
+  onclick={toggleCollapsed}
+>
+  <svg
+    viewBox="0 0 24 24"
+    width="16"
+    height="16"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.6"
+    stroke-linecap="round"
+    aria-hidden="true"
+  >
+    <path d="M4 7h16" />
+    <path d="M4 12h16" />
+    <path d="M4 17h16" />
+  </svg>
+</button>
 
 <div class="shell">
   <aside class="rail" aria-label="Primary navigation">
@@ -401,12 +463,40 @@
     height: 18px;
   }
 
-  /* —— Immersive mode (T-5.16) ————————————————————————
-   * The reader page sets `data-reader-immersive="1"` on <html> when
-   * the user opts into a full-viewport reading view. We hide the
-   * shell's own chrome and let the reader content occupy the whole
-   * grid track. The reader's own top bar / progress foot stay
-   * visible — only cross-screen navigation chrome collapses. */
+  /* —— Hamburger / rail-toggle button (T-5.26) ————————————————
+   * Fixed top-left so it's clickable both when the rail is showing
+   * (sits flush against the rail's left edge) and when the rail has
+   * been collapsed (only thing left to click). High z-index so it
+   * floats over everything except the word side-panel sheet. */
+  .rail-toggle {
+    position: fixed;
+    top: 0.6rem;
+    left: 0.6rem;
+    width: 32px;
+    height: 32px;
+    display: grid;
+    place-items: center;
+    border-radius: 8px;
+    background: var(--card, var(--color-bg));
+    border: 1px solid var(--card-edge, var(--color-border));
+    color: var(--ink-2, var(--color-fg-muted));
+    cursor: pointer;
+    z-index: 30;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.06);
+    transition:
+      background 150ms ease,
+      color 150ms ease;
+  }
+  .rail-toggle:hover {
+    background: var(--accent-soft, var(--color-accent));
+    color: var(--accent-ink, var(--color-accent-fg, #fff));
+  }
+
+  /* —— Immersive mode (T-5.16, retriggered by T-5.26) ——————————
+   * `data-reader-immersive="1"` on <html> hides the rail / top-strip
+   * / bottom-nav so the screen content occupies the whole viewport.
+   * Originally a reader-specific affordance; T-5.26 generalised it
+   * via a hamburger button on the shell. */
   :global(html[data-reader-immersive='1']) .rail,
   :global(html[data-reader-immersive='1']) .top-strip,
   :global(html[data-reader-immersive='1']) .bottom-nav {

--- a/apps/web/src/routes/reader/[textId]/+page.svelte
+++ b/apps/web/src/routes/reader/[textId]/+page.svelte
@@ -7,7 +7,7 @@
   import ReaderScroll from '$lib/components/reader/ReaderScroll.svelte';
   import { ProgressWriter } from '$lib/components/reader/progress-client.js';
   import {
-    readPersistedImmersive,
+    isImmersiveAttributeSet,
     setImmersiveAttribute,
     writePersistedImmersive,
   } from '$lib/components/reader/immersive.js';
@@ -16,16 +16,10 @@
   let { data }: { data: PageData } = $props();
 
   // T-5.16: Immersive mode hides the AppShell rail / bottom-nav so
-  // the reader takes the full viewport. State persists in
-  // sessionStorage for this tab — paging stays immersive — but does
-  // not survive tab close. Cleaned up on unmount so other routes
-  // never inherit the hidden chrome.
-  let immersive = $state(false);
-  function toggleImmersive() {
-    immersive = !immersive;
-    setImmersiveAttribute(immersive);
-    writePersistedImmersive(immersive);
-  }
+  // the reader takes the full viewport. T-5.26 moved the actual
+  // toggle to the AppShell hamburger button — the reader page only
+  // owns the Esc-to-exit shortcut here. The cross-route cleanup also
+  // moved into AppShell, since the rail-toggle is now global.
 
   // Live status mirrors data.text.status; flips when the polling loop
   // hits a terminal state (T-4.4).
@@ -89,18 +83,16 @@
   onMount(() => {
     liveStatus = data.text.status;
 
-    // T-5.16: hydrate immersive mode from sessionStorage so paging
-    // within a reader visit keeps the chrome hidden. Tab close clears
-    // it. Listen for Esc to exit immersive (and only when the side
-    // panel isn't open — the popup owns Esc when it's mounted).
-    immersive = readPersistedImmersive();
-    setImmersiveAttribute(immersive);
+    // T-5.26: AppShell hydrates the immersive flag now. The reader
+    // only owns the Esc-to-exit shortcut — quick way out of
+    // full-screen reading without hunting for the hamburger button.
+    // We skip Esc when the word side-panel is open since the popup
+    // owns that key.
     const onKey = (e: KeyboardEvent) => {
       if (e.key !== 'Escape') return;
-      if (!immersive) return;
+      if (!isImmersiveAttributeSet()) return;
       if (document.querySelector('[data-testid="word-popup"]')) return;
       e.preventDefault();
-      immersive = false;
       setImmersiveAttribute(false);
       writePersistedImmersive(false);
     };
@@ -157,11 +149,6 @@
     return () => {
       cleanupPoll?.();
       window.removeEventListener('keydown', onKey);
-      // T-5.16: clear the attribute when the reader unmounts so other
-      // routes (Library / Words / Settings) never inherit hidden
-      // chrome. The sessionStorage flag stays so re-opening a text in
-      // the same tab restores the user's preference.
-      setImmersiveAttribute(false);
       if (beforeUnloadHandler)
         window.removeEventListener('beforeunload', beforeUnloadHandler);
       void progressWriter?.flush();
@@ -240,33 +227,10 @@
         Aa
       </button>
 
-      <button
-        type="button"
-        class="immersive-toggle"
-        data-active={immersive ? '1' : '0'}
-        onclick={toggleImmersive}
-        aria-pressed={immersive}
-        title={immersive
-          ? 'Exit immersive reading (Esc)'
-          : 'Hide app chrome for immersive reading'}
-        aria-label={immersive ? 'Exit immersive reading' : 'Enter immersive reading'}
-      >
-        {#if immersive}
-          <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <path d="M9 4v5H4" />
-            <path d="M15 4v5h5" />
-            <path d="M9 20v-5H4" />
-            <path d="M15 20v-5h5" />
-          </svg>
-        {:else}
-          <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <path d="M4 9V4h5" />
-            <path d="M20 9V4h-5" />
-            <path d="M4 15v5h5" />
-            <path d="M20 15v5h-5" />
-          </svg>
-        {/if}
-      </button>
+      <!-- T-5.26 moved the immersive / hide-chrome toggle to the
+           AppShell rail (a hamburger glyph) — it's globally available
+           now, not just from the reader top bar. -->
+
     </div>
   </header>
 
@@ -430,25 +394,9 @@
     border-color: var(--accent, var(--color-accent));
     color: var(--accent-ink, var(--color-accent-fg, #fff));
   }
-  .immersive-toggle {
-    width: 32px;
-    height: 32px;
-    display: grid;
-    place-items: center;
-    border: 1px solid var(--rule, var(--color-border));
-    border-radius: 8px;
-    background: transparent;
-    color: var(--ink-2, var(--color-fg-muted));
-    cursor: pointer;
-  }
-  .immersive-toggle:hover {
-    color: var(--ink, var(--color-fg));
-  }
-  .immersive-toggle[data-active='1'] {
-    background: var(--accent-soft, var(--color-accent));
-    border-color: var(--accent, var(--color-accent));
-    color: var(--accent-ink, var(--color-accent-fg, #fff));
-  }
+  /* T-5.26: the immersive-toggle button moved to AppShell as a
+     hamburger icon. The selector is gone but the Esc-to-exit
+     behavior stays in this component. */
   .err {
     color: var(--rose, #b03131);
     background: var(--rose-soft, color-mix(in srgb, #b03131 8%, transparent));


### PR DESCRIPTION
## Summary

Move the immersive-mode toggle from the reader top bar (T-5.16) to a fixed hamburger button on the AppShell. Same underlying behavior — same `data-reader-immersive` attribute, same `cia_reader_immersive` sessionStorage key, same CSS rules — only the button location and icon change.

### Why
Per user feedback the old expand/collapse glyph read as a fullscreen icon and lived in the wrong place — hide-chrome belongs on the shell, not in per-screen content.

### What changed
- **`AppShell.svelte`** — new fixed-position hamburger button at top-left. Click toggles the `data-reader-immersive` attribute via the existing `immersive.ts` helpers. On mount the button bootstraps from `sessionStorage`. A `MutationObserver` on the attribute keeps the button glyph in sync when the reader's Esc handler clears it.
- **Reader `+page.svelte`** — drops the `.immersive-toggle` button + the local `toggleImmersive` state. Esc-to-exit stays so users have a quick way out of full-screen reading. `setImmersiveAttribute(false)` on unmount is also gone since the shell now owns the cross-route lifecycle.
- **`eslint.config.js`** — register `MutationObserver` as a readonly global.

### Tests
All 623 vitest pass · eslint + svelte-check 0/0. The behavioral test surface (`immersive.test.ts`) is unchanged since the helpers are the same.

### Visual conflict to watch
On main + this PR + #201 (T-5.27 close button) merged together, the reader's `×` close button and the rail-toggle hamburger both sit in the top-left area. They don't strictly overlap when the rail is showing (rail eats 232px), but when the user collapses the rail, both end up near `top: 0.6rem; left: 0.6rem`. If we see overlap in practice we'll re-position one in a follow-up — but it'll likely look fine since the hamburger sits flush against viewport-left and the X is offset by the reader-top padding.

Closes #199
Refs #42, #173