### PR TITLE
T-3.14: sibling-lemma fallback in reader popup

### DIFF
--- a/apps/web/src/lib/server/dictionary/get-lemma-translations.test.ts
+++ b/apps/web/src/lib/server/dictionary/get-lemma-translations.test.ts
@@ -1,0 +1,174 @@
+// @vitest-environment node
+/**
+ * DB-mocked unit tests for `getLemmaTranslations` — specifically the
+ * sibling-fallback path added in T-3.14.
+ *
+ * The pure `bucketTranslations` sorter has its own tests in
+ * `lookups.test.ts`; this file covers the wiring around DB calls plus
+ * the sibling-fetch logic that kicks in when the directly-linked lemma
+ * has no translations of its own.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const staged: Array<unknown[]> = [];
+function stage(rows: unknown[]) {
+  staged.push(rows);
+}
+function nextStaged(): unknown[] {
+  const v = staged.shift();
+  if (!v) throw new Error('Test bug: no staged result available');
+  return v;
+}
+
+function makeSelectChain() {
+  const chain: Record<string, unknown> = {};
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.limit = vi.fn(() => chain);
+  chain.innerJoin = vi.fn(() => chain);
+  chain.then = (resolve: (v: unknown) => unknown) => resolve(nextStaged());
+  return chain;
+}
+
+const selectFn = vi.fn(() => makeSelectChain());
+
+vi.mock('../db/index.js', () => ({
+  db: {
+    select: () => selectFn(),
+  },
+  schema: {
+    lemmas: {
+      id: 'lemmas.id',
+      language: 'lemmas.language',
+      headword: 'lemmas.headword',
+    },
+    translations: {
+      id: 'translations.id',
+      lemmaId: 'translations.lemma_id',
+    },
+  },
+}));
+
+const { getLemmaTranslations, LemmaNotFoundError } = await import('./lookups.js');
+
+function lemmaRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'lemma-1',
+    language: 'hi',
+    headword: 'पार्क',
+    pos: 'PROPN',
+    script: 'Deva',
+    glossDefault: null,
+    frequencyRank: null,
+    source: 'official_dictionary',
+    sourceAttribution: null,
+    sourceId: null,
+    curatorLocked: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function translationRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'tr-1',
+    lemmaId: 'lemma-2',
+    source: 'official_dictionary',
+    submittedBy: null,
+    parentTranslationId: null,
+    body: 'park',
+    targetLanguage: 'en',
+    sourceAttribution: 'Wiktionary Hindi via Kaikki.org',
+    sourceId: 'kaikki:hi:पार्क:NOUN:abc123abc123',
+    hidden: false,
+    displayRank: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  staged.length = 0;
+  selectFn.mockClear();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('getLemmaTranslations (T-3.14 sibling fallback)', () => {
+  it('throws LemmaNotFoundError when the primary lemma is missing', async () => {
+    stage([]); // SELECT lemma → none
+    await expect(getLemmaTranslations('missing', null)).rejects.toBeInstanceOf(
+      LemmaNotFoundError,
+    );
+  });
+
+  it('returns primary translations directly when the linked lemma has any', async () => {
+    stage([lemmaRow({ pos: 'NOUN' })]); // SELECT lemma
+    stage([translationRow({ lemmaId: 'lemma-1', body: 'park' })]); // primary translations
+    const out = await getLemmaTranslations('lemma-1', null);
+    expect(out.lemma.id).toBe('lemma-1');
+    expect(out.lemma.pos).toBe('NOUN');
+    expect(out.translations.official.map((t) => t.body)).toEqual(['park']);
+    // Only two SELECT calls — no fallback fetch needed.
+    expect(selectFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls back to sibling lemmas when the primary has zero translations', async () => {
+    // Common case: a token tagged PROPN inside a multi-word proper noun
+    // ("ग्लेशियर नेशनल पार्क") with no PROPN gloss, but a sibling NOUN
+    // lemma carries the actual dictionary entry from Kaikki.
+    stage([lemmaRow({ id: 'lemma-1', pos: 'PROPN' })]); // SELECT lemma
+    stage([]); // primary translations → none
+    stage([
+      // sibling join result: rows shaped as { translation: <row> }
+      { translation: translationRow({ lemmaId: 'lemma-2', body: 'park' }) },
+      { translation: translationRow({ id: 'tr-2', lemmaId: 'lemma-2', body: 'garden' }) },
+    ]);
+    const out = await getLemmaTranslations('lemma-1', null);
+    // Lemma metadata stays the primary's — the user clicked PROPN, we
+    // just borrowed text from the NOUN sibling, we shouldn't lie about
+    // what was clicked.
+    expect(out.lemma.pos).toBe('PROPN');
+    // Translations come from the sibling, bucketed via the existing rules.
+    expect(out.translations.official.map((t) => t.body).sort()).toEqual([
+      'garden',
+      'park',
+    ]);
+    expect(selectFn).toHaveBeenCalledTimes(3);
+  });
+
+  it('still returns empty when neither the primary nor any sibling has translations', async () => {
+    stage([lemmaRow()]);
+    stage([]); // primary empty
+    stage([]); // sibling join empty
+    const out = await getLemmaTranslations('lemma-1', null);
+    expect(out.translations.personal).toEqual([]);
+    expect(out.translations.official).toEqual([]);
+    expect(out.translations.community).toEqual([]);
+  });
+
+  it('honors the viewer when bucketing sibling translations into personal vs community', async () => {
+    stage([lemmaRow()]);
+    stage([]); // primary empty
+    stage([
+      // viewer's own user submission attached to a sibling
+      {
+        translation: translationRow({
+          lemmaId: 'lemma-2',
+          source: 'user',
+          submittedBy: 'u1',
+          body: 'my fork',
+          sourceAttribution: null,
+          sourceId: null,
+        }),
+      },
+    ]);
+    const out = await getLemmaTranslations('lemma-1', { id: 'u1', role: 'user' });
+    expect(out.translations.personal.map((t) => t.body)).toEqual(['my fork']);
+    expect(out.translations.community).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/server/dictionary/lookups.ts
+++ b/apps/web/src/lib/server/dictionary/lookups.ts
@@ -22,7 +22,7 @@
  *                     lands. Hidden rows excluded for anonymous + non-
  *                     curator viewers.
  */
