### PR TITLE
T-5.25: language indicator + picker on the AppShell

### DIFF
--- a/apps/web/src/lib/components/shell/AppShell.svelte
+++ b/apps/web/src/lib/components/shell/AppShell.svelte
@@ -9,6 +9,7 @@
 -->
 <script lang="ts">
   import { page } from '$app/stores';
+  import { invalidateAll } from '$app/navigation';
   import { onMount } from 'svelte';
   import {
     TABS,
@@ -24,14 +25,73 @@
     setImmersiveAttribute,
     writePersistedImmersive,
   } from '../reader/immersive.js';
+  import Sheet from '../overlay/Sheet.svelte';
   import type { Snippet } from 'svelte';
+
+  interface LanguageOption {
+    code: string;
+    displayName: string;
+    nativeName: string;
+    glyph: string;
+  }
 
   interface Props {
     user: { id: string; displayName: string | null; email: string } | null;
+    /** Active language for the current visit. Drives the rail indicator
+     *  + per-screen filters (T-5.25). Null when the user has no
+     *  language data yet (anonymous fresh visitor). */
+    currentLanguage?: string | null;
+    /** Languages the signed-in user has a `user_languages` row for —
+     *  the picker's options. Empty for anonymous visitors. */
+    availableLanguages?: LanguageOption[];
     children: Snippet;
   }
 
-  let { user, children }: Props = $props();
+  let {
+    user,
+    currentLanguage = null,
+    availableLanguages = [],
+    children,
+  }: Props = $props();
+
+  const currentOption = $derived<LanguageOption | null>(
+    availableLanguages.find((l) => l.code === currentLanguage) ?? null,
+  );
+
+  // T-5.25: language picker. Click the indicator → sheet listing
+  // every active language. Selecting one PUTs the cookie + reloads
+  // layout data so the rail + every loader picks up the new pick.
+  let langPickerOpen = $state(false);
+  let switching = $state(false);
+  let switchError = $state<string | null>(null);
+
+  async function pickLanguage(code: string) {
+    if (switching) return;
+    if (code === currentLanguage) {
+      langPickerOpen = false;
+      return;
+    }
+    switching = true;
+    switchError = null;
+    try {
+      const res = await fetch('/api/v1/me/current-language', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ code }),
+      });
+      if (!res.ok) {
+        throw new Error(`PUT failed: ${res.status}`);
+      }
+      langPickerOpen = false;
+      // Re-run every loader so the new currentLanguage is picked up
+      // (rail indicator, home grid, library filter, words filter…).
+      await invalidateAll();
+    } catch (e) {
+      switchError = (e as Error).message;
+    } finally {
+      switching = false;
+    }
+  }
 
   const tabs = $derived<Tab[]>(visibleTabs(TABS, user !== null));
   const activeId = $derived(getActiveTabId($page.url.pathname, tabs));
@@ -118,6 +178,22 @@
       </span>
     </a>
 
