### PR TITLE
fix: Hindi romanizer drops final virama on nukta-bearing finals

### DIFF
--- a/services/nlp/app/romanize.py
+++ b/services/nlp/app/romanize.py
@@ -63,6 +63,7 @@ is reversible. Schwa-deleted Hindi output is intentionally lossy —
 
 from __future__ import annotations
 
+import re
 import unicodedata
 
 from aksharamukha import transliterate as _aksharamukha
@@ -139,6 +140,60 @@ def _resolve_scheme(name: str) -> str:
         ) from e
 
 
+# Word scanner used by :func:`_patch_nukta_final_virama`. The character
+# class lists every Devanagari codepoint that can occur *inside* a Hindi
+# word (consonants, vowel letters, vowel signs, virama, nukta, anusvara,
+# vocalic R/L letters and signs, Vedic accent marks). Punctuation
+# (danda U+0964, double-danda U+0965), the abbreviation sign U+0970, and
+# Devanagari digits U+0966-U+096F are deliberately excluded so they act
+# as word boundaries.
+_DEVA_WORD_RE = re.compile(
+    "[ँ-ःऄ-औक-हऺ-ॏ"
+    "॑-॔क़-य़ॠ-ॣ]+"
+)
+# A word-final nukta-bearing consonant: either a precomposed atomic
+# letter (U+0958-U+095F covers क़ख़ग़ज़ड़ढ़फ़य़, plus U+0931 ऱ) or a
+# base consonant followed by an explicit nukta U+093C.
+_NUKTA_CONS_AT_END = re.compile(
+    r"(?:[क़-य़ऱ]|[क-ह]़)$"
+)
+# Multi-syllable detector: any consonant or full vowel letter sitting
+# before our final nukta consonant means the word has at least two
+# syllables, so the final inherent schwa should drop. Single-syllable
+# forms (just `फ़`, just `क`) keep their schwa, matching aksharamukha's
+# own behavior for non-nukta minimal forms.
+_HAS_PRIOR_SYLLABLE = re.compile(
+    r"[ऄ-औक-हक़-य़ऱॠॡ]"
+)
+
+
+def _patch_nukta_final_virama(text: str) -> str:
+    """Append a virama after word-final nukta-bearing consonants.
+
+    aksharamukha's ``RemoveSchwaHindi`` pre-rule fails to virama-mark
+    the final inherent schwa when a word ends in a nukta-bearing
+    consonant — most reliably when that consonant is preceded by a
+    half-consonant. So बर्फ़ comes back unchanged from aksharamukha and
+    sanscript reads the trailing schwa as a real vowel: ``barfa``
+    instead of ``barf``. This pass closes the gap by scanning each
+    Devanagari word and appending a virama at the tail when the word
+    ends in a nukta consonant and is multi-syllable. Word-medial nukta
+    consonants (the medial फ़ in बर्फ़ानी, the ज़ in दर्ज़ी) and
+    single-syllable forms (standalone फ़) are left alone.
+    """
+
+    def _fix(m: re.Match[str]) -> str:
+        word = m.group(0)
+        tail = _NUKTA_CONS_AT_END.search(word)
+        if tail is None:
+            return word
+        if _HAS_PRIOR_SYLLABLE.search(word[: tail.start()]) is None:
+            return word
+        return word + "्"
+
+    return _DEVA_WORD_RE.sub(_fix, text)
+
+
 def _hindi_schwa_delete(devanagari: str) -> str:
     """Apply aksharamukha's ``RemoveSchwaHindi`` to a Devanagari string.
 
@@ -148,13 +203,17 @@ def _hindi_schwa_delete(devanagari: str) -> str:
     a function so callers (and tests) don't import aksharamukha
     directly and so the dependency is easy to swap if a better Hindi
     schwa-deletion model lands later.
+
+    Followed by :func:`_patch_nukta_final_virama` to compensate for an
+    aksharamukha gap on word-final nukta-bearing consonants.
     """
