### PR TITLE
T-3.13: Translation reorder in curator dictionary editor

### DIFF
--- a/apps/web/drizzle/0011_complete_justin_hammer.sql
+++ b/apps/web/drizzle/0011_complete_justin_hammer.sql
@@ -1,0 +1,2 @@
+ALTER TYPE "public"."lemma_edit_change_type" ADD VALUE 'translation_reorder';--> statement-breakpoint
+ALTER TABLE "translations" ADD COLUMN "display_rank" integer;

--- a/apps/web/drizzle/meta/0011_snapshot.json
+++ b/apps/web/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,2270 @@
+{
+  "id": "3dba226b-e45d-4ef3-8e97-9ac6713da629",
+  "prevId": "e8073f3a-073d-45e3-a7de-44fdf25dc0f5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.curator_languages": {
+      "name": "curator_languages",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "curator_languages_user_idx": {
+          "name": "curator_languages_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "curator_languages_user_id_users_id_fk": {
+          "name": "curator_languages_user_id_users_id_fk",
+          "tableFrom": "curator_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "curator_languages_granted_by_users_id_fk": {
+          "name": "curator_languages_granted_by_users_id_fk",
+          "tableFrom": "curator_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "curator_languages_user_id_language_pk": {
+          "name": "curator_languages_user_id_language_pk",
+          "columns": [
+            "user_id",
+            "language"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.dictionary_imports": {
+      "name": "dictionary_imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_name": {
+          "name": "source_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_at": {
+          "name": "run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lemmas_created": {
+          "name": "lemmas_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lemmas_updated": {
+          "name": "lemmas_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lemmas_skipped_curator_locked": {
+          "name": "lemmas_skipped_curator_locked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "translations_created": {
+          "name": "translations_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "translations_updated": {
+          "name": "translations_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "dictionary_imports_language_idx": {
+          "name": "dictionary_imports_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.form_lemma_overrides": {
+      "name": "form_lemma_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_nfc": {
+          "name": "surface_nfc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_signature": {
+          "name": "context_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "chosen_lemma_id": {
+          "name": "chosen_lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "promoted_at": {
+          "name": "promoted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "promoted_by": {
+          "name": "promoted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "form_lemma_overrides_lookup_idx": {
+          "name": "form_lemma_overrides_lookup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface_nfc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "form_lemma_overrides_chosen_lemma_id_lemmas_id_fk": {
+          "name": "form_lemma_overrides_chosen_lemma_id_lemmas_id_fk",
+          "tableFrom": "form_lemma_overrides",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "chosen_lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_lemma_overrides_promoted_by_users_id_fk": {
+          "name": "form_lemma_overrides_promoted_by_users_id_fk",
+          "tableFrom": "form_lemma_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "promoted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "form_lemma_overrides_lang_surface_ctx_uq": {
+          "name": "form_lemma_overrides_lang_surface_ctx_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "language",
+            "surface_nfc",
+            "context_signature"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.lemma_edit_history": {
+      "name": "lemma_edit_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "editor_id": {
+          "name": "editor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "lemma_edit_change_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change": {
+          "name": "change",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_edit_history_lemma_idx": {
+          "name": "lemma_edit_history_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_edit_history_editor_idx": {
+          "name": "lemma_edit_history_editor_idx",
+          "columns": [
+            {
+              "expression": "editor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_edit_history_lemma_id_lemmas_id_fk": {
+          "name": "lemma_edit_history_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_edit_history",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lemma_edit_history_editor_id_users_id_fk": {
+          "name": "lemma_edit_history_editor_id_users_id_fk",
+          "tableFrom": "lemma_edit_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "editor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemma_forms": {
+      "name": "lemma_forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "romanization": {
+          "name": "romanization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_forms_lemma_idx": {
+          "name": "lemma_forms_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_forms_surface_idx": {
+          "name": "lemma_forms_surface_idx",
+          "columns": [
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_forms_lemma_id_lemmas_id_fk": {
+          "name": "lemma_forms_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_forms",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemmas": {
+      "name": "lemmas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headword": {
+          "name": "headword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos": {
+          "name": "pos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script": {
+          "name": "script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gloss_default": {
+          "name": "gloss_default",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_rank": {
+          "name": "frequency_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "translation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "curator_locked": {
+          "name": "curator_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemmas_language_idx": {
+          "name": "lemmas_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_language_frequency_idx": {
+          "name": "lemmas_language_frequency_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "frequency_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_source_lookup_idx": {
+          "name": "lemmas_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lemmas_language_headword_pos_uq": {
+          "name": "lemmas_language_headword_pos_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "language",
+            "headword",
+            "pos"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.magic_links": {
+      "name": "magic_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "magic_links_user_idx": {
+          "name": "magic_links_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "magic_links_expires_idx": {
+          "name": "magic_links_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "magic_links_user_id_users_id_fk": {
+          "name": "magic_links_user_id_users_id_fk",
+          "tableFrom": "magic_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.nlp_jobs": {
+      "name": "nlp_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "nlp_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nlp_jobs_text_idx": {
+          "name": "nlp_jobs_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nlp_jobs_status_idx": {
+          "name": "nlp_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nlp_jobs_text_id_texts_id_fk": {
+          "name": "nlp_jobs_text_id_texts_id_fk",
+          "tableFrom": "nlp_jobs",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by": {
+          "name": "replaced_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "refresh_tokens_user_idx": {
+          "name": "refresh_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_expires_idx": {
+          "name": "refresh_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.text_chapters": {
+      "name": "text_chapters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idx": {
+          "name": "idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "text_chapters_text_idx": {
+          "name": "text_chapters_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_chapters_text_id_texts_id_fk": {
+          "name": "text_chapters_text_id_texts_id_fk",
+          "tableFrom": "text_chapters",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "text_chapters_text_idx_uq": {
+          "name": "text_chapters_text_idx_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "text_id",
+            "idx"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.text_tokens": {
+      "name": "text_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idx": {
+          "name": "idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lemma_candidates": {
+          "name": "lemma_candidates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_ambiguous": {
+          "name": "is_ambiguous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_oov": {
+          "name": "is_oov",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_word": {
+          "name": "is_word",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sentence_idx": {
+          "name": "sentence_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "romanization": {
+          "name": "romanization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "text_tokens_chapter_scan_idx": {
+          "name": "text_tokens_chapter_scan_idx",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "text_tokens_lemma_idx": {
+          "name": "text_tokens_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_tokens_chapter_id_text_chapters_id_fk": {
+          "name": "text_tokens_chapter_id_text_chapters_id_fk",
+          "tableFrom": "text_tokens",
+          "tableTo": "text_chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_tokens_lemma_id_lemmas_id_fk": {
+          "name": "text_tokens_lemma_id_lemmas_id_fk",
+          "tableFrom": "text_tokens",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "text_tokens_chapter_idx_uq": {
+          "name": "text_tokens_chapter_idx_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chapter_id",
+            "idx"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.texts": {
+      "name": "texts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "status_error": {
+          "name": "status_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "texts_owner_idx": {
+          "name": "texts_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "texts_visibility_idx": {
+          "name": "texts_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "texts_owner_id_users_id_fk": {
+          "name": "texts_owner_id_users_id_fk",
+          "tableFrom": "texts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.translations": {
+      "name": "translations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "translation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_translation_id": {
+          "name": "parent_translation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_language": {
+          "name": "target_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_rank": {
+          "name": "display_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "translations_lemma_idx": {
+          "name": "translations_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translations_submitted_by_idx": {
+          "name": "translations_submitted_by_idx",
+          "columns": [
+            {
+              "expression": "submitted_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translations_source_lookup_idx": {
+          "name": "translations_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "translations_lemma_id_lemmas_id_fk": {
+          "name": "translations_lemma_id_lemmas_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "translations_submitted_by_users_id_fk": {
+          "name": "translations_submitted_by_users_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "translations_parent_translation_id_translations_id_fk": {
+          "name": "translations_parent_translation_id_translations_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "translations",
+          "columnsFrom": [
+            "parent_translation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_known_lemmas": {
+      "name": "user_known_lemmas",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "known_lemma_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'learning'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_known_lemmas_user_idx": {
+          "name": "user_known_lemmas_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_known_lemmas_user_id_users_id_fk": {
+          "name": "user_known_lemmas_user_id_users_id_fk",
+          "tableFrom": "user_known_lemmas",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_known_lemmas_lemma_id_lemmas_id_fk": {
+          "name": "user_known_lemmas_lemma_id_lemmas_id_fk",
+          "tableFrom": "user_known_lemmas",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_known_lemmas_user_id_lemma_id_pk": {
+          "name": "user_known_lemmas_user_id_lemma_id_pk",
+          "columns": [
+            "user_id",
+            "lemma_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_languages": {
+      "name": "user_languages",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script_preference": {
+          "name": "script_preference",
+          "type": "script_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "romanization_scheme": {
+          "name": "romanization_scheme",
+          "type": "romanization_scheme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'iso15919'"
+        },
+        "known_words_count_cache": {
+          "name": "known_words_count_cache",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reader_layout_mode": {
+          "name": "reader_layout_mode",
+          "type": "reader_layout_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'page'"
+        },
+        "words_per_page": {
+          "name": "words_per_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 250
+        },
+        "font_family": {
+          "name": "font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_size": {
+          "name": "font_size",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 18
+        },
+        "line_spacing": {
+          "name": "line_spacing",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1.6
+        },
+        "highlight_style": {
+          "name": "highlight_style",
+          "type": "highlight_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'background'"
+        },
+        "baseline": {
+          "name": "baseline",
+          "type": "language_baseline",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_languages_user_id_users_id_fk": {
+          "name": "user_languages_user_id_users_id_fk",
+          "tableFrom": "user_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_languages_user_id_language_pk": {
+          "name": "user_languages_user_id_language_pk",
+          "columns": [
+            "user_id",
+            "language"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_text_progress": {
+      "name": "user_text_progress",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_chapter_idx": {
+          "name": "last_chapter_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_token_idx": {
+          "name": "last_token_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pct_read": {
+          "name": "pct_read",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_text_progress_user_idx": {
+          "name": "user_text_progress_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_text_progress_user_id_users_id_fk": {
+          "name": "user_text_progress_user_id_users_id_fk",
+          "tableFrom": "user_text_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_text_progress_text_id_texts_id_fk": {
+          "name": "user_text_progress_text_id_texts_id_fk",
+          "tableFrom": "user_text_progress",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_text_progress_user_id_text_id_pk": {
+          "name": "user_text_progress_user_id_text_id_pk",
+          "columns": [
+            "user_id",
+            "text_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_preference": {
+          "name": "theme_preference",
+          "type": "theme_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarded_at": {
+          "name": "onboarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    }
+  },
+  "enums": {
+    "public.highlight_style": {
+      "name": "highlight_style",
+      "schema": "public",
+      "values": [
+        "underline",
+        "background",
+        "colored_text"
+      ]
+    },
+    "public.known_lemma_status": {
+      "name": "known_lemma_status",
+      "schema": "public",
+      "values": [
+        "unknown",
+        "learning",
+        "known",
+        "ignored"
+      ]
+    },
+    "public.language": {
+      "name": "language",
+      "schema": "public",
+      "values": [
+        "hi",
+        "mr",
+        "or"
+      ]
+    },
+    "public.language_baseline": {
+      "name": "language_baseline",
+      "schema": "public",
+      "values": [
+        "none",
+        "beginner",
+        "intermediate"
+      ]
+    },
+    "public.lemma_edit_change_type": {
+      "name": "lemma_edit_change_type",
+      "schema": "public",
+      "values": [
+        "lemma_update",
+        "lemma_unlock",
+        "lemma_lock",
+        "translation_insert",
+        "translation_update",
+        "translation_hide",
+        "translation_unhide",
+        "form_insert",
+        "form_delete",
+        "lemma_merge",
+        "lemma_split",
+        "translation_reorder"
+      ]
+    },
+    "public.nlp_job_status": {
+      "name": "nlp_job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.reader_layout_mode": {
+      "name": "reader_layout_mode",
+      "schema": "public",
+      "values": [
+        "page",
+        "paged_scroll",
+        "continuous"
+      ]
+    },
+    "public.romanization_scheme": {
+      "name": "romanization_scheme",
+      "schema": "public",
+      "values": [
+        "iso15919",
+        "iast",
+        "hunterian",
+        "itrans"
+      ]
+    },
+    "public.script_preference": {
+      "name": "script_preference",
+      "schema": "public",
+      "values": [
+        "native",
+        "native_with_romanization",
+        "romanization_only"
+      ]
+    },
+    "public.text_source_type": {
+      "name": "text_source_type",
+      "schema": "public",
+      "values": [
+        "paste",
+        "txt",
+        "epub"
+      ]
+    },
+    "public.text_status": {
+      "name": "text_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.text_visibility": {
+      "name": "text_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "shared",
+        "official"
+      ]
+    },
+    "public.theme_preference": {
+      "name": "theme_preference",
+      "schema": "public",
+      "values": [
+        "system",
+        "light",
+        "dark"
+      ]
+    },
+    "public.translation_source": {
+      "name": "translation_source",
+      "schema": "public",
+      "values": [
+        "official_dictionary",
+        "curator",
+        "user"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "curator",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1777315161217,
       "tag": "0010_fluffy_ulik",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1777386295790,
+      "tag": "0011_complete_justin_hammer",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/src/lib/server/db/schema.ts
+++ b/apps/web/src/lib/server/db/schema.ts
@@ -295,6 +295,13 @@ export const translations = pgTable(
     sourceAttribution: text('source_attribution'),
     sourceId: text('source_id'),
     hidden: boolean('hidden').notNull().default(false),
+    // Curator-set display order within a translation bucket (T-3.13).
+    // NULL = use the bucket's default tiebreaker (curator > imported,
+    // then createdAt). When non-null, smaller ranks sort earlier within
+    // the same bucket. Stored on every row even though most stay NULL —
+    // a separate ordering table would force a join on every read of the
+    // reader pop-up's translations payload.
+    displayRank: integer('display_rank'),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },
@@ -386,6 +393,11 @@ export const lemmaEditChangeType = pgEnum('lemma_edit_change_type', [
   // moved (for split), so a revert has enough information to reconstruct.
   'lemma_merge',
   'lemma_split',
+  // T-3.13: a curator reordered the translations on a lemma. `change`
+  // carries `before: {translationId, displayRank}[]` and the
+  // corresponding `after` snapshot so the audit can reconstruct either
+  // state.
+  'translation_reorder',
 ]);
 
 export const lemmaEditHistory = pgTable(
@@ -451,6 +463,11 @@ export type LemmaEditChangePayload = {
   bulkImportRow?: number;
   bulkPromote?: boolean;
   bulkAttribution?: boolean;
+  // T-3.13: ordered snapshots of `(translationId, displayRank)` before
+  // and after a `translation_reorder`. Stored as parallel arrays so the
+  // history viewer can render either side as a list.
+  translationOrderBefore?: Array<{ translationId: string; displayRank: number | null }>;
+  translationOrderAfter?: Array<{ translationId: string; displayRank: number | null }>;
 };
 
 /**

--- a/apps/web/src/lib/server/dictionary/curator.test.ts
+++ b/apps/web/src/lib/server/dictionary/curator.test.ts
@@ -121,6 +121,7 @@ const {
   CuratorValidationError,
   getLemmaEditorView,
   mergeLemmas,
+  reorderTranslations,
   setLemmaLock,
   setTranslationHidden,
   splitLemma,
@@ -164,6 +165,7 @@ function translationRow(overrides: Record<string, unknown> = {}) {
     sourceAttribution: null,
     sourceId: null,
     hidden: false,
+    displayRank: null,
     createdAt: new Date(),
     updatedAt: new Date(),
     ...overrides,
@@ -566,5 +568,116 @@ describe('getLemmaEditorView', () => {
     await expect(
       getLemmaEditorView({ id: 'c1', role: 'curator' }, 'lemma-1'),
     ).rejects.toBeInstanceOf(ForbiddenError);
+  });
+});
+
+// -----------------------------------------------------------------------
+// reorderTranslations (T-3.13)
+// -----------------------------------------------------------------------
+
+describe('reorderTranslations', () => {
+  it('rejects an empty reason', async () => {
+    await expect(
+      reorderTranslations(ADMIN, 'lemma-1', ['tr-1', 'tr-2'], '  '),
+    ).rejects.toBeInstanceOf(MissingReasonError);
+  });
+
+  it('rejects an empty order list', async () => {
+    await expect(
+      reorderTranslations(ADMIN, 'lemma-1', [], 'pinning curated meanings up top'),
+    ).rejects.toBeInstanceOf(CuratorValidationError);
+  });
+
+  it('rejects a duplicate id in the order', async () => {
+    await expect(
+      reorderTranslations(
+        ADMIN,
+        'lemma-1',
+        ['tr-1', 'tr-1'],
+        'pinning curated meanings up top',
+      ),
+    ).rejects.toBeInstanceOf(CuratorValidationError);
+  });
+
+  it('rejects a non-curator non-admin', async () => {
+    stage([lemmaRow()]); // loadLemma
+    stage([]); // permission check: no curator_languages row
+    await expect(
+      reorderTranslations(
+        { id: 'plain', role: 'user' },
+        'lemma-1',
+        ['tr-1', 'tr-2'],
+        'pinning curated meanings up top',
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenError);
+  });
+
+  it('rejects when the order count does not match the lemma translations', async () => {
+    stage([lemmaRow()]); // loadLemma
+    stage([translationRow({ id: 'tr-1' }), translationRow({ id: 'tr-2' })]); // existing
+    await expect(
+      reorderTranslations(
+        ADMIN,
+        'lemma-1',
+        ['tr-1'], // missing tr-2
+        'partial reorder',
+      ),
+    ).rejects.toMatchObject({ status: 409 });
+  });
+
+  it('rejects an order containing an unknown translation id', async () => {
+    stage([lemmaRow()]); // loadLemma
+    stage([translationRow({ id: 'tr-1' }), translationRow({ id: 'tr-2' })]); // existing
+    await expect(
+      reorderTranslations(
+        ADMIN,
+        'lemma-1',
+        ['tr-1', 'tr-99'],
+        'order references unknown id',
+      ),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('writes display_rank by index, audits with translation_reorder, and returns the new order', async () => {
+    stage([lemmaRow()]); // loadLemma
+    stage([
+      translationRow({ id: 'tr-2', body: 'second' }),
+      translationRow({ id: 'tr-1', body: 'first' }),
+    ]); // existing — reverse of desired order
+    stage([{ id: 'hist-1' }]); // audit insert
+
+    const result = await reorderTranslations(
+      ADMIN,
+      'lemma-1',
+      ['tr-1', 'tr-2'],
+      'Pinning the more idiomatic gloss first',
+    );
+
+    // Two updates, one per translation, each carrying the right rank.
+    const updateCalls = calls.filter(
+      (c): c is Extract<Call, { kind: 'update' }> => c.kind === 'update',
+    );
+    expect(updateCalls).toHaveLength(2);
+    expect((updateCalls[0]!.set as { displayRank?: number }).displayRank).toBe(0);
+    expect((updateCalls[1]!.set as { displayRank?: number }).displayRank).toBe(1);
+
+    // Returned rows in the new order with the assigned ranks.
+    expect(result.map((t) => t.id)).toEqual(['tr-1', 'tr-2']);
+    expect(result.map((t) => t.displayRank)).toEqual([0, 1]);
+
+    // Single audit insert with the reorder discriminator + before/after.
+    const audit = calls.find(
+      (c): c is Extract<Call, { kind: 'insert' }> =>
+        c.kind === 'insert' &&
+        (c.values as { changeType?: string } | undefined)?.changeType ===
+          'translation_reorder',
+    );
+    expect(audit).toBeDefined();
+    const change = (audit?.values as { change?: { translationOrderBefore?: unknown[]; translationOrderAfter?: unknown[] } } | undefined)?.change;
+    expect(change?.translationOrderBefore).toHaveLength(2);
+    expect(change?.translationOrderAfter).toEqual([
+      { translationId: 'tr-1', displayRank: 0 },
+      { translationId: 'tr-2', displayRank: 1 },
+    ]);
   });
 });

--- a/apps/web/src/lib/server/dictionary/curator.ts
+++ b/apps/web/src/lib/server/dictionary/curator.ts
@@ -21,7 +21,7 @@
  * split moves selected `translations` + `lemma_forms`. The future
  * tickets that introduce those tables will extend these functions.
  */
-import { and, eq, inArray } from 'drizzle-orm';
+import { and, asc, eq, inArray } from 'drizzle-orm';
 
 import { db, schema } from '../db/index.js';
 import { recordLemmaEdit, MissingReasonError } from './audit.js';
@@ -387,6 +387,109 @@ export async function setTranslationHidden(
 }
 
 // -----------------------------------------------------------------------
+// reorderTranslations (T-3.13)
+// -----------------------------------------------------------------------
+
+/**
+ * Set the curator-controlled `display_rank` on every translation of a
+ * lemma. Caller passes the canonical, complete order — the function
+ * rejects partial orders so the UI can't accidentally orphan rows or
+ * race with a concurrent insert. Rank N is assigned by index (0-based);
+ * `bucketTranslations` honors it ahead of the existing tiebreakers.
+ *
+ * Audits a single `translation_reorder` row carrying before/after
+ * snapshots of `(translationId, displayRank)` pairs so the history view
+ * can render either side as a list.
+ */
+export async function reorderTranslations(
+  editor: Editor,
+  lemmaId: string,
+  orderedTranslationIds: string[],
+  reason: string,
+  now: Date = new Date(),
+): Promise<Translation[]> {
+  if (!reason || reason.trim().length < 3) throw new MissingReasonError();
+  if (orderedTranslationIds.length === 0) {
+    throw new CuratorValidationError(
+      'Reorder requires at least one translation id',
+    );
+  }
+  const seen = new Set<string>();
+  for (const id of orderedTranslationIds) {
+    if (seen.has(id)) {
+      throw new CuratorValidationError(
+        `Duplicate translation id in order: ${id}`,
+      );
+    }
+    seen.add(id);
+  }
+
+  const lemma = await loadLemma(lemmaId);
+  await requireCanEditDictionary(editor, lemma.language);
+
+  const existing = (await db
+    .select()
+    .from(schema.translations)
+    .where(eq(schema.translations.lemmaId, lemmaId))) as Translation[];
+
+  if (existing.length !== orderedTranslationIds.length) {
+    throw new CuratorValidationError(
+      'orderedTranslationIds must contain exactly the translations on this lemma — re-fetch and try again',
+      409,
+    );
+  }
+  const existingIds = new Set(existing.map((t) => t.id));
+  for (const id of orderedTranslationIds) {
+    if (!existingIds.has(id)) {
+      throw new CuratorValidationError(
+        `Translation ${id} does not belong to lemma ${lemmaId}`,
+        404,
+      );
+    }
+  }
+
+  const before = existing.map((t) => ({
+    translationId: t.id,
+    displayRank: t.displayRank,
+  }));
+
+  // No transaction wrapper to match the existing merge/split pattern in
+  // this file. A crash mid-loop leaves display_rank values arbitrary,
+  // which a re-run corrects; there's no uniqueness constraint to violate.
+  for (let i = 0; i < orderedTranslationIds.length; i += 1) {
+    const id = orderedTranslationIds[i] as string;
+    await db
+      .update(schema.translations)
+      .set({ displayRank: i, updatedAt: now })
+      .where(eq(schema.translations.id, id));
+  }
+
+  const after = orderedTranslationIds.map((id, i) => ({
+    translationId: id,
+    displayRank: i,
+  }));
+
+  await recordLemmaEdit({
+    lemmaId,
+    editorId: editor.id,
+    changeType: 'translation_reorder',
+    change: {
+      translationOrderBefore: before,
+      translationOrderAfter: after,
+    },
+    reason,
+  });
+
+  // Return rows in the new order so the caller (form action / API) can
+  // render the post-write state without a second select.
+  const byId = new Map(existing.map((t) => [t.id, t]));
+  return orderedTranslationIds.map((id, i) => {
+    const row = byId.get(id) as Translation;
+    return { ...row, displayRank: i, updatedAt: now };
+  });
+}
+
+// -----------------------------------------------------------------------
 // mergeLemmas
 // -----------------------------------------------------------------------
 
@@ -709,10 +812,18 @@ export async function getLemmaEditorView(
 }> {
   const lemma = await loadLemma(lemmaId);
   await requireCanEditDictionary(editor, lemma.language);
+  // Editor view sorts by curator-set rank ascending (Postgres default
+  // is NULLS LAST for ASC, so unranked rows fall to the end), then by
+  // createdAt for stability within ties. Reorder UI relies on this
+  // canonical order matching what the reader will see (T-3.13).
   const translations = (await db
     .select()
     .from(schema.translations)
-    .where(eq(schema.translations.lemmaId, lemmaId))) as Translation[];
+    .where(eq(schema.translations.lemmaId, lemmaId))
+    .orderBy(
+      asc(schema.translations.displayRank),
+      asc(schema.translations.createdAt),
+    )) as Translation[];
   const forms = (await db
     .select()
     .from(schema.lemmaForms)

--- a/apps/web/src/lib/server/dictionary/lookups.test.ts
+++ b/apps/web/src/lib/server/dictionary/lookups.test.ts
@@ -26,6 +26,7 @@ function row(overrides: Partial<Translation>): Translation {
     sourceAttribution: null,
     sourceId: null,
     hidden: false,
+    displayRank: null,
     createdAt: new Date('2026-01-01T00:00:00Z'),
     updatedAt: new Date('2026-01-01T00:00:00Z'),
     ...overrides,
@@ -92,6 +93,89 @@ describe('bucketTranslations — ordering', () => {
     ];
     const out = bucketTranslations(rows, null);
     expect(out.community.map((t) => t.body)).toEqual(['new', 'old']);
+  });
+
+  it('honors curator-set displayRank ahead of source-rank within officials (T-3.13)', () => {
+    const rows: Translation[] = [
+      row({
+        source: 'curator',
+        body: 'cur-second',
+        displayRank: 1,
+        createdAt: new Date('2026-01-01'),
+      }),
+      row({
+        source: 'official_dictionary',
+        body: 'imp-first',
+        displayRank: 0,
+        createdAt: new Date('2025-12-01'),
+      }),
+    ];
+    const out = bucketTranslations(rows, null);
+    // Without ranks the curator row would sort first; ranks override.
+    expect(out.official.map((t) => t.body)).toEqual(['imp-first', 'cur-second']);
+  });
+
+  it('falls back to source-rank when displayRank is null (T-3.13)', () => {
+    // Same setup as the non-rank test above but with all ranks null —
+    // proves the displayRank path doesn't disturb existing behavior.
+    const rows: Translation[] = [
+      row({
+        source: 'official_dictionary',
+        body: 'imp',
+        displayRank: null,
+        createdAt: new Date('2025-12-01'),
+      }),
+      row({
+        source: 'curator',
+        body: 'cur',
+        displayRank: null,
+        createdAt: new Date('2026-03-01'),
+      }),
+    ];
+    const out = bucketTranslations(rows, null);
+    expect(out.official.map((t) => t.body)).toEqual(['cur', 'imp']);
+  });
+
+  it('places null-rank rows after non-null within the same bucket (T-3.13)', () => {
+    const rows: Translation[] = [
+      row({
+        source: 'official_dictionary',
+        body: 'unranked',
+        displayRank: null,
+        createdAt: new Date('2025-12-01'),
+      }),
+      row({
+        source: 'official_dictionary',
+        body: 'ranked',
+        displayRank: 5,
+        createdAt: new Date('2026-04-01'),
+      }),
+    ];
+    const out = bucketTranslations(rows, null);
+    expect(out.official.map((t) => t.body)).toEqual(['ranked', 'unranked']);
+  });
+
+  it('honors displayRank within the community bucket too (T-3.13)', () => {
+    const rows: Translation[] = [
+      row({
+        source: 'user',
+        submittedBy: 'u2',
+        body: 'pinned',
+        displayRank: 0,
+        createdAt: new Date('2026-01-01'),
+      }),
+      row({
+        source: 'user',
+        submittedBy: 'u3',
+        body: 'newer',
+        displayRank: null,
+        createdAt: new Date('2026-04-01'),
+      }),
+    ];
+    const out = bucketTranslations(rows, null);
+    // The community bucket would normally put the newer row first; the
+    // curator's pin overrides.
+    expect(out.community.map((t) => t.body)).toEqual(['pinned', 'newer']);
   });
 
   it('orders personal translations oldest-first (stable across renders)', () => {

--- a/apps/web/src/lib/server/dictionary/lookups.ts
+++ b/apps/web/src/lib/server/dictionary/lookups.ts
@@ -161,15 +161,36 @@ export function bucketTranslations(
   const byCreatedAtDesc = (a: Translation, b: Translation) =>
     b.createdAt.getTime() - a.createdAt.getTime();
 
+  // T-3.13: a curator-set `displayRank` overrides the bucket's default
+  // tiebreaker. NULL ranks sort after any non-NULL rank within the same
+  // bucket, then fall through to the bucket-specific secondary sort.
+  // The personal bucket doesn't accept curator reordering — it's
+  // viewer-private — so it ignores displayRank entirely.
+  const byDisplayRankThen =
+    (fallback: (a: Translation, b: Translation) => number) =>
+    (a: Translation, b: Translation): number => {
+      const ar = a.displayRank;
+      const br = b.displayRank;
+      if (ar !== null && br !== null) {
+        if (ar !== br) return ar - br;
+        return fallback(a, b);
+      }
+      if (ar !== null) return -1;
+      if (br !== null) return 1;
+      return fallback(a, b);
+    };
+
   personal.sort(byCreatedAtAsc);
-  official.sort((a, b) => {
-    // Curator edits sort ahead of raw imports; within each tier,
-    // oldest-first keeps the reader pop-up stable across renders.
-    const sourceRank = (s: Translation['source']) => (s === 'curator' ? 0 : 1);
-    const diff = sourceRank(a.source) - sourceRank(b.source);
-    return diff !== 0 ? diff : byCreatedAtAsc(a, b);
-  });
-  community.sort(byCreatedAtDesc);
+  official.sort(
+    byDisplayRankThen((a, b) => {
+      // Curator edits sort ahead of raw imports; within each tier,
+      // oldest-first keeps the reader pop-up stable across renders.
+      const sourceRank = (s: Translation['source']) => (s === 'curator' ? 0 : 1);
+      const diff = sourceRank(a.source) - sourceRank(b.source);
+      return diff !== 0 ? diff : byCreatedAtAsc(a, b);
+    }),
+  );
+  community.sort(byDisplayRankThen(byCreatedAtDesc));
 
   return {
     personal: personal.map((r) => toPublicTranslation(r, viewer)),

--- a/apps/web/src/lib/server/dictionary/test-support.ts
+++ b/apps/web/src/lib/server/dictionary/test-support.ts
@@ -152,6 +152,7 @@ export class InMemoryDictionaryRepo implements DictionaryRepo {
       sourceAttribution: payload.sourceAttribution ?? null,
       sourceId: payload.sourceId,
       hidden: false,
+      displayRank: null,
       createdAt: nowUtc(),
       updatedAt: nowUtc(),
     };

--- a/apps/web/src/routes/api/v1/admin/lemmas/[id]/translations/reorder/+server.ts
+++ b/apps/web/src/routes/api/v1/admin/lemmas/[id]/translations/reorder/+server.ts
@@ -1,0 +1,58 @@
+/**
+ * PATCH /api/v1/admin/lemmas/:id/translations/reorder (T-3.13).
+ *
+ * Caller passes the canonical ordered list of translation ids for the
+ * lemma. The service writes `display_rank` by index and audits a single
+ * `translation_reorder` row with before/after snapshots.
+ *
+ * Partial reorders are not supported — if the caller doesn't include
+ * every translation currently on the lemma, the service rejects with
+ * 409 so the UI re-fetches and tries again. This pattern keeps the
+ * reorder endpoint trivially idempotent under retry.
+ */
+import { error, json } from '@sveltejs/kit';
+import { z } from 'zod';
+
+import { requireUser } from '$lib/server/auth/require-user.js';
+import {
+  CuratorValidationError,
+  reorderTranslations,
+} from '$lib/server/dictionary/curator.js';
+import { ForbiddenError } from '$lib/server/dictionary/permissions.js';
+import { MissingReasonError } from '$lib/server/dictionary/audit.js';
+import type { RequestHandler } from './$types';
+import { parseJson } from '../../../../../auth/_helpers.js';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const body = z.object({
+  orderedTranslationIds: z
+    .array(z.string().regex(UUID_RE, 'must be a UUID'))
+    .min(1),
+  reason: z.string().min(3).max(500),
+});
+
+function mapCuratorError(err: unknown): never {
+  if (err instanceof CuratorValidationError) throw error(err.status, err.message);
+  if (err instanceof ForbiddenError) throw error(403, err.message);
+  if (err instanceof MissingReasonError) throw error(400, err.message);
+  throw err;
+}
+
+export const PATCH: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  const lemmaId = event.params.id;
+  if (!lemmaId || !UUID_RE.test(lemmaId)) throw error(400, 'Invalid lemma id');
+  const input = await parseJson(event.request, body);
+  try {
+    const translations = await reorderTranslations(
+      user,
+      lemmaId,
+      input.orderedTranslationIds,
+      input.reason,
+    );
+    return json({ translations });
+  } catch (err) {
+    mapCuratorError(err);
+  }
+};

--- a/apps/web/src/routes/api/v1/admin/lemmas/[id]/translations/reorder/reorder-server.test.ts
+++ b/apps/web/src/routes/api/v1/admin/lemmas/[id]/translations/reorder/reorder-server.test.ts
@@ -1,0 +1,142 @@
+// @vitest-environment node
+/**
+ * Route tests for PATCH /api/v1/admin/lemmas/:id/translations/reorder (T-3.13).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const reorderTranslations = vi.fn();
+const requireUser = vi.fn();
+
+vi.mock('$lib/server/dictionary/curator.js', async () => {
+  const actual = await vi.importActual<
+    typeof import('$lib/server/dictionary/curator.js')
+  >('$lib/server/dictionary/curator.js');
+  return {
+    ...actual,
+    reorderTranslations: (...a: unknown[]) => reorderTranslations(...a),
+  };
+});
+
+vi.mock('$lib/server/auth/require-user.js', () => ({
+  requireUser: (...a: unknown[]) => requireUser(...a),
+}));
+
+type PatchFn = (typeof import('./+server.js'))['PATCH'];
+
+const LEMMA = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const T1 = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+const T2 = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+const ADMIN = { id: 'admin-1', role: 'admin' as const };
+
+async function callPatch(body: unknown, user = ADMIN, id = LEMMA) {
+  requireUser.mockResolvedValueOnce(user);
+  const { PATCH } = await import('./+server.js');
+  const event = {
+    params: { id },
+    request: new Request(`http://x/api/v1/admin/lemmas/${id}/translations/reorder`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+  } as unknown as Parameters<PatchFn>[0];
+  try {
+    return await PATCH(event);
+  } catch (e) {
+    return e as { status: number };
+  }
+}
+
+beforeEach(() => {
+  reorderTranslations.mockReset();
+  requireUser.mockReset();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('PATCH /api/v1/admin/lemmas/:id/translations/reorder', () => {
+  it('returns the new ordered translations on success', async () => {
+    reorderTranslations.mockResolvedValueOnce([
+      { id: T1, displayRank: 0 },
+      { id: T2, displayRank: 1 },
+    ]);
+    const res = (await callPatch({
+      orderedTranslationIds: [T1, T2],
+      reason: 'Pinning the more idiomatic gloss first',
+    })) as Response;
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.translations).toEqual([
+      { id: T1, displayRank: 0 },
+      { id: T2, displayRank: 1 },
+    ]);
+    expect(reorderTranslations).toHaveBeenCalledWith(
+      ADMIN,
+      LEMMA,
+      [T1, T2],
+      'Pinning the more idiomatic gloss first',
+    );
+  });
+
+  it('returns 400 when an id is not a UUID', async () => {
+    const res = (await callPatch({
+      orderedTranslationIds: ['not-a-uuid'],
+      reason: 'oops',
+    })) as { status: number };
+    expect(res.status).toBe(400);
+    expect(reorderTranslations).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when the lemma id in the URL is malformed', async () => {
+    const res = (await callPatch(
+      {
+        orderedTranslationIds: [T1, T2],
+        reason: 'order',
+      },
+      ADMIN,
+      'not-a-uuid',
+    )) as { status: number };
+    expect(res.status).toBe(400);
+    expect(reorderTranslations).not.toHaveBeenCalled();
+  });
+
+  it('maps a 409 from a partial-order rejection', async () => {
+    const { CuratorValidationError } = await import(
+      '$lib/server/dictionary/curator.js'
+    );
+    reorderTranslations.mockRejectedValueOnce(
+      new CuratorValidationError(
+        'orderedTranslationIds must contain exactly the translations on this lemma — re-fetch and try again',
+        409,
+      ),
+    );
+    const res = (await callPatch({
+      orderedTranslationIds: [T1],
+      reason: 'partial reorder',
+    })) as { status: number };
+    expect(res.status).toBe(409);
+  });
+
+  it('maps a ForbiddenError from a non-curator caller as 403', async () => {
+    const { ForbiddenError } = await import(
+      '$lib/server/dictionary/permissions.js'
+    );
+    reorderTranslations.mockRejectedValueOnce(
+      new ForbiddenError('Not allowed to edit hi'),
+    );
+    const res = (await callPatch({
+      orderedTranslationIds: [T1, T2],
+      reason: 'forbidden test',
+    })) as { status: number };
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects an empty ordered list with 400', async () => {
+    const res = (await callPatch({
+      orderedTranslationIds: [],
+      reason: 'empty',
+    })) as { status: number };
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/web/src/routes/moderation/dictionary/[id]/+page.server.ts
+++ b/apps/web/src/routes/moderation/dictionary/[id]/+page.server.ts
@@ -22,6 +22,7 @@ import {
   CuratorValidationError,
   getLemmaEditorView,
   mergeLemmas,
+  reorderTranslations,
   setLemmaLock,
   setTranslationHidden,
   splitLemma,
@@ -63,6 +64,9 @@ type MergeFormResult =
 type SplitFormResult =
   | { ok: true; section: 'split'; newLemmaId: string }
   | { ok: false; section: 'split'; message: string };
+type ReorderFormResult =
+  | { ok: true; section: 'reorder' }
+  | { ok: false; section: 'reorder'; message: string };
 
 export const load: PageServerLoad = async ({ params, locals }) => {
   if (!locals.user) throw redirect(303, '/login');
@@ -139,6 +143,14 @@ const hideSchema = z.object({
 
 const mergeSchema = z.object({
   loserId: z.string().regex(UUID_RE),
+  reason: z.string().min(3).max(500),
+});
+
+const reorderSchema = z.object({
+  // Comma- or whitespace-separated UUIDs. The form ships a hidden input
+  // with the canonical order; we parse, dedupe, and validate the count
+  // server-side via the service.
+  orderedTranslationIds: z.string().min(1),
   reason: z.string().min(3).max(500),
 });
 
@@ -317,6 +329,48 @@ export const actions: Actions = {
         section: 'merge',
         message: mapped.message,
       } satisfies MergeFormResult);
+    }
+  },
+
+  reorderTranslations: async ({ params, request, locals }) => {
+    const editor = editorFromLocals(locals);
+    const form = Object.fromEntries(await request.formData());
+    const parsed = reorderSchema.safeParse(form);
+    if (!parsed.success) {
+      return fail(400, {
+        ok: false,
+        section: 'reorder',
+        message: parsed.error.issues
+          .map((i) => `${i.path.join('.')}: ${i.message}`)
+          .join('; '),
+      } satisfies ReorderFormResult);
+    }
+    const orderedIds = parsed.data.orderedTranslationIds
+      .split(/[\s,]+/)
+      .map((s) => s.trim())
+      .filter((s) => UUID_RE.test(s));
+    if (orderedIds.length === 0) {
+      return fail(400, {
+        ok: false,
+        section: 'reorder',
+        message: 'No valid translation ids in orderedTranslationIds',
+      } satisfies ReorderFormResult);
+    }
+    try {
+      await reorderTranslations(
+        editor,
+        params.id,
+        orderedIds,
+        parsed.data.reason,
+      );
+      return { ok: true, section: 'reorder' } satisfies ReorderFormResult;
+    } catch (e) {
+      const mapped = mapError(e);
+      return fail(mapped.status, {
+        ok: false,
+        section: 'reorder',
+        message: mapped.message,
+      } satisfies ReorderFormResult);
     }
   },
 

--- a/apps/web/src/routes/moderation/dictionary/[id]/+page.svelte
+++ b/apps/web/src/routes/moderation/dictionary/[id]/+page.svelte
@@ -34,6 +34,28 @@
       message: form.ok ? 'Saved.' : form.message,
     };
   }
+
+  // T-3.13: per-section reorder reason. Curators type once and the
+  // value is reused for every up/down click in the section. Required
+  // because the audit pipeline rejects empty reasons.
+  let reorderReason = $state('');
+  const canReorder = $derived(reorderReason.trim().length >= 3);
+
+  // Build the comma-separated orderedTranslationIds for swapping rows
+  // (i, j). Returns the unswapped order if either index is out of
+  // range — the corresponding button is disabled in that case anyway,
+  // so the form value doesn't matter; the type-safe path keeps Svelte
+  // happy.
+  function swappedOrder(translations: Array<{ id: string }>, i: number, j: number): string {
+    const ids = translations.map((t) => t.id);
+    if (i < 0 || j < 0 || i >= ids.length || j >= ids.length) {
+      return ids.join(',');
+    }
+    const tmp = ids[i] as string;
+    ids[i] = ids[j] as string;
+    ids[j] = tmp;
+    return ids.join(',');
+  }
 </script>
 
 <svelte:head>
@@ -120,16 +142,63 @@
   <!-- Translations ------------------------------------------------------ -->
   <section>
     <h2>Translations ({data.translations.length})</h2>
+    {#if msgFor('reorder')}
+      <p class:ok={form?.ok} class:err={!form?.ok}>{msgFor('reorder')}</p>
+    {/if}
     {#if data.translations.length === 0}
       <p class="muted">No translations.</p>
     {:else}
+      {#if data.translations.length > 1}
+        <label class="reorder-reason">
+          Reorder reason
+          <input
+            type="text"
+            bind:value={reorderReason}
+            placeholder="Required to use the ↑ / ↓ buttons (≥ 3 chars)"
+          />
+        </label>
+      {/if}
       <ul class="translations">
-        {#each data.translations as t (t.id)}
+        {#each data.translations as t, i (t.id)}
           <li>
             <div class="meta">
               <ProvenanceBadge provenance={t.provenance} />
               <span class="muted">{t.targetLanguage}</span>
               {#if t.hidden}<span class="tag warn">hidden</span>{/if}
+              {#if data.translations.length > 1}
+                <span class="reorder-buttons">
+                  <form method="post" action="?/reorderTranslations" use:enhance>
+                    <input
+                      type="hidden"
+                      name="orderedTranslationIds"
+                      value={swappedOrder(data.translations, i, i - 1)}
+                    />
+                    <input type="hidden" name="reason" value={reorderReason} />
+                    <button
+                      type="submit"
+                      class="arrow"
+                      aria-label="Move up"
+                      disabled={i === 0 || !canReorder}
+                      title={canReorder ? 'Move up' : 'Type a reorder reason first'}
+                    >↑</button>
+                  </form>
+                  <form method="post" action="?/reorderTranslations" use:enhance>
+                    <input
+                      type="hidden"
+                      name="orderedTranslationIds"
+                      value={swappedOrder(data.translations, i, i + 1)}
+                    />
+                    <input type="hidden" name="reason" value={reorderReason} />
+                    <button
+                      type="submit"
+                      class="arrow"
+                      aria-label="Move down"
+                      disabled={i === data.translations.length - 1 || !canReorder}
+                      title={canReorder ? 'Move down' : 'Type a reorder reason first'}
+                    >↓</button>
+                  </form>
+                </span>
+              {/if}
             </div>
             {#if translationMsg(t.id)}
               {@const tm = translationMsg(t.id)!}
@@ -390,6 +459,39 @@
     gap: 0.5rem;
     align-items: center;
     margin-bottom: 0.5rem;
+  }
+  .reorder-reason {
+    display: block;
+    margin-bottom: 0.75rem;
+    font-size: 0.85rem;
+  }
+  .reorder-buttons {
+    display: inline-flex;
+    gap: 0.2rem;
+    margin-left: auto;
+  }
+  .reorder-buttons form {
+    display: inline;
+    margin: 0;
+  }
+  .arrow {
+    min-height: 0;
+    min-width: 1.8rem;
+    padding: 0.1rem 0.4rem;
+    background: transparent;
+    color: var(--color-fg);
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.85rem;
+    line-height: 1;
+  }
+  .arrow:hover:not([disabled]) {
+    background: var(--color-border);
+  }
+  .arrow[disabled] {
+    opacity: 0.35;
+    cursor: not-allowed;
   }
   .history {
     list-style: none;

--- a/apps/web/src/routes/moderation/dictionary/[id]/page-server.test.ts
+++ b/apps/web/src/routes/moderation/dictionary/[id]/page-server.test.ts
@@ -16,6 +16,7 @@ const updateTranslation = vi.fn();
 const setTranslationHidden = vi.fn();
 const mergeLemmas = vi.fn();
 const splitLemma = vi.fn();
+const reorderTranslations = vi.fn();
 
 vi.mock('$lib/server/dictionary/curator.js', async () => {
   const actual = await vi.importActual<
@@ -30,6 +31,7 @@ vi.mock('$lib/server/dictionary/curator.js', async () => {
     setTranslationHidden: (...a: unknown[]) => setTranslationHidden(...a),
     mergeLemmas: (...a: unknown[]) => mergeLemmas(...a),
     splitLemma: (...a: unknown[]) => splitLemma(...a),
+    reorderTranslations: (...a: unknown[]) => reorderTranslations(...a),
   };
 });
 
@@ -76,6 +78,7 @@ beforeEach(() => {
   setTranslationHidden.mockReset();
   mergeLemmas.mockReset();
   splitLemma.mockReset();
+  reorderTranslations.mockReset();
 });
 
 afterEach(() => {
@@ -216,5 +219,31 @@ describe('moderation lemma editor actions', () => {
       true,
       'spam submission',
     );
+  });
+
+  it('reorderTranslations parses the comma-separated id list and forwards in order (T-3.13)', async () => {
+    reorderTranslations.mockResolvedValueOnce([]);
+    const a = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+    const b = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+    const res = await callAction('reorderTranslations', {
+      orderedTranslationIds: `${a}, ${b}`,
+      reason: 'pin curated above import',
+    });
+    expect(res).toEqual({ ok: true, section: 'reorder' });
+    expect(reorderTranslations).toHaveBeenCalledWith(
+      USER,
+      LEMMA_ID,
+      [a, b],
+      'pin curated above import',
+    );
+  });
+
+  it('reorderTranslations rejects when no valid UUIDs survive parsing (T-3.13)', async () => {
+    const res = await callAction('reorderTranslations', {
+      orderedTranslationIds: 'not-a-uuid, also-bad',
+      reason: 'malformed payload',
+    });
+    expect((res as { status?: number }).status ?? 200).toBe(400);
+    expect(reorderTranslations).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Adds the reorder capability listed in T-3.7's spec but never implemented. Curator-set `display_rank` overrides the bucket's default tiebreaker — surfaced as ↑/↓ buttons on each translation row in the moderation lemma editor.

### Schema (migration 0011)

- `translations.display_rank` int nullable. NULL = use bucket default.
- `lemma_edit_change_type` enum gains `translation_reorder`.
- `LemmaEditChangePayload` gains `translationOrderBefore` / `translationOrderAfter` arrays for the audit row.

### Service

`reorderTranslations(editor, lemmaId, orderedIds, reason)` validates the full canonical order (rejects partial / unknown / duplicate ids), assigns `display_rank` by index, and audits a single `translation_reorder` row with before+after snapshots.

`getLemmaEditorView` now orders translations by `displayRank ASC NULLS LAST, createdAt ASC` so the editor list matches the canonical order the reader sees and the swap math stays consistent across reloads.

### Read path

`bucketTranslations` honors `displayRank` ahead of the existing source-rank / createdAt tiebreakers within the **official** and **community** buckets. The personal bucket ignores it (single-viewer, no reorder UX).

### Wire

- `PATCH /api/v1/admin/lemmas/:id/translations/reorder` for programmatic callers.
- `?/reorderTranslations` form action on the moderation lemma page, matching the existing form-action pattern. UI uses paired ↑/↓ form buttons with hidden `orderedTranslationIds` carrying the swapped order; gated on a per-section reason input (≥3 chars) so the audit pipeline never gets an empty reason.

### Known limitation (deferred)

The buckets (personal / official / community) are immutable — `display_rank` only orders within a bucket. A curator who reorders an entry across the bucket boundary in the editor list won't see that reflected in the reader popup. The expected workflow is: promote a community row to curator (existing button), then reorder within the official bucket.

## Test plan

- [x] pnpm test — 83 files / 648 tests pass, including 7 reorder service cases, 4 bucketTranslations displayRank cases, 6 endpoint cases, 2 form-action cases.
- [x] pnpm check — 0 errors / 0 warnings
- [x] pnpm lint — clean
- [x] pnpm build — clean
- [ ] Manual smoke against a real Postgres: run the migration, open /moderation/dictionary/<lemma-id> for a lemma with ≥2 translations, type a reason, click ↑ and ↓, refresh, confirm the order persists and the reader popup reflects it.

Closes #196. Refs #32.