### PR TITLE
fix(reader): drop font-color shift on known words

### DIFF
--- a/apps/web/src/lib/styles/tokens.css
+++ b/apps/web/src/lib/styles/tokens.css
@@ -87,7 +87,6 @@
   --w-l3-bg: oklch(0.8 0.12 70);
   --w-known-bg: transparent;
   --w-ignored-bg: transparent;
-  --w-known-ink: var(--ink-3);
   --w-ignored-ink: var(--ink-4);
 
   --shadow-1:
@@ -340,7 +339,7 @@ html[data-hl='background'] .word[data-s='3'] {
   background: var(--w-l3-bg);
 }
 html[data-hl='background'] .word[data-s='4'] {
-  color: var(--w-known-ink);
+  background: var(--w-known-bg);
 }
 html[data-hl='background'] .word[data-s='5'] {
   color: var(--w-ignored-ink);
@@ -367,7 +366,6 @@ html[data-hl='underline'] .word[data-s='3'] {
 }
 html[data-hl='underline'] .word[data-s='4'] {
   box-shadow: none;
-  color: var(--w-known-ink);
 }
 html[data-hl='underline'] .word[data-s='5'] {
   box-shadow: none;


### PR DESCRIPTION
## Summary
- Known words (`data-s='4'`) now keep the normal body text color in both background and underline highlight modes — only the background-tint or underline distinguishes them when those highlight options are enabled.
- Drops the now-unused `--w-known-ink` token from `tokens.css`.

## Test plan
- [ ] Open a reader page with at least one known word; confirm the word renders in the same color as surrounding prose.
- [ ] Toggle highlight style between `background` and `underline` in the reader settings popover and confirm known words still don't shift color.
- [ ] Verify learning (1/2/3) and ignored (5) tints are unchanged.