### PR TITLE
fix(romanize): re-decompose nukta atomic codepoints after aksharamukha

### DIFF
--- a/services/nlp/app/romanize.py
+++ b/services/nlp/app/romanize.py
@@ -213,7 +213,16 @@ def _hindi_schwa_delete(devanagari: str) -> str:
         devanagari,
         pre_options=["RemoveSchwaHindi"],
     )
-    return _patch_nukta_final_virama(out)
+    # aksharamukha recomposes nukta-bearing consonants back into the
+    # precomposed atomic codepoints in U+0958-U+095F (क़ख़ग़ज़ड़ढ़फ़य़) and
+    # U+0931 (ऱ). sanscript's Devanagari→ISO table only knows the
+    # decomposed form (base + U+093C nukta), so a recomposed ढ़ comes
+    # back as the literal Devanagari character with no romanization
+    # ("paढ़ēṁ" instead of "paṛhēṁ" for पढ़ें). NFD restores the
+    # decomposed form — these codepoints are on Unicode's composition-
+    # exclusion list, so NFD will leave them as base + nukta and NFC
+    # won't recompose them (they round-trip safely).
+    return unicodedata.normalize("NFD", _patch_nukta_final_virama(out))
 
 
 # Hindi merges the ISO 15919 ē/ō length distinction into a single

--- a/services/nlp/tests/test_romanize.py
+++ b/services/nlp/tests/test_romanize.py
@@ -183,6 +183,42 @@ def test_hindi_nukta_final_in_phrase_with_punctuation():
     assert "barfa" not in out
 
 
+# ---- Hindi-specific: aksharamukha recomposes nukta atomic codepoints ----
+#
+# aksharamukha's RemoveSchwaHindi pass leaves the input as decomposed
+# (base + U+093C nukta) on the way IN but recomposes the result back to
+# the precomposed atomic codepoints (U+0958–U+095F + U+0931) on the way
+# OUT. sanscript's Devanagari→ISO table doesn't include those atomic
+# letters, so without a fix the romanizer leaves them untouched in the
+# middle of an otherwise romanized word ("paढ़ēṁ" instead of "paṛhēṁ"
+# for पढ़ें). The romanize module re-applies NFD after aksharamukha to
+# restore the decomposed form sanscript understands. These tests pin
+# the fix and the surrounding nukta-letter coverage.
+
+
+@pytest.mark.parametrize(
+    "native,expected_iso",
+    [
+        ("पढ़ें", "paṛheṁ"),  # the canonical bug — medial ढ़, vowel sign + anusvara
+        ("पढ़ाई", "paṛhāī"),  # ढ़ + long ā + ī, multi-syllable
+        ("बड़ा", "baṛā"),  # ड़ (U+095C) — different nukta letter, same recompose
+        ("ज़माना", "zamānā"),  # ज़ (U+095B) at word start
+        ("ख़ुश", "k͟huś"),  # ख़ (U+0959), sanscript ISO uses k + combining double macron-below
+        ("दर्ज़ी", "darzī"),  # medial ज़; regression guard for the existing fix
+    ],
+)
+def test_hindi_nukta_atomic_codepoints_decompose_for_sanscript(
+    native: str, expected_iso: str
+):
+    out = romanize.to_roman(native, from_script="Deva", to_scheme="iso15919", language="hi")
+    assert out == expected_iso, (
+        f"{native} romanized to {out!r}; expected {expected_iso!r}. "
+        f"Likely cause: aksharamukha's recomposition of nukta letters "
+        f"(U+0958-U+095F + U+0931) reached sanscript's Devanagari table "
+        f"which doesn't know those codepoints."
+    )
+
+
 def test_hindi_language_hint_is_noop_for_orya():
     # The schwa-deletion path is gated on ``from_script="Deva"`` —
     # Odia text with a stray ``language="hi"`` (a caller bug) must


### PR DESCRIPTION
## Summary

Fixes a romanization bug where words containing nukta-bearing consonants showed up half-romanized:

- **Bug:** पढ़ें → \`paढ़ēṁ\` (the ढ़ stayed as Devanagari)
- **Fix:** पढ़ें → \`paṛheṁ\`

## Root cause

\`aksharamukha.RemoveSchwaHindi\` decomposes nukta-bearing consonants (ढ + ़) on the way in, runs the schwa-deletion pass, then **recomposes** them back into the precomposed atomic codepoints in U+0958–U+095F (क़ख़ग़ज़ड़ढ़फ़य़) plus U+0931 ऱ. \`sanscript\`'s Devanagari→ISO/IAST tables only recognize the decomposed form (base + U+093C nukta), so a recomposed ढ़ falls through and shows up as the literal Devanagari character in the middle of an otherwise romanized word.

## Fix

One-line: NFD-normalize the output of the schwa-delete pass before handing it to sanscript. These codepoints are on Unicode's composition exclusion list — NFD restores the decomposed form and NFC won't recompose them, so the round-trip is safe.

## Test plan

- [x] Six new parametric cases covering the affected nukta letters (ढ़, ड़, ज़, ख़) plus a regression guard for दर्ज़ी (the existing medial-nukta case the previous fix already handled).
- [x] All 66 romanize tests pass.
- [ ] Restart the NLP service / reprocess your existing text — pre-fix tokens still carry the broken romanization stored on \`text_tokens.romanization\`. Reprocessing regenerates them.

Refs T-2.5.