+    {#if currentOption}
+      <button
+        type="button"
+        class="lang-indicator"
+        aria-label="Change current language ({currentOption.displayName})"
+        title="Switch language"
+        onclick={() => (langPickerOpen = true)}
+      >
+        <span class="lang-glyph" aria-hidden="true">{currentOption.glyph}</span>
+        <span class="lang-text">
+          <span class="lang-native">{currentOption.nativeName}</span>
+          <span class="lang-en">{currentOption.displayName}</span>
+        </span>
+      </button>
+    {/if}
+
     <nav class="nav" aria-label="Sections">
       {#each groups as group (group.section ?? '_')}
         {#if group.section}
@@ -159,6 +235,17 @@
     <a class="brand-strip" href="/" aria-label="CIA Reader home">
       <span class="brand-mark" aria-hidden="true">अ</span>
     </a>
+    {#if currentOption}
+      <button
+        type="button"
+        class="lang-indicator-compact"
+        aria-label="Change current language ({currentOption.displayName})"
+        title="Switch language"
+        onclick={() => (langPickerOpen = true)}
+      >
+        <span aria-hidden="true">{currentOption.glyph}</span>
+      </button>
+    {/if}
     {#if user}
       <span class="who" aria-label="Signed-in user">
         {user.displayName ?? user.email}
@@ -195,6 +282,49 @@
     {/each}
   </nav>
 </div>
+
+<!-- T-5.25: language picker. Lists every active user_languages row.
+     Manage / add / remove languages still happens on /profile — the
+     picker is just the runtime switcher. -->
+{#if langPickerOpen}
+  <Sheet open={langPickerOpen} onClose={() => (langPickerOpen = false)} title="Switch language">
+    <div class="lang-picker">
+      {#if availableLanguages.length === 0}
+        <p class="lang-empty">
+          You haven't added any languages yet. <a href="/profile">Open settings</a>
+          to pick one.
+        </p>
+      {:else}
+        <ul class="lang-list">
+          {#each availableLanguages as opt (opt.code)}
+            <li>
+              <button
+                type="button"
+                class="lang-row"
+                data-active={opt.code === currentLanguage ? '1' : '0'}
+                disabled={switching}
+                onclick={() => pickLanguage(opt.code)}
+              >
+                <span class="lang-row-glyph" aria-hidden="true">{opt.glyph}</span>
+                <span class="lang-row-text">
+                  <span class="lang-row-native">{opt.nativeName}</span>
+                  <span class="lang-row-en">{opt.displayName}</span>
+                </span>
+                {#if opt.code === currentLanguage}
+                  <span class="lang-row-current" aria-label="Current">●</span>
+                {/if}
+              </button>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+      {#if switchError}
+        <p class="lang-err" role="alert">Could not switch: {switchError}</p>
+      {/if}
+      <a class="lang-manage" href="/profile">Manage languages →</a>
+    </div>
+  </Sheet>
+{/if}
 
 <style>
   /* Desktop: rail + content. Mobile: top-strip + content + bottom-nav.
@@ -490,6 +620,185 @@
   .rail-toggle:hover {
     background: var(--accent-soft, var(--color-accent));
     color: var(--accent-ink, var(--color-accent-fg, #fff));
+  }
+
+  /* —— Language indicator + picker (T-5.25) ————————————————————
+   * The pill in the rail shows the current language at a glance and
+   * opens a Sheet picker on click. Also exists as a compact glyph in
+   * the mobile top-strip so the same affordance is reachable without
+   * the rail being visible. */
+  .lang-indicator {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    padding: 0.55rem 0.65rem;
+    background: var(--card, var(--color-bg));
+    border: 1px solid var(--card-edge, var(--color-border));
+    border-radius: 9px;
+    cursor: pointer;
+    text-align: left;
+    color: inherit;
+    font: inherit;
+    transition: border-color 150ms ease;
+  }
+  .lang-indicator:hover {
+    border-color: color-mix(
+      in oklch,
+      var(--accent, var(--color-accent)) 60%,
+      var(--card-edge, var(--color-border))
+    );
+  }
+  .lang-glyph {
+    width: 28px;
+    height: 28px;
+    border-radius: 6px;
+    background: var(--ink, var(--color-fg));
+    color: var(--paper, var(--color-bg));
+    display: grid;
+    place-items: center;
+    font-family: var(--font-serif-dev, var(--font-serif));
+    font-size: 1rem;
+    line-height: 1;
+    flex-shrink: 0;
+  }
+  .lang-text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+    line-height: 1.1;
+    min-width: 0;
+  }
+  .lang-native {
+    font-family: var(--font-serif-dev, var(--font-serif));
+    font-size: 0.95rem;
+    color: var(--ink, var(--color-fg));
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .lang-en {
+    font-family: var(--font-sans, var(--font-ui));
+    font-size: 0.6rem;
+    color: var(--ink-3, var(--color-fg-muted));
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  .lang-indicator-compact {
+    width: 32px;
+    height: 32px;
+    border-radius: 8px;
+    border: 1px solid var(--card-edge, var(--color-border));
+    background: var(--card, var(--color-bg));
+    color: var(--ink, var(--color-fg));
+    cursor: pointer;
+    font-family: var(--font-serif-dev, var(--font-serif));
+    font-size: 1rem;
+    display: grid;
+    place-items: center;
+  }
+
+  /* Picker sheet contents. */
+  .lang-picker {
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+  }
+  .lang-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+  .lang-row {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: 0.7rem;
+    padding: 0.6rem 0.75rem;
+    border: 1px solid var(--rule, var(--color-border));
+    border-radius: 9px;
+    background: var(--card, var(--color-bg));
+    color: var(--ink, var(--color-fg));
+    cursor: pointer;
+    font: inherit;
+    text-align: left;
+    transition:
+      border-color 150ms ease,
+      background 150ms ease;
+  }
+  .lang-row:hover:not(:disabled) {
+    border-color: color-mix(
+      in oklch,
+      var(--accent, var(--color-accent)) 50%,
+      var(--card-edge, var(--color-border))
+    );
+  }
+  .lang-row[data-active='1'] {
+    border-color: var(--accent, var(--color-accent));
+    background: var(--accent-soft, var(--color-accent));
+  }
+  .lang-row:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+  .lang-row-glyph {
+    width: 32px;
+    height: 32px;
+    border-radius: 7px;
+    background: var(--ink, var(--color-fg));
+    color: var(--paper, var(--color-bg));
+    display: grid;
+    place-items: center;
+    font-family: var(--font-serif-dev, var(--font-serif));
+    font-size: 1.1rem;
+    flex-shrink: 0;
+  }
+  .lang-row-text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+    flex: 1;
+    min-width: 0;
+  }
+  .lang-row-native {
+    font-family: var(--font-serif-dev, var(--font-serif));
+    font-size: 1rem;
+    color: var(--ink, var(--color-fg));
+  }
+  .lang-row-en {
+    font-family: var(--font-sans, var(--font-ui));
+    font-size: 0.7rem;
+    color: var(--ink-3, var(--color-fg-muted));
+  }
+  .lang-row-current {
+    color: var(--accent-ink, var(--color-accent));
+    font-size: 0.85rem;
+  }
+  .lang-empty {
+    color: var(--ink-3, var(--color-fg-muted));
+    font-size: 0.85rem;
+    margin: 0;
+  }
+  .lang-empty a {
+    color: var(--accent-ink, var(--color-accent));
+  }
+  .lang-err {
+    color: var(--rose, var(--color-danger));
+    font-size: 0.78rem;
+    margin: 0;
+  }
+  .lang-manage {
+    align-self: flex-start;
+    color: var(--accent-ink, var(--color-accent));
+    text-decoration: none;
+    font-size: 0.85rem;
+    padding: 0.4rem 0;
+  }
+  .lang-manage:hover {
+    text-decoration: underline;
   }
 
   /* —— Immersive mode (T-5.16, retriggered by T-5.26) ——————————

--- a/apps/web/src/lib/server/language-context.test.ts
+++ b/apps/web/src/lib/server/language-context.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+
+import {
+  LANG_COOKIE,
+  LANG_COOKIE_MAX_AGE,
+  languageOption,
+  resolveCurrentLanguage,
+} from './language-context.js';
+
+describe('resolveCurrentLanguage', () => {
+  it("returns the user's only language when there's no cookie", () => {
+    expect(resolveCurrentLanguage(undefined, ['hi'])).toBe('hi');
+  });
+
+  it("honors a cookie that matches one of the user's active languages", () => {
+    expect(resolveCurrentLanguage('mr', ['hi', 'mr', 'or'])).toBe('mr');
+  });
+
+  it("ignores a cookie pointing at a language the user isn't active in", () => {
+    expect(resolveCurrentLanguage('or', ['hi', 'mr'])).toBe('hi');
+  });
+
+  it('ignores a malformed cookie', () => {
+    expect(resolveCurrentLanguage('not-a-code', ['hi'])).toBe('hi');
+    expect(resolveCurrentLanguage('', ['hi', 'mr'])).toBe('hi');
+  });
+
+  it('falls back to the supported-language registry for anonymous visitors', () => {
+    // No active languages means the user is signed out / hasn't
+    // onboarded; honor the cookie or pick the first supported code.
+    expect(resolveCurrentLanguage('mr', [])).toBe('mr');
+    expect(resolveCurrentLanguage(undefined, [])).toBe('hi');
+  });
+
+  it('returns null only when there are zero supported languages and no cookie (defensive)', () => {
+    // The registry is non-empty in practice, so this branch only
+    // triggers if SUPPORTED_LANGUAGE_CODES is ever drained — but
+    // resolveCurrentLanguage shouldn't crash if it is.
+    const got = resolveCurrentLanguage(undefined, []);
+    // With the real registry this resolves to 'hi'; the test asserts
+    // we don't return null when there's a registry to fall back on.
+    expect(got).toBe('hi');
+  });
+});
+
+describe('languageOption', () => {
+  it("returns the display name + the first glyph of the native name", () => {
+    const hi = languageOption('hi');
+    expect(hi.code).toBe('hi');
+    expect(hi.displayName).toBe('Hindi');
+    expect(hi.nativeName).toBe('हिन्दी');
+    expect(hi.glyph).toBe('ह');
+  });
+
+  it("uses the first codepoint of the native name (covers multi-byte glyphs)", () => {
+    const or = languageOption('or');
+    // 'ଓଡ଼ିଆ' starts with 'ଓ'.
+    expect(or.glyph).toBe('ଓ');
+  });
+});
+
+describe('cookie constants', () => {
+  it('exposes a stable cookie name + 1y max-age', () => {
+    expect(LANG_COOKIE).toBe('cia_lang');
+    expect(LANG_COOKIE_MAX_AGE).toBe(60 * 60 * 24 * 365);
+  });
+});

--- a/apps/web/src/lib/server/language-context.ts
+++ b/apps/web/src/lib/server/language-context.ts
@@ -1,0 +1,74 @@
+/**
+ * Current-language context (T-5.25).
+ *
+ * The "current language" is the script the user is actively reading
+ * — what the home grid and library filter default to, and what the
+ * rail indicator shows. It's a cookie-driven choice so:
+ *   - signed-out visitors can browse a single language without
+ *     setting up a session;
+ *   - the picker can switch instantly on click without a full
+ *     page reload;
+ *   - switching across devices is independent (a per-tab feel that
+ *     matches how learners juggle browsers / phones).
+ *
+ * The cookie is validated against either the supported-language
+ * registry (anonymous) or the user's `user_languages` rows (signed
+ * in) so a stale cookie can't pin the user to a language they don't
+ * actually have data for.
+ */
+import {
+  LANGUAGES,
+  SUPPORTED_LANGUAGE_CODES,
+  isSupportedLanguage,
+  type LanguageCode,
+} from '@ciareader/shared-types';
+
+export const LANG_COOKIE = 'cia_lang';
+export const LANG_COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // 1 year
+
+/** Pick the current language given the cookie + the user's list of
+ *  active language codes. Returns null when the user has no active
+ *  languages (anonymous + no cookie, or signed-in with zero rows). */
+export function resolveCurrentLanguage(
+  cookieValue: string | undefined,
+  activeCodes: readonly LanguageCode[],
+): LanguageCode | null {
+  // For signed-in users, only honor a cookie that matches an active
+  // user_languages row.
+  if (activeCodes.length > 0) {
+    if (cookieValue && isSupportedLanguage(cookieValue)) {
+      const code = cookieValue as LanguageCode;
+      if (activeCodes.includes(code)) return code;
+    }
+    return activeCodes[0]!;
+  }
+
+  // Anonymous: any supported code works as the "current" pick. If
+  // the cookie isn't valid, default to the first supported code.
+  if (cookieValue && isSupportedLanguage(cookieValue)) {
+    return cookieValue as LanguageCode;
+  }
+  return SUPPORTED_LANGUAGE_CODES[0] ?? null;
+}
+
+/** Compact descriptor passed to the client for rendering the rail
+ *  indicator / picker. Keep small + serializable. */
+export interface LanguageOption {
+  code: LanguageCode;
+  displayName: string;
+  nativeName: string;
+  /** Single-glyph icon — first character of `nativeName`. Lets the
+   *  rail render a compact circular indicator without loading any
+   *  per-script asset beyond the design's font stack. */
+  glyph: string;
+}
+
+export function languageOption(code: LanguageCode): LanguageOption {
+  const desc = LANGUAGES[code];
+  return {
+    code,
+    displayName: desc.displayName,
+    nativeName: desc.nativeName,
+    glyph: [...desc.nativeName][0] ?? code.toUpperCase().slice(0, 1),
+  };
+}

--- a/apps/web/src/routes/+layout.server.ts
+++ b/apps/web/src/routes/+layout.server.ts
@@ -1,3 +1,13 @@
+import { eq } from 'drizzle-orm';
+
+import { db } from '$lib/server/db/index.js';
+import { userLanguages } from '$lib/server/db/schema.js';
+import {
+  LANG_COOKIE,
+  languageOption,
+  resolveCurrentLanguage,
+} from '$lib/server/language-context.js';
+import type { LanguageCode } from '@ciareader/shared-types';
 import type { LayoutServerLoad } from './$types';
 
 /**
@@ -5,15 +15,43 @@ import type { LayoutServerLoad } from './$types';
  * +page.server.ts needing to re-pick it off locals. Kept to a small,
  * serializable shape — anything touching secret fields must still go
  * through requireUser on a per-route basis.
+ *
+ * Also resolves the active language (T-5.25): the rail's language
+ * indicator + picker reads `availableLanguages` (the user's
+ * `user_languages` rows) and `currentLanguage` (cookie-driven
+ * choice, validated against the active list).
  */
-export const load: LayoutServerLoad = ({ locals }) => {
-  if (!locals.user) return { user: null };
+export const load: LayoutServerLoad = async ({ locals, cookies }) => {
+  let activeCodes: LanguageCode[] = [];
+  if (locals.user?.id) {
+    try {
+      const rows = await db
+        .select({ language: userLanguages.language })
+        .from(userLanguages)
+        .where(eq(userLanguages.userId, locals.user.id));
+      activeCodes = rows.map((r) => r.language as LanguageCode);
+    } catch (err) {
+      // Don't take the layout offline over a bad query — the picker
+      // just renders empty in that case.
+      console.error('layout: user_languages query failed:', err);
+    }
+  }
+
+  const currentLanguage = resolveCurrentLanguage(
+    cookies.get(LANG_COOKIE),
+    activeCodes,
+  );
+
   return {
-    user: {
-      id: locals.user.id,
-      email: locals.user.email,
-      displayName: locals.user.displayName,
-      role: locals.user.role,
-    },
+    user: locals.user
+      ? {
+          id: locals.user.id,
+          email: locals.user.email,
+          displayName: locals.user.displayName,
+          role: locals.user.role,
+        }
+      : null,
+    currentLanguage,
+    availableLanguages: activeCodes.map(languageOption),
   };
 };

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -6,6 +6,10 @@
   let { data, children }: { data: LayoutData; children: import('svelte').Snippet } = $props();
 </script>
 
-<AppShell user={data.user}>
+<AppShell
+  user={data.user}
+  currentLanguage={data.currentLanguage}
+  availableLanguages={data.availableLanguages}
+>
   {@render children()}
 </AppShell>

--- a/apps/web/src/routes/api/v1/me/current-language/+server.ts
+++ b/apps/web/src/routes/api/v1/me/current-language/+server.ts
@@ -1,0 +1,43 @@
+/**
+ * PUT /api/v1/me/current-language (T-5.25).
+ *
+ * Sets the cia_lang cookie that the layout loader uses to drive the
+ * rail's language indicator. Body: `{ code: 'hi' | 'mr' | 'or' }`.
+ * The handler accepts any supported code — the resolver in
+ * `language-context.ts` will fall back to one of the user's active
+ * languages if the cookie ever becomes stale.
+ */
+import { error, json } from '@sveltejs/kit';
+import { z } from 'zod';
+
+import { LANG_COOKIE, LANG_COOKIE_MAX_AGE } from '$lib/server/language-context.js';
+import { isSupportedLanguage } from '@ciareader/shared-types';
+import type { RequestHandler } from './$types';
+
+const body = z.object({
+  code: z.string().refine(isSupportedLanguage, {
+    message: 'Unsupported language',
+  }),
+});
+
+export const PUT: RequestHandler = async ({ request, cookies }) => {
+  let parsed: { code: string };
+  try {
+    const json_body = await request.json();
+    const result = body.safeParse(json_body);
+    if (!result.success) throw error(400, 'Invalid body');
+    parsed = result.data;
+  } catch (e) {
+    if (e && typeof e === 'object' && 'status' in e) throw e;
+    throw error(400, 'Invalid JSON body');
+  }
+
+  cookies.set(LANG_COOKIE, parsed.code, {
+    path: '/',
+    maxAge: LANG_COOKIE_MAX_AGE,
+    sameSite: 'lax',
+    httpOnly: false, // Client reads it for optimistic updates if needed.
+  });
+
+  return json({ code: parsed.code });
+};

--- a/apps/web/src/routes/layout-server.test.ts
+++ b/apps/web/src/routes/layout-server.test.ts
@@ -92,7 +92,7 @@ describe('root +layout.server.ts load', () => {
       }),
     );
     if (!data) throw new Error('load returned void');
-    expect(data.availableLanguages.map((l) => l.code)).toEqual(['hi', 'mr']);
+    expect(data.availableLanguages.map((l: { code: string }) => l.code)).toEqual(['hi', 'mr']);
     expect(data.currentLanguage).toBe('mr');
   });
 

--- a/apps/web/src/routes/layout-server.test.ts
+++ b/apps/web/src/routes/layout-server.test.ts
@@ -1,31 +1,79 @@
 // @vitest-environment node
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { load } from './+layout.server.js';
+// Mock the user_languages query — the layout loader pulls active
+// languages for the rail picker (T-5.25).
+const userLanguageRows = vi.fn<
+  () => Promise<Array<{ language: string }>>
+>();
+vi.mock('$lib/server/db/index.js', () => ({
+  db: {
+    select() {
+      return {
+        from() {
+          return {
+            where: () => userLanguageRows(),
+          };
+        },
+      };
+    },
+  },
+}));
+
+const { load } = await import('./+layout.server.js');
 
 type LoadEvent = Parameters<typeof load>[0];
 
+function makeEvent({
+  locals,
+  cookie,
+}: {
+  locals: Record<string, unknown>;
+  cookie?: string;
+}): LoadEvent {
+  return {
+    locals,
+    cookies: {
+      get: (name: string) => (name === 'cia_lang' ? cookie : undefined),
+    },
+  } as unknown as LoadEvent;
+}
+
+beforeEach(() => {
+  userLanguageRows.mockReset();
+  userLanguageRows.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
 describe('root +layout.server.ts load', () => {
   it('returns a null user when nobody is signed in', async () => {
-    const data = await load({ locals: {} } as unknown as LoadEvent);
-    expect(data).toEqual({ user: null });
+    const data = await load(makeEvent({ locals: {} }));
+    if (!data) throw new Error('load returned void');
+    expect(data.user).toBeNull();
+    expect(data.availableLanguages).toEqual([]);
+    expect(userLanguageRows).not.toHaveBeenCalled();
   });
 
   it('serializes only the four public user fields when signed in', async () => {
-    const data = await load({
-      locals: {
-        user: {
-          id: 'u1',
-          email: 'a@b.c',
-          displayName: 'Alex',
-          role: 'user',
-          // Fields that must NOT leak via the layout loader — these live on
-          // the full User type but are not safe to send to every page.
-          passwordHash: 'secret',
-          themePreference: 'dark',
+    const data = await load(
+      makeEvent({
+        locals: {
+          user: {
+            id: 'u1',
+            email: 'a@b.c',
+            displayName: 'Alex',
+            role: 'user',
+            // Fields that must NOT leak via the layout loader — these live on
+            // the full User type but are not safe to send to every page.
+            passwordHash: 'secret',
+            themePreference: 'dark',
+          },
         },
-      },
-    } as unknown as LoadEvent);
+      }),
+    );
     if (!data) throw new Error('load returned void');
     expect(data.user).toEqual({
       id: 'u1',
@@ -33,5 +81,43 @@ describe('root +layout.server.ts load', () => {
       displayName: 'Alex',
       role: 'user',
     });
+  });
+
+  it("includes the user's active languages in availableLanguages (T-5.25)", async () => {
+    userLanguageRows.mockResolvedValue([{ language: 'hi' }, { language: 'mr' }]);
+    const data = await load(
+      makeEvent({
+        locals: { user: { id: 'u1', email: 'a@b.c', displayName: null, role: 'user' } },
+        cookie: 'mr',
+      }),
+    );
+    if (!data) throw new Error('load returned void');
+    expect(data.availableLanguages.map((l) => l.code)).toEqual(['hi', 'mr']);
+    expect(data.currentLanguage).toBe('mr');
+  });
+
+  it('falls back when the cia_lang cookie does not match an active language', async () => {
+    userLanguageRows.mockResolvedValue([{ language: 'hi' }]);
+    const data = await load(
+      makeEvent({
+        locals: { user: { id: 'u1', email: 'a@b.c', displayName: null, role: 'user' } },
+        cookie: 'or', // user has no Odia row → cookie ignored, falls back to first active
+      }),
+    );
+    if (!data) throw new Error('load returned void');
+    expect(data.currentLanguage).toBe('hi');
+  });
+
+  it('does not 500 when the user_languages query throws', async () => {
+    userLanguageRows.mockRejectedValue(new Error('db down'));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const data = await load(
+      makeEvent({
+        locals: { user: { id: 'u1', email: 'a@b.c', displayName: null, role: 'user' } },
+      }),
+    );
+    if (!data) throw new Error('load returned void');
+    // Picker is empty but the layout still renders.
+    expect(data.availableLanguages).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Per the user's spec: see + change the active language at any time, filtered to languages they're actually learning (have a `user_languages` row for).

### Server
- **`lib/server/language-context.ts`** — cookie-driven current-language resolution. `resolveCurrentLanguage(cookie, activeCodes)` honors the cookie when it matches one of the user's active languages and falls back to the first active row otherwise. Anonymous visitors fall through to the first supported registry code.
- **Layout loader** (`+layout.server.ts`) queries `user_languages` once and ships `{ user, currentLanguage, availableLanguages }` so every screen picks up the same context. Wrapped in `try/catch` so a bad query renders the layout with an empty picker rather than 500'ing.
- **`PUT /api/v1/me/current-language`** sets the `cia_lang` cookie. Body validated against the supported-language registry.

### AppShell
- **Rail indicator pill** — square `अ`-style glyph (first codepoint of `nativeName`) + native name + small uppercase English label. Clickable.
- **Mobile top-strip glyph** — compact 32×32 mirror of the pill so the picker is reachable when the rail is hidden.
- **Picker** — `<Sheet>` from T-5.15 listing every active language. Click → `PUT` the cookie → `invalidateAll()` so every loader (home grid, library filter, words filter, …) picks up the new pick. Empty state nudges signed-in users to `/profile` to add a language.

### Tests
- `language-context.test.ts` — 8 cases: cookie validation, active-list filtering, anonymous fallback, glyph extraction (including multi-byte Odia), constants.
- `layout-server.test.ts` — rebuilt to mock the `user_languages` query, assert `availableLanguages` + `currentLanguage` shape, and verify the throw-on-query branch keeps the layout reachable.
- All 642 vitest pass · eslint + svelte-check 0/0.

### What's intentionally out
- **No "Manage languages" UI on `/profile`.** The picker has a "Manage languages →" link pointing at `/profile`, but adding/removing languages there is a follow-up — for now that page edits existing rows but doesn't create/delete them. We can land that as a small T-5.25b without blocking this picker.
- **No schema change.** Cookie is the source of truth for "current". Future tickets can promote this to `users.current_language` if we want sync across devices.

Closes #191
Refs #42, #165