### PR TITLE
T-5.1c: mobile reader ergonomics

### DIFF
--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -66,6 +66,8 @@ export default [
         ResizeObserver: 'readonly',
         // Continuous-mode lazy chapter loading (T-5.1a).
         IntersectionObserver: 'readonly',
+        // Mobile reader gestures (T-5.1c).
+        TouchEvent: 'readonly',
       },
     },
   },

--- a/apps/web/src/lib/components/overlay/Sheet.svelte
+++ b/apps/web/src/lib/components/overlay/Sheet.svelte
@@ -15,6 +15,7 @@
   import { activateFocusTrap, type FocusTrap } from './focus-trap.js';
   import { portal } from './portal.js';
   import { lockScroll } from './scroll-lock.js';
+  import { attachKeyboardInsetTracker } from '$lib/components/reader/keyboard-inset.js';
 
   interface Props {
     open: boolean;
@@ -45,6 +46,10 @@
   let panelEl: HTMLDivElement | null = $state(null);
   let trap: FocusTrap | null = null;
   let releaseScroll: (() => void) | null = null;
+  // T-5.1c: track soft-keyboard inset so the bottom sheet on mobile
+  // lifts above the keyboard when an input inside it gains focus.
+  // 0 on desktop / when no keyboard is visible.
+  let kbInsetPx = $state(0);
 
   $effect(() => {
     if (!open) {
@@ -52,16 +57,19 @@
       trap = null;
       releaseScroll?.();
       releaseScroll = null;
+      kbInsetPx = 0;
       return;
     }
     if (!panelEl) return;
     trap = activateFocusTrap(panelEl);
     releaseScroll = lockScroll();
+    const detachKb = attachKeyboardInsetTracker((px) => (kbInsetPx = px));
     return () => {
       trap?.deactivate();
       trap = null;
       releaseScroll?.();
       releaseScroll = null;
+      detachKb();
     };
   });
 
@@ -94,6 +102,7 @@
       aria-labelledby={title ? 'sheet-title' : undefined}
       style:--sheet-width="{width}px"
       style:--sheet-max-height={maxHeight}
+      style:--sheet-kb-inset="{kbInsetPx}px"
     >
       {#if title}
         <header class="sheet-h">
@@ -141,15 +150,18 @@
     flex-direction: column;
     overflow: hidden;
   }
-  /* Bottom-sheet layout (mobile / narrow). */
+  /* Bottom-sheet layout (mobile / narrow). T-5.1c: --sheet-kb-inset
+   * lifts the sheet above the soft keyboard when an input inside it
+   * gets focus; 0 when no keyboard is visible. */
   @media (max-width: 959.98px) {
     .sheet {
       left: 0;
       right: 0;
-      bottom: 0;
+      bottom: var(--sheet-kb-inset, 0);
       max-height: var(--sheet-max-height);
       border-radius: 14px 14px 0 0;
       animation: slide-up 220ms cubic-bezier(0.2, 0, 0, 1);
+      transition: bottom 180ms ease-out;
     }
   }
   /* Side-sheet layout (desktop / wide). */

--- a/apps/web/src/lib/components/reader/ChapterBody.svelte
+++ b/apps/web/src/lib/components/reader/ChapterBody.svelte
@@ -16,6 +16,7 @@
   import TokenSpan from './TokenSpan.svelte';
   import WordPopup from './WordPopup.svelte';
   import WordTooltip from './WordTooltip.svelte';
+  import { LongPressDetector } from './touch-gestures.js';
   import {
     paragraphsOfServerTokens,
     paragraphsOfTokens,
@@ -162,6 +163,43 @@
     activeRect = null;
   }
 
+  // T-5.1c: long-press as a tap alternative on touch devices. A
+  // 500ms hold over a word fires the same WordPopup the click
+  // handler does. The detector cancels on movement so a scroll-y
+  // touch never triggers a spurious popup.
+  const longPress = new LongPressDetector((point) => {
+    const target = document.elementFromPoint(point.x, point.y);
+    const found = findToken(target as HTMLElement | null);
+    if (!found) return;
+    const rect = found.el.getBoundingClientRect();
+    activeToken = found.token;
+    activeRect = {
+      top: rect.top,
+      left: rect.left,
+      bottom: rect.bottom,
+      right: rect.right,
+    };
+    hoverToken = null;
+    hoverRect = null;
+  });
+
+  function onTouchStart(e: TouchEvent) {
+    if (e.touches.length !== 1) {
+      longPress.cancel();
+      return;
+    }
+    const t = e.touches[0]!;
+    longPress.begin({ x: t.clientX, y: t.clientY });
+  }
+  function onTouchMove(e: TouchEvent) {
+    const t = e.touches[0];
+    if (!t) return;
+    longPress.move({ x: t.clientX, y: t.clientY });
+  }
+  function onTouchEnd() {
+    longPress.release();
+  }
+
   function onStatusChange(
     lemmaId: string,
     status: ServerToken['status'],
@@ -187,6 +225,10 @@
   onmouseout={hideHoverTooltip}
   onfocusin={showHoverTooltip}
   onfocusout={hideHoverTooltip}
+  ontouchstart={onTouchStart}
+  ontouchmove={onTouchMove}
+  ontouchend={onTouchEnd}
+  ontouchcancel={onTouchEnd}
 >
   {#if serverParagraphs}
     {#each serverParagraphs as paragraph, pIdx (pIdx)}

--- a/apps/web/src/lib/components/reader/ReaderPage.svelte
+++ b/apps/web/src/lib/components/reader/ReaderPage.svelte
@@ -20,6 +20,7 @@
 
   import ChapterBody from './ChapterBody.svelte';
   import { clampPage, pageCountFor, pageOffset } from './paginate.js';
+  import { classifySwipe } from './touch-gestures.js';
   import type { ChapterView } from './types.js';
 
   let {
@@ -145,6 +146,29 @@
     }
   }
 
+  // T-5.1c: swipe to flip pages on touch devices. The page-flip
+  // arrows still work on mouse / keyboard / desktop touch; swipes
+  // are an additional input. We track only the first finger
+  // (`touches[0]`) so a pinch-zoom doesn't accidentally flip pages.
+  let touchStart: { x: number; y: number } | null = null;
+  function onTouchStart(e: TouchEvent) {
+    if (e.touches.length !== 1) {
+      touchStart = null;
+      return;
+    }
+    const t = e.touches[0]!;
+    touchStart = { x: t.clientX, y: t.clientY };
+  }
+  function onTouchEnd(e: TouchEvent) {
+    if (!touchStart) return;
+    const t = e.changedTouches[0];
+    if (!t) return;
+    const swipe = classifySwipe(touchStart, { x: t.clientX, y: t.clientY });
+    touchStart = null;
+    if (swipe.direction === -1 && hasNext) nextPage();
+    else if (swipe.direction === 1 && hasPrev) prevPage();
+  }
+
   // Measure on mount + on resize / content change. ResizeObserver on
   // both the viewport (window resize, font-size change) and the
   // content (chapter toggle, romanization toggle changing line
@@ -188,7 +212,17 @@
 
 <svelte:window onkeydown={onKeydown} />
 
-<div class="reader-page-wrap" data-mode="page">
+<!-- T-5.1c: swipe gestures supplement the visible arrows + keyboard
+     ←/→; role="region" appeases the static-element-interactions a11y
+     check without claiming this div is the primary control. -->
+<div
+  class="reader-page-wrap"
+  data-mode="page"
+  role="region"
+  aria-label="Reader pages"
+  ontouchstart={onTouchStart}
+  ontouchend={onTouchEnd}
+>
   <button
     type="button"
     class="page-arrow page-arrow-l"

--- a/apps/web/src/lib/components/reader/WordTooltip.svelte
+++ b/apps/web/src/lib/components/reader/WordTooltip.svelte
@@ -44,13 +44,21 @@
   // re-runs whenever the parent rebinds the tooltip to a new word.
   // Defaults seed the first paint near the word; the $effect below
   // refines once we measure for real.
+  // T-5.1c: when the soft keyboard is up, `window.visualViewport.height`
+  // shrinks. Using it as the placement viewport keeps the tooltip
+  // visible above the keyboard instead of slipping behind it.
   const placement = $derived.by(() => {
     const w = measured?.w ?? 240;
     const h = measured?.h ?? 80;
-    return placeTooltip(anchorRect, w, h, {
-      width: typeof window !== 'undefined' ? window.innerWidth : 1024,
-      height: typeof window !== 'undefined' ? window.innerHeight : 768,
-    });
+    const vw =
+      typeof window !== 'undefined'
+        ? window.visualViewport?.width ?? window.innerWidth
+        : 1024;
+    const vh =
+      typeof window !== 'undefined'
+        ? window.visualViewport?.height ?? window.innerHeight
+        : 768;
+    return placeTooltip(anchorRect, w, h, { width: vw, height: vh });
   });
 
   $effect(() => {

--- a/apps/web/src/lib/components/reader/keyboard-inset.test.ts
+++ b/apps/web/src/lib/components/reader/keyboard-inset.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment node
+/**
+ * Tests for keyboard-inset math (T-5.1c).
+ */
+import { describe, expect, it } from 'vitest';
+
+import { computeKeyboardInset } from './keyboard-inset.js';
+
+describe('computeKeyboardInset', () => {
+  it('returns 0 when visualViewport is missing', () => {
+    expect(computeKeyboardInset(800, null)).toBe(0);
+  });
+
+  it('returns 0 when no keyboard is visible (vv covers the layout)', () => {
+    expect(
+      computeKeyboardInset(800, { height: 800, offsetTop: 0 }),
+    ).toBe(0);
+  });
+
+  it('returns the gap when the keyboard occludes the bottom', () => {
+    expect(
+      computeKeyboardInset(800, { height: 480, offsetTop: 0 }),
+    ).toBe(320);
+  });
+
+  it('accounts for an offset top (= a banner / pinned-keyboard configuration)', () => {
+    expect(
+      computeKeyboardInset(800, { height: 480, offsetTop: 100 }),
+    ).toBe(220);
+  });
+
+  it('clamps a negative inset to 0', () => {
+    expect(
+      computeKeyboardInset(800, { height: 900, offsetTop: 0 }),
+    ).toBe(0);
+  });
+});

--- a/apps/web/src/lib/components/reader/keyboard-inset.ts
+++ b/apps/web/src/lib/components/reader/keyboard-inset.ts
@@ -1,0 +1,53 @@
+/**
+ * Soft-keyboard inset tracker for the reader (T-5.1c).
+ *
+ * iOS Safari + most Android browsers expose `window.visualViewport`,
+ * which reports the visible area after the soft keyboard is shown.
+ * The classic `position: fixed` bottom-sheet sits behind the
+ * keyboard otherwise — we set a `--reader-kb-inset` CSS variable on
+ * the document so the Sheet (and any other UI that wants to react)
+ * can lift itself above the keyboard with `bottom: var(--reader-kb-inset, 0)`.
+ *
+ * Pure module exports keep the API small for unit-testing the math:
+ * the stateful side (window.visualViewport listeners) is in
+ * `attachKeyboardInsetTracker`.
+ */
+
+/**
+ * Compute the keyboard inset in CSS pixels — i.e. how far the bottom
+ * of the visible viewport sits *above* the bottom of the layout
+ * viewport. Zero when no keyboard is visible.
+ */
+export function computeKeyboardInset(layoutHeight: number, vv: {
+  height: number;
+  offsetTop: number;
+} | null): number {
+  if (!vv) return 0;
+  const inset = layoutHeight - vv.height - vv.offsetTop;
+  return inset > 0 ? Math.round(inset) : 0;
+}
+
+export type KeyboardInsetSink = (px: number) => void;
+
+/**
+ * Wire up resize / scroll listeners on `window.visualViewport` and
+ * forward the computed inset to `sink`. Returns a teardown function
+ * the caller's $effect runs on unmount.
+ */
+export function attachKeyboardInsetTracker(sink: KeyboardInsetSink): () => void {
+  if (typeof window === 'undefined') return () => {};
+  const vv = window.visualViewport;
+  if (!vv) return () => {};
+  function update() {
+    sink(computeKeyboardInset(window.innerHeight, vv));
+  }
+  vv.addEventListener('resize', update);
+  vv.addEventListener('scroll', update);
+  // Seed immediately so the variable is populated before the first
+  // keyboard event fires.
+  update();
+  return () => {
+    vv.removeEventListener('resize', update);
+    vv.removeEventListener('scroll', update);
+  };
+}

--- a/apps/web/src/lib/components/reader/touch-gestures.test.ts
+++ b/apps/web/src/lib/components/reader/touch-gestures.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment node
+/**
+ * Tests for reader touch gestures (T-5.1c).
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import { LongPressDetector, classifySwipe } from './touch-gestures.js';
+
+describe('classifySwipe', () => {
+  it('reports left-swipe (-1) when end.x < start.x by > threshold', () => {
+    const r = classifySwipe({ x: 200, y: 100 }, { x: 100, y: 110 });
+    expect(r.direction).toBe(-1);
+    expect(r.dx).toBe(-100);
+  });
+
+  it('reports right-swipe (+1) when end.x > start.x by > threshold', () => {
+    const r = classifySwipe({ x: 50, y: 100 }, { x: 200, y: 110 });
+    expect(r.direction).toBe(1);
+  });
+
+  it('reports no swipe when horizontal travel is below the threshold', () => {
+    const r = classifySwipe({ x: 100, y: 100 }, { x: 130, y: 105 });
+    expect(r.direction).toBe(0);
+  });
+
+  it('reports no swipe when vertical movement dominates (= the user was scrolling)', () => {
+    const r = classifySwipe({ x: 100, y: 100 }, { x: 80, y: 400 });
+    expect(r.direction).toBe(0);
+  });
+
+  it('honors a custom threshold', () => {
+    expect(classifySwipe({ x: 100, y: 0 }, { x: 130, y: 0 }, 20).direction).toBe(1);
+    expect(classifySwipe({ x: 100, y: 0 }, { x: 130, y: 0 }, 50).direction).toBe(0);
+  });
+});
+
+describe('LongPressDetector', () => {
+  function makeFakeTimer() {
+    const tasks = new Map<number, () => void>();
+    let next = 1;
+    const setTimer = (cb: () => void) => {
+      const h = next++;
+      tasks.set(h, cb);
+      return h;
+    };
+    const clearTimer = (h: number) => {
+      tasks.delete(h);
+    };
+    const fire = (h: number) => {
+      const cb = tasks.get(h);
+      if (cb) {
+        tasks.delete(h);
+        cb();
+      }
+    };
+    return { setTimer, clearTimer, fire, tasks };
+  }
+
+  it('fires the callback after the hold elapses with the start point', () => {
+    const onLongPress = vi.fn();
+    const t = makeFakeTimer();
+    const d = new LongPressDetector(onLongPress, {
+      holdMs: 500,
+      setTimeout: t.setTimer,
+      clearTimeout: t.clearTimer,
+    });
+    d.begin({ x: 100, y: 200 });
+    expect(d.armed).toBe(true);
+    expect(onLongPress).not.toHaveBeenCalled();
+    // Walk the timer forward.
+    t.fire(1);
+    expect(onLongPress).toHaveBeenCalledWith({ x: 100, y: 200 });
+  });
+
+  it('cancels on movement past the slop radius', () => {
+    const onLongPress = vi.fn();
+    const t = makeFakeTimer();
+    const d = new LongPressDetector(onLongPress, {
+      slopPx: 8,
+      setTimeout: t.setTimer,
+      clearTimeout: t.clearTimer,
+    });
+    d.begin({ x: 100, y: 200 });
+    expect(d.move({ x: 105, y: 202 })).toBe(false);
+    expect(d.armed).toBe(true);
+    expect(d.move({ x: 200, y: 200 })).toBe(true);
+    expect(d.armed).toBe(false);
+    // Even if the timer were to fire, the start point is gone.
+    t.fire(1);
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it('cancels on release', () => {
+    const onLongPress = vi.fn();
+    const t = makeFakeTimer();
+    const d = new LongPressDetector(onLongPress, {
+      setTimeout: t.setTimer,
+      clearTimeout: t.clearTimer,
+    });
+    d.begin({ x: 0, y: 0 });
+    d.release();
+    t.fire(1);
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it('allows back-to-back presses (begin replaces a stale timer)', () => {
+    const onLongPress = vi.fn();
+    const t = makeFakeTimer();
+    const d = new LongPressDetector(onLongPress, {
+      setTimeout: t.setTimer,
+      clearTimeout: t.clearTimer,
+    });
+    d.begin({ x: 0, y: 0 });
+    d.begin({ x: 50, y: 50 });
+    // Original handle 1 was cleared; new handle 2 is the live one.
+    t.fire(2);
+    expect(onLongPress).toHaveBeenCalledOnce();
+    expect(onLongPress).toHaveBeenCalledWith({ x: 50, y: 50 });
+  });
+});

--- a/apps/web/src/lib/components/reader/touch-gestures.ts
+++ b/apps/web/src/lib/components/reader/touch-gestures.ts
@@ -1,0 +1,120 @@
+/**
+ * Touch-gesture helpers for the reader (T-5.1c).
+ *
+ * Pure logic split out so swipe / long-press behavior is unit-tested
+ * without rendering a Svelte component. The Svelte side (page mode,
+ * ChapterBody) wraps these in `onTouchStart` / `onTouchMove` /
+ * `onTouchEnd` listeners.
+ */
+
+export interface SwipeResult {
+  /** -1 swipe-left (next page), +1 swipe-right (prev page), 0 no swipe. */
+  direction: -1 | 0 | 1;
+  /** Horizontal travel in CSS pixels — useful for live-preview drag UI. */
+  dx: number;
+  /** Vertical travel — used to disqualify scrolly drags. */
+  dy: number;
+}
+
+/**
+ * Decide whether a touch start/end pair counts as a horizontal swipe.
+ * Vertical-dominant movement is treated as a scroll and ignored.
+ *
+ * The 50px threshold matches what feels natural on a phone: too small
+ * and a normal scroll registers as a flip; too big and the user has
+ * to drag halfway across the screen.
+ */
+export function classifySwipe(
+  start: { x: number; y: number },
+  end: { x: number; y: number },
+  thresholdPx = 50,
+): SwipeResult {
+  const dx = end.x - start.x;
+  const dy = end.y - start.y;
+  if (Math.abs(dx) < thresholdPx) return { direction: 0, dx, dy };
+  // Vertical motion dominates → user was scrolling, not flipping pages.
+  if (Math.abs(dy) > Math.abs(dx)) return { direction: 0, dx, dy };
+  return { direction: dx > 0 ? 1 : -1, dx, dy };
+}
+
+/**
+ * Long-press detection state machine. The reader's tap target is too
+ * small for some users to land precisely, and a long-press is the
+ * conventional alternative for "open this thing's details panel" on
+ * touch devices.
+ *
+ * The contract:
+ *  - `start(point)` arms a timer that fires `onLongPress(point)` after
+ *    `holdMs` if no `cancel()` came in first.
+ *  - Movement past `slopPx` cancels the press (it was a drag).
+ *  - `release()` cancels the press without firing (a tap or fast
+ *    flick already happened).
+ */
+export interface LongPressOptions {
+  holdMs?: number;
+  slopPx?: number;
+  setTimeout?: (cb: () => void, ms: number) => number;
+  clearTimeout?: (handle: number) => void;
+}
+
+export class LongPressDetector {
+  private timer: number | null = null;
+  private start: { x: number; y: number } | null = null;
+  private readonly holdMs: number;
+  private readonly slopPx: number;
+  private readonly setTimer: (cb: () => void, ms: number) => number;
+  private readonly clearTimer: (handle: number) => void;
+
+  constructor(
+    private readonly onLongPress: (point: { x: number; y: number }) => void,
+    options: LongPressOptions = {},
+  ) {
+    this.holdMs = options.holdMs ?? 500;
+    this.slopPx = options.slopPx ?? 8;
+    // Tests inject deterministic timer callbacks; runtime defaults to
+    // window.setTimeout / clearTimeout.
+    this.setTimer =
+      options.setTimeout ?? ((cb, ms) => window.setTimeout(cb, ms));
+    this.clearTimer =
+      options.clearTimeout ?? ((handle) => window.clearTimeout(handle));
+  }
+
+  begin(point: { x: number; y: number }): void {
+    this.cancel();
+    this.start = point;
+    this.timer = this.setTimer(() => {
+      if (this.start) this.onLongPress(this.start);
+      this.timer = null;
+    }, this.holdMs);
+  }
+
+  /** Called on touchmove. Returns true if the press was cancelled. */
+  move(point: { x: number; y: number }): boolean {
+    if (!this.start) return false;
+    const dx = point.x - this.start.x;
+    const dy = point.y - this.start.y;
+    if (Math.hypot(dx, dy) > this.slopPx) {
+      this.cancel();
+      return true;
+    }
+    return false;
+  }
+
+  /** Called on touchend / pointerup — long press is no longer valid. */
+  release(): void {
+    this.cancel();
+  }
+
+  cancel(): void {
+    if (this.timer != null) {
+      this.clearTimer(this.timer);
+      this.timer = null;
+    }
+    this.start = null;
+  }
+
+  /** True while a press is being measured. Tests assert against this. */
+  get armed(): boolean {
+    return this.timer != null;
+  }
+}


### PR DESCRIPTION
> Stacked on #221 (T-5.1b). Merge that first.

## Summary

Three mobile touch affordances + a soft-keyboard fix for the reader.

1. **Swipe to flip pages** in page mode. Threshold 50px; vertical-dominant motion is treated as a scroll and ignored so the gesture never fights the keyboard or the arrow buttons.
2. **Long-press (500ms) opens the WordPopup** — same surface the click handler does. The detector cancels on movement past 8px slop so a scroll-y touch never triggers a spurious popup.
3. **Soft-keyboard avoidance** via \`window.visualViewport\`. The mobile bottom-sheet (Sheet.svelte) lifts above the keyboard when an input inside it gains focus; \`WordTooltip\` also picks up the \`visualViewport\` height so place-above-or-below stays within the visible area.

Pure helpers (\`classifySwipe\`, \`LongPressDetector\`, \`computeKeyboardInset\`) are exported separately so the math is unit-tested without DOM.

Closes #46.

## Test plan

- [x] \`pnpm --filter @ciareader/web test\` — 93 files / 750 tests pass, including:
  - \`touch-gestures.test.ts\` (9 tests) — swipe direction / threshold / vertical-disqualify; long-press fire / cancel / replace.
  - \`keyboard-inset.test.ts\` (5 tests) — inset = 0 when no visualViewport, when no keyboard, accounts for offsetTop, clamps negative.
- [x] \`pnpm --filter @ciareader/web typecheck\` — 0 errors / 0 warnings.
- [x] \`pnpm --filter @ciareader/web lint\` — clean (added \`TouchEvent\` to globals).

## Out of scope

- The reader toolbar's collapsible-bottom-sheet variant on small viewports — the existing top bar already collapses tools comfortably under \~600px and the gear button + AppShell hamburger handle the overflow. Worth measuring before adding extra chrome.