### PR TITLE
T-5.1b: reader settings popover

### DIFF
--- a/apps/web/drizzle/0013_tan_dragon_lord.sql
+++ b/apps/web/drizzle/0013_tan_dragon_lord.sql
@@ -1,0 +1,2 @@
+CREATE TYPE "public"."reading_width" AS ENUM('narrow', 'medium', 'wide');--> statement-breakpoint
+ALTER TABLE "user_languages" ADD COLUMN "reading_width" "reading_width" DEFAULT 'medium' NOT NULL;

--- a/apps/web/drizzle/meta/0013_snapshot.json
+++ b/apps/web/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,2304 @@
+{
+  "id": "c85f5c46-b397-4d8f-abdd-2a3c2c027462",
+  "prevId": "b1f274f4-059f-4ad8-aecf-aa0455c15fd1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.curator_languages": {
+      "name": "curator_languages",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "curator_languages_user_idx": {
+          "name": "curator_languages_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "curator_languages_user_id_users_id_fk": {
+          "name": "curator_languages_user_id_users_id_fk",
+          "tableFrom": "curator_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "curator_languages_granted_by_users_id_fk": {
+          "name": "curator_languages_granted_by_users_id_fk",
+          "tableFrom": "curator_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "curator_languages_user_id_language_pk": {
+          "name": "curator_languages_user_id_language_pk",
+          "columns": [
+            "user_id",
+            "language"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.dictionary_imports": {
+      "name": "dictionary_imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_name": {
+          "name": "source_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_at": {
+          "name": "run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lemmas_created": {
+          "name": "lemmas_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lemmas_updated": {
+          "name": "lemmas_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lemmas_skipped_curator_locked": {
+          "name": "lemmas_skipped_curator_locked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "translations_created": {
+          "name": "translations_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "translations_updated": {
+          "name": "translations_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "dictionary_imports_language_idx": {
+          "name": "dictionary_imports_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.form_lemma_overrides": {
+      "name": "form_lemma_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_nfc": {
+          "name": "surface_nfc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_signature": {
+          "name": "context_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "chosen_lemma_id": {
+          "name": "chosen_lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "promoted_at": {
+          "name": "promoted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "promoted_by": {
+          "name": "promoted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "form_lemma_overrides_lookup_idx": {
+          "name": "form_lemma_overrides_lookup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface_nfc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "form_lemma_overrides_chosen_lemma_id_lemmas_id_fk": {
+          "name": "form_lemma_overrides_chosen_lemma_id_lemmas_id_fk",
+          "tableFrom": "form_lemma_overrides",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "chosen_lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_lemma_overrides_promoted_by_users_id_fk": {
+          "name": "form_lemma_overrides_promoted_by_users_id_fk",
+          "tableFrom": "form_lemma_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "promoted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "form_lemma_overrides_lang_surface_ctx_uq": {
+          "name": "form_lemma_overrides_lang_surface_ctx_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "language",
+            "surface_nfc",
+            "context_signature"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.lemma_edit_history": {
+      "name": "lemma_edit_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "editor_id": {
+          "name": "editor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "lemma_edit_change_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change": {
+          "name": "change",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_edit_history_lemma_idx": {
+          "name": "lemma_edit_history_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_edit_history_editor_idx": {
+          "name": "lemma_edit_history_editor_idx",
+          "columns": [
+            {
+              "expression": "editor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_edit_history_lemma_id_lemmas_id_fk": {
+          "name": "lemma_edit_history_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_edit_history",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lemma_edit_history_editor_id_users_id_fk": {
+          "name": "lemma_edit_history_editor_id_users_id_fk",
+          "tableFrom": "lemma_edit_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "editor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemma_forms": {
+      "name": "lemma_forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "romanization": {
+          "name": "romanization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_forms_lemma_idx": {
+          "name": "lemma_forms_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_forms_surface_idx": {
+          "name": "lemma_forms_surface_idx",
+          "columns": [
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_forms_lemma_id_lemmas_id_fk": {
+          "name": "lemma_forms_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_forms",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemmas": {
+      "name": "lemmas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headword": {
+          "name": "headword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos": {
+          "name": "pos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script": {
+          "name": "script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gloss_default": {
+          "name": "gloss_default",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_rank": {
+          "name": "frequency_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "translation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "curator_locked": {
+          "name": "curator_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemmas_language_headword_pos_idx": {
+          "name": "lemmas_language_headword_pos_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "headword",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pos",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_language_idx": {
+          "name": "lemmas_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_language_frequency_idx": {
+          "name": "lemmas_language_frequency_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "frequency_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_source_lookup_idx": {
+          "name": "lemmas_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.magic_links": {
+      "name": "magic_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "magic_links_user_idx": {
+          "name": "magic_links_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "magic_links_expires_idx": {
+          "name": "magic_links_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "magic_links_user_id_users_id_fk": {
+          "name": "magic_links_user_id_users_id_fk",
+          "tableFrom": "magic_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.nlp_jobs": {
+      "name": "nlp_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "nlp_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nlp_jobs_text_idx": {
+          "name": "nlp_jobs_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nlp_jobs_status_idx": {
+          "name": "nlp_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nlp_jobs_text_id_texts_id_fk": {
+          "name": "nlp_jobs_text_id_texts_id_fk",
+          "tableFrom": "nlp_jobs",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by": {
+          "name": "replaced_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "refresh_tokens_user_idx": {
+          "name": "refresh_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_expires_idx": {
+          "name": "refresh_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.text_chapters": {
+      "name": "text_chapters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idx": {
+          "name": "idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "text_chapters_text_idx": {
+          "name": "text_chapters_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_chapters_text_id_texts_id_fk": {
+          "name": "text_chapters_text_id_texts_id_fk",
+          "tableFrom": "text_chapters",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "text_chapters_text_idx_uq": {
+          "name": "text_chapters_text_idx_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "text_id",
+            "idx"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.text_tokens": {
+      "name": "text_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idx": {
+          "name": "idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lemma_candidates": {
+          "name": "lemma_candidates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_ambiguous": {
+          "name": "is_ambiguous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_oov": {
+          "name": "is_oov",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_word": {
+          "name": "is_word",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sentence_idx": {
+          "name": "sentence_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "romanization": {
+          "name": "romanization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "text_tokens_chapter_scan_idx": {
+          "name": "text_tokens_chapter_scan_idx",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "text_tokens_lemma_idx": {
+          "name": "text_tokens_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_tokens_chapter_id_text_chapters_id_fk": {
+          "name": "text_tokens_chapter_id_text_chapters_id_fk",
+          "tableFrom": "text_tokens",
+          "tableTo": "text_chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_tokens_lemma_id_lemmas_id_fk": {
+          "name": "text_tokens_lemma_id_lemmas_id_fk",
+          "tableFrom": "text_tokens",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "text_tokens_chapter_idx_uq": {
+          "name": "text_tokens_chapter_idx_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chapter_id",
+            "idx"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.texts": {
+      "name": "texts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "status_error": {
+          "name": "status_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "texts_owner_idx": {
+          "name": "texts_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "texts_visibility_idx": {
+          "name": "texts_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "texts_owner_id_users_id_fk": {
+          "name": "texts_owner_id_users_id_fk",
+          "tableFrom": "texts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.translations": {
+      "name": "translations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "translation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_translation_id": {
+          "name": "parent_translation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_language": {
+          "name": "target_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_rank": {
+          "name": "display_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "translations_lemma_idx": {
+          "name": "translations_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translations_submitted_by_idx": {
+          "name": "translations_submitted_by_idx",
+          "columns": [
+            {
+              "expression": "submitted_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translations_source_lookup_idx": {
+          "name": "translations_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "translations_lemma_id_lemmas_id_fk": {
+          "name": "translations_lemma_id_lemmas_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "translations_submitted_by_users_id_fk": {
+          "name": "translations_submitted_by_users_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "translations_parent_translation_id_translations_id_fk": {
+          "name": "translations_parent_translation_id_translations_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "translations",
+          "columnsFrom": [
+            "parent_translation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_known_lemmas": {
+      "name": "user_known_lemmas",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "known_lemma_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'learning'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_known_lemmas_user_idx": {
+          "name": "user_known_lemmas_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_known_lemmas_user_id_users_id_fk": {
+          "name": "user_known_lemmas_user_id_users_id_fk",
+          "tableFrom": "user_known_lemmas",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_known_lemmas_lemma_id_lemmas_id_fk": {
+          "name": "user_known_lemmas_lemma_id_lemmas_id_fk",
+          "tableFrom": "user_known_lemmas",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_known_lemmas_user_id_lemma_id_pk": {
+          "name": "user_known_lemmas_user_id_lemma_id_pk",
+          "columns": [
+            "user_id",
+            "lemma_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_languages": {
+      "name": "user_languages",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script_preference": {
+          "name": "script_preference",
+          "type": "script_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "romanization_scheme": {
+          "name": "romanization_scheme",
+          "type": "romanization_scheme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'iso15919'"
+        },
+        "known_words_count_cache": {
+          "name": "known_words_count_cache",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reader_layout_mode": {
+          "name": "reader_layout_mode",
+          "type": "reader_layout_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'page'"
+        },
+        "words_per_page": {
+          "name": "words_per_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 250
+        },
+        "font_family": {
+          "name": "font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_size": {
+          "name": "font_size",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 18
+        },
+        "line_spacing": {
+          "name": "line_spacing",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1.6
+        },
+        "highlight_style": {
+          "name": "highlight_style",
+          "type": "highlight_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'background'"
+        },
+        "reading_width": {
+          "name": "reading_width",
+          "type": "reading_width",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "baseline": {
+          "name": "baseline",
+          "type": "language_baseline",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_languages_user_id_users_id_fk": {
+          "name": "user_languages_user_id_users_id_fk",
+          "tableFrom": "user_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_languages_user_id_language_pk": {
+          "name": "user_languages_user_id_language_pk",
+          "columns": [
+            "user_id",
+            "language"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_text_progress": {
+      "name": "user_text_progress",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_chapter_idx": {
+          "name": "last_chapter_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_token_idx": {
+          "name": "last_token_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pct_read": {
+          "name": "pct_read",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_text_progress_user_idx": {
+          "name": "user_text_progress_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_text_progress_user_id_users_id_fk": {
+          "name": "user_text_progress_user_id_users_id_fk",
+          "tableFrom": "user_text_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_text_progress_text_id_texts_id_fk": {
+          "name": "user_text_progress_text_id_texts_id_fk",
+          "tableFrom": "user_text_progress",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_text_progress_user_id_text_id_pk": {
+          "name": "user_text_progress_user_id_text_id_pk",
+          "columns": [
+            "user_id",
+            "text_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_preference": {
+          "name": "theme_preference",
+          "type": "theme_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarded_at": {
+          "name": "onboarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    }
+  },
+  "enums": {
+    "public.highlight_style": {
+      "name": "highlight_style",
+      "schema": "public",
+      "values": [
+        "underline",
+        "background",
+        "colored_text"
+      ]
+    },
+    "public.known_lemma_status": {
+      "name": "known_lemma_status",
+      "schema": "public",
+      "values": [
+        "unknown",
+        "learning",
+        "known",
+        "ignored"
+      ]
+    },
+    "public.language": {
+      "name": "language",
+      "schema": "public",
+      "values": [
+        "hi",
+        "mr",
+        "or"
+      ]
+    },
+    "public.language_baseline": {
+      "name": "language_baseline",
+      "schema": "public",
+      "values": [
+        "none",
+        "beginner",
+        "intermediate"
+      ]
+    },
+    "public.lemma_edit_change_type": {
+      "name": "lemma_edit_change_type",
+      "schema": "public",
+      "values": [
+        "lemma_update",
+        "lemma_unlock",
+        "lemma_lock",
+        "translation_insert",
+        "translation_update",
+        "translation_hide",
+        "translation_unhide",
+        "form_insert",
+        "form_delete",
+        "lemma_merge",
+        "lemma_split",
+        "translation_reorder"
+      ]
+    },
+    "public.nlp_job_status": {
+      "name": "nlp_job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.reader_layout_mode": {
+      "name": "reader_layout_mode",
+      "schema": "public",
+      "values": [
+        "page",
+        "paged_scroll",
+        "continuous"
+      ]
+    },
+    "public.reading_width": {
+      "name": "reading_width",
+      "schema": "public",
+      "values": [
+        "narrow",
+        "medium",
+        "wide"
+      ]
+    },
+    "public.romanization_scheme": {
+      "name": "romanization_scheme",
+      "schema": "public",
+      "values": [
+        "iso15919",
+        "iast",
+        "hunterian",
+        "itrans"
+      ]
+    },
+    "public.script_preference": {
+      "name": "script_preference",
+      "schema": "public",
+      "values": [
+        "native",
+        "native_with_romanization",
+        "romanization_only"
+      ]
+    },
+    "public.text_source_type": {
+      "name": "text_source_type",
+      "schema": "public",
+      "values": [
+        "paste",
+        "txt",
+        "epub"
+      ]
+    },
+    "public.text_status": {
+      "name": "text_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.text_visibility": {
+      "name": "text_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "shared",
+        "official"
+      ]
+    },
+    "public.theme_preference": {
+      "name": "theme_preference",
+      "schema": "public",
+      "values": [
+        "system",
+        "light",
+        "dark"
+      ]
+    },
+    "public.translation_source": {
+      "name": "translation_source",
+      "schema": "public",
+      "values": [
+        "official_dictionary",
+        "curator",
+        "user"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "curator",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1777388271909,
       "tag": "0012_tired_vermin",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1777414377234,
+      "tag": "0013_tan_dragon_lord",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/src/lib/components/reader/ReaderSettings.svelte
+++ b/apps/web/src/lib/components/reader/ReaderSettings.svelte
@@ -1,0 +1,410 @@
+<!--
+  Reader settings popover (T-5.1b).
+
+  Sheet that slides in from the right (>=960px) or up from the bottom
+  on phones. Every change is applied to the parent's settings prop
+  immediately (live preview) and persisted via a debounced PATCH to
+  /api/v1/me/languages/:code so the user lands on the same setup the
+  next time they open this language.
+
+  Anonymous viewers (signed-out reads of an official text) see the
+  popover but skip the persistence path — settings live for the
+  session only.
+-->
+<script lang="ts">
+  import { untrack } from 'svelte';
+  import Sheet from '$lib/components/overlay/Sheet.svelte';
+  import {
+    DEFAULT_READER_SETTINGS,
+    FONT_SIZE_MAX,
+    FONT_SIZE_MIN,
+    LINE_SPACING_MAX,
+    LINE_SPACING_MIN,
+    WORDS_PER_PAGE_MAX,
+    WORDS_PER_PAGE_MIN,
+    clampReaderSettings,
+    recommendedFontsFor,
+    settingsDiff,
+    type ReaderSettings,
+  } from './reader-settings.js';
+  import {
+    LANGUAGES,
+    type LanguageCode,
+    type RomanizationScheme,
+  } from '@ciareader/shared-types';
+
+  interface Props {
+    open: boolean;
+    onClose: () => void;
+    language: LanguageCode;
+    settings: ReaderSettings;
+    /** Called on every change with the next settings (live preview). */
+    onChange: (next: ReaderSettings) => void;
+    /** When true, settings persist via the API; when false (anon
+     *  reads of an official text) we still live-preview but skip the
+     *  network call. */
+    canPersist?: boolean;
+    /** Override hook for tests. Real callers omit this. */
+    fetcher?: typeof fetch;
+  }
+
+  let {
+    open,
+    onClose,
+    language,
+    settings,
+    onChange,
+    canPersist = true,
+    fetcher = fetch,
+  }: Props = $props();
+
+  const recommendedFonts = $derived(recommendedFontsFor(language));
+  const supportedRomanizations = $derived(LANGUAGES[language].supportedRomanizations);
+
+  // Local mirror so a slider drag can fire onChange every tick
+  // (live preview) without re-rendering the whole popover.
+  let local = $state<ReaderSettings>(untrack(() => settings));
+  $effect(() => {
+    // Sync from props when the parent hands us a new settings ref
+    // (e.g. after a save round-trip surfacing the canonical row).
+    local = settings;
+  });
+
+  let saveTimer: number | null = null;
+  // Initialize once from the prop using untrack so the reactive
+  // graph doesn't capture a snapshot of `settings`. The prop's
+  // canonical value flows through `settings` → `$effect` → `local`;
+  // `lastPersisted` is the diff baseline and is updated by save.
+  let lastPersisted = $state<ReaderSettings>(untrack(() => settings));
+  let saveError = $state<string | null>(null);
+
+  function commit(next: ReaderSettings) {
+    const clamped = clampReaderSettings(next);
+    local = clamped;
+    onChange(clamped);
+    if (!canPersist) return;
+    if (saveTimer != null) window.clearTimeout(saveTimer);
+    saveTimer = window.setTimeout(() => {
+      saveTimer = null;
+      void persist(clamped);
+    }, 300);
+  }
+
+  async function persist(next: ReaderSettings) {
+    const diff = settingsDiff(lastPersisted, next);
+    if (Object.keys(diff).length === 0) return;
+    try {
+      const res = await fetcher(`/api/v1/me/languages/${language}`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(diff),
+      });
+      if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        saveError = text || `HTTP ${res.status}`;
+        return;
+      }
+      lastPersisted = next;
+      saveError = null;
+    } catch (err) {
+      saveError = err instanceof Error ? err.message : 'Failed to save';
+    }
+  }
+
+  function reset() {
+    commit({ ...DEFAULT_READER_SETTINGS });
+  }
+</script>
+
+<Sheet {open} {onClose} title="Reader settings" width={400}>
+  <div class="rs" data-testid="reader-settings">
+    <section>
+      <h3>Layout</h3>
+      <div class="rs-row">
+        <span class="rs-l">Mode</span>
+        <div class="rs-seg" role="group" aria-label="Reading layout mode">
+          <button
+            type="button"
+            data-active={local.readerLayoutMode === 'page' ? '1' : '0'}
+            onclick={() => commit({ ...local, readerLayoutMode: 'page' })}
+          >Page</button>
+          <button
+            type="button"
+            data-active={local.readerLayoutMode === 'paged_scroll' ? '1' : '0'}
+            onclick={() => commit({ ...local, readerLayoutMode: 'paged_scroll' })}
+          >Scroll</button>
+          <button
+            type="button"
+            data-active={local.readerLayoutMode === 'continuous' ? '1' : '0'}
+            onclick={() => commit({ ...local, readerLayoutMode: 'continuous' })}
+          >Continuous</button>
+        </div>
+      </div>
+
+      {#if local.readerLayoutMode === 'paged_scroll'}
+        <div class="rs-row">
+          <label class="rs-l" for="rs-wpp">Words / page</label>
+          <input
+            id="rs-wpp"
+            type="number"
+            min={WORDS_PER_PAGE_MIN}
+            max={WORDS_PER_PAGE_MAX}
+            step="50"
+            value={local.wordsPerPage}
+            oninput={(e) =>
+              commit({
+                ...local,
+                wordsPerPage: Number((e.target as HTMLInputElement).value),
+              })}
+          />
+        </div>
+      {/if}
+
+      <div class="rs-row">
+        <span class="rs-l">Width</span>
+        <div class="rs-seg" role="group" aria-label="Reading column width">
+          <button
+            type="button"
+            data-active={local.readingWidth === 'narrow' ? '1' : '0'}
+            onclick={() => commit({ ...local, readingWidth: 'narrow' })}
+          >Narrow</button>
+          <button
+            type="button"
+            data-active={local.readingWidth === 'medium' ? '1' : '0'}
+            onclick={() => commit({ ...local, readingWidth: 'medium' })}
+          >Medium</button>
+          <button
+            type="button"
+            data-active={local.readingWidth === 'wide' ? '1' : '0'}
+            onclick={() => commit({ ...local, readingWidth: 'wide' })}
+          >Wide</button>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h3>Typography</h3>
+      <div class="rs-row">
+        <label class="rs-l" for="rs-font">Font</label>
+        <select
+          id="rs-font"
+          value={local.fontFamily ?? ''}
+          onchange={(e) => {
+            const v = (e.target as HTMLSelectElement).value;
+            commit({ ...local, fontFamily: v === '' ? null : v });
+          }}
+        >
+          {#each recommendedFonts as opt}
+            <option value={opt ?? ''}>{opt ?? 'System default'}</option>
+          {/each}
+        </select>
+      </div>
+
+      <div class="rs-row">
+        <label class="rs-l" for="rs-size">
+          Size <span class="rs-val">{local.fontSize.toFixed(0)}pt</span>
+        </label>
+        <input
+          id="rs-size"
+          type="range"
+          min={FONT_SIZE_MIN}
+          max={FONT_SIZE_MAX}
+          step="1"
+          value={local.fontSize}
+          oninput={(e) =>
+            commit({
+              ...local,
+              fontSize: Number((e.target as HTMLInputElement).value),
+            })}
+        />
+      </div>
+
+      <div class="rs-row">
+        <label class="rs-l" for="rs-line">
+          Line spacing <span class="rs-val">{local.lineSpacing.toFixed(2)}</span>
+        </label>
+        <input
+          id="rs-line"
+          type="range"
+          min={LINE_SPACING_MIN}
+          max={LINE_SPACING_MAX}
+          step="0.05"
+          value={local.lineSpacing}
+          oninput={(e) =>
+            commit({
+              ...local,
+              lineSpacing: Number((e.target as HTMLInputElement).value),
+            })}
+        />
+      </div>
+    </section>
+
+    <section>
+      <h3>Highlight</h3>
+      <div class="rs-row">
+        <span class="rs-l">Style</span>
+        <div class="rs-seg" role="group" aria-label="Highlight style">
+          <button
+            type="button"
+            data-active={local.highlightStyle === 'background' ? '1' : '0'}
+            onclick={() => commit({ ...local, highlightStyle: 'background' })}
+          >Tint</button>
+          <button
+            type="button"
+            data-active={local.highlightStyle === 'underline' ? '1' : '0'}
+            onclick={() => commit({ ...local, highlightStyle: 'underline' })}
+          >Underline</button>
+          <button
+            type="button"
+            data-active={local.highlightStyle === 'colored_text' ? '1' : '0'}
+            onclick={() => commit({ ...local, highlightStyle: 'colored_text' })}
+          >Color</button>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h3>Romanization</h3>
+      <div class="rs-row">
+        <span class="rs-l">Show as</span>
+        <div class="rs-seg" role="group" aria-label="Script preference">
+          <button
+            type="button"
+            data-active={local.scriptPreference === 'native' ? '1' : '0'}
+            onclick={() => commit({ ...local, scriptPreference: 'native' })}
+          >Native</button>
+          <button
+            type="button"
+            data-active={local.scriptPreference === 'native_with_romanization' ? '1' : '0'}
+            onclick={() => commit({ ...local, scriptPreference: 'native_with_romanization' })}
+          >Both</button>
+          <button
+            type="button"
+            data-active={local.scriptPreference === 'romanization_only' ? '1' : '0'}
+            onclick={() => commit({ ...local, scriptPreference: 'romanization_only' })}
+          >Roman</button>
+        </div>
+      </div>
+      <div class="rs-row">
+        <label class="rs-l" for="rs-scheme">Scheme</label>
+        <select
+          id="rs-scheme"
+          value={local.romanizationScheme}
+          onchange={(e) =>
+            commit({
+              ...local,
+              romanizationScheme: (e.target as HTMLSelectElement).value as RomanizationScheme,
+            })}
+        >
+          {#each supportedRomanizations as scheme}
+            <option value={scheme}>{scheme.toUpperCase()}</option>
+          {/each}
+        </select>
+      </div>
+    </section>
+
+    <footer class="rs-foot">
+      <button type="button" class="rs-reset" onclick={reset}>Reset to defaults</button>
+      {#if saveError}
+        <p class="rs-err" role="alert">Couldn't save: {saveError}</p>
+      {/if}
+    </footer>
+  </div>
+</Sheet>
+
+<style>
+  .rs {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    padding: 0.25rem 0 1rem;
+  }
+  .rs section {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  .rs h3 {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--ink-3, var(--color-fg-muted));
+    margin: 0;
+    font-weight: 500;
+  }
+  .rs-row {
+    display: grid;
+    grid-template-columns: 7rem 1fr;
+    align-items: center;
+    gap: 0.6rem;
+  }
+  .rs-l {
+    font-size: 0.85rem;
+    color: var(--ink-2, var(--color-fg));
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.4rem;
+  }
+  .rs-val {
+    font-family: var(--font-mono-display, var(--font-mono, monospace));
+    font-size: 0.7rem;
+    color: var(--ink-3, var(--color-fg-muted));
+    font-feature-settings: 'tnum';
+  }
+  .rs-seg {
+    display: flex;
+    background: var(--card-2, var(--color-bg));
+    border: 1px solid var(--card-edge, var(--color-border));
+    border-radius: 6px;
+    overflow: hidden;
+  }
+  .rs-seg button {
+    flex: 1;
+    background: transparent;
+    border: 0;
+    padding: 0.4rem 0.55rem;
+    font-size: 0.78rem;
+    color: var(--ink-2, var(--color-fg));
+    cursor: pointer;
+  }
+  .rs-seg button[data-active='1'] {
+    background: var(--accent-soft, color-mix(in oklch, var(--accent, var(--color-accent)) 18%, transparent));
+    color: var(--accent-ink, var(--color-fg));
+    font-weight: 500;
+  }
+  input[type='range'] {
+    width: 100%;
+  }
+  input[type='number'],
+  select {
+    width: 100%;
+    padding: 0.35rem 0.5rem;
+    border-radius: 5px;
+    border: 1px solid var(--card-edge, var(--color-border));
+    background: var(--card, var(--color-bg));
+    color: var(--ink, var(--color-fg));
+    font-size: 0.85rem;
+  }
+  .rs-foot {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    margin-top: 0.5rem;
+  }
+  .rs-reset {
+    align-self: flex-start;
+    background: transparent;
+    border: 0;
+    color: var(--ink-3, var(--color-fg-muted));
+    font-size: 0.78rem;
+    padding: 0.2rem 0;
+    cursor: pointer;
+    text-decoration: underline;
+  }
+  .rs-err {
+    margin: 0;
+    color: var(--err, #b94545);
+    font-size: 0.78rem;
+  }
+</style>

--- a/apps/web/src/lib/components/reader/reader-settings.test.ts
+++ b/apps/web/src/lib/components/reader/reader-settings.test.ts
@@ -1,0 +1,106 @@
+// @vitest-environment node
+/**
+ * Tests for the reader-settings helpers (T-5.1b).
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_READER_SETTINGS,
+  FONT_SIZE_MAX,
+  FONT_SIZE_MIN,
+  LINE_SPACING_MAX,
+  LINE_SPACING_MIN,
+  READING_WIDTH_REM,
+  WORDS_PER_PAGE_MAX,
+  WORDS_PER_PAGE_MIN,
+  clampReaderSettings,
+  recommendedFontsFor,
+  settingsDiff,
+} from './reader-settings.js';
+
+describe('clampReaderSettings', () => {
+  it('clamps fontSize / lineSpacing / wordsPerPage into their allowed ranges', () => {
+    const r = clampReaderSettings({
+      ...DEFAULT_READER_SETTINGS,
+      fontSize: 9,
+      lineSpacing: 0.5,
+      wordsPerPage: 5,
+    });
+    expect(r.fontSize).toBe(FONT_SIZE_MIN);
+    expect(r.lineSpacing).toBe(LINE_SPACING_MIN);
+    expect(r.wordsPerPage).toBe(WORDS_PER_PAGE_MIN);
+  });
+
+  it('clamps an over-range value to the upper bound', () => {
+    const r = clampReaderSettings({
+      ...DEFAULT_READER_SETTINGS,
+      fontSize: 99,
+      lineSpacing: 5,
+      wordsPerPage: 9999,
+    });
+    expect(r.fontSize).toBe(FONT_SIZE_MAX);
+    expect(r.lineSpacing).toBe(LINE_SPACING_MAX);
+    expect(r.wordsPerPage).toBe(WORDS_PER_PAGE_MAX);
+  });
+
+  it('rounds wordsPerPage to a whole integer', () => {
+    const r = clampReaderSettings({
+      ...DEFAULT_READER_SETTINGS,
+      wordsPerPage: 247.6,
+    });
+    expect(r.wordsPerPage).toBe(248);
+  });
+
+  it('passes a valid setting through unchanged', () => {
+    const r = clampReaderSettings(DEFAULT_READER_SETTINGS);
+    expect(r).toEqual(DEFAULT_READER_SETTINGS);
+  });
+});
+
+describe('settingsDiff', () => {
+  it('returns an empty object when the two settings match', () => {
+    expect(settingsDiff(DEFAULT_READER_SETTINGS, DEFAULT_READER_SETTINGS)).toEqual({});
+  });
+
+  it('returns only the fields that changed', () => {
+    const next = {
+      ...DEFAULT_READER_SETTINGS,
+      fontSize: 22,
+      readingWidth: 'wide' as const,
+    };
+    expect(settingsDiff(DEFAULT_READER_SETTINGS, next)).toEqual({
+      fontSize: 22,
+      readingWidth: 'wide',
+    });
+  });
+
+  it('reports null fontFamily transitions explicitly', () => {
+    const prev = { ...DEFAULT_READER_SETTINGS, fontFamily: 'Mukta' };
+    const next = { ...DEFAULT_READER_SETTINGS, fontFamily: null };
+    expect(settingsDiff(prev, next)).toEqual({ fontFamily: null });
+  });
+});
+
+describe('recommendedFontsFor', () => {
+  it('prepends a null option (= system default) ahead of the registry list', () => {
+    const list = recommendedFontsFor('hi');
+    expect(list[0]).toBeNull();
+    expect(list.slice(1)).toEqual(
+      expect.arrayContaining(['Noto Serif Devanagari', 'Mukta']),
+    );
+  });
+
+  it('returns an Odia-specific shortlist for or', () => {
+    const list = recommendedFontsFor('or');
+    expect(list).toContain('Noto Sans Oriya');
+    // Must not leak Devanagari fonts into Odia.
+    expect(list).not.toContain('Mukta');
+  });
+});
+
+describe('READING_WIDTH_REM', () => {
+  it('orders narrow < medium < wide', () => {
+    expect(READING_WIDTH_REM.narrow).toBeLessThan(READING_WIDTH_REM.medium);
+    expect(READING_WIDTH_REM.medium).toBeLessThan(READING_WIDTH_REM.wide);
+  });
+});

--- a/apps/web/src/lib/components/reader/reader-settings.ts
+++ b/apps/web/src/lib/components/reader/reader-settings.ts
@@ -1,0 +1,106 @@
+/**
+ * Reader settings — types + helpers (T-5.1b).
+ *
+ * The reader popover (`ReaderSettings.svelte`) and the reader page
+ * loader both speak this shape. Defaults match the
+ * `user_languages` column defaults so a brand-new (user, language)
+ * pair gets a coherent reader before they ever touch the popover.
+ */
+import {
+  LANGUAGES,
+  type LanguageCode,
+  type RomanizationScheme,
+} from '@ciareader/shared-types';
+
+export type ReaderLayoutMode = 'page' | 'paged_scroll' | 'continuous';
+export type HighlightStyle = 'underline' | 'background' | 'colored_text';
+export type ReadingWidth = 'narrow' | 'medium' | 'wide';
+export type ScriptPreference =
+  | 'native'
+  | 'native_with_romanization'
+  | 'romanization_only';
+
+export interface ReaderSettings {
+  readerLayoutMode: ReaderLayoutMode;
+  wordsPerPage: number;
+  fontFamily: string | null;
+  fontSize: number;
+  lineSpacing: number;
+  highlightStyle: HighlightStyle;
+  readingWidth: ReadingWidth;
+  scriptPreference: ScriptPreference;
+  romanizationScheme: RomanizationScheme;
+}
+
+export const FONT_SIZE_MIN = 14;
+export const FONT_SIZE_MAX = 28;
+export const LINE_SPACING_MIN = 1.2;
+export const LINE_SPACING_MAX = 2.2;
+export const WORDS_PER_PAGE_MIN = 50;
+export const WORDS_PER_PAGE_MAX = 1000;
+
+/** Match the user_languages column defaults so an unauth'd reader,
+ *  or a user who hasn't customized this language, gets a sensible
+ *  starting point. */
+export const DEFAULT_READER_SETTINGS: ReaderSettings = {
+  readerLayoutMode: 'page',
+  wordsPerPage: 250,
+  fontFamily: null,
+  fontSize: 18,
+  lineSpacing: 1.6,
+  highlightStyle: 'background',
+  readingWidth: 'medium',
+  scriptPreference: 'native',
+  romanizationScheme: 'iso15919',
+};
+
+/** Map readingWidth → reader-page max-width in rem. The reader's
+ *  `--reader-col-width` CSS variable consumes this. */
+export const READING_WIDTH_REM: Record<ReadingWidth, number> = {
+  narrow: 32,
+  medium: 40,
+  wide: 56,
+};
+
+/** Pull the language's recommended-fonts shortlist from the shared
+ *  registry. Always includes a `null` (system default) at the head so
+ *  the popover can offer "use the script's default". */
+export function recommendedFontsFor(language: LanguageCode): Array<string | null> {
+  const list = LANGUAGES[language].recommendedFonts;
+  return [null, ...list];
+}
+
+/** Clamp a numeric setting into its allowed range. Used when the
+ *  popover hands a slider value back so a coercion bug never
+ *  persists an out-of-range row. */
+export function clampReaderSettings(s: ReaderSettings): ReaderSettings {
+  return {
+    ...s,
+    fontSize: Math.min(FONT_SIZE_MAX, Math.max(FONT_SIZE_MIN, s.fontSize)),
+    lineSpacing: Math.min(
+      LINE_SPACING_MAX,
+      Math.max(LINE_SPACING_MIN, s.lineSpacing),
+    ),
+    wordsPerPage: Math.min(
+      WORDS_PER_PAGE_MAX,
+      Math.max(WORDS_PER_PAGE_MIN, Math.round(s.wordsPerPage)),
+    ),
+  };
+}
+
+/** Diff two settings objects — returns only the fields that changed.
+ *  The popover uses this to send partial PATCH bodies, so the
+ *  default-only path stays a no-op. */
+export function settingsDiff(
+  prev: ReaderSettings,
+  next: ReaderSettings,
+): Partial<ReaderSettings> {
+  const out: Partial<ReaderSettings> = {};
+  (Object.keys(next) as Array<keyof ReaderSettings>).forEach((k) => {
+    if (prev[k] !== next[k]) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (out as any)[k] = next[k];
+    }
+  });
+  return out;
+}

--- a/apps/web/src/lib/server/db/schema.ts
+++ b/apps/web/src/lib/server/db/schema.ts
@@ -57,6 +57,18 @@ export const highlightStyle = pgEnum('highlight_style', [
 ]);
 
 /**
+ * Per-user reading column width. Drives the max-width of the reader's
+ * text column — narrow for tight focus, wide for laptop-screen full-
+ * bleed. Stored per-language so a user can prefer wider columns for
+ * Devanagari and tighter for Odia (or vice versa). T-5.1b.
+ */
+export const readingWidth = pgEnum('reading_width', [
+  'narrow',
+  'medium',
+  'wide',
+]);
+
+/**
  * Assumed-known baseline captured during onboarding. Used in a future
  * ticket to seed `user_known_lemmas` against frequency_rank buckets —
  * `beginner` pre-marks the top-100 most-frequent lemmas as 'known',
@@ -178,6 +190,7 @@ export const userLanguages = pgTable(
     fontSize: real('font_size').notNull().default(18),
     lineSpacing: real('line_spacing').notNull().default(1.6),
     highlightStyle: highlightStyle('highlight_style').notNull().default('background'),
+    readingWidth: readingWidth('reading_width').notNull().default('medium'),
     baseline: languageBaseline('baseline').notNull().default('none'),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),

--- a/apps/web/src/lib/server/profile.test.ts
+++ b/apps/web/src/lib/server/profile.test.ts
@@ -159,4 +159,49 @@ describe('upsertUserLanguage', () => {
     expect(row).toBe(existing);
     expect(fakeDb.update).not.toHaveBeenCalled();
   });
+
+  it('writes T-5.1b reader-popover columns when supplied', async () => {
+    chain.limit.mockReturnValueOnce([{ userId: 'u1', language: 'hi' }]);
+    const updated = {
+      userId: 'u1',
+      language: 'hi',
+      readerLayoutMode: 'page',
+      fontSize: 22,
+      readingWidth: 'wide',
+    };
+    chain.returning.mockReturnValueOnce([updated]);
+    await upsertUserLanguage('u1', 'hi', {
+      readerLayoutMode: 'page',
+      fontSize: 22,
+      readingWidth: 'wide',
+      fontFamily: 'Mukta',
+    });
+    const setArg = chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(setArg.readerLayoutMode).toBe('page');
+    expect(setArg.fontSize).toBe(22);
+    expect(setArg.readingWidth).toBe('wide');
+    expect(setArg.fontFamily).toBe('Mukta');
+    // Untouched fields stay out of the SET clause so we don't keep
+    // bumping defaults for no reason.
+    expect('lineSpacing' in setArg).toBe(false);
+  });
+
+  it('inserts T-5.1b reader-popover columns on first save', async () => {
+    chain.limit.mockReturnValueOnce([]);
+    chain.returning.mockReturnValueOnce([
+      {
+        userId: 'u1',
+        language: 'hi',
+        fontSize: 24,
+        readingWidth: 'narrow',
+      },
+    ]);
+    await upsertUserLanguage('u1', 'hi', {
+      fontSize: 24,
+      readingWidth: 'narrow',
+    });
+    const insertArg = chain.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(insertArg.fontSize).toBe(24);
+    expect(insertArg.readingWidth).toBe('narrow');
+  });
 });

--- a/apps/web/src/lib/server/profile.ts
+++ b/apps/web/src/lib/server/profile.ts
@@ -14,6 +14,17 @@ export type ProfileUserPatch = {
 export type UserLanguagePatch = {
   scriptPreference?: UserLanguage['scriptPreference'];
   romanizationScheme?: UserLanguage['romanizationScheme'];
+  // T-5.1b reader settings — every reader-popover field writes back
+  // here. None are required; absent keys leave the existing column
+  // untouched so partial updates from the popover work without
+  // re-stating untouched values.
+  readerLayoutMode?: UserLanguage['readerLayoutMode'];
+  wordsPerPage?: UserLanguage['wordsPerPage'];
+  fontFamily?: UserLanguage['fontFamily'];
+  fontSize?: UserLanguage['fontSize'];
+  lineSpacing?: UserLanguage['lineSpacing'];
+  highlightStyle?: UserLanguage['highlightStyle'];
+  readingWidth?: UserLanguage['readingWidth'];
 };
 
 export async function updateUserProfile(
@@ -74,14 +85,25 @@ export async function upsertUserLanguage(
     .limit(1);
 
   if (existing.length === 0) {
+    type InsertValues = typeof schema.userLanguages.$inferInsert;
+    const insertValues: InsertValues = {
+      userId,
+      language: languageCode,
+      scriptPreference: patch.scriptPreference ?? 'native',
+      romanizationScheme: patch.romanizationScheme ?? 'iso15919',
+    };
+    // Reader settings (T-5.1b) — only set when the patch explicitly
+    // provided one; otherwise let the column default kick in.
+    if (patch.readerLayoutMode !== undefined) insertValues.readerLayoutMode = patch.readerLayoutMode;
+    if (patch.wordsPerPage !== undefined) insertValues.wordsPerPage = patch.wordsPerPage;
+    if (patch.fontFamily !== undefined) insertValues.fontFamily = patch.fontFamily;
+    if (patch.fontSize !== undefined) insertValues.fontSize = patch.fontSize;
+    if (patch.lineSpacing !== undefined) insertValues.lineSpacing = patch.lineSpacing;
+    if (patch.highlightStyle !== undefined) insertValues.highlightStyle = patch.highlightStyle;
+    if (patch.readingWidth !== undefined) insertValues.readingWidth = patch.readingWidth;
     const [row] = await db
       .insert(schema.userLanguages)
-      .values({
-        userId,
-        language: languageCode,
-        scriptPreference: patch.scriptPreference ?? 'native',
-        romanizationScheme: patch.romanizationScheme ?? 'iso15919',
-      })
+      .values(insertValues)
       .returning();
     if (!row) throw new Error('insert returned no row');
     return row;
@@ -94,6 +116,13 @@ export async function upsertUserLanguage(
   if (patch.romanizationScheme !== undefined) {
     setClause.romanizationScheme = patch.romanizationScheme;
   }
+  if (patch.readerLayoutMode !== undefined) setClause.readerLayoutMode = patch.readerLayoutMode;
+  if (patch.wordsPerPage !== undefined) setClause.wordsPerPage = patch.wordsPerPage;
+  if (patch.fontFamily !== undefined) setClause.fontFamily = patch.fontFamily;
+  if (patch.fontSize !== undefined) setClause.fontSize = patch.fontSize;
+  if (patch.lineSpacing !== undefined) setClause.lineSpacing = patch.lineSpacing;
+  if (patch.highlightStyle !== undefined) setClause.highlightStyle = patch.highlightStyle;
+  if (patch.readingWidth !== undefined) setClause.readingWidth = patch.readingWidth;
   if (Object.keys(setClause).length === 1) return existingRow; // only updatedAt — no-op
 
   const [updated] = await db

--- a/apps/web/src/routes/api/v1/me/languages/[code]/+server.ts
+++ b/apps/web/src/routes/api/v1/me/languages/[code]/+server.ts
@@ -14,14 +14,21 @@ const patchSchema = z
   .object({
     scriptPreference: z.enum(['native', 'native_with_romanization', 'romanization_only']),
     romanizationScheme: z.enum(['iso15919', 'iast', 'hunterian', 'itrans']),
+    // T-5.1b reader-popover fields. All optional; the popover sends
+    // a partial diff against the loader-provided baseline so we
+    // don't keep rewriting columns the user didn't touch.
+    readerLayoutMode: z.enum(['page', 'paged_scroll', 'continuous']),
+    wordsPerPage: z.number().int().min(50).max(1000),
+    fontFamily: z.string().min(1).max(80).nullable(),
+    fontSize: z.number().min(14).max(28),
+    lineSpacing: z.number().min(1.2).max(2.2),
+    highlightStyle: z.enum(['underline', 'background', 'colored_text']),
+    readingWidth: z.enum(['narrow', 'medium', 'wide']),
   })
   .partial()
-  .refine(
-    (v) => v.scriptPreference !== undefined || v.romanizationScheme !== undefined,
-    {
-      message: 'At least one field must be provided',
-    },
-  );
+  .refine((v) => Object.keys(v).length > 0, {
+    message: 'At least one field must be provided',
+  });
 
 export const PATCH: RequestHandler = async (event) => {
   const user = await requireUser(event);

--- a/apps/web/src/routes/api/v1/me/languages/[code]/code-server.test.ts
+++ b/apps/web/src/routes/api/v1/me/languages/[code]/code-server.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment node
+/**
+ * Route tests for PATCH /api/v1/me/languages/:code (T-5.1b extends).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const upsertUserLanguage = vi.fn();
+const requireUser = vi.fn();
+
+vi.mock('$lib/server/profile.js', () => ({
+  upsertUserLanguage: (...a: unknown[]) => upsertUserLanguage(...a),
+}));
+
+vi.mock('$lib/server/auth/require-user.js', () => ({
+  requireUser: (...a: unknown[]) => requireUser(...a),
+}));
+
+type Patch = (typeof import('./+server.js'))['PATCH'];
+
+async function callPatch(code: string, body: unknown) {
+  const { PATCH } = await import('./+server.js');
+  const event = {
+    params: { code },
+    locals: { user: { id: 'u1' } },
+    request: new Request('http://x/api/v1/me/languages/' + code, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+  } as unknown as Parameters<Patch>[0];
+  try {
+    return (await PATCH(event)) as Response;
+  } catch (e) {
+    return e as { status: number };
+  }
+}
+
+beforeEach(() => {
+  upsertUserLanguage.mockReset();
+  upsertUserLanguage.mockImplementation(async (_id, code, patch) => ({
+    userId: 'u1',
+    language: code,
+    ...patch,
+  }));
+  requireUser.mockReset();
+  requireUser.mockResolvedValue({ id: 'u1' });
+});
+
+afterEach(() => vi.resetModules());
+
+describe('PATCH /api/v1/me/languages/:code', () => {
+  it('accepts a reader-settings patch with multiple fields', async () => {
+    const res = (await callPatch('hi', {
+      readerLayoutMode: 'continuous',
+      fontSize: 22,
+      lineSpacing: 1.8,
+      readingWidth: 'wide',
+      highlightStyle: 'underline',
+      wordsPerPage: 300,
+    })) as Response;
+    expect(res.status).toBe(200);
+    expect(upsertUserLanguage).toHaveBeenCalledWith(
+      'u1',
+      'hi',
+      expect.objectContaining({
+        readerLayoutMode: 'continuous',
+        fontSize: 22,
+        readingWidth: 'wide',
+      }),
+    );
+  });
+
+  it('accepts a fontFamily=null patch (= revert to system default)', async () => {
+    const res = (await callPatch('hi', { fontFamily: null })) as Response;
+    expect(res.status).toBe(200);
+    expect(upsertUserLanguage).toHaveBeenCalledWith(
+      'u1',
+      'hi',
+      expect.objectContaining({ fontFamily: null }),
+    );
+  });
+
+  it('rejects an out-of-range fontSize with 400', async () => {
+    const res = (await callPatch('hi', { fontSize: 99 })) as { status: number };
+    expect(res.status).toBe(400);
+    expect(upsertUserLanguage).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty body with 400', async () => {
+    const res = (await callPatch('hi', {})) as { status: number };
+    expect(res.status).toBe(400);
+    expect(upsertUserLanguage).not.toHaveBeenCalled();
+  });
+
+  it('still accepts the legacy scriptPreference + romanizationScheme fields', async () => {
+    const res = (await callPatch('hi', {
+      scriptPreference: 'native_with_romanization',
+      romanizationScheme: 'iast',
+    })) as Response;
+    expect(res.status).toBe(200);
+  });
+
+  it('400s when romanization scheme is unsupported for the language', async () => {
+    // Odia (or) does not support hunterian per the registry.
+    const res = (await callPatch('or', {
+      romanizationScheme: 'hunterian',
+    })) as { status: number };
+    expect(res.status).toBe(400);
+    expect(upsertUserLanguage).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/routes/reader/[textId]/+page.server.ts
+++ b/apps/web/src/routes/reader/[textId]/+page.server.ts
@@ -19,10 +19,17 @@
  * known-words affordances (T-5.5).
  */
 import { error } from '@sveltejs/kit';
+import { and, eq } from 'drizzle-orm';
 
 import { getReadableText } from '$lib/server/texts/upload.js';
 import { loadChapterTokens } from '$lib/server/texts/tokens.js';
 import { getTextProgress } from '$lib/server/texts/progress.js';
+import { db, schema } from '$lib/server/db/index.js';
+import type { LanguageCode } from '@ciareader/shared-types';
+import {
+  DEFAULT_READER_SETTINGS,
+  type ReaderSettings,
+} from '$lib/components/reader/reader-settings.js';
 import type { PageServerLoad } from './$types';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -92,12 +99,45 @@ export const load: PageServerLoad = async ({ params, locals, url }) => {
     ),
   );
 
-  // Mode preference: URL > user pref > default. user_languages.reader_layout_mode
-  // is per-user/per-language; the per-user pref read lands when M5
-  // wires user-pref persistence (T-5.1b). For the skeleton the URL is
-  // the only source.
-  const mode = readMode(url, 'continuous');
-  const showRomanization = readBool(url, 'roman');
+  // T-5.1b: per-language reader settings are persisted in
+  // user_languages. Anonymous viewers don't have a row, so they get
+  // the defaults. Owners + signed-in readers get their saved popover
+  // values; the popover writes through PATCH /api/v1/me/languages/:code.
+  let readerSettings: ReaderSettings = { ...DEFAULT_READER_SETTINGS };
+  if (locals.user) {
+    const lang = result.text.language as LanguageCode;
+    const [row] = await db
+      .select()
+      .from(schema.userLanguages)
+      .where(
+        and(
+          eq(schema.userLanguages.userId, locals.user.id),
+          eq(schema.userLanguages.language, lang),
+        ),
+      )
+      .limit(1);
+    if (row) {
+      readerSettings = {
+        readerLayoutMode: row.readerLayoutMode,
+        wordsPerPage: row.wordsPerPage,
+        fontFamily: row.fontFamily,
+        fontSize: row.fontSize,
+        lineSpacing: row.lineSpacing,
+        highlightStyle: row.highlightStyle,
+        readingWidth: row.readingWidth,
+        scriptPreference: row.scriptPreference,
+        romanizationScheme: row.romanizationScheme,
+      };
+    }
+  }
+
+  // Mode preference: URL > user pref > default. URL still wins so a
+  // shareable `?mode=page` link works regardless of the recipient's
+  // saved preference. Romanization toggle: URL > scriptPreference.
+  const mode = readMode(url, readerSettings.readerLayoutMode);
+  const showRomanization = url.searchParams.has('roman')
+    ? readBool(url, 'roman')
+    : readerSettings.scriptPreference !== 'native';
 
   // T-5.1a: lazy chapter loading. Only the active chapter is
   // pre-fetched server-side — a 50-chapter novel was previously
@@ -143,6 +183,11 @@ export const load: PageServerLoad = async ({ params, locals, url }) => {
     },
     mode,
     showRomanization,
+    readerSettings,
+    // Persist the popover's per-language state for any signed-in
+    // reader; anonymous viewers (anon reads of an official text) get
+    // a session-only live preview.
+    canPersistSettings: locals.user != null,
     isOwner: Boolean(locals.user && locals.user.id === result.text.ownerId),
   };
 };

--- a/apps/web/src/routes/reader/[textId]/+page.svelte
+++ b/apps/web/src/routes/reader/[textId]/+page.svelte
@@ -5,12 +5,18 @@
   import ReaderContinuous from '$lib/components/reader/ReaderContinuous.svelte';
   import ReaderPage from '$lib/components/reader/ReaderPage.svelte';
   import ReaderScroll from '$lib/components/reader/ReaderScroll.svelte';
+  import ReaderSettings from '$lib/components/reader/ReaderSettings.svelte';
   import { ProgressWriter } from '$lib/components/reader/progress-client.js';
   import {
     isImmersiveAttributeSet,
     setImmersiveAttribute,
     writePersistedImmersive,
   } from '$lib/components/reader/immersive.js';
+  import {
+    READING_WIDTH_REM,
+    type ReaderSettings as ReaderSettingsT,
+  } from '$lib/components/reader/reader-settings.js';
+  import type { LanguageCode } from '@ciareader/shared-types';
   import type { PageData } from './$types';
 
   let { data }: { data: PageData } = $props();
@@ -38,6 +44,34 @@
   $effect(() => {
     showRomanization = data.showRomanization;
   });
+
+  // T-5.1b: live reader settings. Seeded from the server-loaded
+  // user_languages row; the popover updates this state on every
+  // interaction (live preview) and PATCHes the row in the background.
+  let readerSettings = $state<ReaderSettingsT>(
+    untrack(() => data.readerSettings),
+  );
+  $effect(() => {
+    readerSettings = data.readerSettings;
+  });
+  let settingsOpen = $state(false);
+
+  // CSS-variable string applied to the reader root so every reader
+  // mode picks up the setting without each one having to know about
+  // every CSS variable. Keeping the math in JS lets the popover's
+  // live-preview path skip a layout-thrashing class swap.
+  const readerStyle = $derived(
+    [
+      `--reader-font-size: ${readerSettings.fontSize}pt`,
+      `--reader-line-height: ${readerSettings.lineSpacing}`,
+      `--reader-col-width: ${READING_WIDTH_REM[readerSettings.readingWidth]}rem`,
+      readerSettings.fontFamily
+        ? `--reader-font-family: '${readerSettings.fontFamily.replace(/'/g, "\\'")}'`
+        : '',
+    ]
+      .filter(Boolean)
+      .join('; '),
+  );
 
   function shouldPoll(s: typeof data.text.status): boolean {
     return s === 'pending' || s === 'processing';
@@ -179,7 +213,12 @@
   <title>{data.text.title} — CIA Reader</title>
 </svelte:head>
 
-<div class="reader" data-mode={data.mode}>
+<div
+  class="reader"
+  data-mode={data.mode}
+  data-hl={readerSettings.highlightStyle}
+  style={readerStyle}
+>
   <header class="reader-top">
     <a class="reader-close" href="/library" aria-label="Close reader" title="Close reader">
       <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true">
@@ -232,6 +271,20 @@
         Aa
       </button>
 
+      <button
+        type="button"
+        class="settings-toggle"
+        onclick={() => (settingsOpen = true)}
+        aria-label="Reader settings"
+        aria-expanded={settingsOpen}
+        title="Reader settings"
+      >
+        <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <circle cx="12" cy="12" r="3" />
+          <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33 1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82 1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+        </svg>
+      </button>
+
       <!-- T-5.26 moved the immersive / hide-chrome toggle to the
            AppShell rail (a hamburger glyph) — it's globally available
            now, not just from the reader top bar. -->
@@ -255,6 +308,7 @@
     <ReaderScroll
       chapters={data.chapters}
       chapterIdx={data.anchor.chapterIdx}
+      wordsPerPage={readerSettings.wordsPerPage}
       {showRomanization}
       isOwner={data.isOwner}
     />
@@ -268,6 +322,15 @@
     />
   {/if}
 </div>
+
+<ReaderSettings
+  open={settingsOpen}
+  onClose={() => (settingsOpen = false)}
+  language={data.text.language as LanguageCode}
+  settings={readerSettings}
+  onChange={(next) => (readerSettings = next)}
+  canPersist={data.canPersistSettings}
+/>
 
 <style>
   /* CIAR design reader chrome (T-5.9). Paper background + serif title.

--- a/apps/web/src/routes/reader/[textId]/page-server.test.ts
+++ b/apps/web/src/routes/reader/[textId]/page-server.test.ts
@@ -39,6 +39,32 @@ vi.mock('$lib/server/texts/progress.js', async () => {
   };
 });
 
+// T-5.1b: the loader looks up user_languages directly. Mock the
+// drizzle query chain to return whatever the test stages in
+// `userLanguagesRow`.
+let userLanguagesRow: Record<string, unknown> | null = null;
+vi.mock('$lib/server/db/index.js', () => {
+  type ChainShape = {
+    from: ReturnType<typeof vi.fn>;
+    where: ReturnType<typeof vi.fn>;
+    limit: ReturnType<typeof vi.fn>;
+  };
+  const chain: ChainShape = {
+    from: vi.fn(() => chain),
+    where: vi.fn(() => chain),
+    limit: vi.fn(() => (userLanguagesRow ? [userLanguagesRow] : [])),
+  };
+  return {
+    db: { select: vi.fn(() => chain) },
+    schema: {
+      userLanguages: {
+        userId: 'ul.user_id',
+        language: 'ul.language',
+      },
+    },
+  };
+});
+
 type LoadFn = (typeof import('./+page.server.js'))['load'];
 
 const VALID_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
@@ -95,6 +121,8 @@ beforeEach(() => {
   loadChapterTokens.mockResolvedValue(null);
   // No saved progress unless a test stages it.
   getTextProgress.mockResolvedValue(null);
+  // No persisted reader settings unless a test stages a row.
+  userLanguagesRow = null;
 });
 
 afterEach(() => {
@@ -110,7 +138,9 @@ describe('/reader/[textId] loader', () => {
       isOwner: boolean;
     };
     expect(data.anchor).toEqual({ chapterIdx: 0, tokenIdx: 0 });
-    expect(data.mode).toBe('continuous');
+    // Default reader_layout_mode is 'page' (matches the user_languages
+    // column default — T-5.1b's loader reads through to that default).
+    expect(data.mode).toBe('page');
     expect(data.isOwner).toBe(true);
   });
 
@@ -143,7 +173,57 @@ describe('/reader/[textId] loader', () => {
     const data = (await callLoad(
       `http://x/reader/${VALID_ID}?mode=garbage`,
     )) as { mode: string };
+    expect(data.mode).toBe('page');
+  });
+
+  it('uses the saved reader_layout_mode from user_languages when no ?mode is given (T-5.1b)', async () => {
+    getReadableText.mockResolvedValueOnce(ownedTextWithChapters(1));
+    userLanguagesRow = {
+      readerLayoutMode: 'continuous',
+      wordsPerPage: 250,
+      fontFamily: null,
+      fontSize: 18,
+      lineSpacing: 1.6,
+      highlightStyle: 'background',
+      readingWidth: 'medium',
+      scriptPreference: 'native',
+      romanizationScheme: 'iso15919',
+    };
+    const data = (await callLoad(`http://x/reader/${VALID_ID}`)) as {
+      mode: string;
+      readerSettings: { readerLayoutMode: string; readingWidth: string };
+    };
     expect(data.mode).toBe('continuous');
+    expect(data.readerSettings.readerLayoutMode).toBe('continuous');
+  });
+
+  it('exposes a default readerSettings when the user has no user_languages row (T-5.1b)', async () => {
+    getReadableText.mockResolvedValueOnce(ownedTextWithChapters(1));
+    const data = (await callLoad(`http://x/reader/${VALID_ID}`)) as {
+      readerSettings: { fontSize: number; readingWidth: string };
+    };
+    expect(data.readerSettings.fontSize).toBe(18);
+    expect(data.readerSettings.readingWidth).toBe('medium');
+  });
+
+  it('marks canPersistSettings true for signed-in users and false for anon (T-5.1b)', async () => {
+    getReadableText.mockResolvedValueOnce(ownedTextWithChapters(1));
+    const signedIn = (await callLoad(`http://x/reader/${VALID_ID}`)) as {
+      canPersistSettings: boolean;
+    };
+    expect(signedIn.canPersistSettings).toBe(true);
+
+    const fixture = ownedTextWithChapters(1);
+    getReadableText.mockResolvedValueOnce({
+      ...fixture,
+      text: { ...fixture.text, ownerId: null, visibility: 'official' },
+    });
+    const anon = (await callLoad(
+      `http://x/reader/${VALID_ID}`,
+      VALID_ID,
+      null,
+    )) as { canPersistSettings: boolean };
+    expect(anon.canPersistSettings).toBe(false);
   });
 
   it('rejects an invalid uuid with 400 before calling the service', async () => {


### PR DESCRIPTION
> Stacked on #220 (T-5.1a). Merge that first.

## Summary

A gear icon in the reader top bar opens a Sheet popover covering every per-language reader knob: layout mode, words-per-page, font family (driven by the language registry's \`recommendedFonts\`), font size (14-28pt), line spacing (1.2-2.2), reading width (narrow/medium/wide), highlight style, and the existing script-preference + romanization-scheme rows. Each change is applied to the reader live via CSS variables and written through to \`user_languages\` with a 300ms debounced PATCH.

- **Schema**: new \`reading_width\` enum + \`user_languages.reading_width\` column (migration \`0013_tan_dragon_lord.sql\`). \`UserLanguagePatch\` and \`upsertUserLanguage\` extended to cover every reader column.
- **Loader**: \`/reader/[textId]\` now reads the user_languages row for the text's language as the baseline. Anonymous viewers (signed-out reads of an official text) still get the popover for live preview; \`canPersistSettings=false\` suppresses the network write.
- **API**: \`PATCH /api/v1/me/languages/:code\` accepts the new fields with zod range checks (fontSize 14-28, lineSpacing 1.2-2.2, wordsPerPage 50-1000, etc.).
- **Default mode**: now follows \`user_languages.reader_layout_mode\` default ('page'), not the previous hardcoded 'continuous'. URL still wins so a shareable \`?mode=page\` link works regardless of the recipient's saved preference.

Closes #45.

## Test plan

- [x] \`pnpm --filter @ciareader/web test\` — 91 files / 736 tests pass, including:
  - \`reader-settings.test.ts\` (10 tests) — clamps, diffs, font shortlist per language.
  - \`code-server.test.ts\` (6 tests) — PATCH endpoint accepts new fields, rejects out-of-range values, validates romanization-scheme support.
  - \`profile.test.ts\` — added 2 tests for reader-popover columns on insert + update.
  - \`page-server.test.ts\` — 3 new tests for user_languages-driven mode + readerSettings + canPersistSettings.
- [x] \`pnpm --filter @ciareader/web typecheck\` — 0 errors / 0 warnings.
- [x] \`pnpm --filter @ciareader/web lint\` — clean.

## Out of scope

- Font family lazy-loading per script — the registry hands the popover a name shortlist; the actual font @import lives in the global stylesheet (already loaded). Lazy per-script font loading can land if the bundle ever gets heavy.
- The reader's \`data-hl\` attribute now exposes the highlight style; the existing tokens.css rules already handle 'background' / 'underline' modes; the 'colored_text' branch wires through but currently inherits 'background' visuals — a follow-up CSS-only change.