### PR TITLE
Reader: horizontal page flip + static rail + interactive panel

### DIFF
--- a/apps/web/src/lib/components/reader/ReaderPage.svelte
+++ b/apps/web/src/lib/components/reader/ReaderPage.svelte
@@ -1,11 +1,13 @@
 <!--
   Page-mode reader (T-5.1, token-aware in T-5.2, chrome polish in T-5.9,
-  no-scroll pagination in T-5.23).
+  no-scroll pagination in T-5.23, horizontal column flow now).
 
-  The chapter renders into a fixed-height viewport that hides
-  overflow. Each "page" is one viewport-height slice of the chapter,
-  positioned via translateY. Off-screen content is still in the DOM
-  (so screen readers + Cmd-F still find it) — just clipped.
+  The chapter renders into a fixed-size viewport that hides overflow
+  and uses CSS multi-column with `column-width = viewport-width` so
+  content snake-flows into one tall column per page, side-by-side.
+  translateX slides between pages — like flipping a book's spread —
+  instead of slicing the chapter vertically. Off-screen content stays
+  in the DOM (screen readers + Cmd-F still find it).
 
   Side arrows + keyboard ←/→ step through pages within a chapter and
   spill over into the prev/next chapter at the boundaries. The
@@ -42,14 +44,17 @@
 
   // Pagination state. Recomputed on resize / chapter change /
   // showRomanization toggle (which changes line-height).
+  // pageW is one column's width (= the viewport's content-box width);
+  // contentW is the multicolumn container's total scrollWidth across
+  // every column laid out side-by-side.
   let viewportEl: HTMLDivElement | null = $state(null);
   let contentEl: HTMLDivElement | null = $state(null);
-  let viewportH = $state(0);
-  let contentH = $state(0);
+  let pageW = $state(0);
+  let contentW = $state(0);
   let pageInChapter = $state(0);
 
-  const pageCount = $derived(pageCountFor(contentH, viewportH));
-  const offset = $derived(pageOffset(pageInChapter, viewportH));
+  const pageCount = $derived(pageCountFor(contentW, pageW));
+  const offset = $derived(pageOffset(pageInChapter, pageW));
 
   // Reset to the first page whenever the chapter changes — the user
   // shouldn't see "stuck" mid-page state when they navigate.
@@ -144,18 +149,40 @@
   // both the viewport (window resize, font-size change) and the
   // content (chapter toggle, romanization toggle changing line
   // height) keeps pageCount honest.
+  //
+  // Horizontal pagination wants column-width to equal one visible
+  // column's width — i.e. the content element's own clientWidth.
+  // Set it inline first so the browser knows to lay the chapter out
+  // as side-by-side columns, then read scrollWidth (which forces a
+  // layout flush) to get the resulting total span.
+  function measure() {
+    if (!viewportEl || !contentEl) return;
+    const w = contentEl.clientWidth;
+    if (w <= 0) return;
+    contentEl.style.columnWidth = `${w}px`;
+    // Reading scrollWidth flushes pending layout, so by the next
+    // statement the column flow is committed.
+    const total = contentEl.scrollWidth;
+    pageW = w;
+    contentW = total;
+  }
+
   onMount(() => {
     if (typeof ResizeObserver === 'undefined') return;
-    const ro = new ResizeObserver(() => {
-      if (viewportEl) viewportH = viewportEl.clientHeight;
-      if (contentEl) contentH = contentEl.scrollHeight;
-    });
+    const ro = new ResizeObserver(() => measure());
     if (viewportEl) ro.observe(viewportEl);
     if (contentEl) ro.observe(contentEl);
     // Seed initial measurements before the observer fires.
-    if (viewportEl) viewportH = viewportEl.clientHeight;
-    if (contentEl) contentH = contentEl.scrollHeight;
+    measure();
     return () => ro.disconnect();
+  });
+
+  // Re-measure when the chapter or romanization toggle changes — both
+  // mutate the content's natural size and we want pageCount to track.
+  $effect(() => {
+    void chapterIdx;
+    void showRomanization;
+    measure();
   });
 </script>
 
@@ -172,24 +199,24 @@
     <span class="arrow-glyph" aria-hidden="true">‹</span>
   </button>
 
