### PR TITLE
T-5.1a: lazy-load reader chapters

### DIFF
--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -64,6 +64,8 @@ export default [
         MutationObserver: 'readonly',
         // Page-mode pagination measurement (T-5.23).
         ResizeObserver: 'readonly',
+        // Continuous-mode lazy chapter loading (T-5.1a).
+        IntersectionObserver: 'readonly',
       },
     },
   },

--- a/apps/web/src/lib/components/reader/ReaderContinuous.svelte
+++ b/apps/web/src/lib/components/reader/ReaderContinuous.svelte
@@ -1,35 +1,132 @@
 <!--
-  Continuous reading mode (T-5.1, token-aware in T-5.2).
+  Continuous reading mode (T-5.1, token-aware in T-5.2, lazy chapter
+  loading in T-5.1a).
 
   Renders every chapter stacked vertically. Token rendering is
   delegated to <ChapterBody/> so all three modes use the same
-  status/OOV/ambiguous logic. Virtual scrolling for very long books
-  (T-5.1a) is wired by the caller's chunking, not here.
+  status/OOV/ambiguous logic.
+
+  T-5.1a: only the active chapter ships with server-rendered tokens
+  on first paint. Sibling chapters are fetched on demand via an
+  IntersectionObserver — when a section comes within ~600px of the
+  viewport we kick off a fetch and merge the result back into the
+  ChapterView so the next render colours the lemmas. While the fetch
+  is in flight (or before the observer fires) the chapter's body
+  still renders via the whitespace fallback, so the text is always
+  readable.
 -->
 <script lang="ts">
+  import { onMount, untrack } from 'svelte';
+
   import ChapterBody from './ChapterBody.svelte';
-  import type { ChapterView } from './types.js';
+  import { LazyTokenLoader, type ChapterTokenFetcher } from './lazy-tokens.js';
+  import type { ChapterView, ServerToken } from './types.js';
 
   let {
     chapters,
     initialChapterIdx = 0,
     showRomanization = false,
     isOwner = false,
+    textId,
+    /** Override hook for tests — defaults to a real fetch when omitted. */
+    fetcher,
   }: {
     chapters: ChapterView[];
     initialChapterIdx?: number;
     showRomanization?: boolean;
     isOwner?: boolean;
+    textId: string;
+    fetcher?: ChapterTokenFetcher;
   } = $props();
+
+  // Map of chapterIdx → fetched tokens (or `null` if the worker
+  // hasn't run for that chapter — same fallback as the SSR path).
+  // Seeded with the initial chapter so re-renders don't trigger an
+  // unnecessary network round-trip for the chapter we already have.
+  let lazyTokens = $state(new Map<number, ServerToken[] | null>());
+
+  const loader = $derived(
+    new LazyTokenLoader(textId, fetcher),
+  );
+
+  // The chapter views handed to ChapterBody — sibling chapters get
+  // their tokens patched in once the lazy loader resolves them.
+  const renderedChapters = $derived.by(() => {
+    return chapters.map((c) => {
+      if (c.tokens != null) return c;
+      const fetched = lazyTokens.get(c.idx);
+      if (fetched === undefined) return c;
+      return { ...c, tokens: fetched };
+    });
+  });
+
+  function ensureChapter(chapterIdx: number) {
+    // Skip when the chapter already shipped tokens (active chapter)
+    // or we've already fetched / are fetching this idx.
+    const existing = chapters.find((c) => c.idx === chapterIdx);
+    if (!existing || existing.tokens != null) return;
+    if (lazyTokens.has(chapterIdx)) return;
+    void loader
+      .load(chapterIdx)
+      .then((tokens) => {
+        const next = new Map(untrack(() => lazyTokens));
+        next.set(chapterIdx, tokens);
+        lazyTokens = next;
+      })
+      .catch(() => {
+        // Swallow — the chapter still renders via the whitespace
+        // fallback, just without lemma colouring. A retry happens
+        // automatically the next time the observer trips because
+        // we never wrote to `lazyTokens`.
+      });
+  }
+
+  let sectionRefs: Map<number, HTMLElement> = new Map();
+  function bindSection(node: HTMLElement, idx: number) {
+    sectionRefs.set(idx, node);
+    return {
+      destroy() {
+        sectionRefs.delete(idx);
+      },
+    };
+  }
+
+  onMount(() => {
+    if (typeof IntersectionObserver === 'undefined') {
+      // jsdom / SSR fallback: prefetch every chapter eagerly so the
+      // experience degrades gracefully (still better than the old
+      // load-everything-server-side behavior because each chapter
+      // ships in its own JSON response and Postgres roundtrip).
+      for (const c of chapters) ensureChapter(c.idx);
+      return;
+    }
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (!entry.isIntersecting) continue;
+          const idxAttr = (entry.target as HTMLElement).dataset.chapterIdx;
+          if (!idxAttr) continue;
+          const idx = Number.parseInt(idxAttr, 10);
+          if (Number.isFinite(idx)) ensureChapter(idx);
+        }
+      },
+      { rootMargin: '600px 0px' },
+    );
+    for (const node of sectionRefs.values()) io.observe(node);
+    return () => io.disconnect();
+  });
 </script>
 
 <div class="reader-continuous" data-mode="continuous" data-initial-chapter={initialChapterIdx}>
