### PR TITLE
T-5.28: portal the hover tooltip to <body>

### DIFF
--- a/apps/web/src/lib/components/reader/WordTooltip.svelte
+++ b/apps/web/src/lib/components/reader/WordTooltip.svelte
@@ -22,6 +22,24 @@
   let tipEl: HTMLDivElement | null = $state(null);
   let measured = $state<{ w: number; h: number } | null>(null);
 
+  // T-5.28: portal to <body>. `position: fixed` sits relative to the
+  // nearest ancestor with `transform`, `backdrop-filter`, `filter`,
+  // or `will-change` (a CSS containing-block gotcha). The reader
+  // wraps tokens in a translateY-driven page slider, and Sheet's
+  // backdrop has `backdrop-filter: blur` — both create new
+  // containing blocks that throw off our viewport-relative
+  // coordinates. Portaling lifts the tooltip out so its `position:
+  // fixed` is genuinely viewport-relative again.
+  function portal(node: HTMLElement) {
+    if (typeof document === 'undefined') return {};
+    document.body.appendChild(node);
+    return {
+      destroy() {
+        if (node.parentNode) node.parentNode.removeChild(node);
+      },
+    };
+  }
+
   // Placement is derived from the anchor + measured dimensions so it
   // re-runs whenever the parent rebinds the tooltip to a new word.
   // Defaults seed the first paint near the word; the $effect below
@@ -49,6 +67,7 @@
   class="tip"
   role="tooltip"
   aria-hidden="false"
+  use:portal
   style:top="{placement.top}px"
   style:left="{placement.left}px"
 >

--- a/apps/web/src/lib/components/reader/WordTooltip.test.ts
+++ b/apps/web/src/lib/components/reader/WordTooltip.test.ts
@@ -31,52 +31,69 @@ function makeToken(overrides: Partial<ServerToken> = {}): ServerToken {
 }
 
 beforeEach(() => {
-  // Reset DOM between tests so multiple renders don't pile up
-  // .tip elements that confuse querySelector.
+  // T-5.28: the tooltip portals to <body>, so any .tip leftover from
+  // a previous test (e.g. cleanup() didn't remove it because the
+  // portal action's destroy fired late) would confuse queries.
+  document.body.querySelectorAll('.tip').forEach((el) => el.remove());
 });
 
 afterEach(() => {
   cleanup();
+  // Belt + braces: clear any portaled tooltip the cleanup didn't.
+  document.body.querySelectorAll('.tip').forEach((el) => el.remove());
 });
 
+// T-5.28: WordTooltip portals its DOM to <body>, so we query the
+// document body rather than the testing-library `container`.
 describe('WordTooltip — gloss display (T-5.18)', () => {
   it("shows the lemma's glossDefault when present", () => {
-    const { container } = render(WordTooltip, {
+    render(WordTooltip, {
       token: makeToken({ glossDefault: 'morning, dawn' }),
       anchorRect: ANCHOR,
     });
-    const def = container.querySelector('.tip-def');
+    const def = document.body.querySelector('.tip-def');
     expect(def?.textContent).toBe('morning, dawn');
     expect(def?.classList.contains('muted')).toBe(false);
   });
 
   it("falls back to italic 'No translations' when glossDefault is null but the lemma is known (T-5.20)", () => {
-    const { container } = render(WordTooltip, {
+    render(WordTooltip, {
       token: makeToken({ glossDefault: null }),
       anchorRect: ANCHOR,
     });
-    const def = container.querySelector('.tip-def');
+    const def = document.body.querySelector('.tip-def');
     expect(def?.textContent).toBe('No translations');
     expect(def?.classList.contains('empty')).toBe(true);
   });
 
   it("shows 'No dictionary match' for OOV tokens regardless of glossDefault (T-5.20)", () => {
-    const { container } = render(WordTooltip, {
+    render(WordTooltip, {
       token: makeToken({ isOov: true, glossDefault: 'should not show' }),
       anchorRect: ANCHOR,
     });
-    const def = container.querySelector('.tip-def');
+    const def = document.body.querySelector('.tip-def');
     expect(def?.textContent).toBe('No dictionary match');
     expect(def?.classList.contains('empty')).toBe(true);
   });
 
   it("treats no-lemma tokens like an empty-translation lemma — italic 'No translations' (T-5.20)", () => {
-    const { container } = render(WordTooltip, {
+    render(WordTooltip, {
       token: makeToken({ lemmaId: null, glossDefault: null }),
       anchorRect: ANCHOR,
     });
-    expect(container.querySelector('.tip-def')?.textContent).toBe(
+    expect(document.body.querySelector('.tip-def')?.textContent).toBe(
       'No translations',
     );
+  });
+
+  it('portals the tooltip to document.body (T-5.28)', () => {
+    const { container } = render(WordTooltip, {
+      token: makeToken({ glossDefault: 'morning' }),
+      anchorRect: ANCHOR,
+    });
+    // The .tip element should NOT live inside the testing-library
+    // container — that proves it portaled successfully.
+    expect(container.querySelector('.tip')).toBeNull();
+    expect(document.body.querySelector('.tip')).not.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

User reported the hover tooltip wasn't aligning to the hovered word ([#203](https://github.com/chickendude/CIA-Reader/issues/203)). Most likely culprit is the **CSS containing-block gotcha** — `position: fixed` sits relative to the nearest ancestor with `transform`, `backdrop-filter`, `filter`, or `will-change`, not the viewport. The reader hits this on multiple paths:

- The Sheet (T-5.10) paints a backdrop with `backdrop-filter: blur(...)` when dimmed → creates a containing block.
- T-5.23 page-mode pagination wraps content in `translateY(...)` → another containing block.

A tooltip mounted inside ChapterBody can therefore land in the wrong spot whenever any of those ancestors are active.

### Fix
Add a small `portal` action that appends the tooltip's root element to `document.body` on mount and removes it on destroy. The `position: fixed` math then resolves against the actual viewport.

### Tests
- Existing WordTooltip cases query `document.body` (the .tip is no longer inside the testing-library container).
- New case asserts `.tip` is *not* inside the container and *is* in body — proves the portal works.
- `beforeEach`/`afterEach` scrub any stray `.tip` nodes between tests.
- All 624 vitest pass · eslint + svelte-check 0/0.

### Side-panel layout regression (also in #203)
Vague repro — needs screenshots / DOM. Not addressed here. Filing this as a partial fix; the side-panel piece will come in a follow-up once we have specifics.

Refs #203
Refs #42, #160