### PR TITLE
T-5.29: scroll mode — hover tooltips + matching font size

### DIFF
--- a/apps/web/src/lib/components/reader/ChapterBody.svelte
+++ b/apps/web/src/lib/components/reader/ChapterBody.svelte
@@ -223,10 +223,12 @@
 {/if}
 
 <style>
+  /* Inherit font-size + line-height from the reader's content rule
+     so page mode and scroll mode look identical (T-5.29 fixed an
+     earlier mismatch where this paragraph rule shadowed the parent
+     at 1.05rem). */
   .body {
     margin: 0 0 1rem;
-    line-height: 1.85;
-    font-size: 1.05rem;
   }
   .word {
     cursor: pointer;

--- a/apps/web/src/lib/components/reader/ReaderScroll.svelte
+++ b/apps/web/src/lib/components/reader/ReaderScroll.svelte
@@ -19,6 +19,7 @@
   } from './types.js';
 
   import WordPopup from './WordPopup.svelte';
+  import WordTooltip from './WordTooltip.svelte';
 
   let {
     chapters,
@@ -129,23 +130,79 @@
     right: number;
   } | null>(null);
 
-  function onArticleClick(event: MouseEvent) {
-    const target = event.target as HTMLElement | null;
-    if (!target) return;
+  // T-5.29: hover wiring matches ChapterBody (used by ReaderPage) so
+  // both modes show the WordTooltip on word hover.
+  let hoverToken = $state<ServerToken | null>(null);
+  let hoverRect = $state<{
+    top: number;
+    left: number;
+    bottom: number;
+    right: number;
+    width: number;
+    height: number;
+  } | null>(null);
+
+  function findToken(target: HTMLElement | null): {
+    token: ServerToken;
+    el: HTMLElement;
+  } | null {
+    if (!target) return null;
     const span = target.closest('[data-token-id]') as HTMLElement | null;
-    if (!span) return;
+    if (!span) return null;
     const tokenId = span.getAttribute('data-token-id');
-    if (!tokenId) return;
+    if (!tokenId) return null;
     const token = tokensById.get(tokenId);
-    if (!token || !token.isWord) return;
-    const rect = span.getBoundingClientRect();
-    activeToken = token;
+    if (!token || !token.isWord) return null;
+    return { token, el: span };
+  }
+
+  function onArticleClick(event: MouseEvent) {
+    const found = findToken(event.target as HTMLElement);
+    if (!found) return;
+    const rect = found.el.getBoundingClientRect();
+    activeToken = found.token;
     activeRect = {
       top: rect.top,
       left: rect.left,
       bottom: rect.bottom,
       right: rect.right,
     };
+    hoverToken = null;
+    hoverRect = null;
+  }
+
+  function showHoverTooltip(event: Event) {
+    const found = findToken(event.target as HTMLElement);
+    if (!found) {
+      hoverToken = null;
+      hoverRect = null;
+      return;
+    }
+    if (activeToken && activeToken.id === found.token.id) {
+      hoverToken = null;
+      hoverRect = null;
+      return;
+    }
+    const rect = found.el.getBoundingClientRect();
+    hoverToken = found.token;
+    hoverRect = {
+      top: rect.top,
+      left: rect.left,
+      bottom: rect.bottom,
+      right: rect.right,
+      width: rect.width,
+      height: rect.height,
+    };
+  }
+
+  function hideHoverTooltip(event: Event) {
+    const related =
+      'relatedTarget' in event ? (event.relatedTarget as HTMLElement | null) : null;
+    if (related && (event.currentTarget as HTMLElement).contains(related)) {
+      return;
+    }
+    hoverToken = null;
+    hoverRect = null;
   }
 
   function closePopup() {
@@ -200,7 +257,14 @@
 
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-  <article onclick={onArticleClick}>
+  <!-- svelte-ignore a11y_mouse_events_have_key_events -->
+  <article
+    onclick={onArticleClick}
+    onmouseover={showHoverTooltip}
+    onmouseout={hideHoverTooltip}
+    onfocusin={showHoverTooltip}
+    onfocusout={hideHoverTooltip}
+  >
     {#if visibleServer}
       {#each visibleServer as paragraph, pIdx (pIdx)}
         <p class="body">
@@ -226,6 +290,10 @@
     <button type="button" disabled={!hasNext} onclick={next}>Next page →</button>
   </nav>
 </div>
+
+{#if hoverToken && hoverRect}
+  <WordTooltip token={hoverToken} anchorRect={hoverRect} />
+{/if}
 
 {#if activeToken && activeRect}
   <WordPopup


### PR DESCRIPTION
## Summary

Two scroll-mode regressions per user feedback ([#207](https://github.com/chickendude/CIA-Reader/issues/207)).

### 1. Hover tooltips missing
ReaderScroll renders tokens directly in its own `<article onclick>` block instead of routing through ChapterBody, so the mouseover→WordTooltip wiring T-5.10 added never fired. Click-to-open-side-panel worked but hover did nothing.

**Fix:** wire ReaderScroll's article element with the same hover surface ChapterBody uses — `mouseover` / `mouseout` / `focusin` / `focusout`, a shared `findToken` helper, `hoverToken` / `hoverRect` state, and a mounted `<WordTooltip>` when a word is under the cursor. Same "skip the tooltip when the side panel is locked on the same word" rule so they don't double up.

### 2. Font size mismatch with page mode
ReaderScroll's `article` rule uses 1.1rem (1.25rem at ≥768px) — same scale as `ReaderPage`'s `.reader-page-content`. But `ChapterBody`'s `.body` paragraph rule shadowed the parent at **1.05rem**, so page mode rendered slightly smaller than scroll mode.

**Fix:** drop ChapterBody's `font-size` override. Both modes now inherit the parent's reader-content rule and match.

### Tests
All 630 vitest pass · eslint + svelte-check 0/0. No new tests — these are pure UI behavior changes that piggyback on existing component wiring.

### Stack
Branched off `main`. Will rebase cleanly once #198 (T-5.23/T-5.24/T-5.27 stack) lands; the additive hover handlers and ChapterBody font-size deletion shouldn't conflict with that PR's CSS reshuffle.

Closes #207
Refs #42, #160