### PR TITLE
T-6.1: alternate-meanings UI in word popup

### DIFF
--- a/apps/web/drizzle/0014_ordinary_gabe_jones.sql
+++ b/apps/web/drizzle/0014_ordinary_gabe_jones.sql
@@ -1,0 +1,32 @@
+CREATE TYPE "public"."token_correction_type" AS ENUM('pick_candidate', 'manual_lemma', 'new_lemma', 'mark_proper_noun', 'mark_foreign', 'mark_not_a_word');--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "token_corrections" (
+	"user_id" uuid NOT NULL,
+	"token_id" uuid NOT NULL,
+	"type" "token_correction_type" NOT NULL,
+	"chosen_lemma_id" uuid,
+	"note" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "token_corrections_user_id_token_id_pk" PRIMARY KEY("user_id","token_id")
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "token_corrections" ADD CONSTRAINT "token_corrections_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "token_corrections" ADD CONSTRAINT "token_corrections_token_id_text_tokens_id_fk" FOREIGN KEY ("token_id") REFERENCES "public"."text_tokens"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "token_corrections" ADD CONSTRAINT "token_corrections_chosen_lemma_id_lemmas_id_fk" FOREIGN KEY ("chosen_lemma_id") REFERENCES "public"."lemmas"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "token_corrections_token_idx" ON "token_corrections" USING btree ("token_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "token_corrections_chosen_lemma_idx" ON "token_corrections" USING btree ("chosen_lemma_id","type");

--- a/apps/web/drizzle/meta/0014_snapshot.json
+++ b/apps/web/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,2457 @@
+{
+  "id": "f7e7c2c1-2b51-442b-a2b7-59b0dbeb00c2",
+  "prevId": "c85f5c46-b397-4d8f-abdd-2a3c2c027462",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.curator_languages": {
+      "name": "curator_languages",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "curator_languages_user_idx": {
+          "name": "curator_languages_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "curator_languages_user_id_users_id_fk": {
+          "name": "curator_languages_user_id_users_id_fk",
+          "tableFrom": "curator_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "curator_languages_granted_by_users_id_fk": {
+          "name": "curator_languages_granted_by_users_id_fk",
+          "tableFrom": "curator_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "curator_languages_user_id_language_pk": {
+          "name": "curator_languages_user_id_language_pk",
+          "columns": [
+            "user_id",
+            "language"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.dictionary_imports": {
+      "name": "dictionary_imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_name": {
+          "name": "source_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_at": {
+          "name": "run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lemmas_created": {
+          "name": "lemmas_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lemmas_updated": {
+          "name": "lemmas_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lemmas_skipped_curator_locked": {
+          "name": "lemmas_skipped_curator_locked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "translations_created": {
+          "name": "translations_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "translations_updated": {
+          "name": "translations_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "dictionary_imports_language_idx": {
+          "name": "dictionary_imports_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.form_lemma_overrides": {
+      "name": "form_lemma_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_nfc": {
+          "name": "surface_nfc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_signature": {
+          "name": "context_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "chosen_lemma_id": {
+          "name": "chosen_lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "promoted_at": {
+          "name": "promoted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "promoted_by": {
+          "name": "promoted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "form_lemma_overrides_lookup_idx": {
+          "name": "form_lemma_overrides_lookup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface_nfc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "form_lemma_overrides_chosen_lemma_id_lemmas_id_fk": {
+          "name": "form_lemma_overrides_chosen_lemma_id_lemmas_id_fk",
+          "tableFrom": "form_lemma_overrides",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "chosen_lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_lemma_overrides_promoted_by_users_id_fk": {
+          "name": "form_lemma_overrides_promoted_by_users_id_fk",
+          "tableFrom": "form_lemma_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "promoted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "form_lemma_overrides_lang_surface_ctx_uq": {
+          "name": "form_lemma_overrides_lang_surface_ctx_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "language",
+            "surface_nfc",
+            "context_signature"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.lemma_edit_history": {
+      "name": "lemma_edit_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "editor_id": {
+          "name": "editor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "lemma_edit_change_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change": {
+          "name": "change",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_edit_history_lemma_idx": {
+          "name": "lemma_edit_history_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_edit_history_editor_idx": {
+          "name": "lemma_edit_history_editor_idx",
+          "columns": [
+            {
+              "expression": "editor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_edit_history_lemma_id_lemmas_id_fk": {
+          "name": "lemma_edit_history_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_edit_history",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lemma_edit_history_editor_id_users_id_fk": {
+          "name": "lemma_edit_history_editor_id_users_id_fk",
+          "tableFrom": "lemma_edit_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "editor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemma_forms": {
+      "name": "lemma_forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "romanization": {
+          "name": "romanization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_forms_lemma_idx": {
+          "name": "lemma_forms_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_forms_surface_idx": {
+          "name": "lemma_forms_surface_idx",
+          "columns": [
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_forms_lemma_id_lemmas_id_fk": {
+          "name": "lemma_forms_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_forms",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemmas": {
+      "name": "lemmas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headword": {
+          "name": "headword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos": {
+          "name": "pos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script": {
+          "name": "script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gloss_default": {
+          "name": "gloss_default",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_rank": {
+          "name": "frequency_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "translation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "curator_locked": {
+          "name": "curator_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemmas_language_headword_pos_idx": {
+          "name": "lemmas_language_headword_pos_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "headword",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pos",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_language_idx": {
+          "name": "lemmas_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_language_frequency_idx": {
+          "name": "lemmas_language_frequency_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "frequency_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_source_lookup_idx": {
+          "name": "lemmas_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.magic_links": {
+      "name": "magic_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "magic_links_user_idx": {
+          "name": "magic_links_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "magic_links_expires_idx": {
+          "name": "magic_links_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "magic_links_user_id_users_id_fk": {
+          "name": "magic_links_user_id_users_id_fk",
+          "tableFrom": "magic_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.nlp_jobs": {
+      "name": "nlp_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "nlp_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nlp_jobs_text_idx": {
+          "name": "nlp_jobs_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nlp_jobs_status_idx": {
+          "name": "nlp_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nlp_jobs_text_id_texts_id_fk": {
+          "name": "nlp_jobs_text_id_texts_id_fk",
+          "tableFrom": "nlp_jobs",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by": {
+          "name": "replaced_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "refresh_tokens_user_idx": {
+          "name": "refresh_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_expires_idx": {
+          "name": "refresh_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.text_chapters": {
+      "name": "text_chapters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idx": {
+          "name": "idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "text_chapters_text_idx": {
+          "name": "text_chapters_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_chapters_text_id_texts_id_fk": {
+          "name": "text_chapters_text_id_texts_id_fk",
+          "tableFrom": "text_chapters",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "text_chapters_text_idx_uq": {
+          "name": "text_chapters_text_idx_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "text_id",
+            "idx"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.text_tokens": {
+      "name": "text_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idx": {
+          "name": "idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lemma_candidates": {
+          "name": "lemma_candidates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_ambiguous": {
+          "name": "is_ambiguous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_oov": {
+          "name": "is_oov",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_word": {
+          "name": "is_word",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sentence_idx": {
+          "name": "sentence_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "romanization": {
+          "name": "romanization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "text_tokens_chapter_scan_idx": {
+          "name": "text_tokens_chapter_scan_idx",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "text_tokens_lemma_idx": {
+          "name": "text_tokens_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_tokens_chapter_id_text_chapters_id_fk": {
+          "name": "text_tokens_chapter_id_text_chapters_id_fk",
+          "tableFrom": "text_tokens",
+          "tableTo": "text_chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_tokens_lemma_id_lemmas_id_fk": {
+          "name": "text_tokens_lemma_id_lemmas_id_fk",
+          "tableFrom": "text_tokens",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "text_tokens_chapter_idx_uq": {
+          "name": "text_tokens_chapter_idx_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chapter_id",
+            "idx"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.texts": {
+      "name": "texts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "status_error": {
+          "name": "status_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "texts_owner_idx": {
+          "name": "texts_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "texts_visibility_idx": {
+          "name": "texts_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "texts_owner_id_users_id_fk": {
+          "name": "texts_owner_id_users_id_fk",
+          "tableFrom": "texts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.token_corrections": {
+      "name": "token_corrections",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "token_correction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chosen_lemma_id": {
+          "name": "chosen_lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "token_corrections_token_idx": {
+          "name": "token_corrections_token_idx",
+          "columns": [
+            {
+              "expression": "token_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "token_corrections_chosen_lemma_idx": {
+          "name": "token_corrections_chosen_lemma_idx",
+          "columns": [
+            {
+              "expression": "chosen_lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "token_corrections_user_id_users_id_fk": {
+          "name": "token_corrections_user_id_users_id_fk",
+          "tableFrom": "token_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "token_corrections_token_id_text_tokens_id_fk": {
+          "name": "token_corrections_token_id_text_tokens_id_fk",
+          "tableFrom": "token_corrections",
+          "tableTo": "text_tokens",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "token_corrections_chosen_lemma_id_lemmas_id_fk": {
+          "name": "token_corrections_chosen_lemma_id_lemmas_id_fk",
+          "tableFrom": "token_corrections",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "chosen_lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "token_corrections_user_id_token_id_pk": {
+          "name": "token_corrections_user_id_token_id_pk",
+          "columns": [
+            "user_id",
+            "token_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.translations": {
+      "name": "translations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "translation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_translation_id": {
+          "name": "parent_translation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_language": {
+          "name": "target_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_rank": {
+          "name": "display_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "translations_lemma_idx": {
+          "name": "translations_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translations_submitted_by_idx": {
+          "name": "translations_submitted_by_idx",
+          "columns": [
+            {
+              "expression": "submitted_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translations_source_lookup_idx": {
+          "name": "translations_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "translations_lemma_id_lemmas_id_fk": {
+          "name": "translations_lemma_id_lemmas_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "translations_submitted_by_users_id_fk": {
+          "name": "translations_submitted_by_users_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "translations_parent_translation_id_translations_id_fk": {
+          "name": "translations_parent_translation_id_translations_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "translations",
+          "columnsFrom": [
+            "parent_translation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_known_lemmas": {
+      "name": "user_known_lemmas",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "known_lemma_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'learning'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_known_lemmas_user_idx": {
+          "name": "user_known_lemmas_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_known_lemmas_user_id_users_id_fk": {
+          "name": "user_known_lemmas_user_id_users_id_fk",
+          "tableFrom": "user_known_lemmas",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_known_lemmas_lemma_id_lemmas_id_fk": {
+          "name": "user_known_lemmas_lemma_id_lemmas_id_fk",
+          "tableFrom": "user_known_lemmas",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_known_lemmas_user_id_lemma_id_pk": {
+          "name": "user_known_lemmas_user_id_lemma_id_pk",
+          "columns": [
+            "user_id",
+            "lemma_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_languages": {
+      "name": "user_languages",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script_preference": {
+          "name": "script_preference",
+          "type": "script_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "romanization_scheme": {
+          "name": "romanization_scheme",
+          "type": "romanization_scheme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'iso15919'"
+        },
+        "known_words_count_cache": {
+          "name": "known_words_count_cache",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reader_layout_mode": {
+          "name": "reader_layout_mode",
+          "type": "reader_layout_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'page'"
+        },
+        "words_per_page": {
+          "name": "words_per_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 250
+        },
+        "font_family": {
+          "name": "font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_size": {
+          "name": "font_size",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 18
+        },
+        "line_spacing": {
+          "name": "line_spacing",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1.6
+        },
+        "highlight_style": {
+          "name": "highlight_style",
+          "type": "highlight_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'background'"
+        },
+        "reading_width": {
+          "name": "reading_width",
+          "type": "reading_width",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "baseline": {
+          "name": "baseline",
+          "type": "language_baseline",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_languages_user_id_users_id_fk": {
+          "name": "user_languages_user_id_users_id_fk",
+          "tableFrom": "user_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_languages_user_id_language_pk": {
+          "name": "user_languages_user_id_language_pk",
+          "columns": [
+            "user_id",
+            "language"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_text_progress": {
+      "name": "user_text_progress",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_chapter_idx": {
+          "name": "last_chapter_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_token_idx": {
+          "name": "last_token_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pct_read": {
+          "name": "pct_read",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_text_progress_user_idx": {
+          "name": "user_text_progress_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_text_progress_user_id_users_id_fk": {
+          "name": "user_text_progress_user_id_users_id_fk",
+          "tableFrom": "user_text_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_text_progress_text_id_texts_id_fk": {
+          "name": "user_text_progress_text_id_texts_id_fk",
+          "tableFrom": "user_text_progress",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_text_progress_user_id_text_id_pk": {
+          "name": "user_text_progress_user_id_text_id_pk",
+          "columns": [
+            "user_id",
+            "text_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_preference": {
+          "name": "theme_preference",
+          "type": "theme_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarded_at": {
+          "name": "onboarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    }
+  },
+  "enums": {
+    "public.highlight_style": {
+      "name": "highlight_style",
+      "schema": "public",
+      "values": [
+        "underline",
+        "background",
+        "colored_text"
+      ]
+    },
+    "public.known_lemma_status": {
+      "name": "known_lemma_status",
+      "schema": "public",
+      "values": [
+        "unknown",
+        "learning",
+        "known",
+        "ignored"
+      ]
+    },
+    "public.language": {
+      "name": "language",
+      "schema": "public",
+      "values": [
+        "hi",
+        "mr",
+        "or"
+      ]
+    },
+    "public.language_baseline": {
+      "name": "language_baseline",
+      "schema": "public",
+      "values": [
+        "none",
+        "beginner",
+        "intermediate"
+      ]
+    },
+    "public.lemma_edit_change_type": {
+      "name": "lemma_edit_change_type",
+      "schema": "public",
+      "values": [
+        "lemma_update",
+        "lemma_unlock",
+        "lemma_lock",
+        "translation_insert",
+        "translation_update",
+        "translation_hide",
+        "translation_unhide",
+        "form_insert",
+        "form_delete",
+        "lemma_merge",
+        "lemma_split",
+        "translation_reorder"
+      ]
+    },
+    "public.nlp_job_status": {
+      "name": "nlp_job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.reader_layout_mode": {
+      "name": "reader_layout_mode",
+      "schema": "public",
+      "values": [
+        "page",
+        "paged_scroll",
+        "continuous"
+      ]
+    },
+    "public.reading_width": {
+      "name": "reading_width",
+      "schema": "public",
+      "values": [
+        "narrow",
+        "medium",
+        "wide"
+      ]
+    },
+    "public.romanization_scheme": {
+      "name": "romanization_scheme",
+      "schema": "public",
+      "values": [
+        "iso15919",
+        "iast",
+        "hunterian",
+        "itrans"
+      ]
+    },
+    "public.script_preference": {
+      "name": "script_preference",
+      "schema": "public",
+      "values": [
+        "native",
+        "native_with_romanization",
+        "romanization_only"
+      ]
+    },
+    "public.text_source_type": {
+      "name": "text_source_type",
+      "schema": "public",
+      "values": [
+        "paste",
+        "txt",
+        "epub"
+      ]
+    },
+    "public.text_status": {
+      "name": "text_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.text_visibility": {
+      "name": "text_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "shared",
+        "official"
+      ]
+    },
+    "public.theme_preference": {
+      "name": "theme_preference",
+      "schema": "public",
+      "values": [
+        "system",
+        "light",
+        "dark"
+      ]
+    },
+    "public.token_correction_type": {
+      "name": "token_correction_type",
+      "schema": "public",
+      "values": [
+        "pick_candidate",
+        "manual_lemma",
+        "new_lemma",
+        "mark_proper_noun",
+        "mark_foreign",
+        "mark_not_a_word"
+      ]
+    },
+    "public.translation_source": {
+      "name": "translation_source",
+      "schema": "public",
+      "values": [
+        "official_dictionary",
+        "curator",
+        "user"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "curator",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1777414377234,
       "tag": "0013_tan_dragon_lord",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1777415283231,
+      "tag": "0014_ordinary_gabe_jones",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/src/lib/components/reader/ChapterBody.svelte
+++ b/apps/web/src/lib/components/reader/ChapterBody.svelte
@@ -40,17 +40,52 @@
   // token tied to the same lemma flips its highlight in real time
   // (the next page load reflects the same state via the loader).
   let statusOverrides = $state(new Map<string, ServerToken['status']>());
+  // T-6.1: per-token lemma corrections live here so picking an
+  // alternate meaning in the popup re-renders that token with the
+  // chosen lemma immediately. Server-side persistence happens in
+  // T-6.4's loader join; this state is purely for the current
+  // session.
+  let lemmaCorrections = $state(new Map<string, string>());
 
   // Apply any pending optimistic status flips to the token list
   // before paragraph splitting so the .status-* classes update live.
   const tokensWithOverrides = $derived.by(() => {
     if (!chapter.tokens) return null;
-    if (statusOverrides.size === 0) return chapter.tokens;
-    return chapter.tokens.map((t) =>
-      t.lemmaId && statusOverrides.has(t.lemmaId)
-        ? { ...t, status: statusOverrides.get(t.lemmaId)! }
-        : t,
-    );
+    if (statusOverrides.size === 0 && lemmaCorrections.size === 0) {
+      return chapter.tokens;
+    }
+    return chapter.tokens.map((t) => {
+      // T-6.1: lemma override wins; the corrected lemmaId becomes
+      // the active pick for this token + the candidate that *was*
+      // active drops back into the alternates list (so the user
+      // can revert without re-opening the candidate menu).
+      const correctedLemmaId = lemmaCorrections.get(t.id);
+      let next = t;
+      if (correctedLemmaId && correctedLemmaId !== t.lemmaId) {
+        const chosen = t.candidates.find((c) => c.lemmaId === correctedLemmaId);
+        if (chosen) {
+          const remaining = t.candidates.filter(
+            (c) => c.lemmaId !== correctedLemmaId,
+          );
+          // The previous primary becomes a candidate so the user
+          // can flip back. We synthesize a candidate row from the
+          // current token's lemma metadata; if we don't have it on
+          // hand (status only — no headword), we still leave the
+          // remaining list as-is so at least the new pick lands.
+          next = {
+            ...t,
+            lemmaId: chosen.lemmaId,
+            glossDefault: chosen.glossDefault ?? t.glossDefault,
+            candidates: remaining,
+            isAmbiguous: remaining.length > 0,
+          };
+        }
+      }
+      if (next.lemmaId && statusOverrides.has(next.lemmaId)) {
+        next = { ...next, status: statusOverrides.get(next.lemmaId)! };
+      }
+      return next;
+    });
   });
 
   const serverParagraphs = $derived(
@@ -210,6 +245,12 @@
     next.set(lemmaId, status);
     statusOverrides = next;
   }
+
+  function onCorrectionApplied(tokenId: string, chosenLemmaId: string) {
+    const next = new Map(lemmaCorrections);
+    next.set(tokenId, chosenLemmaId);
+    lemmaCorrections = next;
+  }
 </script>
 
 <!-- The hover tooltip is decorative chrome — keyboard / focus users get
@@ -261,6 +302,7 @@
     {isOwner}
     onClose={closePopup}
     {onStatusChange}
+    {onCorrectionApplied}
   />
 {/if}
 

--- a/apps/web/src/lib/components/reader/ReaderScroll.svelte
+++ b/apps/web/src/lib/components/reader/ReaderScroll.svelte
@@ -45,10 +45,40 @@
   // tokens beat the client fallback.
   type ParaServer = ServerToken[];
   type ParaFallback = RenderToken[];
+  // T-6.1: apply per-token lemma corrections + per-lemma status
+  // overrides before paragraph splitting so the new picks colour
+  // the rendered tokens immediately.
+  const correctedTokens = $derived.by(() => {
+    if (!current?.tokens) return null;
+    if (statusOverrides.size === 0 && lemmaCorrections.size === 0) {
+      return current.tokens;
+    }
+    return current.tokens.map((t) => {
+      const correctedLemmaId = lemmaCorrections.get(t.id);
+      let next = t;
+      if (correctedLemmaId && correctedLemmaId !== t.lemmaId) {
+        const chosen = t.candidates.find((c) => c.lemmaId === correctedLemmaId);
+        if (chosen) {
+          const remaining = t.candidates.filter(
+            (c) => c.lemmaId !== correctedLemmaId,
+          );
+          next = {
+            ...t,
+            lemmaId: chosen.lemmaId,
+            glossDefault: chosen.glossDefault ?? t.glossDefault,
+            candidates: remaining,
+            isAmbiguous: remaining.length > 0,
+          };
+        }
+      }
+      if (next.lemmaId && statusOverrides.has(next.lemmaId)) {
+        next = { ...next, status: statusOverrides.get(next.lemmaId)! };
+      }
+      return next;
+    });
+  });
   const serverParagraphs = $derived(
-    current && current.tokens
-      ? paragraphsOfServerTokens(current.tokens)
-      : null,
+    correctedTokens ? paragraphsOfServerTokens(correctedTokens) : null,
   );
   const fallbackParagraphs = $derived(
     current && !current.tokens ? paragraphsOfTokens(tokenize(current.body)) : null,
@@ -217,6 +247,16 @@
     statusOverrides = next;
   }
 
+  // T-6.1: scroll mode shares the per-token correction state pattern
+  // with ChapterBody so picking an alternate lemma in the popup
+  // re-renders the corrected token on the current page immediately.
+  let lemmaCorrections = $state(new Map<string, string>());
+  function onCorrectionApplied(tokenId: string, chosenLemmaId: string) {
+    const next = new Map(lemmaCorrections);
+    next.set(tokenId, chosenLemmaId);
+    lemmaCorrections = next;
+  }
+
   // T-5.7: ←/→ flip pages within the chapter.
   function isTypingInsideElement(target: EventTarget | null): boolean {
     if (!(target instanceof HTMLElement)) return false;
@@ -319,6 +359,7 @@
     {isOwner}
     onClose={closePopup}
     {onStatusChange}
+    {onCorrectionApplied}
   />
 {/if}
 

--- a/apps/web/src/lib/components/reader/WordPopup.svelte
+++ b/apps/web/src/lib/components/reader/WordPopup.svelte
@@ -60,6 +60,7 @@
     isOwner,
     onClose,
     onStatusChange,
+    onCorrectionApplied,
   }: {
     token: ServerToken;
     anchorRect?: { top: number; left: number; bottom: number; right: number };
@@ -69,6 +70,9 @@
       lemmaId: string,
       status: 'unknown' | 'learning' | 'known' | 'ignored',
     ) => void;
+    /** T-6.1: parent applies the new lemma to the token's render so
+     *  the reader reflects the correction without a page reload. */
+    onCorrectionApplied?: (tokenId: string, chosenLemmaId: string) => void;
   } = $props();
 
   let payload = $state<LemmaPayload | null>(null);
@@ -78,6 +82,11 @@
     untrack(() => token.status),
   );
   let writeError = $state<string | null>(null);
+  // T-6.1: tracks the in-flight candidate pick so the "This one"
+  // button can disable itself while the POST resolves and so the
+  // user sees a visible "saving" state.
+  let pickingLemmaId = $state<string | null>(null);
+  let pickError = $state<string | null>(null);
 
   // Re-fetch translations whenever the token prop changes. `$effect`
   // runs the body each time `token` (and thus `token.id` / `lemmaId`)
@@ -313,6 +322,40 @@
     }
   }
 
+  // T-6.1: write a `pick_candidate` correction. The reader's
+  // colour rendering for this token is updated optimistically via
+  // the `onCorrectionApplied` callback so the user sees the new
+  // lemma immediately; the server row backs the change for next
+  // read (handled by T-6.4's loader join).
+  async function pickCandidate(lemmaId: string) {
+    pickingLemmaId = lemmaId;
+    pickError = null;
+    try {
+      const res = await fetch('/api/v1/me/token-corrections', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          tokenId: token.id,
+          type: 'pick_candidate',
+          chosenLemmaId: lemmaId,
+        }),
+      });
+      if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        throw new Error(text || `HTTP ${res.status}`);
+      }
+      onCorrectionApplied?.(token.id, lemmaId);
+      // Close the popup after a successful pick so the user lands
+      // back on the reader; the parent's reactive state has already
+      // re-rendered the token with the new lemma.
+      onClose();
+    } catch (e) {
+      pickError = (e as Error).message;
+    } finally {
+      pickingLemmaId = null;
+    }
+  }
+
   async function markStatus(
     status: 'unknown' | 'learning' | 'known' | 'ignored',
   ) {
@@ -529,20 +572,41 @@
       {/if}
     {/if}
 
-    {#if token.isAmbiguous}
+    {#if token.isAmbiguous && token.candidates.length > 0}
       <button
         type="button"
         class="alt-toggle"
         onclick={() => (showAlternates = !showAlternates)}
         aria-expanded={showAlternates}
       >
-        {showAlternates ? 'Hide' : 'Show'} alternate meanings
+        <span class="chev" aria-hidden="true" data-open={showAlternates ? '1' : '0'}>›</span>
+        {token.candidates.length} alternate {token.candidates.length === 1 ? 'meaning' : 'meanings'}
       </button>
       {#if showAlternates}
-        <p class="muted small">
-          Alternate-candidate selection lands in T-6.1. The reader knows
-          this token has more than one plausible parse.
-        </p>
+        <ul class="alt-list" data-testid="alt-candidates">
+          {#each token.candidates as cand (cand.lemmaId)}
+            <li class="alt" data-lemma-id={cand.lemmaId}>
+              <div class="alt-head">
+                <span class="alt-h">{cand.headword}</span>
+                <span class="alt-pos">{cand.pos}</span>
+              </div>
+              {#if cand.glossDefault}
+                <p class="alt-gloss">{cand.glossDefault}</p>
+              {/if}
+              <button
+                type="button"
+                class="alt-pick"
+                disabled={pickingLemmaId === cand.lemmaId}
+                onclick={() => pickCandidate(cand.lemmaId)}
+              >
+                {pickingLemmaId === cand.lemmaId ? 'Saving…' : 'This one'}
+              </button>
+            </li>
+          {/each}
+        </ul>
+        {#if pickError}
+          <p class="err small" role="alert">{pickError}</p>
+        {/if}
       {/if}
     {/if}
   </div>
@@ -824,5 +888,68 @@
     font-size: 0.78rem;
     color: var(--ink-3, var(--color-fg-muted));
     cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+  }
+  .alt-toggle .chev {
+    display: inline-block;
+    transition: transform 140ms ease;
+    font-size: 0.95rem;
+    line-height: 0.8;
+  }
+  .alt-toggle .chev[data-open='1'] {
+    transform: rotate(90deg);
+  }
+  .alt-list {
+    list-style: none;
+    margin: 0.6rem 0 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
+  }
+  .alt {
+    border: 1px solid var(--rule, var(--color-border));
+    border-radius: 8px;
+    padding: 0.55rem 0.7rem;
+    background: var(--card, var(--color-bg));
+  }
+  .alt-head {
+    display: flex;
+    align-items: baseline;
+    gap: 0.55rem;
+    margin-bottom: 0.2rem;
+  }
+  .alt-h {
+    font-family: var(--font-serif-dev, var(--font-serif));
+    font-size: 1.05rem;
+    color: var(--ink, var(--color-fg));
+  }
+  .alt-pos {
+    font-size: 0.66rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--ink-3, var(--color-fg-muted));
+  }
+  .alt-gloss {
+    margin: 0 0 0.45rem;
+    font-size: 0.82rem;
+    color: var(--ink-2, var(--color-fg));
+    line-height: 1.35;
+  }
+  .alt-pick {
+    background: var(--accent, var(--color-accent));
+    color: var(--accent-ink, var(--color-bg));
+    border: 0;
+    border-radius: 6px;
+    padding: 0.35rem 0.7rem;
+    font: inherit;
+    font-size: 0.78rem;
+    cursor: pointer;
+  }
+  .alt-pick:disabled {
+    opacity: 0.6;
+    cursor: progress;
   }
 </style>

--- a/apps/web/src/lib/components/reader/WordTooltip.test.ts
+++ b/apps/web/src/lib/components/reader/WordTooltip.test.ts
@@ -25,6 +25,7 @@ function makeToken(overrides: Partial<ServerToken> = {}): ServerToken {
     lemmaId: 'lem-1',
     romanization: 'prabhāt',
     glossDefault: null,
+    candidates: [],
     status: 'unknown',
     ...overrides,
   };

--- a/apps/web/src/lib/components/reader/lazy-tokens.test.ts
+++ b/apps/web/src/lib/components/reader/lazy-tokens.test.ts
@@ -18,6 +18,7 @@ function fakeTokens(n: number): ServerToken[] {
     lemmaId: `lem-${i}`,
     romanization: null,
     glossDefault: null,
+    candidates: [],
     status: 'unknown',
   }));
 }

--- a/apps/web/src/lib/components/reader/types.ts
+++ b/apps/web/src/lib/components/reader/types.ts
@@ -7,6 +7,20 @@
  * every mode (T-5.2 onward).
  */
 
+/** One alternate-meaning entry the popup expands when
+ *  isAmbiguous=true (T-6.1). The reader pulls these from the
+ *  worker's `lemma_candidates` jsonb column and joins them against
+ *  `lemmas` so the row already carries headword + POS + gloss for
+ *  the popup. */
+export type ServerCandidate = {
+  lemmaId: string;
+  headword: string;
+  pos: string;
+  glossDefault: string | null;
+  score: number;
+  features: Record<string, string>;
+};
+
 /** Per-token row from the NLP worker (T-5.2). When present, the
  *  component renders these spans directly; when null, it falls back
  *  to client-side whitespace tokenization. */
@@ -22,6 +36,10 @@ export type ServerToken = {
   /** Canonical short gloss for the lemma — surfaced in the hover
    *  tooltip (T-5.18). Null when there's no lemma or no gloss yet. */
   glossDefault: string | null;
+  /** T-6.1: alternate-meaning candidates for is_ambiguous tokens.
+   *  Empty array when the worker scored only one viable candidate
+   *  or hasn't run yet. */
+  candidates: ServerCandidate[];
   status: 'known' | 'learning' | 'ignored' | 'unknown';
 };
 

--- a/apps/web/src/lib/server/corrections.test.ts
+++ b/apps/web/src/lib/server/corrections.test.ts
@@ -1,0 +1,167 @@
+// @vitest-environment node
+/**
+ * Unit tests for the correction service (T-6.1).
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const rows: Array<Record<string, unknown>> = [];
+type ChainShape = {
+  from: ReturnType<typeof vi.fn>;
+  where: ReturnType<typeof vi.fn>;
+  limit: ReturnType<typeof vi.fn>;
+  values: ReturnType<typeof vi.fn>;
+  onConflictDoUpdate: ReturnType<typeof vi.fn>;
+  returning: ReturnType<typeof vi.fn>;
+};
+const chain: ChainShape = {
+  from: vi.fn(() => chain),
+  where: vi.fn(() => chain),
+  limit: vi.fn(() => rows),
+  values: vi.fn(() => chain),
+  onConflictDoUpdate: vi.fn(() => chain),
+  returning: vi.fn(() => rows),
+};
+const fakeDb = {
+  select: vi.fn(() => chain),
+  insert: vi.fn(() => chain),
+};
+
+vi.mock('./db/index.js', () => ({
+  db: fakeDb,
+  schema: {
+    textTokens: { id: 'tt.id' },
+    lemmas: { id: 'l.id' },
+    tokenCorrections: {
+      userId: 'tc.user_id',
+      tokenId: 'tc.token_id',
+    },
+  },
+}));
+
+const { writeTokenCorrection, correctionsForTokens, CorrectionValidationError } =
+  await import('./corrections.js');
+
+function resetAll() {
+  rows.length = 0;
+  for (const fn of Object.values(chain))
+    (fn as ReturnType<typeof vi.fn>).mockClear();
+  fakeDb.select.mockClear();
+  fakeDb.insert.mockClear();
+}
+
+beforeEach(resetAll);
+
+describe('writeTokenCorrection', () => {
+  it('upserts a pick_candidate row when the lemma + token both exist', async () => {
+    // First select: token lookup → present.
+    chain.limit.mockReturnValueOnce([{ id: 'tok-1' }]);
+    // Second select: lemma lookup → present.
+    chain.limit.mockReturnValueOnce([{ id: 'lem-2' }]);
+    // returning() resolves the upsert.
+    chain.returning.mockReturnValueOnce([
+      {
+        userId: 'u1',
+        tokenId: 'tok-1',
+        type: 'pick_candidate',
+        chosenLemmaId: 'lem-2',
+      },
+    ]);
+    const row = await writeTokenCorrection({
+      userId: 'u1',
+      tokenId: 'tok-1',
+      type: 'pick_candidate',
+      chosenLemmaId: 'lem-2',
+    });
+    expect(row.chosenLemmaId).toBe('lem-2');
+    expect(fakeDb.insert).toHaveBeenCalledOnce();
+  });
+
+  it('rejects pick_candidate without a chosenLemmaId', async () => {
+    await expect(
+      writeTokenCorrection({
+        userId: 'u1',
+        tokenId: 'tok-1',
+        type: 'pick_candidate',
+      }),
+    ).rejects.toBeInstanceOf(CorrectionValidationError);
+    expect(fakeDb.select).not.toHaveBeenCalled();
+  });
+
+  it('rejects mark_proper_noun WITH a chosenLemmaId (the type IS the verdict)', async () => {
+    await expect(
+      writeTokenCorrection({
+        userId: 'u1',
+        tokenId: 'tok-1',
+        type: 'mark_proper_noun',
+        chosenLemmaId: 'lem-2',
+      }),
+    ).rejects.toBeInstanceOf(CorrectionValidationError);
+  });
+
+  it('returns 404 when the token does not exist', async () => {
+    chain.limit.mockReturnValueOnce([]); // token lookup → empty
+    await expect(
+      writeTokenCorrection({
+        userId: 'u1',
+        tokenId: 'missing',
+        type: 'mark_foreign',
+      }),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('returns 404 when chosen_lemma_id does not exist', async () => {
+    chain.limit
+      .mockReturnValueOnce([{ id: 'tok-1' }]) // token present
+      .mockReturnValueOnce([]); // lemma absent
+    await expect(
+      writeTokenCorrection({
+        userId: 'u1',
+        tokenId: 'tok-1',
+        type: 'pick_candidate',
+        chosenLemmaId: 'no-such-lemma',
+      }),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('writes a mark_* correction with chosen_lemma_id=null', async () => {
+    chain.limit.mockReturnValueOnce([{ id: 'tok-9' }]);
+    chain.returning.mockReturnValueOnce([
+      {
+        userId: 'u1',
+        tokenId: 'tok-9',
+        type: 'mark_not_a_word',
+        chosenLemmaId: null,
+      },
+    ]);
+    const row = await writeTokenCorrection({
+      userId: 'u1',
+      tokenId: 'tok-9',
+      type: 'mark_not_a_word',
+    });
+    expect(row.chosenLemmaId).toBeNull();
+    const insertArg = chain.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(insertArg.chosenLemmaId).toBeNull();
+  });
+});
+
+describe('correctionsForTokens', () => {
+  it('returns an empty map when no token ids are passed', async () => {
+    const m = await correctionsForTokens('u1', []);
+    expect(m.size).toBe(0);
+    expect(fakeDb.select).not.toHaveBeenCalled();
+  });
+
+  it('keys the result by tokenId', async () => {
+    // The drizzle chain resolves on await; the fake `where` returns
+    // the rows directly so the implementation can `await` without
+    // calling .limit()/.returning().
+    chain.where.mockReturnValueOnce([
+      { userId: 'u1', tokenId: 't1', type: 'pick_candidate' },
+      { userId: 'u1', tokenId: 't2', type: 'mark_foreign' },
+    ]);
+    const m = await correctionsForTokens('u1', ['t1', 't2', 't3']);
+    expect(m.get('t1')?.type).toBe('pick_candidate');
+    expect(m.get('t2')?.type).toBe('mark_foreign');
+    expect(m.has('t3')).toBe(false);
+  });
+});

--- a/apps/web/src/lib/server/corrections.ts
+++ b/apps/web/src/lib/server/corrections.ts
@@ -1,0 +1,145 @@
+/**
+ * Token-correction service (T-6.1, extended in T-6.2 / T-6.3).
+ *
+ * The reader's WordPopup writes through here when the user picks an
+ * alternate lemma, marks the token as a proper noun, etc. Each
+ * correction lands as one row keyed on (user, token); re-correcting
+ * upserts.
+ *
+ * Visibility: the writer is always the acting user. We don't gate
+ * who can write a correction on which text — corrections are
+ * attached to a token, and the reader only surfaces tokens the user
+ * already has read access to (via `getReadableText`).
+ */
+import { and, eq, inArray } from 'drizzle-orm';
+
+import { db, schema } from './db/index.js';
+import type { TokenCorrection } from './db/schema.js';
+
+export type CorrectionType = TokenCorrection['type'];
+
+export type WriteCorrectionInput = {
+  userId: string;
+  tokenId: string;
+  type: CorrectionType;
+  chosenLemmaId?: string | null;
+  note?: string | null;
+};
+
+export class CorrectionValidationError extends Error {
+  constructor(
+    message: string,
+    public readonly status: 400 | 404 = 400,
+  ) {
+    super(message);
+    this.name = 'CorrectionValidationError';
+  }
+}
+
+const LEMMA_REQUIRED_TYPES: ReadonlyArray<CorrectionType> = [
+  'pick_candidate',
+  'manual_lemma',
+];
+
+/**
+ * Upsert a correction on a single token.
+ *
+ * `pick_candidate` and `manual_lemma` require a `chosenLemmaId`.
+ * The other branches must NOT carry a lemma — the type itself is
+ * the verdict. We defend that contract here so the reader doesn't
+ * silently turn a stray UI field into a wrong-shaped row.
+ *
+ * Returns the canonical row (insert OR update result) so the caller
+ * can confirm the write and surface it back to the client without
+ * a follow-up SELECT.
+ */
+export async function writeTokenCorrection(
+  input: WriteCorrectionInput,
+): Promise<TokenCorrection> {
+  const requiresLemma = LEMMA_REQUIRED_TYPES.includes(input.type);
+  if (requiresLemma && !input.chosenLemmaId) {
+    throw new CorrectionValidationError(
+      `correction type '${input.type}' requires chosenLemmaId`,
+    );
+  }
+  if (!requiresLemma && input.chosenLemmaId) {
+    throw new CorrectionValidationError(
+      `correction type '${input.type}' must not carry chosenLemmaId`,
+    );
+  }
+
+  // Verify the token actually exists. A bogus tokenId would land as
+  // a 23503 foreign-key error; pre-checking lets the API endpoint
+  // return a clean 404 instead of a generic 500.
+  const [token] = await db
+    .select({ id: schema.textTokens.id })
+    .from(schema.textTokens)
+    .where(eq(schema.textTokens.id, input.tokenId))
+    .limit(1);
+  if (!token) {
+    throw new CorrectionValidationError('token not found', 404);
+  }
+
+  // Optional: when a lemma is required, verify it exists too.
+  if (input.chosenLemmaId) {
+    const [lemma] = await db
+      .select({ id: schema.lemmas.id })
+      .from(schema.lemmas)
+      .where(eq(schema.lemmas.id, input.chosenLemmaId))
+      .limit(1);
+    if (!lemma) {
+      throw new CorrectionValidationError('lemma not found', 404);
+    }
+  }
+
+  const now = new Date();
+  const [row] = await db
+    .insert(schema.tokenCorrections)
+    .values({
+      userId: input.userId,
+      tokenId: input.tokenId,
+      type: input.type,
+      chosenLemmaId: input.chosenLemmaId ?? null,
+      note: input.note ?? null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: [
+        schema.tokenCorrections.userId,
+        schema.tokenCorrections.tokenId,
+      ],
+      set: {
+        type: input.type,
+        chosenLemmaId: input.chosenLemmaId ?? null,
+        note: input.note ?? null,
+        updatedAt: now,
+      },
+    })
+    .returning();
+  if (!row) throw new Error('upsert returned no row');
+  return row;
+}
+
+/**
+ * Bulk fetch the acting user's corrections for a given set of
+ * token ids — used by the reader loader (T-6.4) to apply per-user
+ * picks at read time. Returns a map keyed by tokenId for O(1)
+ * lookup in the token-render path.
+ */
+export async function correctionsForTokens(
+  userId: string,
+  tokenIds: string[],
+): Promise<Map<string, TokenCorrection>> {
+  if (tokenIds.length === 0) return new Map();
+  const rows = await db
+    .select()
+    .from(schema.tokenCorrections)
+    .where(
+      and(
+        eq(schema.tokenCorrections.userId, userId),
+        inArray(schema.tokenCorrections.tokenId, tokenIds),
+      ),
+    );
+  return new Map((rows as TokenCorrection[]).map((r) => [r.tokenId, r]));
+}

--- a/apps/web/src/lib/server/db/schema.ts
+++ b/apps/web/src/lib/server/db/schema.ts
@@ -829,6 +829,78 @@ export const formLemmaOverrides = pgTable(
   }),
 );
 
+/**
+ * Per-user lemma corrections on a specific token (T-6.1 + onwards).
+ *
+ * The reader's WordPopup shows the NLP worker's top guess; when the
+ * user knows it's wrong they can:
+ *
+ *  - pick_candidate     — select one of the top-K lemma_candidates
+ *                         the worker returned (T-6.1 — the cheapest
+ *                         flow; data already on-row).
+ *  - manual_lemma       — search the dictionary and pick a lemma
+ *                         that wasn't in the candidate list (T-6.2).
+ *  - new_lemma          — propose a new lemma that doesn't exist
+ *                         yet (T-6.3 — also creates a lemma_proposal).
+ *  - mark_proper_noun / — soft "this surface isn't a learnable word"
+ *    mark_foreign /       flags. They suppress the OOV / unknown
+ *    mark_not_a_word      colouring without surfacing a lemma at all.
+ *
+ * Primary-keyed on (user, token) so re-correcting overwrites — a
+ * user changes their mind, the reader reflects the new pick. The
+ * crowdsourced aggregation worker (T-6.7) reads this table to
+ * promote consensus picks into `form_lemma_overrides`.
+ */
+export const tokenCorrectionType = pgEnum('token_correction_type', [
+  'pick_candidate',
+  'manual_lemma',
+  'new_lemma',
+  'mark_proper_noun',
+  'mark_foreign',
+  'mark_not_a_word',
+]);
+
+export const tokenCorrections = pgTable(
+  'token_corrections',
+  {
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    tokenId: uuid('token_id')
+      .notNull()
+      .references(() => textTokens.id, { onDelete: 'cascade' }),
+    type: tokenCorrectionType('type').notNull(),
+    // Set for `pick_candidate` / `manual_lemma`. NULL for the
+    // mark_* and new_lemma branches (new_lemma also writes a
+    // lemma_proposals row that carries the proposed entry —
+    // landing in T-6.3). On lemma deletion the row is kept (set
+    // null) so the audit trail isn't lost; the reader treats a
+    // null chosen_lemma_id like any other absent correction.
+    chosenLemmaId: uuid('chosen_lemma_id').references(() => lemmas.id, {
+      onDelete: 'set null',
+    }),
+    // Free-form reporter note. Optional today; T-6.5 surfaces it on
+    // the moderation dashboard.
+    note: text('note'),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => ({
+    pk: primaryKey({ columns: [t.userId, t.tokenId] }),
+    tokenIdx: index('token_corrections_token_idx').on(t.tokenId),
+    // Aggregation worker (T-6.7) groups by (lemma, type) — index
+    // matches that lookup so the cron stays cheap.
+    lemmaIdx: index('token_corrections_chosen_lemma_idx').on(
+      t.chosenLemmaId,
+      t.type,
+    ),
+  }),
+);
+
 export type Text = InferSelectModel<typeof texts>;
 export type TextChapter = InferSelectModel<typeof textChapters>;
 export type NlpJob = InferSelectModel<typeof nlpJobs>;
@@ -836,3 +908,4 @@ export type TextToken = InferSelectModel<typeof textTokens>;
 export type UserKnownLemma = InferSelectModel<typeof userKnownLemmas>;
 export type UserTextProgress = InferSelectModel<typeof userTextProgress>;
 export type FormLemmaOverride = InferSelectModel<typeof formLemmaOverrides>;
+export type TokenCorrection = InferSelectModel<typeof tokenCorrections>;

--- a/apps/web/src/lib/server/texts/tokens.test.ts
+++ b/apps/web/src/lib/server/texts/tokens.test.ts
@@ -158,6 +158,60 @@ describe('loadChapterTokens', () => {
     expect(selectFn).toHaveBeenCalledTimes(3);
   });
 
+  it('populates token.candidates with metadata pulled from the lemmas table (T-6.1)', async () => {
+    stage([
+      tokenRow({
+        id: 't1',
+        idx: 0,
+        lemmaId: 'lem-primary',
+        isAmbiguous: true,
+        lemmaCandidates: [
+          { lemmaId: 'lem-primary', features: { Case: 'Nom' }, score: 0.6 },
+          { lemmaId: 'lem-alt', features: { Case: 'Acc' }, score: 0.3 },
+          // Candidate with no resolved lemma — must be filtered out.
+          { lemmaId: null, features: {}, score: 0.1 },
+        ],
+      }),
+    ]);
+    stage([]); // user_known_lemmas
+    stage([
+      {
+        id: 'lem-primary',
+        language: 'hi',
+        headword: 'पाठ',
+        pos: 'NOUN',
+        glossDefault: 'lesson',
+      },
+      {
+        id: 'lem-alt',
+        language: 'hi',
+        headword: 'पाठ',
+        pos: 'VERB',
+        glossDefault: 'to read',
+      },
+    ]);
+    const result = await loadChapterTokens('chap-1', 'user-1');
+    expect(result![0]).toMatchObject({
+      id: 't1',
+      isAmbiguous: true,
+      glossDefault: 'lesson',
+    });
+    // The primary's lemma is excluded from the candidate list (the
+    // popup never offers the user their already-active pick), the
+    // null-lemmaId candidate is dropped, and what remains carries
+    // headword + POS + gloss for the popup.
+    expect(result![0]!.candidates).toEqual([
+      {
+        lemmaId: 'lem-alt',
+        headword: 'पाठ',
+        pos: 'VERB',
+        glossDefault: 'to read',
+        score: 0.3,
+        features: { Case: 'Acc' },
+      },
+    ]);
+  });
+
   it('handles anonymous viewers (no user_known_lemmas SELECT, every status=unknown)', async () => {
     stage([tokenRow({ id: 't1', idx: 0 })]);
     stage([]); // lemmas (gloss lookup) — only this second SELECT runs

--- a/apps/web/src/lib/server/texts/tokens.ts
+++ b/apps/web/src/lib/server/texts/tokens.ts
@@ -16,6 +16,29 @@ import { and, eq, inArray, isNotNull } from 'drizzle-orm';
 import { db, schema } from '../db/index.js';
 import type { TextToken, UserKnownLemma } from '../db/schema.js';
 
+/**
+ * One candidate in the disambiguation list (T-6.1). Set on
+ * is_ambiguous=true tokens; the reader popup expands the list so
+ * the user can pick the correct lemma.
+ *
+ * `lemmaId` is nullable on the on-disk row (the worker may have
+ * surfaced a candidate it couldn't link to a dictionary entry —
+ * e.g. an OOV form). The reader filters those out so only
+ * resolvable picks render.
+ */
+export type RenderedCandidate = {
+  lemmaId: string;
+  headword: string;
+  pos: string;
+  glossDefault: string | null;
+  /** Worker-time score (higher = more confident). Surfaced in
+   *  attribute form so the popup can sort or label without re-running
+   *  the math client-side. */
+  score: number;
+  /** Morphology features the worker emitted for this candidate. */
+  features: Record<string, string>;
+};
+
 export type RenderedToken = {
   id: string;
   idx: number;
@@ -30,6 +53,11 @@ export type RenderedToken = {
    *  locking the side panel. Null when the lemma has no glossDefault
    *  on file, or when the token has no lemma id (whitespace, OOV). */
   glossDefault: string | null;
+  /** T-6.1: alternate lemma candidates the worker scored. Empty
+   *  array when the token has no candidates beyond the top pick
+   *  (or when the worker hasn't run). The popup hides the
+   *  alternate-meanings affordance when this is empty. */
+  candidates: RenderedCandidate[];
   status: 'known' | 'learning' | 'ignored' | 'unknown';
 };
 
@@ -51,8 +79,23 @@ export async function loadChapterTokens(
 
   if (tokens.length === 0) return null;
 
+  // Primary lemma for each token (the worker's top pick).
+  const primaryLemmaIds = tokens
+    .map((t) => t.lemmaId)
+    .filter((id): id is string => !!id);
+  // T-6.1: also pre-fetch every lemma referenced as a CANDIDATE so
+  // the popup's alternate-meanings list can render headword + POS
+  // + gloss without a per-token fetch when the user expands it. The
+  // candidate list is small per token (typically 2-5 entries), so
+  // unioning across the chapter still hits one SELECT.
+  const candidateLemmaIds: string[] = [];
+  for (const t of tokens) {
+    for (const c of t.lemmaCandidates) {
+      if (c.lemmaId) candidateLemmaIds.push(c.lemmaId);
+    }
+  }
   const lemmaIds = Array.from(
-    new Set(tokens.map((t) => t.lemmaId).filter((id): id is string => !!id)),
+    new Set([...primaryLemmaIds, ...candidateLemmaIds]),
   );
 
   // Anonymous viewers have no `user_known_lemmas` rows; every word
@@ -89,7 +132,15 @@ export async function loadChapterTokens(
   // under NOUN. Pre-fix the tooltip said "No translations"; post-fix
   // it shows the sibling NOUN's gloss. Mirrors the popup-side
   // fallback in `getLemmaTranslations` so both surfaces stay in sync.
+  // T-6.1: extend the lemma fetch to include `pos` so candidate
+  // entries can render headword + POS + gloss in the alternate-
+  // meanings list. We re-use the same SELECT for the primary's
+  // glossDefault path.
   const glossByLemma = new Map<string, string | null>();
+  const lemmaMetaById = new Map<
+    string,
+    { language: string; headword: string; pos: string }
+  >();
   const lemmaHeadwords: Array<{
     id: string;
     language: string;
@@ -101,6 +152,7 @@ export async function loadChapterTokens(
         id: schema.lemmas.id,
         language: schema.lemmas.language,
         headword: schema.lemmas.headword,
+        pos: schema.lemmas.pos,
         glossDefault: schema.lemmas.glossDefault,
       })
       .from(schema.lemmas)
@@ -108,10 +160,16 @@ export async function loadChapterTokens(
       id: string;
       language: string;
       headword: string;
+      pos: string;
       glossDefault: string | null;
     }>;
     for (const r of lemmaRows) {
       glossByLemma.set(r.id, r.glossDefault);
+      lemmaMetaById.set(r.id, {
+        language: r.language,
+        headword: r.headword,
+        pos: r.pos,
+      });
       if (!r.glossDefault) {
         lemmaHeadwords.push({
           id: r.id,
@@ -169,6 +227,28 @@ export async function loadChapterTokens(
       t.lemmaId && statusByLemma.has(t.lemmaId)
         ? statusByLemma.get(t.lemmaId)!
         : 'unknown';
+    // T-6.1: build the candidate list, dropping (a) candidates with
+    // no lemmaId (the worker couldn't link them — those become
+    // "search the dictionary" picks under T-6.2), and (b) the
+    // current primary's lemmaId so the popup never offers the user
+    // their already-active pick. Sort descending by score so the
+    // strongest alternative reads first.
+    const candidates: RenderedCandidate[] = [];
+    for (const c of t.lemmaCandidates) {
+      if (!c.lemmaId) continue;
+      if (c.lemmaId === t.lemmaId) continue;
+      const meta = lemmaMetaById.get(c.lemmaId);
+      if (!meta) continue;
+      candidates.push({
+        lemmaId: c.lemmaId,
+        headword: meta.headword,
+        pos: meta.pos,
+        glossDefault: glossByLemma.get(c.lemmaId) ?? null,
+        score: c.score,
+        features: c.features,
+      });
+    }
+    candidates.sort((a, b) => b.score - a.score);
     return {
       id: t.id,
       idx: t.idx,
@@ -179,6 +259,7 @@ export async function loadChapterTokens(
       lemmaId: t.lemmaId,
       romanization: t.romanization,
       glossDefault: t.lemmaId ? glossByLemma.get(t.lemmaId) ?? null : null,
+      candidates,
       status,
     };
   });

--- a/apps/web/src/routes/api/v1/me/token-corrections/+server.ts
+++ b/apps/web/src/routes/api/v1/me/token-corrections/+server.ts
@@ -1,0 +1,64 @@
+/**
+ * POST /api/v1/me/token-corrections (T-6.1).
+ *
+ * The reader's WordPopup posts here when the user picks an
+ * alternate lemma, marks the token as a proper noun, or otherwise
+ * overrides the worker's parse. The body is a single correction;
+ * upserts on (user, token).
+ *
+ * The endpoint is intentionally per-token. T-6.2b's "apply
+ * everywhere" follow-up writes a separate batch surface.
+ */
+import { error, json } from '@sveltejs/kit';
+import { z } from 'zod';
+
+import { requireUser } from '$lib/server/auth/require-user.js';
+import {
+  CorrectionValidationError,
+  writeTokenCorrection,
+} from '$lib/server/corrections.js';
+import { parseJson } from '../../auth/_helpers.js';
+import type { RequestHandler } from './$types';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const bodySchema = z
+  .object({
+    tokenId: z.string().regex(UUID_RE, 'tokenId must be a uuid'),
+    type: z.enum([
+      'pick_candidate',
+      'manual_lemma',
+      'new_lemma',
+      'mark_proper_noun',
+      'mark_foreign',
+      'mark_not_a_word',
+    ]),
+    chosenLemmaId: z
+      .string()
+      .regex(UUID_RE, 'chosenLemmaId must be a uuid')
+      .nullable()
+      .optional(),
+    note: z.string().max(2000).nullable().optional(),
+  })
+  .strict();
+
+export const POST: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  const body = await parseJson(event.request, bodySchema);
+
+  try {
+    const row = await writeTokenCorrection({
+      userId: user.id,
+      tokenId: body.tokenId,
+      type: body.type,
+      chosenLemmaId: body.chosenLemmaId ?? null,
+      note: body.note ?? null,
+    });
+    return json({ correction: row }, { status: 201 });
+  } catch (err) {
+    if (err instanceof CorrectionValidationError) {
+      throw error(err.status, err.message);
+    }
+    throw err;
+  }
+};

--- a/apps/web/src/routes/api/v1/me/token-corrections/token-corrections-server.test.ts
+++ b/apps/web/src/routes/api/v1/me/token-corrections/token-corrections-server.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment node
+/**
+ * Route tests for POST /api/v1/me/token-corrections (T-6.1).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const writeTokenCorrection = vi.fn();
+const requireUser = vi.fn();
+
+vi.mock('$lib/server/corrections.js', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/corrections.js')>(
+    '$lib/server/corrections.js',
+  );
+  return {
+    ...actual,
+    writeTokenCorrection: (...a: unknown[]) => writeTokenCorrection(...a),
+  };
+});
+
+vi.mock('$lib/server/auth/require-user.js', () => ({
+  requireUser: (...a: unknown[]) => requireUser(...a),
+}));
+
+type Post = (typeof import('./+server.js'))['POST'];
+
+const TOKEN_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const LEMMA_ID = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+
+async function callPost(body: unknown) {
+  const { POST } = await import('./+server.js');
+  const event = {
+    request: new Request('http://x/api/v1/me/token-corrections', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+  } as unknown as Parameters<Post>[0];
+  try {
+    return (await POST(event)) as Response;
+  } catch (e) {
+    return e as { status: number };
+  }
+}
+
+beforeEach(() => {
+  writeTokenCorrection.mockReset();
+  requireUser.mockReset();
+  requireUser.mockResolvedValue({ id: 'u1' });
+});
+
+afterEach(() => vi.resetModules());
+
+describe('POST /api/v1/me/token-corrections', () => {
+  it('writes a pick_candidate correction', async () => {
+    writeTokenCorrection.mockResolvedValueOnce({
+      userId: 'u1',
+      tokenId: TOKEN_ID,
+      type: 'pick_candidate',
+      chosenLemmaId: LEMMA_ID,
+    });
+    const res = (await callPost({
+      tokenId: TOKEN_ID,
+      type: 'pick_candidate',
+      chosenLemmaId: LEMMA_ID,
+    })) as Response;
+    expect(res.status).toBe(201);
+    expect(writeTokenCorrection).toHaveBeenCalledWith({
+      userId: 'u1',
+      tokenId: TOKEN_ID,
+      type: 'pick_candidate',
+      chosenLemmaId: LEMMA_ID,
+      note: null,
+    });
+  });
+
+  it('writes a mark_proper_noun correction with no lemma', async () => {
+    writeTokenCorrection.mockResolvedValueOnce({
+      userId: 'u1',
+      tokenId: TOKEN_ID,
+      type: 'mark_proper_noun',
+      chosenLemmaId: null,
+    });
+    const res = (await callPost({
+      tokenId: TOKEN_ID,
+      type: 'mark_proper_noun',
+    })) as Response;
+    expect(res.status).toBe(201);
+  });
+
+  it('rejects an unknown correction type with 400', async () => {
+    const r = (await callPost({
+      tokenId: TOKEN_ID,
+      type: 'totally_made_up',
+      chosenLemmaId: LEMMA_ID,
+    })) as { status: number };
+    expect(r.status).toBe(400);
+    expect(writeTokenCorrection).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-uuid tokenId with 400', async () => {
+    const r = (await callPost({
+      tokenId: 'not-a-uuid',
+      type: 'mark_foreign',
+    })) as { status: number };
+    expect(r.status).toBe(400);
+  });
+
+  it('surfaces a 404 when the service reports missing token / lemma', async () => {
+    const { CorrectionValidationError } = await import(
+      '$lib/server/corrections.js'
+    );
+    writeTokenCorrection.mockRejectedValueOnce(
+      new CorrectionValidationError('token not found', 404),
+    );
+    const r = (await callPost({
+      tokenId: TOKEN_ID,
+      type: 'mark_foreign',
+    })) as { status: number };
+    expect(r.status).toBe(404);
+  });
+});


### PR DESCRIPTION
> Stacked on #222 (T-5.1c). Merge that first.

## Summary

When the NLP worker tags a token as ambiguous (\`is_ambiguous = true\`), the reader popup now expands an inline list of alternate-meaning candidates and lets the user pick the right one with a single tap.

- **Schema** — new \`token_corrections\` table (migration \`0014_ordinary_gabe_jones.sql\`). Primary-keyed on \`(user, token)\` so re-correcting upserts; \`type\` enum covers \`pick_candidate\` / \`manual_lemma\` / \`new_lemma\` / \`mark_proper_noun\` / \`mark_foreign\` / \`mark_not_a_word\`. M6 follow-up tickets write through the same table.
- **Service + endpoint** — \`corrections.ts\` validates the per-type contract (pick_candidate + manual_lemma require \`chosen_lemma_id\`; the \`mark_*\` variants must NOT carry one), pre-checks token + lemma existence for clean 404s, and upserts via \`ON CONFLICT\`. \`POST /api/v1/me/token-corrections\` is the write surface.
- **Reader loader** — \`loadChapterTokens\` populates each token's \`candidates\` array with \`headword + POS + gloss\` from the lemmas table; drops null-lemmaId rows the worker couldn't resolve, drops the current primary so the popup never offers the user's already-active pick.
- **Popup** — disclosure renders the candidates with a chevron, gloss preview, and a \"This one\" button. The button POSTs the correction, pushes a session-only override into the parent (ChapterBody / ReaderScroll) so the corrected token re-renders with the new lemma immediately, and closes the popup. The previous primary drops back into the candidate list so the user can flip back without reopening the menu.

T-6.4 will land the loader-side join so corrections persist across page reloads — for now the row is on disk, so the next reader session picks it up via that ticket.

Closes #55.

## Test plan

- [x] \`pnpm --filter @ciareader/web test\` — 95 files / 764 tests pass, including:
  - \`corrections.test.ts\` (7 tests) — service contract: type/lemma compatibility, 404s on missing token/lemma, mark_* writes nullable lemma, bulk read returns map keyed by tokenId.
  - \`token-corrections-server.test.ts\` (5 tests) — endpoint accepts pick_candidate / mark_proper_noun, rejects unknown types + non-uuid token id, surfaces 404 from the service.
  - \`tokens.test.ts\` — added a candidates-population test covering the lemma metadata join + filtering of nulls + dedup against the active primary.
- [x] \`pnpm --filter @ciareader/web typecheck\` — 0 errors / 0 warnings.
- [x] \`pnpm --filter @ciareader/web lint\` — clean.

## Out of scope

- The "Customize" / dictionary search / new-lemma flows on the popup — they live on T-6.2 / T-6.3 and reuse the same \`token_corrections\` plumbing.
- Server-side application of the correction at read-time — T-6.4 will join \`text_tokens\` against \`token_corrections\` in \`loadChapterTokens\` so the corrected lemma is the new primary on subsequent loads.