-  {#each chapters as chapter (chapter.id)}
+  {#each renderedChapters as chapter (chapter.id)}
     <section
       id={`chapter-${chapter.idx}`}
+      data-chapter-idx={chapter.idx}
       class:active={chapter.idx === initialChapterIdx}
+      use:bindSection={chapter.idx}
+
     >
-      {#if chapter.title || chapters.length > 1}
+      {#if chapter.title || renderedChapters.length > 1}
         <h2>
           {chapter.title ?? `Chapter ${chapter.idx + 1}`}
           <span class="muted">({chapter.tokenCount.toLocaleString()} tokens)</span>

--- a/apps/web/src/lib/components/reader/lazy-tokens.test.ts
+++ b/apps/web/src/lib/components/reader/lazy-tokens.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment node
+/**
+ * Tests for the per-chapter token lazy loader (T-5.1a).
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import { LazyTokenLoader, type ChapterTokensResponse } from './lazy-tokens.js';
+import type { ServerToken } from './types.js';
+
+function fakeTokens(n: number): ServerToken[] {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `t-${i}`,
+    idx: i,
+    surface: `w${i}`,
+    isWord: true,
+    isAmbiguous: false,
+    isOov: false,
+    lemmaId: `lem-${i}`,
+    romanization: null,
+    glossDefault: null,
+    status: 'unknown',
+  }));
+}
+
+describe('LazyTokenLoader', () => {
+  it('fetches tokens once per chapter and caches the result', async () => {
+    const fetcher = vi
+      .fn<(textId: string, idx: number) => Promise<ChapterTokensResponse>>()
+      .mockImplementation(async (_textId, idx) => ({
+        chapterId: `c-${idx}`,
+        chapterIdx: idx,
+        tokens: fakeTokens(2),
+      }));
+    const loader = new LazyTokenLoader('text-1', fetcher);
+    const a = await loader.load(2);
+    const b = await loader.load(2);
+    expect(a).toHaveLength(2);
+    expect(b).toBe(a);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('dedupes concurrent loads for the same chapter', async () => {
+    let resolveFn: ((v: ChapterTokensResponse) => void) | null = null;
+    const promise = new Promise<ChapterTokensResponse>((resolve) => {
+      resolveFn = resolve;
+    });
+    const fetcher = vi.fn().mockReturnValue(promise);
+    const loader = new LazyTokenLoader('t1', fetcher);
+    const p1 = loader.load(1);
+    const p2 = loader.load(1);
+    resolveFn!({ chapterId: 'c1', chapterIdx: 1, tokens: null });
+    const [a, b] = await Promise.all([p1, p2]);
+    expect(a).toBeNull();
+    expect(b).toBeNull();
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports loading state while a fetch is in flight', async () => {
+    const fetcher = vi
+      .fn()
+      .mockReturnValue(
+        new Promise<ChapterTokensResponse>(() => {
+          /* never resolves */
+        }),
+      );
+    const loader = new LazyTokenLoader('t1', fetcher);
+    expect(loader.state(0)).toEqual({ kind: 'idle' });
+    void loader.load(0);
+    expect(loader.state(0)).toEqual({ kind: 'loading' });
+  });
+
+  it('records error state when the fetch rejects', async () => {
+    const fetcher = vi.fn().mockRejectedValue(new Error('boom'));
+    const loader = new LazyTokenLoader('t1', fetcher);
+    await expect(loader.load(0)).rejects.toThrow('boom');
+    expect(loader.state(0)).toEqual({ kind: 'error', message: 'boom' });
+  });
+
+  it('passes through a null tokens response (worker has not run yet)', async () => {
+    const fetcher = vi.fn().mockResolvedValue({
+      chapterId: 'c1',
+      chapterIdx: 1,
+      tokens: null,
+    });
+    const loader = new LazyTokenLoader('t1', fetcher);
+    expect(await loader.load(1)).toBeNull();
+    expect(loader.state(1)).toEqual({ kind: 'loaded', tokens: null });
+  });
+});

