### PR TITLE
Reader: page-mode no-scroll, sheet portal, chevron rail toggle

### DIFF
--- a/apps/web/src/lib/components/overlay/Sheet.svelte
+++ b/apps/web/src/lib/components/overlay/Sheet.svelte
@@ -13,6 +13,7 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
   import { activateFocusTrap, type FocusTrap } from './focus-trap.js';
+  import { portal } from './portal.js';
   import { lockScroll } from './scroll-lock.js';
 
   interface Props {
@@ -78,6 +79,7 @@
 
 {#if open}
   <div
+    use:portal
     class="sheet-back"
     class:dimmed
     role="presentation"

--- a/apps/web/src/lib/components/overlay/Sheet.test.ts
+++ b/apps/web/src/lib/components/overlay/Sheet.test.ts
@@ -21,34 +21,56 @@ afterEach(() => {
 
 describe('Sheet — dimmed prop (T-5.17)', () => {
   it('paints a dimmed scrim by default', () => {
-    const { container } = render(Sheet, { open: true, onClose: () => {} });
-    const back = container.querySelector('.sheet-back');
+    render(Sheet, { open: true, onClose: () => {} });
+    const back = document.body.querySelector('.sheet-back');
     expect(back).not.toBeNull();
     expect(back!.classList.contains('dimmed')).toBe(true);
   });
 
   it('omits the .dimmed class when dimmed={false} so the reader text stays readable', () => {
-    const { container } = render(Sheet, {
+    render(Sheet, {
       open: true,
       onClose: () => {},
       dimmed: false,
     });
-    const back = container.querySelector('.sheet-back');
+    const back = document.body.querySelector('.sheet-back');
     expect(back).not.toBeNull();
     expect(back!.classList.contains('dimmed')).toBe(false);
   });
 
   it('keeps the backdrop element so click-outside-to-close still works when dimmed=false', async () => {
     let closed = 0;
-    const { container } = render(Sheet, {
+    render(Sheet, {
       open: true,
       dimmed: false,
       onClose: () => {
         closed += 1;
       },
     });
-    const back = container.querySelector('.sheet-back') as HTMLElement;
+    const back = document.body.querySelector('.sheet-back') as HTMLElement;
     await fireEvent.click(back);
     expect(closed).toBe(1);
+  });
+});
+
+describe('Sheet — portal (T-5.28)', () => {
+  // The reader's page-mode content uses `transform` for the page-flip
+  // slide, which creates a containing block for fixed-positioned
+  // descendants. Without portaling, the sheet's backdrop would inherit
+  // that translated, max-width-capped column instead of spanning the
+  // viewport. Lock that the backdrop ends up directly under <body>.
+  it('portals the backdrop to <body> so it escapes ancestor containing blocks', () => {
+    const { container } = render(Sheet, { open: true, onClose: () => {} });
+    expect(container.querySelector('.sheet-back')).toBeNull();
+    const back = document.body.querySelector('.sheet-back');
+    expect(back).not.toBeNull();
+    expect(back!.parentElement).toBe(document.body);
+  });
+
+  it('removes the portaled backdrop when the sheet unmounts', () => {
+    const { unmount } = render(Sheet, { open: true, onClose: () => {} });
+    expect(document.body.querySelector('.sheet-back')).not.toBeNull();
+    unmount();
+    expect(document.body.querySelector('.sheet-back')).toBeNull();
   });
 });

--- a/apps/web/src/lib/components/overlay/portal.ts
+++ b/apps/web/src/lib/components/overlay/portal.ts
@@ -1,0 +1,21 @@
+/**
+ * Portal action — moves the host node to <body> so it escapes any
+ * ancestor that creates a containing block for fixed-positioned
+ * descendants (transform, filter, will-change, contain, …).
+ *
+ * The reader's page content uses `transform` for the page-flip slide,
+ * which would otherwise pin the word side-panel's backdrop to that
+ * translated, max-width-capped column instead of the viewport.
+ */
+export function portal(node: HTMLElement) {
+  if (typeof document === 'undefined') return {};
+  const target = document.body;
+  target.appendChild(node);
+  return {
+    destroy() {
+      if (node.parentNode === target) {
+        target.removeChild(node);
+      }
+    },
+  };
+}

--- a/apps/web/src/lib/components/shell/AppShell.svelte
+++ b/apps/web/src/lib/components/shell/AppShell.svelte
@@ -81,12 +81,15 @@
   };
 </script>
 
-<!-- T-5.26: hamburger button toggles the rail / shell chrome.
-     Positioned fixed so it stays clickable when the rail itself is
-     hidden — clicking it again brings the chrome back. -->
+<!-- T-5.26: chevron toggles the rail / shell chrome. Positioned fixed
+     so it stays clickable in both states — sits flush against the
+     rail's inner-right edge when expanded (chevron points left, "tuck
+     it in"), and snaps to the viewport's left edge when collapsed
+     (chevron points right, "pull it out"). -->
 <button
   type="button"
   class="rail-toggle"
+  data-collapsed={collapsed ? '1' : '0'}
   aria-label={collapsed ? 'Show navigation' : 'Hide navigation'}
   aria-pressed={collapsed}
   title={collapsed ? 'Show navigation' : 'Hide navigation'}
@@ -94,17 +97,20 @@
 >
   <svg
     viewBox="0 0 24 24"
-    width="16"
-    height="16"
+    width="14"
+    height="14"
     fill="none"
     stroke="currentColor"
-    stroke-width="1.6"
+    stroke-width="2"
     stroke-linecap="round"
+    stroke-linejoin="round"
     aria-hidden="true"
   >
-    <path d="M4 7h16" />
-    <path d="M4 12h16" />
-    <path d="M4 17h16" />
+    {#if collapsed}
+      <path d="M9 6l6 6-6 6" />
+    {:else}
+      <path d="M15 6l-6 6 6 6" />
+    {/if}
   </svg>
 </button>
 
@@ -463,29 +469,46 @@
     height: 18px;
   }
 
-  /* —— Hamburger / rail-toggle button (T-5.26) ————————————————
-   * Fixed top-left so it's clickable both when the rail is showing
-   * (sits flush against the rail's left edge) and when the rail has
-   * been collapsed (only thing left to click). High z-index so it
-   * floats over everything except the word side-panel sheet. */
+  /* —— Chevron / rail-toggle button (T-5.26) ————————————————
+   * Fixed-position so it stays clickable in both states. When the
+   * rail is open it sits flush inside the rail's right border (chevron
+   * points left, "collapse"); when the rail is hidden it snaps to the
+   * viewport's left edge (chevron points right, "expand"). High
+   * z-index so it floats over everything except the word side-panel.
+   *
+   * Mobile (<960px) doesn't have a rail to toggle into — keep the
+   * button at the top-left as a simple immersive-toggle there. */
   .rail-toggle {
     position: fixed;
-    top: 0.6rem;
-    left: 0.6rem;
-    width: 32px;
-    height: 32px;
+    top: 50%;
+    left: 0;
+    width: 22px;
+    height: 44px;
     display: grid;
     place-items: center;
-    border-radius: 8px;
+    border-radius: 0 8px 8px 0;
     background: var(--card, var(--color-bg));
     border: 1px solid var(--card-edge, var(--color-border));
-    color: var(--ink-2, var(--color-fg-muted));
+    border-left: 0;
+    color: var(--ink-3, var(--color-fg-muted));
     cursor: pointer;
     z-index: 30;
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.06);
+    box-shadow: 2px 0 8px rgba(0, 0, 0, 0.08);
+    transform: translateY(-50%);
     transition:
+      left 200ms cubic-bezier(0.2, 0, 0, 1),
       background 150ms ease,
       color 150ms ease;
+  }
+  /* Expanded: dock against the rail's right border (rail is 232px). */
+  @media (min-width: 960px) {
+    .rail-toggle[data-collapsed='0'] {
+      left: calc(232px - 22px);
+      border-radius: 8px 0 0 8px;
+      border-left: 1px solid var(--card-edge, var(--color-border));
+      border-right: 0;
+      box-shadow: -2px 0 8px rgba(0, 0, 0, 0.08);
+    }
   }
   .rail-toggle:hover {
     background: var(--accent-soft, var(--color-accent));

--- a/apps/web/src/routes/reader/[textId]/+page.svelte
+++ b/apps/web/src/routes/reader/[textId]/+page.svelte
@@ -179,7 +179,7 @@
   <title>{data.text.title} — CIA Reader</title>
 </svelte:head>
 
-<div class="reader">
+<div class="reader" data-mode={data.mode}>
   <header class="reader-top">
     <a class="reader-close" href="/library" aria-label="Close reader" title="Close reader">
       <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true">
@@ -281,6 +281,16 @@
     min-height: 100dvh;
     display: flex;
     flex-direction: column;
+  }
+  /* Page mode is meant to behave like a book — no vertical scroll;
+     overflow stays inside the viewport, page arrows step through it.
+     Hard-cap the height so the inner flex chain (.reader-page-wrap →
+     .reader-page-viewport with overflow:hidden) actually constrains
+     the content, instead of letting min-height grow with it. */
+  .reader[data-mode='page'] {
+    height: 100dvh;
+    min-height: 0;
+    overflow: hidden;
   }
   .reader-top {
     position: sticky;


### PR DESCRIPTION
## Summary

- **Page mode no longer scrolls.** `.reader` had `min-height: 100dvh`, which let the box grow with chapter content even though the inner flex chain (`.reader-page-wrap` → `.reader-page-viewport` with `overflow:hidden`) intended to clip it. Added `data-mode={data.mode}` and a `.reader[data-mode='page'] { height: 100dvh; min-height: 0; overflow: hidden }` rule so the viewport actually constrains content — page arrows are the only way forward, like a book.
- **Word side panel snaps right and full-height again.** `.reader-page-content` carries `transform: translateY(...)` for the page-flip slide, which per spec creates a containing block for `position: fixed` descendants. The Sheet backdrop was inheriting that translated, `max-width: 40rem; margin: 0 auto` column, so it rendered shifted down and centered instead of flush against the viewport edge. New `portal` Svelte action moves `.sheet-back` to `<body>`, escaping the containing block. Addresses the side-panel half of #203.
- **Rail toggle redesigned.** Hamburger glyph at the fixed top-left becomes a 22×44 chevron tab, vertically centered. Docks against the rail's inner-right border when expanded (chevron points left, "collapse"); snaps to the viewport's left edge when collapsed (chevron points right, "expand"). Smooth `left` transition between states; mobile keeps the simple left-edge behavior since there's no rail to dock against.

Refs #203

## Test plan

- [x] `pnpm test` — 657 tests pass (added 2 new portal tests in `Sheet.test.ts`)
- [x] `pnpm check` — 0 errors, 0 warnings
- [ ] Open a reader at `?mode=page`, scroll-wheel, trackpad-flick, arrow-down — page should not move
- [ ] Click a word in page mode — side panel slides in flush against the right edge, top-to-bottom
- [ ] Click the chevron when rail is open — rail collapses, button slides to the left edge with chevron now pointing right
- [ ] Click again — rail re-opens, button slides back to the rail's right border with chevron pointing left
- [ ] Switch to scroll/continuous modes and confirm scrolling still works as before