### PR TITLE
T-6.5: parse_reports table + duplicate merging

### DIFF
--- a/apps/web/drizzle/0015_foamy_victor_mancha.sql
+++ b/apps/web/drizzle/0015_foamy_victor_mancha.sql
@@ -1,0 +1,47 @@
+CREATE TYPE "public"."parse_report_status" AS ENUM('open', 'triaged', 'resolved', 'rejected', 'duplicate', 'deferred');--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "parse_reports" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"token_id" uuid,
+	"language" "language" NOT NULL,
+	"surface_nfc" text NOT NULL,
+	"context_signature" text DEFAULT '' NOT NULL,
+	"original_candidates" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"corrected_lemma_id" uuid,
+	"correction_type" "token_correction_type" NOT NULL,
+	"reporter_id" uuid,
+	"note" text,
+	"status" "parse_report_status" DEFAULT 'open' NOT NULL,
+	"assigned_reviewer_id" uuid,
+	"resolved_at" timestamp with time zone,
+	"resolution_note" text,
+	"duplicate_count" integer DEFAULT 1 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "parse_reports" ADD CONSTRAINT "parse_reports_token_id_text_tokens_id_fk" FOREIGN KEY ("token_id") REFERENCES "public"."text_tokens"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "parse_reports" ADD CONSTRAINT "parse_reports_corrected_lemma_id_lemmas_id_fk" FOREIGN KEY ("corrected_lemma_id") REFERENCES "public"."lemmas"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "parse_reports" ADD CONSTRAINT "parse_reports_reporter_id_users_id_fk" FOREIGN KEY ("reporter_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "parse_reports" ADD CONSTRAINT "parse_reports_assigned_reviewer_id_users_id_fk" FOREIGN KEY ("assigned_reviewer_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "parse_reports_lang_status_idx" ON "parse_reports" USING btree ("language","status");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "parse_reports_dedup_idx" ON "parse_reports" USING btree ("language","surface_nfc","context_signature","corrected_lemma_id");

--- a/apps/web/drizzle/meta/0015_snapshot.json
+++ b/apps/web/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,2700 @@
+{
+  "id": "e5116ebc-0764-4fa5-b2d8-4094ff1bbe01",
+  "prevId": "f7e7c2c1-2b51-442b-a2b7-59b0dbeb00c2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.curator_languages": {
+      "name": "curator_languages",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "curator_languages_user_idx": {
+          "name": "curator_languages_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "curator_languages_user_id_users_id_fk": {
+          "name": "curator_languages_user_id_users_id_fk",
+          "tableFrom": "curator_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "curator_languages_granted_by_users_id_fk": {
+          "name": "curator_languages_granted_by_users_id_fk",
+          "tableFrom": "curator_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "curator_languages_user_id_language_pk": {
+          "name": "curator_languages_user_id_language_pk",
+          "columns": [
+            "user_id",
+            "language"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.dictionary_imports": {
+      "name": "dictionary_imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_name": {
+          "name": "source_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_at": {
+          "name": "run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lemmas_created": {
+          "name": "lemmas_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lemmas_updated": {
+          "name": "lemmas_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lemmas_skipped_curator_locked": {
+          "name": "lemmas_skipped_curator_locked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "translations_created": {
+          "name": "translations_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "translations_updated": {
+          "name": "translations_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "dictionary_imports_language_idx": {
+          "name": "dictionary_imports_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.form_lemma_overrides": {
+      "name": "form_lemma_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_nfc": {
+          "name": "surface_nfc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_signature": {
+          "name": "context_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "chosen_lemma_id": {
+          "name": "chosen_lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "promoted_at": {
+          "name": "promoted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "promoted_by": {
+          "name": "promoted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "form_lemma_overrides_lookup_idx": {
+          "name": "form_lemma_overrides_lookup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface_nfc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "form_lemma_overrides_chosen_lemma_id_lemmas_id_fk": {
+          "name": "form_lemma_overrides_chosen_lemma_id_lemmas_id_fk",
+          "tableFrom": "form_lemma_overrides",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "chosen_lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_lemma_overrides_promoted_by_users_id_fk": {
+          "name": "form_lemma_overrides_promoted_by_users_id_fk",
+          "tableFrom": "form_lemma_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "promoted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "form_lemma_overrides_lang_surface_ctx_uq": {
+          "name": "form_lemma_overrides_lang_surface_ctx_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "language",
+            "surface_nfc",
+            "context_signature"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.lemma_edit_history": {
+      "name": "lemma_edit_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "editor_id": {
+          "name": "editor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "lemma_edit_change_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change": {
+          "name": "change",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_edit_history_lemma_idx": {
+          "name": "lemma_edit_history_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_edit_history_editor_idx": {
+          "name": "lemma_edit_history_editor_idx",
+          "columns": [
+            {
+              "expression": "editor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_edit_history_lemma_id_lemmas_id_fk": {
+          "name": "lemma_edit_history_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_edit_history",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lemma_edit_history_editor_id_users_id_fk": {
+          "name": "lemma_edit_history_editor_id_users_id_fk",
+          "tableFrom": "lemma_edit_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "editor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemma_forms": {
+      "name": "lemma_forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "romanization": {
+          "name": "romanization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_forms_lemma_idx": {
+          "name": "lemma_forms_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_forms_surface_idx": {
+          "name": "lemma_forms_surface_idx",
+          "columns": [
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_forms_lemma_id_lemmas_id_fk": {
+          "name": "lemma_forms_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_forms",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemmas": {
+      "name": "lemmas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headword": {
+          "name": "headword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos": {
+          "name": "pos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script": {
+          "name": "script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gloss_default": {
+          "name": "gloss_default",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_rank": {
+          "name": "frequency_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "translation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "curator_locked": {
+          "name": "curator_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemmas_language_headword_pos_idx": {
+          "name": "lemmas_language_headword_pos_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "headword",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pos",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_language_idx": {
+          "name": "lemmas_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_language_frequency_idx": {
+          "name": "lemmas_language_frequency_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "frequency_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_source_lookup_idx": {
+          "name": "lemmas_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.magic_links": {
+      "name": "magic_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "magic_links_user_idx": {
+          "name": "magic_links_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "magic_links_expires_idx": {
+          "name": "magic_links_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "magic_links_user_id_users_id_fk": {
+          "name": "magic_links_user_id_users_id_fk",
+          "tableFrom": "magic_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.nlp_jobs": {
+      "name": "nlp_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "nlp_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nlp_jobs_text_idx": {
+          "name": "nlp_jobs_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nlp_jobs_status_idx": {
+          "name": "nlp_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nlp_jobs_text_id_texts_id_fk": {
+          "name": "nlp_jobs_text_id_texts_id_fk",
+          "tableFrom": "nlp_jobs",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.parse_reports": {
+      "name": "parse_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_nfc": {
+          "name": "surface_nfc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_signature": {
+          "name": "context_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "original_candidates": {
+          "name": "original_candidates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "corrected_lemma_id": {
+          "name": "corrected_lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "correction_type": {
+          "name": "correction_type",
+          "type": "token_correction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "parse_report_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "assigned_reviewer_id": {
+          "name": "assigned_reviewer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_note": {
+          "name": "resolution_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duplicate_count": {
+          "name": "duplicate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parse_reports_lang_status_idx": {
+          "name": "parse_reports_lang_status_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parse_reports_dedup_idx": {
+          "name": "parse_reports_dedup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface_nfc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_signature",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "corrected_lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parse_reports_token_id_text_tokens_id_fk": {
+          "name": "parse_reports_token_id_text_tokens_id_fk",
+          "tableFrom": "parse_reports",
+          "tableTo": "text_tokens",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "parse_reports_corrected_lemma_id_lemmas_id_fk": {
+          "name": "parse_reports_corrected_lemma_id_lemmas_id_fk",
+          "tableFrom": "parse_reports",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "corrected_lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "parse_reports_reporter_id_users_id_fk": {
+          "name": "parse_reports_reporter_id_users_id_fk",
+          "tableFrom": "parse_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "parse_reports_assigned_reviewer_id_users_id_fk": {
+          "name": "parse_reports_assigned_reviewer_id_users_id_fk",
+          "tableFrom": "parse_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_reviewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by": {
+          "name": "replaced_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "refresh_tokens_user_idx": {
+          "name": "refresh_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_expires_idx": {
+          "name": "refresh_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.text_chapters": {
+      "name": "text_chapters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idx": {
+          "name": "idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "text_chapters_text_idx": {
+          "name": "text_chapters_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_chapters_text_id_texts_id_fk": {
+          "name": "text_chapters_text_id_texts_id_fk",
+          "tableFrom": "text_chapters",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "text_chapters_text_idx_uq": {
+          "name": "text_chapters_text_idx_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "text_id",
+            "idx"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.text_tokens": {
+      "name": "text_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idx": {
+          "name": "idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lemma_candidates": {
+          "name": "lemma_candidates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_ambiguous": {
+          "name": "is_ambiguous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_oov": {
+          "name": "is_oov",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_word": {
+          "name": "is_word",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sentence_idx": {
+          "name": "sentence_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "romanization": {
+          "name": "romanization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "text_tokens_chapter_scan_idx": {
+          "name": "text_tokens_chapter_scan_idx",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "text_tokens_lemma_idx": {
+          "name": "text_tokens_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_tokens_chapter_id_text_chapters_id_fk": {
+          "name": "text_tokens_chapter_id_text_chapters_id_fk",
+          "tableFrom": "text_tokens",
+          "tableTo": "text_chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_tokens_lemma_id_lemmas_id_fk": {
+          "name": "text_tokens_lemma_id_lemmas_id_fk",
+          "tableFrom": "text_tokens",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "text_tokens_chapter_idx_uq": {
+          "name": "text_tokens_chapter_idx_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chapter_id",
+            "idx"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.texts": {
+      "name": "texts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "status_error": {
+          "name": "status_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "texts_owner_idx": {
+          "name": "texts_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "texts_visibility_idx": {
+          "name": "texts_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "texts_owner_id_users_id_fk": {
+          "name": "texts_owner_id_users_id_fk",
+          "tableFrom": "texts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.token_corrections": {
+      "name": "token_corrections",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "token_correction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chosen_lemma_id": {
+          "name": "chosen_lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "token_corrections_token_idx": {
+          "name": "token_corrections_token_idx",
+          "columns": [
+            {
+              "expression": "token_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "token_corrections_chosen_lemma_idx": {
+          "name": "token_corrections_chosen_lemma_idx",
+          "columns": [
+            {
+              "expression": "chosen_lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "token_corrections_user_id_users_id_fk": {
+          "name": "token_corrections_user_id_users_id_fk",
+          "tableFrom": "token_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "token_corrections_token_id_text_tokens_id_fk": {
+          "name": "token_corrections_token_id_text_tokens_id_fk",
+          "tableFrom": "token_corrections",
+          "tableTo": "text_tokens",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "token_corrections_chosen_lemma_id_lemmas_id_fk": {
+          "name": "token_corrections_chosen_lemma_id_lemmas_id_fk",
+          "tableFrom": "token_corrections",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "chosen_lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "token_corrections_user_id_token_id_pk": {
+          "name": "token_corrections_user_id_token_id_pk",
+          "columns": [
+            "user_id",
+            "token_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.translations": {
+      "name": "translations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "translation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_translation_id": {
+          "name": "parent_translation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_language": {
+          "name": "target_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_rank": {
+          "name": "display_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "translations_lemma_idx": {
+          "name": "translations_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translations_submitted_by_idx": {
+          "name": "translations_submitted_by_idx",
+          "columns": [
+            {
+              "expression": "submitted_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translations_source_lookup_idx": {
+          "name": "translations_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "translations_lemma_id_lemmas_id_fk": {
+          "name": "translations_lemma_id_lemmas_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "translations_submitted_by_users_id_fk": {
+          "name": "translations_submitted_by_users_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "translations_parent_translation_id_translations_id_fk": {
+          "name": "translations_parent_translation_id_translations_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "translations",
+          "columnsFrom": [
+            "parent_translation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_known_lemmas": {
+      "name": "user_known_lemmas",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "known_lemma_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'learning'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_known_lemmas_user_idx": {
+          "name": "user_known_lemmas_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_known_lemmas_user_id_users_id_fk": {
+          "name": "user_known_lemmas_user_id_users_id_fk",
+          "tableFrom": "user_known_lemmas",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_known_lemmas_lemma_id_lemmas_id_fk": {
+          "name": "user_known_lemmas_lemma_id_lemmas_id_fk",
+          "tableFrom": "user_known_lemmas",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_known_lemmas_user_id_lemma_id_pk": {
+          "name": "user_known_lemmas_user_id_lemma_id_pk",
+          "columns": [
+            "user_id",
+            "lemma_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_languages": {
+      "name": "user_languages",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script_preference": {
+          "name": "script_preference",
+          "type": "script_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "romanization_scheme": {
+          "name": "romanization_scheme",
+          "type": "romanization_scheme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'iso15919'"
+        },
+        "known_words_count_cache": {
+          "name": "known_words_count_cache",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reader_layout_mode": {
+          "name": "reader_layout_mode",
+          "type": "reader_layout_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'page'"
+        },
+        "words_per_page": {
+          "name": "words_per_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 250
+        },
+        "font_family": {
+          "name": "font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_size": {
+          "name": "font_size",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 18
+        },
+        "line_spacing": {
+          "name": "line_spacing",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1.6
+        },
+        "highlight_style": {
+          "name": "highlight_style",
+          "type": "highlight_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'background'"
+        },
+        "reading_width": {
+          "name": "reading_width",
+          "type": "reading_width",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "baseline": {
+          "name": "baseline",
+          "type": "language_baseline",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_languages_user_id_users_id_fk": {
+          "name": "user_languages_user_id_users_id_fk",
+          "tableFrom": "user_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_languages_user_id_language_pk": {
+          "name": "user_languages_user_id_language_pk",
+          "columns": [
+            "user_id",
+            "language"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_text_progress": {
+      "name": "user_text_progress",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_chapter_idx": {
+          "name": "last_chapter_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_token_idx": {
+          "name": "last_token_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pct_read": {
+          "name": "pct_read",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_text_progress_user_idx": {
+          "name": "user_text_progress_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_text_progress_user_id_users_id_fk": {
+          "name": "user_text_progress_user_id_users_id_fk",
+          "tableFrom": "user_text_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_text_progress_text_id_texts_id_fk": {
+          "name": "user_text_progress_text_id_texts_id_fk",
+          "tableFrom": "user_text_progress",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_text_progress_user_id_text_id_pk": {
+          "name": "user_text_progress_user_id_text_id_pk",
+          "columns": [
+            "user_id",
+            "text_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_preference": {
+          "name": "theme_preference",
+          "type": "theme_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarded_at": {
+          "name": "onboarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    }
+  },
+  "enums": {
+    "public.highlight_style": {
+      "name": "highlight_style",
+      "schema": "public",
+      "values": [
+        "underline",
+        "background",
+        "colored_text"
+      ]
+    },
+    "public.known_lemma_status": {
+      "name": "known_lemma_status",
+      "schema": "public",
+      "values": [
+        "unknown",
+        "learning",
+        "known",
+        "ignored"
+      ]
+    },
+    "public.language": {
+      "name": "language",
+      "schema": "public",
+      "values": [
+        "hi",
+        "mr",
+        "or"
+      ]
+    },
+    "public.language_baseline": {
+      "name": "language_baseline",
+      "schema": "public",
+      "values": [
+        "none",
+        "beginner",
+        "intermediate"
+      ]
+    },
+    "public.lemma_edit_change_type": {
+      "name": "lemma_edit_change_type",
+      "schema": "public",
+      "values": [
+        "lemma_update",
+        "lemma_unlock",
+        "lemma_lock",
+        "translation_insert",
+        "translation_update",
+        "translation_hide",
+        "translation_unhide",
+        "form_insert",
+        "form_delete",
+        "lemma_merge",
+        "lemma_split",
+        "translation_reorder"
+      ]
+    },
+    "public.nlp_job_status": {
+      "name": "nlp_job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.parse_report_status": {
+      "name": "parse_report_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "triaged",
+        "resolved",
+        "rejected",
+        "duplicate",
+        "deferred"
+      ]
+    },
+    "public.reader_layout_mode": {
+      "name": "reader_layout_mode",
+      "schema": "public",
+      "values": [
+        "page",
+        "paged_scroll",
+        "continuous"
+      ]
+    },
+    "public.reading_width": {
+      "name": "reading_width",
+      "schema": "public",
+      "values": [
+        "narrow",
+        "medium",
+        "wide"
+      ]
+    },
+    "public.romanization_scheme": {
+      "name": "romanization_scheme",
+      "schema": "public",
+      "values": [
+        "iso15919",
+        "iast",
+        "hunterian",
+        "itrans"
+      ]
+    },
+    "public.script_preference": {
+      "name": "script_preference",
+      "schema": "public",
+      "values": [
+        "native",
+        "native_with_romanization",
+        "romanization_only"
+      ]
+    },
+    "public.text_source_type": {
+      "name": "text_source_type",
+      "schema": "public",
+      "values": [
+        "paste",
+        "txt",
+        "epub"
+      ]
+    },
+    "public.text_status": {
+      "name": "text_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.text_visibility": {
+      "name": "text_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "shared",
+        "official"
+      ]
+    },
+    "public.theme_preference": {
+      "name": "theme_preference",
+      "schema": "public",
+      "values": [
+        "system",
+        "light",
+        "dark"
+      ]
+    },
+    "public.token_correction_type": {
+      "name": "token_correction_type",
+      "schema": "public",
+      "values": [
+        "pick_candidate",
+        "manual_lemma",
+        "new_lemma",
+        "mark_proper_noun",
+        "mark_foreign",
+        "mark_not_a_word"
+      ]
+    },
+    "public.translation_source": {
+      "name": "translation_source",
+      "schema": "public",
+      "values": [
+        "official_dictionary",
+        "curator",
+        "user"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "curator",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1777415283231,
       "tag": "0014_ordinary_gabe_jones",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1777416125218,
+      "tag": "0015_foamy_victor_mancha",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/src/lib/server/db/schema.ts
+++ b/apps/web/src/lib/server/db/schema.ts
@@ -901,6 +901,109 @@ export const tokenCorrections = pgTable(
   }),
 );
 
+/**
+ * Curator moderation queue for parse / lemma errors (T-6.5).
+ *
+ * Distinct from `token_corrections`: corrections are *per-user*
+ * picks the reader applies to their own view. A `parse_report` is
+ * a *site-wide* claim that the worker (or the dictionary) is
+ * mis-modeling a specific surface — surfaced to curators on T-6.6's
+ * moderation page, who promote accepted reports to
+ * `form_lemma_overrides` (the global override table) and/or fix
+ * the dictionary itself.
+ *
+ * Two routes file rows here:
+ *
+ *  - User-initiated: T-6.2's correction modal optionally checks
+ *    "Also report to moderators" when the user picks a manual
+ *    lemma / proposes a new one. (Default OFF for `pick_candidate`,
+ *    ON for `manual_lemma` / `new_lemma`.)
+ *
+ *  - System-initiated: T-6.7's aggregation worker auto-files a
+ *    `triaged`-status report when ≥K users converge on the same
+ *    correction. The curator's choice in T-6.6 promotes or vetoes.
+ *
+ * Duplicate merging: a new report whose
+ * `(language, surface_nfc, context_signature, corrected_lemma_id)`
+ * matches an existing open / triaged row increments that row's
+ * `duplicate_count` instead of creating a new row. Resolved /
+ * rejected rows do NOT collide — re-files after a curator
+ * resolution start a new conversation.
+ */
+export const parseReportStatus = pgEnum('parse_report_status', [
+  'open',
+  'triaged',
+  'resolved',
+  'rejected',
+  'duplicate',
+  'deferred',
+]);
+
+export const parseReports = pgTable(
+  'parse_reports',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    tokenId: uuid('token_id').references(() => textTokens.id, {
+      onDelete: 'set null',
+    }),
+    language: language('language').notNull(),
+    surfaceNfc: text('surface_nfc').notNull(),
+    // sha1-16 of (prev_pos, cur_pos, next_pos) — same shape as
+    // form_lemma_overrides.context_signature so the dedup math
+    // matches what T-6.7's aggregation worker writes downstream.
+    contextSignature: text('context_signature').notNull().default(''),
+    // Snapshot of the worker's top-K candidate list at report time —
+    // useful for the moderation UI even when the underlying token
+    // has since been re-processed.
+    originalCandidates: jsonb('original_candidates')
+      .$type<
+        Array<{
+          lemmaId: string | null;
+          score: number;
+          features: Record<string, string>;
+        }>
+      >()
+      .notNull()
+      .default([]),
+    correctedLemmaId: uuid('corrected_lemma_id').references(() => lemmas.id, {
+      onDelete: 'set null',
+    }),
+    correctionType: tokenCorrectionType('correction_type').notNull(),
+    reporterId: uuid('reporter_id').references(() => users.id, {
+      onDelete: 'set null',
+    }),
+    note: text('note'),
+    status: parseReportStatus('status').notNull().default('open'),
+    assignedReviewerId: uuid('assigned_reviewer_id').references(
+      () => users.id,
+      {
+        onDelete: 'set null',
+      },
+    ),
+    resolvedAt: timestamp('resolved_at', { withTimezone: true }),
+    resolutionNote: text('resolution_note'),
+    duplicateCount: integer('duplicate_count').notNull().default(1),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => ({
+    languageStatusIdx: index('parse_reports_lang_status_idx').on(
+      t.language,
+      t.status,
+    ),
+    dedupIdx: index('parse_reports_dedup_idx').on(
+      t.language,
+      t.surfaceNfc,
+      t.contextSignature,
+      t.correctedLemmaId,
+    ),
+  }),
+);
+
 export type Text = InferSelectModel<typeof texts>;
 export type TextChapter = InferSelectModel<typeof textChapters>;
 export type NlpJob = InferSelectModel<typeof nlpJobs>;
@@ -909,3 +1012,4 @@ export type UserKnownLemma = InferSelectModel<typeof userKnownLemmas>;
 export type UserTextProgress = InferSelectModel<typeof userTextProgress>;
 export type FormLemmaOverride = InferSelectModel<typeof formLemmaOverrides>;
 export type TokenCorrection = InferSelectModel<typeof tokenCorrections>;
+export type ParseReport = InferSelectModel<typeof parseReports>;

--- a/apps/web/src/lib/server/parse-reports.test.ts
+++ b/apps/web/src/lib/server/parse-reports.test.ts
@@ -1,0 +1,156 @@
+// @vitest-environment node
+/**
+ * Tests for the parse_reports service (T-6.5).
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const rows: Array<Record<string, unknown>> = [];
+type ChainShape = {
+  from: ReturnType<typeof vi.fn>;
+  where: ReturnType<typeof vi.fn>;
+  limit: ReturnType<typeof vi.fn>;
+  offset: ReturnType<typeof vi.fn>;
+  orderBy: ReturnType<typeof vi.fn>;
+  set: ReturnType<typeof vi.fn>;
+  values: ReturnType<typeof vi.fn>;
+  returning: ReturnType<typeof vi.fn>;
+  $dynamic: ReturnType<typeof vi.fn>;
+};
+const chain: ChainShape = {
+  from: vi.fn(() => chain),
+  where: vi.fn(() => chain),
+  limit: vi.fn(() => chain),
+  offset: vi.fn(() => rows),
+  orderBy: vi.fn(() => chain),
+  set: vi.fn(() => chain),
+  values: vi.fn(() => chain),
+  returning: vi.fn(() => rows),
+  $dynamic: vi.fn(() => chain),
+};
+const fakeDb = {
+  select: vi.fn(() => chain),
+  insert: vi.fn(() => chain),
+  update: vi.fn(() => chain),
+};
+
+vi.mock('./db/index.js', () => ({
+  db: fakeDb,
+  schema: {
+    parseReports: {
+      id: 'pr.id',
+      language: 'pr.language',
+      surfaceNfc: 'pr.surface_nfc',
+      contextSignature: 'pr.context_signature',
+      correctedLemmaId: 'pr.corrected_lemma_id',
+      correctionType: 'pr.correction_type',
+      status: 'pr.status',
+      duplicateCount: 'pr.duplicate_count',
+      updatedAt: 'pr.updated_at',
+    },
+  },
+}));
+
+const { fileParseReport, listParseReports } = await import('./parse-reports.js');
+
+function resetAll() {
+  rows.length = 0;
+  for (const fn of Object.values(chain))
+    (fn as ReturnType<typeof vi.fn>).mockClear();
+  fakeDb.select.mockClear();
+  fakeDb.insert.mockClear();
+  fakeDb.update.mockClear();
+}
+
+beforeEach(resetAll);
+
+const baseInput = {
+  reporterId: 'u1',
+  tokenId: 'tok-1',
+  language: 'hi' as const,
+  surfaceNfc: 'पाठ',
+  contextSignature: 'sig',
+  originalCandidates: [],
+  correctedLemmaId: 'lem-2',
+  correctionType: 'manual_lemma' as const,
+  note: 'wrong parse',
+};
+
+describe('fileParseReport', () => {
+  it('creates a fresh report when no open match exists', async () => {
+    chain.limit.mockReturnValueOnce([]); // dedup lookup → none
+    chain.returning.mockReturnValueOnce([
+      { id: 'pr-1', duplicateCount: 1, status: 'open' },
+    ]);
+    const r = await fileParseReport(baseInput);
+    expect(r.merged).toBe(false);
+    expect(r.report.id).toBe('pr-1');
+    expect(fakeDb.insert).toHaveBeenCalledOnce();
+    expect(fakeDb.update).not.toHaveBeenCalled();
+  });
+
+  it('increments duplicate_count when an open report matches the dedup tuple', async () => {
+    chain.limit.mockReturnValueOnce([
+      { id: 'pr-existing', duplicateCount: 3, status: 'open' },
+    ]);
+    chain.returning.mockReturnValueOnce([
+      { id: 'pr-existing', duplicateCount: 4, status: 'open' },
+    ]);
+    const r = await fileParseReport(baseInput);
+    expect(r.merged).toBe(true);
+    expect(r.report.duplicateCount).toBe(4);
+    expect(fakeDb.update).toHaveBeenCalledOnce();
+    expect(fakeDb.insert).not.toHaveBeenCalled();
+    const setArg = chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(setArg.duplicateCount).toBe(4);
+  });
+
+  it('honors initialStatus when provided (T-6.7 system reports land triaged)', async () => {
+    chain.limit.mockReturnValueOnce([]);
+    chain.returning.mockReturnValueOnce([{ id: 'pr-1', status: 'triaged' }]);
+    await fileParseReport({ ...baseInput, initialStatus: 'triaged' });
+    const args = chain.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(args.status).toBe('triaged');
+  });
+
+  it('passes through originalCandidates + correctionType verbatim', async () => {
+    chain.limit.mockReturnValueOnce([]);
+    chain.returning.mockReturnValueOnce([{ id: 'pr-1' }]);
+    const cands: Array<{
+      lemmaId: string | null;
+      score: number;
+      features: Record<string, string>;
+    }> = [
+      { lemmaId: 'a', score: 0.5, features: { Case: 'Nom' } },
+      { lemmaId: null, score: 0.2, features: {} },
+    ];
+    await fileParseReport({
+      ...baseInput,
+      originalCandidates: cands,
+      correctionType: 'new_lemma',
+    });
+    const args = chain.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(args.originalCandidates).toEqual(cands);
+    expect(args.correctionType).toBe('new_lemma');
+  });
+});
+
+describe('listParseReports', () => {
+  it('runs an unfiltered list against the table when filter is empty', async () => {
+    chain.offset.mockReturnValueOnce([{ id: 'pr-1' }, { id: 'pr-2' }]);
+    const list = await listParseReports({});
+    expect(list).toHaveLength(2);
+    // No filter ⇒ no WHERE clause is appended.
+    expect(chain.where).not.toHaveBeenCalled();
+  });
+
+  it('passes through language + status + correctionType filters', async () => {
+    chain.offset.mockReturnValueOnce([{ id: 'pr-1' }]);
+    await listParseReports({
+      language: 'hi',
+      status: 'open',
+      correctionType: 'manual_lemma',
+    });
+    // Single composite WHERE call carries all three filters.
+    expect(chain.where).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/lib/server/parse-reports.ts
+++ b/apps/web/src/lib/server/parse-reports.ts
@@ -1,0 +1,154 @@
+/**
+ * parse_reports service (T-6.5).
+ *
+ * Two surface routines:
+ *
+ *  - `fileParseReport(...)` — used by the correction modal (T-6.2)
+ *    when "Also report to moderators" is checked, by T-6.3's
+ *    new-lemma proposal flow, and by T-6.7's aggregation worker.
+ *    Implements the duplicate-merging contract: a new report whose
+ *    `(language, surface_nfc, context_signature, corrected_lemma_id)`
+ *    matches an existing open / triaged row increments that row's
+ *    `duplicate_count` instead of creating a new row. Resolved /
+ *    rejected rows do NOT collide — that lets the system re-open
+ *    a conversation after a curator decision if the issue resurfaces.
+ *
+ *  - `listOpenParseReports(...)` — paged list for T-6.6's curator
+ *    moderation UI. Filters by language + status + (optional)
+ *    correction_type so the queue stays scannable.
+ */
+import { and, desc, eq, inArray, sql } from 'drizzle-orm';
+
+import { db, schema } from './db/index.js';
+import type { ParseReport, TokenCorrection } from './db/schema.js';
+import type { LanguageCode } from '@ciareader/shared-types';
+
+export type FileParseReportInput = {
+  reporterId: string | null;
+  tokenId: string | null;
+  language: LanguageCode;
+  surfaceNfc: string;
+  contextSignature?: string;
+  originalCandidates: Array<{
+    lemmaId: string | null;
+    score: number;
+    features: Record<string, string>;
+  }>;
+  correctedLemmaId: string | null;
+  correctionType: TokenCorrection['type'];
+  note?: string | null;
+  /** Bypass the dedup-merge path and create a triaged-status row
+   *  directly. Used by T-6.7's aggregation worker so a system-filed
+   *  report doesn't masquerade as a duplicate of a manual one. */
+  initialStatus?: ParseReport['status'];
+};
+
+const OPEN_STATUSES = ['open', 'triaged'] as const;
+
+/**
+ * Upsert a parse report. Returns the canonical row + a flag
+ * reporting whether this call merged into an existing report
+ * (`merged=true`) or created a new one (`merged=false`). Callers
+ * use the flag to decide UX copy ("Reported" vs "Added to existing
+ * report").
+ */
+export async function fileParseReport(
+  input: FileParseReportInput,
+): Promise<{ report: ParseReport; merged: boolean }> {
+  const contextSignature = input.contextSignature ?? '';
+  // Dedup lookup: same `(language, surface_nfc, context_signature,
+  // corrected_lemma_id)` AND status open / triaged. The four-column
+  // tuple matches the schema's dedup index so this is a single
+  // index hit.
+  //
+  // We compare corrected_lemma_id with `IS NOT DISTINCT FROM` so a
+  // null-on-both side (mark_* corrections) merges correctly.
+  const existing = (await db
+    .select()
+    .from(schema.parseReports)
+    .where(
+      and(
+        eq(schema.parseReports.language, input.language),
+        eq(schema.parseReports.surfaceNfc, input.surfaceNfc),
+        eq(schema.parseReports.contextSignature, contextSignature),
+        sql`${schema.parseReports.correctedLemmaId} IS NOT DISTINCT FROM ${input.correctedLemmaId}`,
+        inArray(
+          schema.parseReports.status,
+          OPEN_STATUSES as unknown as ParseReport['status'][],
+        ),
+      ),
+    )
+    .limit(1)) as ParseReport[];
+
+  if (existing.length > 0) {
+    const row = existing[0]!;
+    const [updated] = await db
+      .update(schema.parseReports)
+      .set({
+        duplicateCount: row.duplicateCount + 1,
+        updatedAt: new Date(),
+      })
+      .where(eq(schema.parseReports.id, row.id))
+      .returning();
+    if (!updated) throw new Error('parse_report update returned no row');
+    return { report: updated as ParseReport, merged: true };
+  }
+
+  const [created] = await db
+    .insert(schema.parseReports)
+    .values({
+      reporterId: input.reporterId,
+      tokenId: input.tokenId,
+      language: input.language,
+      surfaceNfc: input.surfaceNfc,
+      contextSignature,
+      originalCandidates: input.originalCandidates,
+      correctedLemmaId: input.correctedLemmaId,
+      correctionType: input.correctionType,
+      note: input.note ?? null,
+      status: input.initialStatus ?? 'open',
+    })
+    .returning();
+  if (!created) throw new Error('parse_report insert returned no row');
+  return { report: created as ParseReport, merged: false };
+}
+
+export type ListParseReportsFilter = {
+  language?: LanguageCode;
+  status?: ParseReport['status'];
+  correctionType?: TokenCorrection['type'];
+  limit?: number;
+  offset?: number;
+};
+
+/**
+ * Paged list for the curator moderation UI (T-6.6). Sorted by
+ * `(duplicate_count DESC, updated_at DESC)` so the most-corroborated
+ * reports float to the top.
+ */
+export async function listParseReports(
+  filter: ListParseReportsFilter,
+): Promise<ParseReport[]> {
+  const where = [] as unknown[];
+  if (filter.language) {
+    where.push(eq(schema.parseReports.language, filter.language));
+  }
+  if (filter.status) {
+    where.push(eq(schema.parseReports.status, filter.status));
+  }
+  if (filter.correctionType) {
+    where.push(eq(schema.parseReports.correctionType, filter.correctionType));
+  }
+  let q = db.select().from(schema.parseReports).$dynamic();
+  if (where.length > 0) {
+    q = q.where(and(...(where as Parameters<typeof and>))) as typeof q;
+  }
+  const rows = (await q
+    .orderBy(
+      desc(schema.parseReports.duplicateCount),
+      desc(schema.parseReports.updatedAt),
+    )
+    .limit(filter.limit ?? 50)
+    .offset(filter.offset ?? 0)) as ParseReport[];
+  return rows;
+}


### PR DESCRIPTION
> Stacked on the M5/M6 chain landing in #221 (T-5.1b → T-5.1c → T-6.1 → T-6.4 → this).

## Summary

Schema + service for the curator moderation queue. Distinct from \`token_corrections\` (per-user picks): a \`parse_report\` is a *site-wide* claim that the worker / dictionary is mis-modeling a specific surface, surfaced to curators on T-6.6's moderation page.

- **Schema** — new \`parse_reports\` table (migration \`0015_foamy_victor_mancha.sql\`) with every field listed in the ticket. Indexed on \`(language, status)\` for the moderation queue and on the \`(language, surface_nfc, context_signature, corrected_lemma_id)\` dedup tuple.
- **Service** — \`fileParseReport()\` implements the dedup-merge: a new report whose tuple matches an open / triaged row increments that row's \`duplicate_count\` instead of inserting. Match uses \`IS NOT DISTINCT FROM\` on \`corrected_lemma_id\` so \`mark_*\` nullables collide correctly. Resolved / rejected rows do NOT collide — re-files after a curator resolution start a new conversation.
- \`listParseReports()\` for T-6.6's UI: sorted by \`(duplicate_count DESC, updated_at DESC)\`.

T-6.7's aggregation worker writes through the same surface with \`initialStatus='triaged'\` so system reports don't masquerade as user-filed dupes.

Closes #61.

## Test plan
- 96 files / 773 tests pass; new \`parse-reports.test.ts\` covers fresh-insert, dedup-merge, initialStatus override, candidates passthrough, list filters.
- typecheck + lint clean.