--- a/apps/web/src/lib/components/reader/lazy-tokens.ts
+++ b/apps/web/src/lib/components/reader/lazy-tokens.ts
@@ -1,0 +1,91 @@
+/**
+ * Per-chapter token lazy loader (T-5.1a).
+ *
+ * The reader's SSR loader only ships the active chapter's token rows
+ * (a 50-chapter novel would otherwise blow up first-paint). This
+ * helper fetches sibling chapters on demand from the
+ * `/api/v1/texts/:id/chapters/:idx/tokens` endpoint, deduping
+ * concurrent requests for the same chapter and surfacing a tiny
+ * status state so a caller (continuous mode) can render a "loading"
+ * affordance without juggling its own bookkeeping.
+ *
+ * Single-shot per chapter — once a fetch resolves we don't refetch,
+ * which matches the reader's data flow (status overrides happen
+ * client-side via WordPopup, not by re-pulling rows).
+ */
+import type { ServerToken } from './types.js';
+
+export type ChapterTokensResponse = {
+  chapterId: string;
+  chapterIdx: number;
+  tokens: ServerToken[] | null;
+};
+
+export type FetchState =
+  | { kind: 'idle' }
+  | { kind: 'loading' }
+  | { kind: 'loaded'; tokens: ServerToken[] | null }
+  | { kind: 'error'; message: string };
+
+export type ChapterTokenFetcher = (
+  textId: string,
+  chapterIdx: number,
+) => Promise<ChapterTokensResponse>;
+
+export const defaultFetcher: ChapterTokenFetcher = async (textId, idx) => {
+  const res = await fetch(
+    `/api/v1/texts/${encodeURIComponent(textId)}/chapters/${idx}/tokens`,
+  );
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}`);
+  }
+  return (await res.json()) as ChapterTokensResponse;
+};
+
+/**
+ * Tracks per-chapter fetch state. Reused across mounts of a single
+ * reader page so a chapter scrolled out and back in doesn't refetch.
+ */
+export class LazyTokenLoader {
+  private states = new Map<number, FetchState>();
+  private inflight = new Map<number, Promise<ChapterTokensResponse>>();
+
+  constructor(
+    private readonly textId: string,
+    private readonly fetcher: ChapterTokenFetcher = defaultFetcher,
+  ) {}
+
+  state(chapterIdx: number): FetchState {
+    return this.states.get(chapterIdx) ?? { kind: 'idle' };
+  }
+
+  /**
+   * Kick off (or join) a fetch for `chapterIdx`. Resolves to the
+   * fetched tokens or null if the worker hasn't run for that chapter
+   * yet — same shape the SSR loader returns for the active chapter,
+   * so callers can drop the result straight into the ChapterView.
+   */
+  async load(chapterIdx: number): Promise<ServerToken[] | null> {
+    const existing = this.states.get(chapterIdx);
+    if (existing?.kind === 'loaded') return existing.tokens;
+    const existingPromise = this.inflight.get(chapterIdx);
+    if (existingPromise) {
+      const r = await existingPromise;
+      return r.tokens;
+    }
+    this.states.set(chapterIdx, { kind: 'loading' });
+    const promise = this.fetcher(this.textId, chapterIdx);
+    this.inflight.set(chapterIdx, promise);
+    try {
+      const r = await promise;
+      this.states.set(chapterIdx, { kind: 'loaded', tokens: r.tokens });
+      return r.tokens;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Fetch failed';
+      this.states.set(chapterIdx, { kind: 'error', message });
+      throw err;
+    } finally {
+      this.inflight.delete(chapterIdx);
+    }
+  }
+}

--- a/apps/web/src/routes/api/v1/texts/[id]/chapters/[idx]/tokens/+server.ts
+++ b/apps/web/src/routes/api/v1/texts/[id]/chapters/[idx]/tokens/+server.ts
@@ -1,0 +1,43 @@
+/**
+ * GET /api/v1/texts/:id/chapters/:idx/tokens (T-5.1a).
+ *
+ * The reader's lazy chapter loader. The page-level SSR loader only
+ * ships the active chapter's tokens; this endpoint backs the
+ * per-chapter fetches that fill in siblings as the user navigates
+ * (page/paged_scroll mode hands a new active chapter through goto())
+ * or scrolls into them (continuous mode prefetches near the bottom).
+ *
+ * Visibility goes through the same `getReadableText` gate the reader
+ * page uses — owner OR official OR shared, never wider. Anonymous
+ * viewers get tokens for official texts; status comes back as
+ * 'unknown' for everyone since they have no `user_known_lemmas` row.
+ */
+import { error, json } from '@sveltejs/kit';
+
+import { getReadableText } from '$lib/server/texts/upload.js';
+import { loadChapterTokens } from '$lib/server/texts/tokens.js';
+import type { RequestHandler } from './$types';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const GET: RequestHandler = async ({ params, locals }) => {
+  const textId = params.id;
+  if (!textId || !UUID_RE.test(textId)) throw error(400, 'Invalid text id');
+  const idxRaw = params.idx;
+  if (!idxRaw) throw error(400, 'Invalid chapter index');
+  const idx = Number.parseInt(idxRaw, 10);
+  if (!Number.isFinite(idx) || idx < 0) throw error(400, 'Invalid chapter index');
+
+  const viewer = locals.user ? { id: locals.user.id } : null;
+  const result = await getReadableText(viewer, textId);
+  if (!result) throw error(404, 'Text not found');
+  const chapter = result.chapters.find((c) => c.idx === idx);
+  if (!chapter) throw error(404, 'Chapter not found');
+
+  const tokens = await loadChapterTokens(chapter.id, viewer?.id ?? null);
+  return json({
+    chapterId: chapter.id,
+    chapterIdx: chapter.idx,
+    tokens,
+  });
+};

--- a/apps/web/src/routes/api/v1/texts/[id]/chapters/[idx]/tokens/tokens-server.test.ts
+++ b/apps/web/src/routes/api/v1/texts/[id]/chapters/[idx]/tokens/tokens-server.test.ts
@@ -1,0 +1,139 @@
+// @vitest-environment node
+/**
+ * Tests for GET /api/v1/texts/:id/chapters/:idx/tokens (T-5.1a).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getReadableText = vi.fn();
+const loadChapterTokens = vi.fn();
+
+vi.mock('$lib/server/texts/upload.js', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/texts/upload.js')>(
+    '$lib/server/texts/upload.js',
+  );
+  return {
+    ...actual,
+    getReadableText: (...a: unknown[]) => getReadableText(...a),
+    getOwnedText: (...a: unknown[]) => getReadableText(...a),
+  };
+});
+
+vi.mock('$lib/server/texts/tokens.js', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/texts/tokens.js')>(
+    '$lib/server/texts/tokens.js',
+  );
+  return {
+    ...actual,
+    loadChapterTokens: (...a: unknown[]) => loadChapterTokens(...a),
+  };
+});
+
+const VALID_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+
+type Get = (typeof import('./+server.js'))['GET'];
+
+async function callGet(
+  textId: string,
+  idx: string,
+  user: { id: string } | null = { id: 'user-1' },
+) {
+  const { GET } = await import('./+server.js');
+  const event = {
+    params: { id: textId, idx },
+    locals: { user },
+  } as unknown as Parameters<Get>[0];
+  try {
+    return (await GET(event)) as Response;
+  } catch (e) {
+    return e as { status: number };
+  }
+}
+
+function fixtureWithChapters(n: number) {
+  return {
+    text: { id: VALID_ID, ownerId: 'user-1', visibility: 'private' },
+    chapters: Array.from({ length: n }, (_, i) => ({
+      id: `c${i}`,
+      idx: i,
+      title: null,
+      body: '',
+      tokenCount: 0,
+    })),
+  };
+}
+
+beforeEach(() => {
+  getReadableText.mockReset();
+  loadChapterTokens.mockReset();
+  loadChapterTokens.mockResolvedValue(null);
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('GET /api/v1/texts/:id/chapters/:idx/tokens', () => {
+  it('returns tokens for the requested chapter', async () => {
+    getReadableText.mockResolvedValueOnce(fixtureWithChapters(3));
+    loadChapterTokens.mockResolvedValueOnce([
+      {
+        id: 't0',
+        idx: 0,
+        surface: 'पाठ',
+        isWord: true,
+        isAmbiguous: false,
+        isOov: false,
+        lemmaId: 'lem-1',
+        romanization: null,
+        glossDefault: null,
+        status: 'unknown',
+      },
+    ]);
+    const res = (await callGet(VALID_ID, '1')) as Response;
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      chapterId: string;
+      chapterIdx: number;
+      tokens: unknown[] | null;
+    };
+    expect(body.chapterIdx).toBe(1);
+    expect(body.chapterId).toBe('c1');
+    expect(body.tokens).toHaveLength(1);
+    expect(loadChapterTokens).toHaveBeenCalledWith('c1', 'user-1');
+  });
+
+  it('rejects an invalid uuid with 400', async () => {
+    const r = (await callGet('not-a-uuid', '0')) as { status: number };
+    expect(r.status).toBe(400);
+    expect(getReadableText).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-numeric chapter idx with 400', async () => {
+    const r = (await callGet(VALID_ID, 'abc')) as { status: number };
+    expect(r.status).toBe(400);
+  });
+
+  it('rejects a negative chapter idx with 400', async () => {
+    const r = (await callGet(VALID_ID, '-1')) as { status: number };
+    expect(r.status).toBe(400);
+  });
+
+  it('returns 404 for an unreadable text', async () => {
+    getReadableText.mockResolvedValueOnce(null);
+    const r = (await callGet(VALID_ID, '0')) as { status: number };
+    expect(r.status).toBe(404);
+  });
+
+  it('returns 404 when the chapter idx is out of range', async () => {
+    getReadableText.mockResolvedValueOnce(fixtureWithChapters(2));
+    const r = (await callGet(VALID_ID, '99')) as { status: number };
+    expect(r.status).toBe(404);
+  });
+
+  it('forwards anonymous viewers to the readability gate', async () => {
+    getReadableText.mockResolvedValueOnce(fixtureWithChapters(1));
+    await callGet(VALID_ID, '0', null);
+    expect(getReadableText).toHaveBeenCalledWith(null, VALID_ID);
+    expect(loadChapterTokens).toHaveBeenCalledWith('c0', null);
+  });
+});

--- a/apps/web/src/routes/reader/[textId]/+page.server.ts
+++ b/apps/web/src/routes/reader/[textId]/+page.server.ts
@@ -99,19 +99,19 @@ export const load: PageServerLoad = async ({ params, locals, url }) => {
   const mode = readMode(url, 'continuous');
   const showRomanization = readBool(url, 'roman');
 
-  // Pre-fetch NLP tokens for every chapter that has them. Chapters
-  // without tokens fall back to client-side whitespace tokenization
-  // in the components — no NLP, no colouring, but still readable.
-  // We load all chapters here rather than just the active one
-  // because `continuous` mode renders every chapter; `page` and
-  // `paged_scroll` ignore the inactive ones, so the cost is wasted
-  // on those modes — we'll narrow it once the per-mode loader split
-  // (T-5.1a) lands.
+  // T-5.1a: lazy chapter loading. Only the active chapter is
+  // pre-fetched server-side — a 50-chapter novel was previously
+  // shipping every chapter's token rows on first paint, blowing up
+  // the SSR payload and stalling time-to-first-byte for long books.
+  // Other chapters get `tokens: null` here; the components fetch on
+  // demand via /api/v1/texts/:id/chapters/:idx/tokens (paged-mode
+  // navigation re-runs this loader; continuous mode prefetches the
+  // next chapter near the bottom of the visible one).
   const viewerId = locals.user?.id ?? null;
-  const tokenMap: Record<string, Awaited<ReturnType<typeof loadChapterTokens>>> = {};
-  for (const c of result.chapters) {
-    tokenMap[c.id] = await loadChapterTokens(c.id, viewerId);
-  }
+  const activeChapter = result.chapters[chapterIdx];
+  const activeTokens = activeChapter
+    ? await loadChapterTokens(activeChapter.id, viewerId)
+    : null;
 
   return {
     text: {
@@ -130,10 +130,12 @@ export const load: PageServerLoad = async ({ params, locals, url }) => {
       title: c.title,
       body: c.body,
       tokenCount: c.tokenCount,
-      // Server-rendered tokens (or null if the worker hasn't run for
-      // this chapter yet — the components fall back to a
-      // whitespace tokenizer in that case).
-      tokens: tokenMap[c.id] ?? null,
+      // Only the active chapter ships with server-rendered tokens;
+      // siblings carry `tokens: null` and are filled in client-side
+      // by the lazy-load endpoint. A null payload also still happens
+      // when the NLP worker hasn't run for this chapter — the reader
+      // components transparently fall back to whitespace tokenization.
+      tokens: c.idx === chapterIdx ? activeTokens : null,
     })),
     anchor: {
       chapterIdx,

--- a/apps/web/src/routes/reader/[textId]/+page.svelte
+++ b/apps/web/src/routes/reader/[textId]/+page.svelte
@@ -262,6 +262,7 @@
     <ReaderContinuous
       chapters={data.chapters}
       initialChapterIdx={data.anchor.chapterIdx}
+      textId={data.text.id}
       {showRomanization}
       isOwner={data.isOwner}
     />

--- a/apps/web/src/routes/reader/[textId]/page-server.test.ts
+++ b/apps/web/src/routes/reader/[textId]/page-server.test.ts
@@ -226,8 +226,8 @@ describe('/reader/[textId] loader', () => {
     expect(data.anchor.chapterIdx).toBe(1);
   });
 
-  it('attaches server tokens onto each chapter when the worker has run', async () => {
-    getReadableText.mockResolvedValueOnce(ownedTextWithChapters(2));
+  it('attaches server tokens to the active chapter only (T-5.1a)', async () => {
+    getReadableText.mockResolvedValueOnce(ownedTextWithChapters(3));
     const tokenRow = (id: string, idx: number) => ({
       id,
       idx,
@@ -237,19 +237,32 @@ describe('/reader/[textId] loader', () => {
       isOov: false,
       lemmaId: 'lem-1',
       romanization: null,
+      glossDefault: null,
       status: 'unknown' as const,
     });
-    loadChapterTokens
-      .mockResolvedValueOnce([tokenRow('t0', 0)])
-      .mockResolvedValueOnce(null);
+    loadChapterTokens.mockResolvedValueOnce([tokenRow('t0', 0)]);
     const data = (await callLoad(`http://x/reader/${VALID_ID}`)) as {
       chapters: Array<{ id: string; tokens: unknown }>;
     };
     expect(data.chapters[0]!.tokens).toHaveLength(1);
     expect(data.chapters[1]!.tokens).toBeNull();
