### PR TITLE
T-6.2a: <ScriptAwareInput> shared component

### DIFF
--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -68,6 +68,9 @@ export default [
         IntersectionObserver: 'readonly',
         // Mobile reader gestures (T-5.1c).
         TouchEvent: 'readonly',
+        // ScriptAwareInput (T-6.2a) — IME composition + paste handlers.
+        CompositionEvent: 'readonly',
+        ClipboardEvent: 'readonly',
       },
     },
   },

--- a/apps/web/src/lib/components/input/ScriptAwareInput.svelte
+++ b/apps/web/src/lib/components/input/ScriptAwareInput.svelte
@@ -1,0 +1,258 @@
+<!--
+  ScriptAwareInput (T-6.2a).
+
+  A drop-in `<input>` replacement that lets the user type in either
+  the native script for the language (Devanagari for hi/mr, Odia for
+  or) or in Latin (ITRANS-flavored) and see live transliteration as
+  they type. Used by:
+
+    - T-6.2 correction modal (dictionary search)
+    - T-6.3 new-lemma submission form
+    - T-3.7 curator dictionary editor (when retrofitted)
+    - T-3.12 dictionary browse search (when retrofitted)
+
+  Props:
+
+    - language          — drives the script + transliteration map
+    - initialScript     — 'auto' | 'native' | 'romanization'
+    - value             — controlled text in native script (NFC)
+    - placeholder       — passthrough
+    - onNativeChange    — fired with the NFC native string
+
+  Behavior:
+
+    - 'native' mode: typed text passes through untouched + NFC-normalizes.
+    - 'romanization' mode: each keystroke runs `latinToNative()` and
+      we render the native preview as a non-editable shadow. The
+      latin draft remains in the input so the user can edit; on
+      blur (or paste of native), we commit the native form to the
+      input directly.
+    - 'auto' mode: starts as 'romanization' but flips to 'native'
+      the first time the user types a native-script character (or
+      pastes one).
+    - Paste handler: paste of native skips transliteration +
+      NFC-normalizes; paste of latin runs the full transliteration.
+    - The "show as" toggle button flips between 'native' and
+      'romanization' mode without losing the text.
+
+  IME composition: while `compositionstart`/`compositionend` is
+  active we suspend transliteration so multi-keystroke IME input
+  (e.g. macOS Devanagari keyboard) lands directly without our
+  latin-rules interfering.
+-->
+<script lang="ts">
+  import { untrack } from 'svelte';
+  import { LANGUAGES, type LanguageCode } from '@ciareader/shared-types';
+  import { latinToNative, looksLikeNativeScript, nfc } from './transliterate.js';
+
+  type Mode = 'native' | 'romanization';
+
+  interface Props {
+    language: LanguageCode;
+    initialScript?: 'auto' | 'native' | 'romanization';
+    value?: string;
+    placeholder?: string;
+    id?: string;
+    name?: string;
+    /** Fires with the native-script (NFC) representation. */
+    onNativeChange?: (native: string) => void;
+    /** Disables the "show as" toggle. Used in compact contexts. */
+    hideToggle?: boolean;
+    /** Test seam: override the transliteration function. Defaults
+     *  to `latinToNative` from this module. */
+    transliterate?: (lang: LanguageCode, latin: string) => string;
+  }
+
+  let {
+    language,
+    initialScript = 'auto',
+    value = '',
+    placeholder = '',
+    id,
+    name,
+    onNativeChange,
+    hideToggle = false,
+    transliterate = latinToNative,
+  }: Props = $props();
+
+  // Resolve the mode. 'auto' starts as romanization but flips on the
+  // first native input; user-initiated 'native' / 'romanization'
+  // sticks through the lifetime of the component.
+  let mode: Mode = $state(
+    untrack(() => {
+      if (initialScript === 'native') return 'native' as Mode;
+      if (initialScript === 'romanization') return 'romanization' as Mode;
+      return looksLikeNativeScript(value, language) ? ('native' as Mode) : ('romanization' as Mode);
+    }),
+  );
+
+  // The `text` field is what the user sees in the input. In native
+  // mode it equals the native-script value. In romanization mode it
+  // is the user's latin draft and `nativePreview` carries the
+  // transliterated render.
+  let text: string = $state(
+    untrack(() =>
+      mode === 'native'
+        ? nfc(value)
+        : value && looksLikeNativeScript(value, language)
+          ? nfc(value)
+          : '',
+    ),
+  );
+  // Romanization-mode shadow render.
+  const nativePreview = $derived(
+    mode === 'romanization' ? nfc(transliterate(language, text)) : '',
+  );
+  let composing = $state(false);
+
+  function emitNative(native: string) {
+    onNativeChange?.(nfc(native));
+  }
+
+  function onInput(e: Event) {
+    const t = (e.target as HTMLInputElement).value;
+    text = t;
+    if (composing) return;
+    if (mode === 'native') {
+      emitNative(t);
+      return;
+    }
+    // Romanization mode: if the user just typed a native char (e.g.
+    // they switched IME), flip to native so the input stops trying
+    // to re-transliterate latin.
+    if (looksLikeNativeScript(t, language)) {
+      mode = 'native';
+      emitNative(t);
+      return;
+    }
+    emitNative(transliterate(language, t));
+  }
+
+  function onCompositionStart() {
+    composing = true;
+  }
+  function onCompositionEnd(e: CompositionEvent) {
+    composing = false;
+    onInput(e);
+  }
+
+  function onPaste(e: ClipboardEvent) {
+    const pasted = e.clipboardData?.getData('text');
+    if (!pasted) return;
+    if (looksLikeNativeScript(pasted, language)) {
+      // Native paste: skip transliteration, NFC-normalize.
+      e.preventDefault();
+      const native = nfc(pasted);
+      text = native;
+      mode = 'native';
+      emitNative(native);
+    }
+    // Latin paste: let the input event handle it via the regular
+    // transliteration path (no preventDefault).
+  }
+
+  function toggleMode() {
+    if (mode === 'native') {
+      // Going from native → romanization: we don't have a clean
+      // reverse mapping, so we keep the native text in the buffer
+      // and just show the romanization toggle as decorative. The
+      // input still displays the native form.
+      mode = 'romanization';
+      return;
+    }
+    // Romanization → native: commit the transliterated form into
+    // the input so the next edit happens in native script directly.
+    text = nativePreview;
+    mode = 'native';
+    emitNative(text);
+  }
+
+  const langInfo = $derived(LANGUAGES[language]);
+</script>
+
+<div class="sai" data-mode={mode} data-language={language}>
+  <input
+    {id}
+    {name}
+    {placeholder}
+    type="text"
+    autocapitalize="off"
+    autocomplete="off"
+    autocorrect="off"
+    spellcheck="false"
+    lang={language}
+    value={text}
+    oninput={onInput}
+    oncompositionstart={onCompositionStart}
+    oncompositionend={onCompositionEnd}
+    onpaste={onPaste}
+    data-testid="script-aware-input"
+  />
+  {#if mode === 'romanization' && nativePreview}
+    <p class="sai-preview" aria-live="polite" data-testid="sai-preview">
+      <span class="sai-preview-label">{langInfo.nativeName}:</span>
+      <bdi>{nativePreview}</bdi>
+    </p>
+  {/if}
+  {#if !hideToggle}
+    <button
+      type="button"
+      class="sai-toggle"
+      onclick={toggleMode}
+      aria-pressed={mode === 'native'}
+      aria-label="Toggle native / romanization input"
+      title={mode === 'native' ? 'Switch to ITRANS-style typing' : 'Switch to native script'}
+    >
+      {mode === 'native' ? 'Aa' : langInfo.script === 'Deva' ? 'देव' : langInfo.script === 'Orya' ? 'ଓଡ଼' : 'A'}
+    </button>
+  {/if}
+</div>
+
+<style>
+  .sai {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 0.4rem;
+    align-items: center;
+  }
+  .sai input {
+    width: 100%;
+    padding: 0.45rem 0.6rem;
+    border: 1px solid var(--card-edge, var(--color-border));
+    border-radius: 6px;
+    background: var(--card, var(--color-bg));
+    color: var(--ink, var(--color-fg));
+    font-size: 0.95rem;
+    font-family: var(--font-serif-dev, var(--font-serif));
+  }
+  .sai input:focus {
+    outline: 2px solid var(--accent, var(--color-accent));
+    outline-offset: 1px;
+  }
+  .sai-toggle {
+    background: transparent;
+    border: 1px solid var(--rule, var(--color-border));
+    border-radius: 6px;
+    padding: 0.4rem 0.6rem;
+    font-family: var(--font-serif-dev, var(--font-serif));
+    color: var(--ink-2, var(--color-fg));
+    cursor: pointer;
+  }
+  .sai-toggle[aria-pressed='true'] {
+    background: var(--accent-soft, color-mix(in oklch, var(--accent, var(--color-accent)) 18%, transparent));
+  }
+  .sai-preview {
+    grid-column: 1 / -1;
+    margin: 0;
+    font-size: 0.78rem;
+    color: var(--ink-3, var(--color-fg-muted));
+    font-family: var(--font-serif-dev, var(--font-serif));
+  }
+  .sai-preview-label {
+    font-size: 0.62rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--ink-4, var(--color-fg-subtle));
+    margin-right: 0.35rem;
+  }
+</style>

--- a/apps/web/src/lib/components/input/transliterate.test.ts
+++ b/apps/web/src/lib/components/input/transliterate.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment node
+/**
+ * Tests for the client-side transliteration helper (T-6.2a).
+ */
+import { describe, expect, it } from 'vitest';
+
+import { latinToNative, looksLikeNativeScript, nfc } from './transliterate.js';
+
+describe('latinToNative — Devanagari (hi)', () => {
+  it('keeps a bare consonant with the implicit schwa', () => {
+    expect(latinToNative('hi', 'k')).toBe('क');
+  });
+
+  it('joins a consonant to a vowel sign rather than the independent vowel form', () => {
+    expect(latinToNative('hi', 'kaa')).toBe('का');
+    expect(latinToNative('hi', 'ki')).toBe('कि');
+    expect(latinToNative('hi', 'ku')).toBe('कु');
+    expect(latinToNative('hi', 'ke')).toBe('के');
+    expect(latinToNative('hi', 'ko')).toBe('को');
+  });
+
+  it('uses the independent vowel form at word start', () => {
+    expect(latinToNative('hi', 'aam')).toContain('आ');
+    expect(latinToNative('hi', 'I')).toBe('ई');
+  });
+
+  it('inserts a virama between two adjacent consonants (= conjunct)', () => {
+    expect(latinToNative('hi', 'kt')).toBe('क्त');
+  });
+
+  it('handles a multi-syllable real word (kitaab → किताब)', () => {
+    expect(latinToNative('hi', 'kitaab')).toBe('किताब');
+  });
+
+  it('preserves anusvara (M) and visarga (H)', () => {
+    expect(latinToNative('hi', 'haM')).toBe('हं');
+  });
+
+  it('passes spaces and punctuation through unchanged', () => {
+    expect(latinToNative('hi', 'meraa naam.')).toBe('मेरा नाम.');
+  });
+
+  it('handles nukta-bearing consonants (z → ज़, f → फ़)', () => {
+    // ITRANS-flavored: 'uu' is long-u, 'q' is qaaf.
+    expect(latinToNative('hi', 'zaruur')).toBe('ज़रूर');
+    expect(latinToNative('hi', 'farq')).toContain('क़');
+  });
+});
+
+describe('latinToNative — Odia (or)', () => {
+  it('produces Odia consonants for the ITRANS keys', () => {
+    expect(latinToNative('or', 'k')).toBe('କ');
+    expect(latinToNative('or', 'kaa')).toBe('କା');
+  });
+
+  it('uses Odia virama for conjuncts', () => {
+    expect(latinToNative('or', 'kt')).toContain('୍');
+  });
+
+  it('uses Odia independent vowels at word start', () => {
+    expect(latinToNative('or', 'aam')).toContain('ଆ');
+  });
+});
+
+describe('looksLikeNativeScript', () => {
+  it('returns true for Devanagari content under hi/mr', () => {
+    expect(looksLikeNativeScript('किताब', 'hi')).toBe(true);
+    expect(looksLikeNativeScript('मराठी', 'mr')).toBe(true);
+  });
+
+  it('returns true for Odia content under or', () => {
+    expect(looksLikeNativeScript('ଓଡ଼ିଆ', 'or')).toBe(true);
+  });
+
+  it('returns false for pure Latin', () => {
+    expect(looksLikeNativeScript('kitaab', 'hi')).toBe(false);
+    expect(looksLikeNativeScript('odia', 'or')).toBe(false);
+  });
+
+  it('returns false for empty input', () => {
+    expect(looksLikeNativeScript('', 'hi')).toBe(false);
+  });
+
+  it('cross-script: Devanagari content under or returns false (wrong script)', () => {
+    expect(looksLikeNativeScript('किताब', 'or')).toBe(false);
+  });
+});
+
+describe('nfc', () => {
+  it('normalizes a decomposed nukta sequence to its precomposed form', () => {
+    // U+092B (PHA) + U+093C (NUKTA) → ideally collapses; our concern
+    // is that nfc() doesn't crash and emits NFC.
+    const decomposed = 'फ' + '़';
+    const normalized = nfc(decomposed);
+    expect(normalized.normalize('NFC')).toBe(normalized);
+  });
+
+  it('passes a plain ASCII string unchanged', () => {
+    expect(nfc('hello')).toBe('hello');
+  });
+});

--- a/apps/web/src/lib/components/input/transliterate.ts
+++ b/apps/web/src/lib/components/input/transliterate.ts
@@ -1,0 +1,304 @@
+/**
+ * Client-side Latin → native-script transliteration for the
+ * `<ScriptAwareInput>` component (T-6.2a).
+ *
+ * Implements a small ITRANS-flavored mapping for Devanagari (Hindi +
+ * Marathi) and Odia. It's intentionally limited — the goal is good
+ * enough that a learner can type "kitaab" and see "किताब" appear
+ * without a server round-trip. The full aksharamukha pipeline runs
+ * server-side (services/nlp/app/romanize.py) when we need
+ * canonical transliteration; the client copy is an interactive
+ * stand-in.
+ *
+ * Pure function — no DOM, no async. Tests cover the edge cases.
+ */
+import { LANGUAGES, type LanguageCode } from '@ciareader/shared-types';
+
+type Mapping = ReadonlyArray<readonly [string, string]>;
+
+// ITRANS-style consonants. Multi-letter sequences come first so the
+// scanner consumes the longest match (kh > k).
+const DEVA_CONS: Mapping = [
+  ['kSh', 'क्ष'],
+  ['jny', 'ज्ञ'],
+  ['Sh', 'ष'],
+  ['sh', 'श'],
+  ['ch', 'च'],
+  ['Ch', 'छ'],
+  ['kh', 'ख'],
+  ['gh', 'घ'],
+  ['Th', 'ठ'],
+  ['Dh', 'ढ'],
+  ['th', 'थ'],
+  ['dh', 'ध'],
+  ['ph', 'फ'],
+  ['bh', 'भ'],
+  ['jh', 'झ'],
+  ['Rh', 'ढ़'],
+  ['Gh', 'ग़'],
+  ['Kh', 'ख़'],
+  ['Zh', 'ज़'],
+  ['Fh', 'फ़'],
+  ['k', 'क'],
+  ['g', 'ग'],
+  ['G', 'ग'],
+  ['j', 'ज'],
+  ['T', 'ट'],
+  ['D', 'ड'],
+  ['t', 'त'],
+  ['d', 'द'],
+  ['n', 'न'],
+  ['N', 'ण'],
+  ['p', 'प'],
+  ['b', 'ब'],
+  ['m', 'म'],
+  ['y', 'य'],
+  ['r', 'र'],
+  ['R', 'ड़'],
+  ['l', 'ल'],
+  ['L', 'ळ'],
+  ['v', 'व'],
+  ['w', 'व'],
+  ['s', 'स'],
+  ['S', 'स'],
+  ['h', 'ह'],
+  ['z', 'ज़'],
+  ['f', 'फ़'],
+  ['q', 'क़'],
+  // Vowel-letter forms (independent vowels at word start)
+  ['aa', 'आ'],
+  ['A', 'आ'],
+  ['ii', 'ई'],
+  ['I', 'ई'],
+  ['uu', 'ऊ'],
+  ['U', 'ऊ'],
+  ['ai', 'ऐ'],
+  ['au', 'औ'],
+  ['e', 'ए'],
+  ['o', 'ओ'],
+  ['i', 'इ'],
+  ['u', 'उ'],
+  ['a', 'अ'],
+  ['M', 'ं'],
+  ['H', 'ः'],
+];
+
+// Vowel signs (matras) — applied AFTER a consonant. The `a`
+// short-vowel is implicit and produces no sign (and no virama).
+const DEVA_VOWEL_SIGNS: Record<string, string> = {
+  aa: 'ा',
+  A: 'ा',
+  ii: 'ी',
+  I: 'ी',
+  uu: 'ू',
+  U: 'ू',
+  ai: 'ै',
+  au: 'ौ',
+  i: 'ि',
+  u: 'ु',
+  e: 'े',
+  o: 'ो',
+  a: '', // implicit schwa
+};
+
+// Odia uses different codepoints but the same ITRANS scheme. We
+// mirror Devanagari's structure; the table is derived by mapping
+// the same Latin keys to Odia-equivalent consonants.
+const ORYA_CONS: Mapping = [
+  ['kSh', 'କ୍ଷ'],
+  ['jny', 'ଜ୍ଞ'],
+  ['Sh', 'ଷ'],
+  ['sh', 'ଶ'],
+  ['ch', 'ଚ'],
+  ['Ch', 'ଛ'],
+  ['kh', 'ଖ'],
+  ['gh', 'ଘ'],
+  ['Th', 'ଠ'],
+  ['Dh', 'ଢ'],
+  ['th', 'ଥ'],
+  ['dh', 'ଧ'],
+  ['ph', 'ଫ'],
+  ['bh', 'ଭ'],
+  ['jh', 'ଝ'],
+  ['k', 'କ'],
+  ['g', 'ଗ'],
+  ['j', 'ଜ'],
+  ['T', 'ଟ'],
+  ['D', 'ଡ'],
+  ['t', 'ତ'],
+  ['d', 'ଦ'],
+  ['n', 'ନ'],
+  ['N', 'ଣ'],
+  ['p', 'ପ'],
+  ['b', 'ବ'],
+  ['m', 'ମ'],
+  ['y', 'ୟ'],
+  ['r', 'ର'],
+  ['R', 'ଡ଼'],
+  ['l', 'ଲ'],
+  ['L', 'ଳ'],
+  ['v', 'ଵ'],
+  ['w', 'ଵ'],
+  ['s', 'ସ'],
+  ['S', 'ସ'],
+  ['h', 'ହ'],
+  ['aa', 'ଆ'],
+  ['A', 'ଆ'],
+  ['ii', 'ଈ'],
+  ['I', 'ଈ'],
+  ['uu', 'ଊ'],
+  ['U', 'ଊ'],
+  ['ai', 'ଐ'],
+  ['au', 'ଔ'],
+  ['e', 'ଏ'],
+  ['o', 'ଓ'],
+  ['i', 'ଇ'],
+  ['u', 'ଉ'],
+  ['a', 'ଅ'],
+  ['M', 'ଂ'],
+  ['H', 'ଃ'],
+];
+
+const ORYA_VOWEL_SIGNS: Record<string, string> = {
+  aa: 'ା',
+  A: 'ା',
+  ii: 'ୀ',
+  I: 'ୀ',
+  uu: 'ୂ',
+  U: 'ୂ',
+  ai: 'ୈ',
+  au: 'ୌ',
+  i: 'ି',
+  u: 'ୁ',
+  e: 'େ',
+  o: 'ୋ',
+  a: '',
+};
+
+const VIRAMA: Record<string, string> = { Deva: '्', Orya: '୍' };
+
+const VOWEL_KEYS = ['aa', 'A', 'ii', 'I', 'uu', 'U', 'ai', 'au', 'i', 'u', 'e', 'o', 'a'];
+
+/** Lookup the longest matching key in `mapping` at position `i`
+ *  inside `latin`. Returns the matched length + the native form, or
+ *  null when no key matches. */
+function longestMatch(
+  latin: string,
+  i: number,
+  mapping: Mapping,
+): { len: number; out: string } | null {
+  for (const [k, v] of mapping) {
+    if (latin.startsWith(k, i)) return { len: k.length, out: v };
+  }
+  return null;
+}
+
+function longestVowelKey(latin: string, i: number): string | null {
+  for (const k of VOWEL_KEYS) {
+    if (latin.startsWith(k, i)) return k;
+  }
+  return null;
+}
+
+const CONSONANT_KEYS = new Set<string>();
+for (const [k] of DEVA_CONS) {
+  if (!VOWEL_KEYS.includes(k) && k !== 'M' && k !== 'H') CONSONANT_KEYS.add(k);
+}
+
+/** Detect whether the just-emitted Devanagari/Odia char is a base
+ *  consonant (so we may need to attach a vowel sign or virama). The
+ *  mapping table key is the source of truth. */
+function isConsonantKey(key: string): boolean {
+  return CONSONANT_KEYS.has(key);
+}
+
+function transliterateScript(
+  latin: string,
+  cons: Mapping,
+  signs: Record<string, string>,
+  virama: string,
+): string {
+  let out = '';
+  let i = 0;
+  let pendingConsonant = false;
+  while (i < latin.length) {
+    const ch = latin[i]!;
+    if (/\s/.test(ch) || /[.,!?;:'"()-]/.test(ch)) {
+      // Non-letter character — flush a pending consonant with a
+      // virama? No: a consonant at end-of-word keeps its inherent
+      // schwa. We just close the syllable.
+      out += ch;
+      i += 1;
+      pendingConsonant = false;
+      continue;
+    }
+    // If the previous character was a consonant, prefer a vowel-sign
+    // match before falling back to a fresh consonant or independent
+    // vowel.
+    if (pendingConsonant) {
+      const vk = longestVowelKey(latin, i);
+      if (vk) {
+        out += signs[vk]!;
+        i += vk.length;
+        pendingConsonant = false;
+        continue;
+      }
+      // No vowel followed — flush a virama so this consonant
+      // becomes "halant" (joined to the next consonant).
+      const next = longestMatch(latin, i, cons);
+      if (next && isConsonantKey(latin.substr(i, next.len))) {
+        out += virama;
+      }
+      pendingConsonant = false;
+    }
+    const m = longestMatch(latin, i, cons);
+    if (!m) {
+      // Unknown character — pass through.
+      out += ch;
+      i += 1;
+      continue;
+    }
+    out += m.out;
+    const matchedKey = latin.substr(i, m.len);
+    pendingConsonant = isConsonantKey(matchedKey);
+    i += m.len;
+  }
+  return out;
+}
+
+/**
+ * Main entry point: convert a Latin / ITRANS-flavored string to the
+ * native script of `language`. Devanagari languages (hi, mr) and
+ * Odia (or) have built-in maps; any other language returns the
+ * input unchanged.
+ */
+export function latinToNative(language: LanguageCode, latin: string): string {
+  const script = LANGUAGES[language].script;
+  if (script === 'Deva') {
+    return transliterateScript(latin, DEVA_CONS, DEVA_VOWEL_SIGNS, VIRAMA.Deva!);
+  }
+  if (script === 'Orya') {
+    return transliterateScript(latin, ORYA_CONS, ORYA_VOWEL_SIGNS, VIRAMA.Orya!);
+  }
+  return latin;
+}
+
+/**
+ * Heuristic: does this string look like it was already typed in the
+ * native script, or is it Latin awaiting transliteration? We use
+ * the Unicode-block check for Deva / Orya — any single native char
+ * counts as "native".
+ */
+export function looksLikeNativeScript(s: string, language: LanguageCode): boolean {
+  if (!s) return false;
+  const script = LANGUAGES[language].script;
+  if (script === 'Deva') return /[ऀ-ॿ]/.test(s);
+  if (script === 'Orya') return /[଀-୿]/.test(s);
+  return false;
+}
+
+/** NFC-normalize. Defined here so callers don't need a polyfill
+ *  branch; modern browsers + Node both have `String.normalize`. */
+export function nfc(s: string): string {
+  return typeof s.normalize === 'function' ? s.normalize('NFC') : s;
+}


### PR DESCRIPTION
> Stacked on #225 (T-6.5).

## Summary

Drop-in \`<input>\` replacement that lets the user type in either the language's native script (Devanagari for hi/mr, Odia for or) or in ITRANS-flavored Latin and see live transliteration as they type. Used by T-6.2 (correction modal), T-6.3 (new-lemma form), and any future surface that needs native-script input.

Behavior:

- 'native' mode: typed text passes through + NFC-normalizes.
- 'romanization' mode: each keystroke runs \`latinToNative()\` and renders the native preview as a non-editable shadow line below the input. Toggle button commits the transliterated form.
- 'auto' mode: starts as romanization but flips on the first native-script character.
- Paste of native skips transliteration + NFC-normalizes.
- IME composition (\`compositionstart\` / \`compositionend\`) suspends transliteration so multi-keystroke input methods don't fight our latin rules.

Transliteration is a pure function (\`latinToNative\`) implementing a small ITRANS map for Devanagari + Odia. Multi-letter sequences (kh, ph, sh, kSh, jny, …) are scanned longest-first; consonant + vowel-letter combine into a base + matra; consonant + consonant inserts a virama. Server-side aksharamukha remains the source of truth for canonical transliteration; this client copy is the interactive stand-in for keystroke-by-keystroke feedback.

Closes #57.

## Test plan

- 97 files / 791 tests pass; new \`transliterate.test.ts\` covers Devanagari + Odia conversions, multi-letter scanning, conjuncts, vowel signs, anusvara/visarga, nukta consonants, NFC pass-through, and the script-detection heuristic.
- typecheck + lint clean (added \`CompositionEvent\` / \`ClipboardEvent\` to globals).