-  <div class="reader-page-viewport" bind:this={viewportEl}>
-    <div
-      class="reader-page-content"
-      bind:this={contentEl}
-      style:transform="translateY(-{offset}px)"
-    >
-      {#if current}
-        <header class="chapter-h">
-          {current.title ?? `Chapter ${current.idx + 1}`}
-          <span class="roman">
-            Chapter {current.idx + 1} of {chapters.length}
-            · {current.tokenCount.toLocaleString()} tokens
-          </span>
-        </header>
-        <article>
-          <ChapterBody chapter={current} {showRomanization} {isOwner} />
-        </article>
-      {/if}
+  <div class="reader-page-viewport">
+    <div class="reader-page-window" bind:this={viewportEl}>
+      <div class="reader-page-track" style:transform="translateX(-{offset}px)">
+        <div class="reader-page-content" bind:this={contentEl}>
+          {#if current}
+            <header class="chapter-h">
+              {current.title ?? `Chapter ${current.idx + 1}`}
+              <span class="roman">
+                Chapter {current.idx + 1} of {chapters.length}
+                · {current.tokenCount.toLocaleString()} tokens
+              </span>
+            </header>
+            <article>
+              <ChapterBody chapter={current} {showRomanization} {isOwner} />
+            </article>
+          {/if}
+        </div>
+      </div>
     </div>
   </div>
 
@@ -236,6 +263,8 @@
     min-height: 0;
     overflow: hidden;
     padding: 1.25rem 3rem;
+    display: flex;
+    justify-content: center;
   }
   @media (min-width: 1024px) {
     .reader-page-viewport {
@@ -243,17 +272,50 @@
     }
   }
 
+  /* The "window" is the clipping mask. It's exactly one column wide
+     (max 40rem so reading stays comfortable on big screens), and its
+     overflow:hidden is what hides the off-page columns sitting to its
+     right. The track inside (translateX target) carries the content,
+     and the content's overflow extends past the window horizontally. */
+  .reader-page-window {
+    flex: 1;
+    width: 100%;
+    max-width: 40rem;
+    height: 100%;
+    overflow: hidden;
+    position: relative;
+  }
+
+  /* The track is the transform target. We can't translateX a CSS
+     multicolumn container directly — Blink renders fragmented column
+     boxes and the transform is dropped — so the track wraps the
+     content and slides it with the chapter's overflow following. */
+  .reader-page-track {
+    width: 100%;
+    height: 100%;
+    transition: transform 200ms ease;
+    will-change: transform;
+  }
+
+  /* Horizontal pagination via CSS multi-column. The content element
+     fills its parent window and `column-width` is set inline to that
+     same width by `measure()`, so exactly one column is visible at a
+     time and the browser auto-flows the chapter into however many
+     columns the height allows. `column-fill: auto` keeps content
+     packing into the current column to its full height before starting
+     the next — without it the browser tries to balance columns, which
+     short-circuits the pagination. */
   .reader-page-content {
     font-family: var(--font-serif-dev, var(--font-serif));
     font-size: 1.1rem;
     line-height: 2;
     color: var(--ink, var(--color-fg));
-    max-width: 40rem;
-    margin: 0 auto;
+    width: 100%;
+    height: 100%;
+    column-gap: 0;
+    column-fill: auto;
     word-spacing: 0.03em;
     text-wrap: pretty;
-    transition: transform 200ms ease;
-    will-change: transform;
   }
   @media (min-width: 768px) {
     .reader-page-content {
@@ -388,7 +450,7 @@
 
   /* Respect reduced-motion: skip the page-flip slide. */
   @media (prefers-reduced-motion: reduce) {
-    .reader-page-content {
+    .reader-page-track {
       transition: none;
     }
   }

--- a/apps/web/src/lib/components/reader/paginate.test.ts
+++ b/apps/web/src/lib/components/reader/paginate.test.ts
@@ -12,7 +12,7 @@ describe('pageCountFor', () => {
     expect(pageCountFor(1201, 600)).toBe(3);
   });
 
-  it("doesn't return 0 even for a zero-height viewport (defensive)", () => {
+  it("doesn't return 0 even for a zero-size viewport (defensive)", () => {
     expect(pageCountFor(1200, 0)).toBe(1);
   });
 });
@@ -36,7 +36,7 @@ describe('pageOffset', () => {
     expect(pageOffset(0, 600)).toBe(0);
   });
 
-  it('returns idx * viewportH for subsequent pages', () => {
+  it('returns idx * pageSize for subsequent pages', () => {
     expect(pageOffset(1, 600)).toBe(600);
     expect(pageOffset(3, 600)).toBe(1800);
   });

--- a/apps/web/src/lib/components/reader/paginate.ts
+++ b/apps/web/src/lib/components/reader/paginate.ts
@@ -1,22 +1,20 @@
 /**
  * Reader page-mode pagination helpers (T-5.23).
  *
- * The page mode renders the whole chapter into a fixed-height
- * viewport and slides between "pages" with a CSS transform. Pure
- * helpers that the component composes:
- *   - `pageCountFor(contentH, viewportH)` — how many pages a chapter
- *     splits into.
- *   - `clampPage(idx, count)` — keep the active page index in range.
- *   - `pageOffset(idx, viewportH)` — the translateY offset for a
- *     given page.
- *
- * Kept pure / DOM-free so the maths is unit-tested without rendering.
+ * Page mode renders the whole chapter into a fixed-size viewport and
+ * slides between "pages" with a CSS transform. The helpers are
+ * dimension-agnostic — they take a content size and a page size and
+ * tell the component how many pages exist, where to clamp the active
+ * index, and what translate offset matches the active index. The
+ * component decides whether those numbers are widths (horizontal
+ * pagination, the current default) or heights (the previous vertical
+ * slice). Kept DOM-free so the maths can be unit-tested in isolation.
  */
 
-export function pageCountFor(contentH: number, viewportH: number): number {
-  if (viewportH <= 0) return 1;
-  if (contentH <= 0) return 1;
-  return Math.max(1, Math.ceil(contentH / viewportH));
+export function pageCountFor(contentSize: number, pageSize: number): number {
+  if (pageSize <= 0) return 1;
+  if (contentSize <= 0) return 1;
+  return Math.max(1, Math.ceil(contentSize / pageSize));
 }
 
 export function clampPage(idx: number, count: number): number {
@@ -26,7 +24,7 @@ export function clampPage(idx: number, count: number): number {
   return idx;
 }
 
-export function pageOffset(idx: number, viewportH: number): number {
-  if (viewportH <= 0) return 0;
-  return Math.max(0, idx) * viewportH;
+export function pageOffset(idx: number, pageSize: number): number {
+  if (pageSize <= 0) return 0;
+  return Math.max(0, idx) * pageSize;
 }


### PR DESCRIPTION
## Summary

Three reader UX changes shipped together:

### Horizontal page flip
Page mode now flows like a real book. Each page is one column, side by side, and the reader flips between them with a horizontal `translateX` slide. Previously each page was a `100dvh - chrome` slice and the chapter scrolled vertically inside the viewport.

- **CSS multi-column for the chapter body.** The content gets `column-width` set inline (matching its own clientWidth) and `column-fill: auto`, so the browser auto-flows the chapter into as many side-by-side columns as the height allows. `column-fill: auto` is load-bearing — without it Blink balances columns and short-circuits the pagination.
- **Clipping window** sits inside the viewport. Its `overflow: hidden` is what hides the off-page columns to the right.
- **Track wrapper carries the transform.** Translating the multi-column container itself does not paint in Blink — the fragmented column boxes ignore the transform. Wrapping it in a non-fragmented track and translating that one moves the whole column row, including overflow, as expected.
- **Synchronous re-measure on chapter / romanization change.** Reading `scrollWidth` flushes pending layout, so `pageW` and `contentW` stay in sync.
- **paginate.ts** helpers are now dimension-agnostic (`pageSize`); the component decides whether to feed widths or heights. Tests updated.

### Static rail on desktop
The chevron rail-toggle is now mobile-only. On desktop the rail is always visible — the collapse affordance was extra chrome to think about for little benefit. The reader window also drops its `max-width: 40rem` cap so the chapter text fills the rail-minus-arrows space instead of leaving a wide empty band.

- Rail-toggle button hidden via `@media (min-width: 960px) { display: none }`. On mobile it still toggles immersive (hide top-strip + bottom-nav).
- Removed `.rail` from the `data-reader-immersive` CSS rule + the matching shell `grid-template-columns` override (rail can no longer be hidden on desktop).
- Removed `max-width: 40rem` from `.reader-page-window`.

### Hover tooltips fall through the side panel
The undimmed Sheet's backdrop covered the whole viewport with `pointer-events: auto`, so hovering a word with the side panel locked open hit `.sheet-back` instead of the token — no hover tooltip fired. Switch the backdrop to `pointer-events: none` in undimmed mode and opt `.sheet` itself back in so it still catches clicks.

Click-outside-to-close stops working in undimmed mode as a side effect (real-user clicks now bypass the backdrop), so the WordPopup header gets an explicit close button. Dimmed sheets are unchanged — backdrop still catches outside clicks.

## Test plan

- [x] `pnpm test` — 695 tests pass
- [x] `pnpm check` — 0 errors, 0 warnings
- [x] Open `/reader/<id>?mode=page`, click `›` — track translates by one page-width, content slides left, page indicator advances; `‹` reverses
- [x] Last page of a chapter spills into the next chapter
- [x] Desktop: rail always visible, no toggle button, reader text spans full available width
- [x] Hover a word while the side panel is open — tooltip appears for the hovered word, panel stays locked on the original
- [x] Close button in side-panel header dismisses the panel
- [ ] Mobile (<960px): toggle still appears and still hides top-strip + bottom-nav
- [ ] Esc still closes the side panel
- [ ] Reduced-motion users skip the slide animation