-    // The loader called the token service once per chapter, with the
-    // viewer id forwarded.
-    expect(loadChapterTokens).toHaveBeenCalledTimes(2);
+    expect(data.chapters[2]!.tokens).toBeNull();
+    // Single fetch — only the active (chapter 0) chapter is hit;
+    // siblings get filled in client-side via the lazy-load endpoint.
+    expect(loadChapterTokens).toHaveBeenCalledTimes(1);
     expect(loadChapterTokens).toHaveBeenCalledWith('c0', USER.id);
+  });
+
+  it('lazy-loads only the requested chapter when ?chapter=N is set (T-5.1a)', async () => {
+    getReadableText.mockResolvedValueOnce(ownedTextWithChapters(5));
+    loadChapterTokens.mockResolvedValueOnce(null);
+    const data = (await callLoad(
+      `http://x/reader/${VALID_ID}?chapter=3`,
+    )) as { chapters: Array<{ tokens: unknown }> };
+    // The loader is invoked exactly once, for the requested chapter's
+    // chapter id ("c3").
+    expect(loadChapterTokens).toHaveBeenCalledTimes(1);
+    expect(loadChapterTokens).toHaveBeenCalledWith('c3', USER.id);
+    expect(data.chapters.map((c) => c.tokens)).toEqual([null, null, null, null, null]);
   });
 });


