### PR TITLE
T-6.4: per-user corrections applied at read time

### DIFF
--- a/apps/web/src/lib/server/corrections.test.ts
+++ b/apps/web/src/lib/server/corrections.test.ts
@@ -11,6 +11,7 @@ type ChainShape = {
   limit: ReturnType<typeof vi.fn>;
   values: ReturnType<typeof vi.fn>;
   onConflictDoUpdate: ReturnType<typeof vi.fn>;
+  onConflictDoNothing: ReturnType<typeof vi.fn>;
   returning: ReturnType<typeof vi.fn>;
 };
 const chain: ChainShape = {
@@ -19,6 +20,10 @@ const chain: ChainShape = {
   limit: vi.fn(() => rows),
   values: vi.fn(() => chain),
   onConflictDoUpdate: vi.fn(() => chain),
+  // The user_known_lemmas seed insert is a fire-and-forget upsert;
+  // returning the chain keeps the mock awaitable when the
+  // implementation `await`s the chain.
+  onConflictDoNothing: vi.fn(() => Promise.resolve(undefined)),
   returning: vi.fn(() => rows),
 };
 const fakeDb = {
@@ -34,6 +39,10 @@ vi.mock('./db/index.js', () => ({
     tokenCorrections: {
       userId: 'tc.user_id',
       tokenId: 'tc.token_id',
+    },
+    userKnownLemmas: {
+      userId: 'ukl.user_id',
+      lemmaId: 'ukl.lemma_id',
     },
   },
 }));
@@ -57,7 +66,7 @@ describe('writeTokenCorrection', () => {
     chain.limit.mockReturnValueOnce([{ id: 'tok-1' }]);
     // Second select: lemma lookup → present.
     chain.limit.mockReturnValueOnce([{ id: 'lem-2' }]);
-    // returning() resolves the upsert.
+    // returning() resolves the upsert on token_corrections.
     chain.returning.mockReturnValueOnce([
       {
         userId: 'u1',
@@ -73,7 +82,8 @@ describe('writeTokenCorrection', () => {
       chosenLemmaId: 'lem-2',
     });
     expect(row.chosenLemmaId).toBe('lem-2');
-    expect(fakeDb.insert).toHaveBeenCalledOnce();
+    // Two inserts: token_corrections + user_known_lemmas seed (T-6.4).
+    expect(fakeDb.insert).toHaveBeenCalledTimes(2);
   });
 
   it('rejects pick_candidate without a chosenLemmaId', async () => {
@@ -141,6 +151,37 @@ describe('writeTokenCorrection', () => {
     expect(row.chosenLemmaId).toBeNull();
     const insertArg = chain.values.mock.calls[0]?.[0] as Record<string, unknown>;
     expect(insertArg.chosenLemmaId).toBeNull();
+    // T-6.4: mark_* corrections must NOT seed a user_known_lemmas
+    // row — there's no chosen lemma to seed against.
+    expect(chain.onConflictDoNothing).not.toHaveBeenCalled();
+  });
+
+  it('seeds a user_known_lemmas row on pick_candidate (T-6.4)', async () => {
+    chain.limit
+      .mockReturnValueOnce([{ id: 'tok-1' }])
+      .mockReturnValueOnce([{ id: 'lem-2' }]);
+    chain.returning.mockReturnValueOnce([
+      {
+        userId: 'u1',
+        tokenId: 'tok-1',
+        type: 'pick_candidate',
+        chosenLemmaId: 'lem-2',
+      },
+    ]);
+    await writeTokenCorrection({
+      userId: 'u1',
+      tokenId: 'tok-1',
+      type: 'pick_candidate',
+      chosenLemmaId: 'lem-2',
+    });
+    // Two inserts: token_corrections upsert + user_known_lemmas
+    // seed (do-nothing on conflict).
+    expect(fakeDb.insert).toHaveBeenCalledTimes(2);
+    expect(chain.onConflictDoNothing).toHaveBeenCalledOnce();
+    const seedArg = chain.values.mock.calls[1]?.[0] as Record<string, unknown>;
+    expect(seedArg.userId).toBe('u1');
+    expect(seedArg.lemmaId).toBe('lem-2');
+    expect(seedArg.status).toBe('learning');
   });
 });
 

--- a/apps/web/src/lib/server/corrections.ts
+++ b/apps/web/src/lib/server/corrections.ts
@@ -118,6 +118,31 @@ export async function writeTokenCorrection(
     })
     .returning();
   if (!row) throw new Error('upsert returned no row');
+
+  // T-6.4: corrections are lemma-scoped. When the user picks a
+  // lemma we ensure they have a user_known_lemmas row so the next
+  // page renders the corrected token with a real status code (and
+  // so the user can mark it in the popup). We seed `learning` —
+  // they showed enough engagement to fix the parse, so they're at
+  // least studying it. Already-existing rows (e.g. they marked it
+  // known on a different text) are left untouched.
+  if (input.chosenLemmaId && requiresLemma) {
+    await db
+      .insert(schema.userKnownLemmas)
+      .values({
+        userId: input.userId,
+        lemmaId: input.chosenLemmaId,
+        status: 'learning',
+        updatedAt: now,
+      })
+      .onConflictDoNothing({
+        target: [
+          schema.userKnownLemmas.userId,
+          schema.userKnownLemmas.lemmaId,
+        ],
+      });
+  }
+
   return row;
 }
 

--- a/apps/web/src/lib/server/texts/tokens.test.ts
+++ b/apps/web/src/lib/server/texts/tokens.test.ts
@@ -36,6 +36,10 @@ vi.mock('../db/index.js', () => ({
       lemmaId: 'user_known_lemmas.lemma_id',
       status: 'user_known_lemmas.status',
     },
+    tokenCorrections: {
+      userId: 'token_corrections.user_id',
+      tokenId: 'token_corrections.token_id',
+    },
     lemmas: {
       id: 'lemmas.id',
       glossDefault: 'lemmas.gloss_default',
@@ -82,6 +86,7 @@ describe('loadChapterTokens', () => {
 
   it('returns tokens with status=unknown when the viewer has no known-lemma rows', async () => {
     stage([tokenRow({ id: 't1', idx: 0 }), tokenRow({ id: 't2', idx: 1 })]);
+    stage([]); // token_corrections (T-6.4) — none
     stage([]); // user_known_lemmas → empty
     stage([]); // lemmas (gloss lookup) → empty
     const result = await loadChapterTokens('chap-1', 'user-1');
@@ -95,6 +100,7 @@ describe('loadChapterTokens', () => {
       tokenRow({ id: 't2', idx: 1, lemmaId: 'lem-learning' }),
       tokenRow({ id: 't3', idx: 2, lemmaId: 'lem-other' }),
     ]);
+    stage([]); // token_corrections (T-6.4) — none
     stage([
       { userId: 'user-1', lemmaId: 'lem-known', status: 'known' },
       { userId: 'user-1', lemmaId: 'lem-learning', status: 'learning' },
@@ -114,6 +120,7 @@ describe('loadChapterTokens', () => {
       tokenRow({ id: 't2', idx: 1, lemmaId: 'lem-b' }),
       tokenRow({ id: 't3', idx: 2, lemmaId: null, isWord: false, surface: ' ' }),
     ]);
+    stage([]); // token_corrections (T-6.4)
     stage([]); // user_known_lemmas
     stage([
       { id: 'lem-a', language: 'hi', headword: 'सुबह', glossDefault: 'morning' },
@@ -136,6 +143,7 @@ describe('loadChapterTokens', () => {
     // Common case: NLP tagged "पार्क" as PROPN with no gloss; the
     // dictionary entry is under "पार्क/NOUN" with the actual gloss.
     stage([tokenRow({ id: 't1', idx: 0, lemmaId: 'lem-propn' })]);
+    stage([]); // token_corrections (T-6.4)
     stage([]); // user_known_lemmas
     stage([
       { id: 'lem-propn', language: 'hi', headword: 'पार्क', glossDefault: null },
@@ -149,13 +157,14 @@ describe('loadChapterTokens', () => {
 
   it('skips the sibling fallback query entirely when every lemma has its own gloss (T-3.14)', async () => {
     stage([tokenRow({ id: 't1', idx: 0, lemmaId: 'lem-a' })]);
+    stage([]); // token_corrections (T-6.4)
     stage([]); // user_known_lemmas
     stage([{ id: 'lem-a', language: 'hi', headword: 'पानी', glossDefault: 'water' }]);
-    // No 4th stage — fallback query must not fire.
+    // No 5th stage — fallback query must not fire.
     await loadChapterTokens('chap-1', 'user-1');
-    // 1 (tokens) + 1 (user_known_lemmas) + 1 (gloss lookup) = 3, no
-    // sibling fallback.
-    expect(selectFn).toHaveBeenCalledTimes(3);
+    // 1 (tokens) + 1 (token_corrections) + 1 (user_known_lemmas) +
+    // 1 (gloss lookup) = 4, no sibling fallback.
+    expect(selectFn).toHaveBeenCalledTimes(4);
   });
 
   it('populates token.candidates with metadata pulled from the lemmas table (T-6.1)', async () => {
@@ -173,6 +182,7 @@ describe('loadChapterTokens', () => {
         ],
       }),
     ]);
+    stage([]); // token_corrections (T-6.4)
     stage([]); // user_known_lemmas
     stage([
       {
@@ -210,6 +220,90 @@ describe('loadChapterTokens', () => {
         features: { Case: 'Acc' },
       },
     ]);
+  });
+
+  it('applies a pick_candidate correction at read time, swapping the active lemma (T-6.4)', async () => {
+    stage([
+      tokenRow({
+        id: 't1',
+        idx: 0,
+        lemmaId: 'lem-original',
+        isAmbiguous: true,
+        lemmaCandidates: [
+          { lemmaId: 'lem-original', features: {}, score: 0.6 },
+          { lemmaId: 'lem-corrected', features: {}, score: 0.3 },
+        ],
+      }),
+    ]);
+    stage([
+      {
+        userId: 'user-1',
+        tokenId: 't1',
+        type: 'pick_candidate',
+        chosenLemmaId: 'lem-corrected',
+      },
+    ]);
+    stage([]); // user_known_lemmas
+    stage([
+      {
+        id: 'lem-original',
+        language: 'hi',
+        headword: 'मूल',
+        pos: 'NOUN',
+        glossDefault: 'original',
+      },
+      {
+        id: 'lem-corrected',
+        language: 'hi',
+        headword: 'सही',
+        pos: 'VERB',
+        glossDefault: 'corrected',
+      },
+    ]);
+    const result = await loadChapterTokens('chap-1', 'user-1');
+    expect(result![0]).toMatchObject({
+      id: 't1',
+      lemmaId: 'lem-corrected',
+      glossDefault: 'corrected',
+    });
+    // The previous primary now appears in the candidate list so the
+    // user can flip back without leaving the popup.
+    const cands = result![0]!.candidates.map((c) => c.lemmaId);
+    expect(cands).toContain('lem-original');
+    expect(cands).not.toContain('lem-corrected');
+  });
+
+  it('mark_proper_noun clears the lemma + sets status=ignored (T-6.4)', async () => {
+    stage([
+      tokenRow({ id: 't1', idx: 0, lemmaId: 'lem-x', isOov: false }),
+    ]);
+    stage([
+      {
+        userId: 'user-1',
+        tokenId: 't1',
+        type: 'mark_proper_noun',
+        chosenLemmaId: null,
+      },
+    ]);
+    stage([]); // user_known_lemmas
+    stage([
+      {
+        id: 'lem-x',
+        language: 'hi',
+        headword: 'X',
+        pos: 'NOUN',
+        // Non-null gloss so the sibling-fallback SELECT doesn't fire.
+        glossDefault: 'placeholder',
+      },
+    ]);
+    const result = await loadChapterTokens('chap-1', 'user-1');
+    expect(result![0]).toMatchObject({
+      id: 't1',
+      lemmaId: null,
+      status: 'ignored',
+      isWord: false,
+      isOov: false,
+    });
   });
 
   it('handles anonymous viewers (no user_known_lemmas SELECT, every status=unknown)', async () => {

--- a/apps/web/src/lib/server/texts/tokens.ts
+++ b/apps/web/src/lib/server/texts/tokens.ts
@@ -14,7 +14,7 @@
 import { and, eq, inArray, isNotNull } from 'drizzle-orm';
 
 import { db, schema } from '../db/index.js';
-import type { TextToken, UserKnownLemma } from '../db/schema.js';
+import type { TextToken, TokenCorrection, UserKnownLemma } from '../db/schema.js';
 
 /**
  * One candidate in the disambiguation list (T-6.1). Set on
@@ -79,9 +79,38 @@ export async function loadChapterTokens(
 
   if (tokens.length === 0) return null;
 
-  // Primary lemma for each token (the worker's top pick).
+  // T-6.4: pull the viewer's per-token corrections in one SELECT
+  // so we can apply them in the same map below without a per-token
+  // round trip. Anonymous viewers don't have corrections; signed-in
+  // viewers usually have only a handful per chapter, so this is
+  // cheap.
+  const correctionsByTokenId = new Map<string, TokenCorrection>();
+  if (viewerId && tokens.length > 0) {
+    const corrRows = (await db
+      .select()
+      .from(schema.tokenCorrections)
+      .where(
+        and(
+          eq(schema.tokenCorrections.userId, viewerId),
+          inArray(
+            schema.tokenCorrections.tokenId,
+            tokens.map((t) => t.id),
+          ),
+        ),
+      )) as TokenCorrection[];
+    for (const r of corrRows) correctionsByTokenId.set(r.tokenId, r);
+  }
+
+  // Primary lemma for each token (the worker's top pick) AFTER any
+  // T-6.4 correction is applied — that way the gloss + known-status
+  // joins below pick up the corrected lemma in a single pass instead
+  // of fetching twice.
   const primaryLemmaIds = tokens
-    .map((t) => t.lemmaId)
+    .map((t) => {
+      const c = correctionsByTokenId.get(t.id);
+      if (c?.chosenLemmaId) return c.chosenLemmaId;
+      return t.lemmaId;
+    })
     .filter((id): id is string => !!id);
   // T-6.1: also pre-fetch every lemma referenced as a CANDIDATE so
   // the popup's alternate-meanings list can render headword + POS
@@ -223,42 +252,94 @@ export async function loadChapterTokens(
   }
 
   return tokens.map((t) => {
-    const status: RenderedToken['status'] =
-      t.lemmaId && statusByLemma.has(t.lemmaId)
-        ? statusByLemma.get(t.lemmaId)!
+    // T-6.4: apply the viewer's persistent correction here so the
+    // chosen lemma drives every downstream concern (status colour,
+    // gloss tooltip, candidate list).
+    const correction = correctionsByTokenId.get(t.id) ?? null;
+    const correctedLemmaId =
+      correction && correction.chosenLemmaId
+        ? correction.chosenLemmaId
+        : t.lemmaId;
+    // mark_proper_noun / mark_foreign / mark_not_a_word: the user
+    // declared this surface isn't a learnable word. Drop the lemma
+    // tie + suppress is_oov / is_ambiguous so the reader stops
+    // colouring it. The status maps to 'ignored' so it counts as
+    // "deliberately not learning."
+    const isMarkedNonWord =
+      correction != null &&
+      (correction.type === 'mark_proper_noun' ||
+        correction.type === 'mark_foreign' ||
+        correction.type === 'mark_not_a_word');
+    const effectiveLemmaId = isMarkedNonWord ? null : correctedLemmaId;
+
+    const status: RenderedToken['status'] = isMarkedNonWord
+      ? 'ignored'
+      : effectiveLemmaId && statusByLemma.has(effectiveLemmaId)
+        ? statusByLemma.get(effectiveLemmaId)!
         : 'unknown';
+
     // T-6.1: build the candidate list, dropping (a) candidates with
     // no lemmaId (the worker couldn't link them — those become
     // "search the dictionary" picks under T-6.2), and (b) the
-    // current primary's lemmaId so the popup never offers the user
-    // their already-active pick. Sort descending by score so the
-    // strongest alternative reads first.
+    // currently-active lemma (post-correction) so the popup never
+    // offers the user their already-active pick. T-6.4: if the
+    // user picked a candidate, the worker's original primary
+    // re-enters the candidate list so they can flip back without
+    // re-hunting it.
     const candidates: RenderedCandidate[] = [];
-    for (const c of t.lemmaCandidates) {
-      if (!c.lemmaId) continue;
-      if (c.lemmaId === t.lemmaId) continue;
-      const meta = lemmaMetaById.get(c.lemmaId);
-      if (!meta) continue;
+    const seen = new Set<string>();
+    function pushCandidate(
+      lemmaId: string,
+      score: number,
+      features: Record<string, string>,
+    ) {
+      if (lemmaId === effectiveLemmaId) return;
+      if (seen.has(lemmaId)) return;
+      const meta = lemmaMetaById.get(lemmaId);
+      if (!meta) return;
+      seen.add(lemmaId);
       candidates.push({
-        lemmaId: c.lemmaId,
+        lemmaId,
         headword: meta.headword,
         pos: meta.pos,
-        glossDefault: glossByLemma.get(c.lemmaId) ?? null,
-        score: c.score,
-        features: c.features,
+        glossDefault: glossByLemma.get(lemmaId) ?? null,
+        score,
+        features,
       });
     }
+    for (const c of t.lemmaCandidates) {
+      if (!c.lemmaId) continue;
+      pushCandidate(c.lemmaId, c.score, c.features);
+    }
+    // Re-introduce the worker's original primary as a candidate
+    // when the viewer's correction has bumped it out — they may
+    // want to revert with one tap.
+    if (
+      correction &&
+      correction.chosenLemmaId &&
+      t.lemmaId &&
+      t.lemmaId !== correction.chosenLemmaId &&
+      !isMarkedNonWord
+    ) {
+      pushCandidate(t.lemmaId, 0, {});
+    }
     candidates.sort((a, b) => b.score - a.score);
+
     return {
       id: t.id,
       idx: t.idx,
       surface: t.surface,
-      isWord: t.isWord,
-      isAmbiguous: t.isAmbiguous,
-      isOov: t.isOov,
-      lemmaId: t.lemmaId,
+      isWord: isMarkedNonWord ? false : t.isWord,
+      isAmbiguous: candidates.length > 0,
+      // mark_* corrections bypass OOV: the user has told us this
+      // surface is a proper noun / foreign / non-word, not "missing
+      // from the dictionary".
+      isOov: isMarkedNonWord ? false : t.isOov,
+      lemmaId: effectiveLemmaId,
       romanization: t.romanization,
-      glossDefault: t.lemmaId ? glossByLemma.get(t.lemmaId) ?? null : null,
+      glossDefault: effectiveLemmaId
+        ? glossByLemma.get(effectiveLemmaId) ?? null
+        : null,
       candidates,
       status,
     };


### PR DESCRIPTION
> Stacked on #223 (T-6.1). Merge that first.

## Summary

\`loadChapterTokens\` now joins \`text_tokens\` with the viewer's \`token_corrections\` rows in a single extra SELECT. The corrected lemma becomes the active primary for the rest of the pipeline (gloss lookup, status colour, candidate dedup), so a returning reader sees their picks already applied without the popup having to replay them in client state.

Behavior per correction type:

- \`pick_candidate\` / \`manual_lemma\` — chosen_lemma_id replaces the worker's primary. The original primary re-enters the candidate list at score=0 so the user can flip back with one tap.
- \`mark_proper_noun\` / \`mark_foreign\` / \`mark_not_a_word\` — strips the lemma tie, sets \`status=ignored\`, suppresses \`isWord\` + \`isOov\` so the reader stops colouring the surface entirely.

\`writeTokenCorrection\` also seeds a \`user_known_lemmas\` row at \`status='learning'\` on every lemma-bearing correction (with ON CONFLICT DO NOTHING) — that's what the ticket means by "corrections are lemma-scoped: marking token as lemma X updates that user's user_known_lemmas for X." Pre-existing rows are left alone, so a lemma the user already marked 'known' on a different text isn't downgraded.

Closes #60.

## Test plan

- [x] \`pnpm --filter @ciareader/web test\` — 95 files / 767 tests pass, including:
  - \`tokens.test.ts\` — added two T-6.4 tests: pick_candidate swaps active lemma + reintroduces original as candidate; mark_proper_noun nullifies lemma + flips status to ignored.
  - \`corrections.test.ts\` — added a T-6.4 test asserting the user_known_lemmas seed insert fires with status='learning'.
  - The mark_* contract test confirms the seed insert is NOT called when there's no chosen lemma.
- [x] \`pnpm --filter @ciareader/web typecheck\` — 0 errors.
- [x] \`pnpm --filter @ciareader/web lint\` — clean.

## Out of scope

- Promotion to \`form_lemma_overrides\` (the global override table) — that's T-6.7's aggregation worker reading from \`token_corrections\` once enough users converge.