-    return _aksharamukha.process(
+    out = _aksharamukha.process(
         "Devanagari",
         "Devanagari",
         devanagari,
         pre_options=["RemoveSchwaHindi"],
     )
+    return _patch_nukta_final_virama(out)
 
 
 # Hindi merges the ISO 15919 ē/ō length distinction into a single

--- a/services/nlp/tests/test_romanize.py
+++ b/services/nlp/tests/test_romanize.py
@@ -134,6 +134,55 @@ def test_default_language_keeps_legacy_sanscript_behavior():
     assert out == "rāma"
 
 
+# ---- Hindi-specific: nukta-final schwa-deletion gap ----
+#
+# aksharamukha's ``RemoveSchwaHindi`` pre-rule occasionally fails to
+# virama-mark the final inherent schwa when a word ends in a
+# nukta-bearing consonant (most reliably when preceded by a
+# half-consonant). The romanize module patches the gap by appending a
+# virama post-hoc; these tests pin both the fix (बर्फ़ → barf, not
+# barfa) and the boundary cases that must NOT change.
+
+
+@pytest.mark.parametrize(
+    "native,expected_iso",
+    [
+        ("बर्फ़", "barf"),  # the canonical bug — half-consonant + final फ़
+        ("काग़ज़", "kāġaz"),  # already correct via aksharamukha; regression guard
+        ("दर्ज़ी", "darzī"),  # medial nukta + final ी; must stay untouched
+        ("बर्फ़ानी", "barfānī"),  # word-internal nukta-final + vowel sign
+    ],
+)
+def test_hindi_nukta_final_schwa_deletion_iso(native: str, expected_iso: str):
+    out = romanize.to_roman(native, from_script="Deva", to_scheme="iso15919", language="hi")
+    assert out == expected_iso
+
+
+def test_hindi_nukta_final_schwa_deletion_iast():
+    # Same fix must apply regardless of the requested roman scheme,
+    # since schwa-deletion is a fact about the Devanagari side.
+    assert (
+        romanize.to_roman("बर्फ़", from_script="Deva", to_scheme="iast", language="hi") == "barf"
+    )
+
+
+def test_hindi_single_syllable_nukta_keeps_schwa():
+    # Standalone single-syllable nukta-final words retain their inherent
+    # schwa — matching aksharamukha's behavior for non-nukta finals
+    # like क → "ka". Patching this would over-correct.
+    assert romanize.to_roman("फ़", from_script="Deva", to_scheme="iso15919", language="hi") == "fa"
+
+
+def test_hindi_nukta_final_in_phrase_with_punctuation():
+    # The patch must operate at word boundaries, not just end-of-string,
+    # so trailing punctuation / whitespace / danda still trigger it.
+    out = romanize.to_roman(
+        "बर्फ़ है।", from_script="Deva", to_scheme="iso15919", language="hi"
+    )
+    assert out.startswith("barf ")
+    assert "barfa" not in out
+
+
 def test_hindi_language_hint_is_noop_for_orya():
     # The schwa-deletion path is gated on ``from_script="Deva"`` —
     # Odia text with a stray ``language="hi"`` (a caller bug) must


### PR DESCRIPTION
## Summary

- Hindi romanization kept the final inherent schwa on words ending in a nukta-bearing consonant (फ़, क़, ख़, ग़, ड़, ढ़, य़, ऱ, base + U+093C). `बर्फ़` came back as `barfa` instead of `barf`.
- Root cause is upstream in aksharamukha's `RemoveSchwaHindi` pre-rule — it only fails reliably when the nukta consonant follows a half-consonant. Patched here with a scoped post-pass on the schwa-deleted Devanagari, before sanscript runs.
- Word-internal nukta consonants (medial फ़ in `बर्फ़ानी`, ज़ in `दर्ज़ी`) and single-syllable forms (standalone `फ़` → `fa`) are intentionally left alone, matching aksharamukha's own behavior for non-nukta minimal forms.

Refs #214

## Test plan

- [x] New parametrized cases in `services/nlp/tests/test_romanize.py`: `बर्फ़ → barf`, `काग़ज़ → kāġaz`, `दर्ज़ी → darzī`, `बर्फ़ानी → barfānī`, plus IAST mirror, single-syllable retention, and a phrase + danda boundary case.
- [x] `pytest services/nlp/` — 188 passed, 3 deselected; `app/romanize.py` coverage 100%, project coverage 94.22% (gate 70%).