### PR DESCRIPTION
## Summary

The SSR reader loader was pulling token rows for *every* chapter on first paint. A 50-chapter novel shipped tens of thousands of tokens in the page payload before the user had scrolled past chapter 1. Now the loader only hydrates the active chapter; siblings ship with \`tokens=null\` and the components transparently fall back to the existing whitespace tokenizer (still readable, just no lemma colouring) until their real tokens land.

- **Page / paged_scroll modes** — chapter navigation already runs through \`goto()\`, which re-runs the SSR loader for the new active chapter, so they pick up tokens for free with no extra plumbing.
- **Continuous mode** — an \`IntersectionObserver\` with a 600px rootMargin kicks off a fetch once a chapter scrolls within range. The new \`GET /api/v1/texts/:id/chapters/:idx/tokens\` endpoint backs it; \`LazyTokenLoader\` dedupes + caches per chapter so the same idx isn't requested twice.
- The new endpoint reuses the same \`getReadableText\` visibility gate the reader page uses — owner OR official OR shared, never wider.

Closes #44.

## Test plan

- [x] \`pnpm --filter @ciareader/web test\` — 89 files / 715 tests pass, including:
  - \`lazy-tokens.test.ts\` — 5 unit tests covering caching, in-flight dedup, loading state, error state, null tokens.
  - \`tokens-server.test.ts\` — 7 endpoint tests covering happy path, invalid uuid, invalid idx, 404 on unreadable text, 404 on out-of-range idx, anonymous viewer plumbing.
  - \`page-server.test.ts\` — updated existing \"server tokens per chapter\" test, added \"only the requested chapter\" test for \`?chapter=N\`.
- [x] \`pnpm --filter @ciareader/web typecheck\` — 0 errors.
- [x] \`pnpm --filter @ciareader/web lint\` — clean.

## Out of scope

- The \`LazyTokenLoader\` could prefetch the *next* chapter from the active one's bottom; today it waits for IO. Worth measuring before adding — IO with a generous \`rootMargin\` already prefetches before the user scrolls into a chapter.