-import { and, eq } from 'drizzle-orm';
+import { and, eq, ne } from 'drizzle-orm';
 
 import { db, schema } from '../db/index.js';
 import type { Lemma, Translation, User } from '../db/schema.js';
@@ -217,7 +217,7 @@ export async function getLemmaTranslations(
     .limit(1);
   if (!lemma) throw new LemmaNotFoundError(lemmaId);
 
-  const rows = await db
+  const primaryRows = await db
     .select()
     .from(schema.translations)
     .where(
@@ -230,8 +230,37 @@ export async function getLemmaTranslations(
       ),
     );
 
+  // T-3.14: when the directly-linked lemma has no translations of its
+  // own, fall back to sibling lemmas (same language + same headword,
+  // any POS). This matters because the NLP pipeline frequently tags a
+  // word with a context-dependent POS — "पार्क" inside "ग्लेशियर नेशनल पार्क"
+  // gets PROPN — while the dictionary entry that ships the gloss is
+  // under a different POS (NOUN). The user clicked the token expecting
+  // its meaning, not a metadata lecture about how the parser tagged
+  // it. Only triggered on empty primaries so the cost is paid exactly
+  // when it would otherwise be a dead-end click.
+  const lemmaTyped = lemma as Lemma;
+  let rows: Translation[] = primaryRows as Translation[];
+  if (rows.length === 0) {
+    const joined = await db
+      .select({ translation: schema.translations })
+      .from(schema.translations)
+      .innerJoin(
+        schema.lemmas,
+        eq(schema.translations.lemmaId, schema.lemmas.id),
+      )
+      .where(
+        and(
+          eq(schema.lemmas.language, lemmaTyped.language),
+          eq(schema.lemmas.headword, lemmaTyped.headword),
+          ne(schema.lemmas.id, lemmaId),
+        ),
+      );
+    rows = joined.map((r) => r.translation as Translation);
+  }
+
   return {
-    lemma: toPublicLemma(lemma as Lemma),
-    translations: bucketTranslations(rows as Translation[], viewer),
+    lemma: toPublicLemma(lemmaTyped),
+    translations: bucketTranslations(rows, viewer),
   };
 }


### PR DESCRIPTION
## Summary

When the directly-linked lemma has zero translations, fall back to **sibling lemmas** (same language + same headword, any POS) so the popup surfaces the dictionary entry the user actually wanted.

**Common case:** the NLP pipeline tags `पार्क` inside `ग्लेशियर नेशनल पार्क` as `PROPN` because it's part of a multi-word proper name. The PROPN row carries no translation. But the dictionary entry imported from Kaikki under `पार्क/NOUN` carries the gloss `park`. Pre-fix the popup said *"no dictionary match"*; post-fix it shows *park* with the Wiktionary provenance badge.

This will make the dictionary feel substantially more populated — anywhere the NLP's POS tagging diverges from the dictionary's, the user will now see the right gloss instead of a dead end.

## Implementation

- `getLemmaTranslations` in `lookups.ts`: after fetching primary translations, if zero rows came back, run a second query joining `translations` to `lemmas` on `(language, headword)` excluding the primary's id. Reuses the existing `bucketTranslations` sorter unchanged — source-rank, `displayRank`, hidden filtering, and viewer-relative personal/community classification all behave identically.
- The returned `lemma` metadata stays the **primary's** — we don't pretend the user clicked a different POS. Translations carry their own provenance badges so the source is honest about which row they came from.
- The `lemmas_language_headword_pos_idx` from T-3.10 already covers this lookup, so the sibling fetch is one index scan.
- The fallback fires only when the primary is empty, so the cost is paid exactly when it would otherwise be a dead-end click.

## Test plan

- [x] `pnpm test` — 86 files / 695 tests pass, including 5 new DB-mocked cases (primary populated, primary empty + sibling populated, both empty, viewer-relative bucketing on a sibling's user submission, missing-lemma 404).
- [x] `pnpm check` — 0 errors / 0 warnings.
- [x] `pnpm lint` — clean.
- [x] **End-to-end against local Postgres**: ran the SQL the new code emits against the live DB for `पार्क/PROPN` (id `0460c32c…`) — returns the two sibling translations *park* and *garden* from `पार्क/NOUN`. ⚠️ A running dev server needs a restart to pick up the change since SvelteKit holds server-only modules in memory.

Refs #25.