### PR TITLE
T-6.2: wrong-word correction modal

### DIFF
--- a/apps/web/src/lib/components/reader/ChapterBody.svelte
+++ b/apps/web/src/lib/components/reader/ChapterBody.svelte
@@ -17,6 +17,7 @@
   import WordPopup from './WordPopup.svelte';
   import WordTooltip from './WordTooltip.svelte';
   import { LongPressDetector } from './touch-gestures.js';
+  import type { LanguageCode } from '@ciareader/shared-types';
   import {
     paragraphsOfServerTokens,
     paragraphsOfTokens,
@@ -27,10 +28,14 @@
 
   let {
     chapter,
+    language,
     showRomanization = false,
     isOwner = false,
   }: {
     chapter: ChapterView;
+    /** T-6.2: drives the CorrectionModal's dictionary-search
+     *  language + script. */
+    language: LanguageCode;
     showRomanization?: boolean;
     isOwner?: boolean;
   } = $props();
@@ -246,9 +251,16 @@
     statusOverrides = next;
   }
 
-  function onCorrectionApplied(tokenId: string, chosenLemmaId: string) {
+  function onCorrectionApplied(tokenId: string, chosenLemmaId: string | null) {
     const next = new Map(lemmaCorrections);
-    next.set(tokenId, chosenLemmaId);
+    if (chosenLemmaId == null) {
+      // T-6.2 mark_* path: the user declared this surface isn't a
+      // learnable word. Clear any prior pick so the next render
+      // falls through to the worker's (now cleared) primary.
+      next.delete(tokenId);
+    } else {
+      next.set(tokenId, chosenLemmaId);
+    }
     lemmaCorrections = next;
   }
 </script>
@@ -299,6 +311,7 @@
   <WordPopup
     token={activeToken}
     anchorRect={activeRect}
+    {language}
     {isOwner}
     onClose={closePopup}
     {onStatusChange}

--- a/apps/web/src/lib/components/reader/CorrectionModal.svelte
+++ b/apps/web/src/lib/components/reader/CorrectionModal.svelte
@@ -1,0 +1,468 @@
+<!--
+  Wrong-word correction modal (T-6.2).
+
+  Opens from the WordPopup's "Fix" button. Surfaces:
+
+    a. The candidate list — same data the alternate-meanings
+       disclosure uses, but here it's the primary affordance.
+    b. Script-agnostic dictionary search via <ScriptAwareInput> +
+       /api/v1/dictionary/:language/lemmas?q=…
+    c. Quick mark_* buttons (proper noun / foreign / not a word).
+    d. "Add new word" — defers to T-6.3's new-lemma form (the
+       parent supplies the open callback).
+
+  Footer: "Also report to moderators" checkbox. Default OFF for
+  pick_candidate (the reader's own correction is enough); default
+  ON for manual_lemma + new_lemma since those involve
+  curator-relevant judgment.
+
+  Submission flow:
+
+    1. POST /api/v1/me/token-corrections (always).
+    2. If "Also report" is checked AND the type is non-trivial,
+       POST /api/v1/me/parse-reports.
+    3. Surface optimistic correction back to the parent so the
+       reader re-renders the token immediately + close the modal.
+-->
+<script lang="ts">
+  import { LANGUAGES, type LanguageCode } from '@ciareader/shared-types';
+  import Modal from '$lib/components/overlay/Modal.svelte';
+  import ScriptAwareInput from '$lib/components/input/ScriptAwareInput.svelte';
+  import type { ServerToken } from './types.js';
+
+  type CorrectionType =
+    | 'pick_candidate'
+    | 'manual_lemma'
+    | 'mark_proper_noun'
+    | 'mark_foreign'
+    | 'mark_not_a_word';
+
+  type DictionaryHit = {
+    id: string;
+    headword: string;
+    pos: string;
+    glossDefault: string | null;
+  };
+
+  interface Props {
+    open: boolean;
+    token: ServerToken;
+    language: LanguageCode;
+    onClose: () => void;
+    /** Parent applies the correction so the reader re-renders. */
+    onApplied: (lemmaId: string | null) => void;
+    /** Opens T-6.3's new-lemma form; modal closes itself first. */
+    onAddNewWord?: () => void;
+    /** Test seam. */
+    fetcher?: typeof fetch;
+  }
+
+  let {
+    open,
+    token,
+    language,
+    onClose,
+    onApplied,
+    onAddNewWord,
+    fetcher = fetch,
+  }: Props = $props();
+
+  let searchQuery = $state('');
+  let searchHits = $state<DictionaryHit[]>([]);
+  let searchLoading = $state(false);
+  let searchError = $state<string | null>(null);
+  let alsoReport = $state(false);
+  let savingType = $state<CorrectionType | null>(null);
+  let saveError = $state<string | null>(null);
+
+  // Debounce the dictionary search so we don't fire a request on
+  // every keystroke. 200ms is short enough that the user perceives
+  // it as live and long enough to skip mid-word fetches.
+  let searchTimer: number | null = null;
+  function scheduleSearch(q: string) {
+    if (searchTimer != null) window.clearTimeout(searchTimer);
+    if (!q.trim()) {
+      searchHits = [];
+      searchError = null;
+      return;
+    }
+    searchTimer = window.setTimeout(() => {
+      void runSearch(q);
+    }, 200);
+  }
+
+  async function runSearch(q: string) {
+    searchLoading = true;
+    searchError = null;
+    try {
+      const url = `/api/v1/dictionary/${language}/lemmas?q=${encodeURIComponent(q)}&limit=10`;
+      const res = await fetcher(url);
+      if (!res.ok) {
+        searchError = `HTTP ${res.status}`;
+        return;
+      }
+      const data = (await res.json()) as { lemmas: DictionaryHit[] };
+      searchHits = data.lemmas ?? [];
+    } catch (e) {
+      searchError = e instanceof Error ? e.message : 'Search failed';
+    } finally {
+      searchLoading = false;
+    }
+  }
+
+  // T-6.2 default-checkbox rules. We compute it per-action (not as
+  // a single state value) since the user could mix actions in one
+  // session.
+  function defaultReportFor(type: CorrectionType): boolean {
+    return type === 'manual_lemma';
+  }
+
+  async function submitCorrection(
+    type: CorrectionType,
+    chosenLemmaId: string | null,
+  ) {
+    savingType = type;
+    saveError = null;
+    try {
+      const res = await fetcher('/api/v1/me/token-corrections', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          tokenId: token.id,
+          type,
+          chosenLemmaId,
+        }),
+      });
+      if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        throw new Error(text || `HTTP ${res.status}`);
+      }
+      // T-6.5 wiring: optionally file a parse_report alongside the
+      // per-user correction so curators see the issue.
+      const shouldReport = alsoReport ?? defaultReportFor(type);
+      if (shouldReport && type !== 'pick_candidate') {
+        await fetcher('/api/v1/me/parse-reports', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            tokenId: token.id,
+            language,
+            surfaceNfc: token.surface,
+            originalCandidates: token.candidates.map((c) => ({
+              lemmaId: c.lemmaId,
+              score: c.score,
+              features: c.features,
+            })),
+            correctedLemmaId: chosenLemmaId,
+            correctionType: type,
+          }),
+        });
+      }
+      onApplied(chosenLemmaId);
+      onClose();
+    } catch (e) {
+      saveError = e instanceof Error ? e.message : 'Save failed';
+    } finally {
+      savingType = null;
+    }
+  }
+
+  function pickCandidate(lemmaId: string) {
+    return submitCorrection('pick_candidate', lemmaId);
+  }
+  function pickHit(hit: DictionaryHit) {
+    return submitCorrection('manual_lemma', hit.id);
+  }
+  function markProperNoun() {
+    return submitCorrection('mark_proper_noun', null);
+  }
+  function markForeign() {
+    return submitCorrection('mark_foreign', null);
+  }
+  function markNotAWord() {
+    return submitCorrection('mark_not_a_word', null);
+  }
+
+  // Seed the alsoReport flag on open based on what's available.
+  // A user with candidates is more likely to pick_candidate (default
+  // OFF) than manual_lemma (default ON) — a reasonable starting
+  // checkbox state.
+  $effect(() => {
+    if (open) {
+      alsoReport = token.candidates.length === 0;
+    }
+  });
+</script>
+
+<Modal
+  {open}
+  {onClose}
+  title="Fix this word"
+  width={560}
+>
+  <div class="cm" data-testid="correction-modal">
+    <header class="cm-head">
+      <span class="cm-surface">{token.surface}</span>
+      {#if token.romanization}
+        <span class="cm-roman">{token.romanization}</span>
+      {/if}
+    </header>
+
+    {#if token.candidates.length > 0}
+      <section class="cm-section">
+        <h3>Pick from candidates</h3>
+        <ul class="cm-list">
+          {#each token.candidates as cand (cand.lemmaId)}
+            <li class="cm-row">
+              <div class="cm-row-meta">
+                <span class="cm-h">{cand.headword}</span>
+                <span class="cm-pos">{cand.pos}</span>
+                {#if cand.glossDefault}
+                  <span class="cm-gloss">{cand.glossDefault}</span>
+                {/if}
+              </div>
+              <button
+                type="button"
+                disabled={savingType !== null}
+                onclick={() => pickCandidate(cand.lemmaId)}
+              >
+                {savingType === 'pick_candidate' ? 'Saving…' : 'Use'}
+              </button>
+            </li>
+          {/each}
+        </ul>
+      </section>
+    {/if}
+
+    <section class="cm-section">
+      <h3>Search the dictionary</h3>
+      <ScriptAwareInput
+        {language}
+        initialScript="auto"
+        placeholder={`Type in ${LANGUAGES[language].nativeName} or Latin`}
+        onNativeChange={(v) => {
+          searchQuery = v;
+          scheduleSearch(v);
+        }}
+      />
+      {#if searchLoading}
+        <p class="cm-muted">Searching…</p>
+      {:else if searchError}
+        <p class="cm-err" role="alert">{searchError}</p>
+      {:else if searchHits.length > 0}
+        <ul class="cm-list">
+          {#each searchHits as hit (hit.id)}
+            <li class="cm-row">
+              <div class="cm-row-meta">
+                <span class="cm-h">{hit.headword}</span>
+                <span class="cm-pos">{hit.pos}</span>
+                {#if hit.glossDefault}
+                  <span class="cm-gloss">{hit.glossDefault}</span>
+                {/if}
+              </div>
+              <button
+                type="button"
+                disabled={savingType !== null}
+                onclick={() => pickHit(hit)}
+              >
+                {savingType === 'manual_lemma' ? 'Saving…' : 'Use'}
+              </button>
+            </li>
+          {/each}
+        </ul>
+      {:else if searchQuery}
+        <p class="cm-muted">
+          No matches.
+          {#if onAddNewWord}
+            <button
+              type="button"
+              class="cm-link"
+              onclick={() => {
+                onClose();
+                onAddNewWord?.();
+              }}
+            >
+              Add new word
+            </button>
+          {/if}
+        </p>
+      {/if}
+    </section>
+
+    <section class="cm-section">
+      <h3>Or mark this surface</h3>
+      <div class="cm-marks">
+        <button
+          type="button"
+          disabled={savingType !== null}
+          onclick={markProperNoun}
+        >
+          Proper noun
+        </button>
+        <button
+          type="button"
+          disabled={savingType !== null}
+          onclick={markForeign}
+        >
+          Foreign / code-switched
+        </button>
+        <button
+          type="button"
+          disabled={savingType !== null}
+          onclick={markNotAWord}
+        >
+          Not a word
+        </button>
+      </div>
+    </section>
+
+    <footer class="cm-foot">
+      <label class="cm-also">
+        <input
+          type="checkbox"
+          bind:checked={alsoReport}
+        />
+        Also report to moderators
+      </label>
+      {#if saveError}
+        <p class="cm-err" role="alert">{saveError}</p>
+      {/if}
+    </footer>
+  </div>
+</Modal>
+
+<style>
+  .cm {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+  .cm-head {
+    display: flex;
+    align-items: baseline;
+    gap: 0.7rem;
+  }
+  .cm-surface {
+    font-family: var(--font-serif-dev, var(--font-serif));
+    font-size: 1.5rem;
+    color: var(--ink, var(--color-fg));
+  }
+  .cm-roman {
+    font-family: var(--font-mono-display, var(--font-mono));
+    font-size: 0.78rem;
+    color: var(--ink-3, var(--color-fg-muted));
+  }
+  .cm-section h3 {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--ink-3, var(--color-fg-muted));
+    margin: 0 0 0.45rem;
+    font-weight: 500;
+  }
+  .cm-list {
+    list-style: none;
+    padding: 0;
+    margin: 0.4rem 0 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+  .cm-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.6rem;
+    padding: 0.4rem 0.55rem;
+    border: 1px solid var(--rule, var(--color-border));
+    border-radius: 6px;
+    background: var(--card, var(--color-bg));
+  }
+  .cm-row-meta {
+    display: flex;
+    align-items: baseline;
+    gap: 0.45rem;
+    flex-wrap: wrap;
+    flex: 1;
+    min-width: 0;
+  }
+  .cm-h {
+    font-family: var(--font-serif-dev, var(--font-serif));
+    font-size: 1.05rem;
+  }
+  .cm-pos {
+    font-size: 0.62rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--ink-3, var(--color-fg-muted));
+  }
+  .cm-gloss {
+    font-size: 0.82rem;
+    color: var(--ink-2, var(--color-fg));
+    flex: 1;
+    min-width: 0;
+  }
+  .cm-row button {
+    background: var(--accent, var(--color-accent));
+    color: var(--accent-ink, var(--color-bg));
+    border: 0;
+    border-radius: 5px;
+    padding: 0.3rem 0.6rem;
+    font: inherit;
+    font-size: 0.78rem;
+    cursor: pointer;
+    flex-shrink: 0;
+  }
+  .cm-row button:disabled {
+    opacity: 0.6;
+    cursor: progress;
+  }
+  .cm-marks {
+    display: flex;
+    gap: 0.45rem;
+    flex-wrap: wrap;
+  }
+  .cm-marks button {
+    border: 1px solid var(--rule, var(--color-border));
+    background: var(--card, var(--color-bg));
+    color: var(--ink, var(--color-fg));
+    padding: 0.35rem 0.7rem;
+    border-radius: 6px;
+    font: inherit;
+    font-size: 0.85rem;
+    cursor: pointer;
+  }
+  .cm-foot {
+    border-top: 1px solid var(--rule, var(--color-border));
+    padding-top: 0.7rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+  .cm-also {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.85rem;
+    color: var(--ink-2, var(--color-fg));
+  }
+  .cm-link {
+    background: none;
+    border: 0;
+    padding: 0;
+    color: var(--accent, var(--color-accent));
+    cursor: pointer;
+    font: inherit;
+    text-decoration: underline;
+  }
+  .cm-muted {
+    color: var(--ink-3, var(--color-fg-muted));
+    font-size: 0.85rem;
+    margin: 0.4rem 0 0;
+  }
+  .cm-err {
+    color: var(--err, #b94545);
+    font-size: 0.82rem;
+    margin: 0.3rem 0 0;
+  }
+</style>

--- a/apps/web/src/lib/components/reader/ReaderContinuous.svelte
+++ b/apps/web/src/lib/components/reader/ReaderContinuous.svelte
@@ -28,6 +28,7 @@
     showRomanization = false,
     isOwner = false,
     textId,
+    language,
     /** Override hook for tests — defaults to a real fetch when omitted. */
     fetcher,
   }: {
@@ -36,6 +37,7 @@
     showRomanization?: boolean;
     isOwner?: boolean;
     textId: string;
+    language: import('@ciareader/shared-types').LanguageCode;
     fetcher?: ChapterTokenFetcher;
   } = $props();
 
@@ -132,7 +134,7 @@
           <span class="muted">({chapter.tokenCount.toLocaleString()} tokens)</span>
         </h2>
       {/if}
-      <ChapterBody {chapter} {showRomanization} {isOwner} />
+      <ChapterBody {chapter} {language} {showRomanization} {isOwner} />
     </section>
   {/each}
 </div>

--- a/apps/web/src/lib/components/reader/ReaderPage.svelte
+++ b/apps/web/src/lib/components/reader/ReaderPage.svelte
@@ -27,12 +27,14 @@
     chapters,
     chapterIdx,
     textId,
+    language,
     showRomanization = false,
     isOwner = false,
   }: {
     chapters: ChapterView[];
     chapterIdx: number;
     textId: string;
+    language: import('@ciareader/shared-types').LanguageCode;
     showRomanization?: boolean;
     isOwner?: boolean;
   } = $props();
@@ -246,7 +248,7 @@
               </span>
             </header>
             <article>
-              <ChapterBody chapter={current} {showRomanization} {isOwner} />
+              <ChapterBody chapter={current} {language} {showRomanization} {isOwner} />
             </article>
           {/if}
         </div>

--- a/apps/web/src/lib/components/reader/ReaderScroll.svelte
+++ b/apps/web/src/lib/components/reader/ReaderScroll.svelte
@@ -27,12 +27,14 @@
     wordsPerPage = 250,
     showRomanization = false,
     isOwner = false,
+    language,
   }: {
     chapters: ChapterView[];
     chapterIdx: number;
     wordsPerPage?: number;
     showRomanization?: boolean;
     isOwner?: boolean;
+    language: import('@ciareader/shared-types').LanguageCode;
   } = $props();
 
   let page = $state(0);
@@ -251,9 +253,13 @@
   // with ChapterBody so picking an alternate lemma in the popup
   // re-renders the corrected token on the current page immediately.
   let lemmaCorrections = $state(new Map<string, string>());
-  function onCorrectionApplied(tokenId: string, chosenLemmaId: string) {
+  function onCorrectionApplied(tokenId: string, chosenLemmaId: string | null) {
     const next = new Map(lemmaCorrections);
-    next.set(tokenId, chosenLemmaId);
+    if (chosenLemmaId == null) {
+      next.delete(tokenId);
+    } else {
+      next.set(tokenId, chosenLemmaId);
+    }
     lemmaCorrections = next;
   }
 
@@ -356,6 +362,7 @@
   <WordPopup
     token={activeToken}
     anchorRect={activeRect}
+    {language}
     {isOwner}
     onClose={closePopup}
     {onStatusChange}

--- a/apps/web/src/lib/components/reader/WordPopup.svelte
+++ b/apps/web/src/lib/components/reader/WordPopup.svelte
@@ -20,7 +20,9 @@
 <script lang="ts">
   import { untrack } from 'svelte';
   import Sheet from '../overlay/Sheet.svelte';
+  import CorrectionModal from './CorrectionModal.svelte';
   import { customizableOfficialIds } from './customize-eligibility.js';
+  import type { LanguageCode } from '@ciareader/shared-types';
   import type { ServerToken } from './types.js';
 
   type Provenance =
@@ -57,12 +59,16 @@
   // backward compat with callers that still pass it.
   let {
     token,
+    language,
     isOwner,
     onClose,
     onStatusChange,
     onCorrectionApplied,
   }: {
     token: ServerToken;
+    /** Drives the CorrectionModal's dictionary search + script
+     *  selection. Required from T-6.2 forward. */
+    language: LanguageCode;
     anchorRect?: { top: number; left: number; bottom: number; right: number };
     isOwner: boolean;
     onClose: () => void;
@@ -72,12 +78,14 @@
     ) => void;
     /** T-6.1: parent applies the new lemma to the token's render so
      *  the reader reflects the correction without a page reload. */
-    onCorrectionApplied?: (tokenId: string, chosenLemmaId: string) => void;
+    onCorrectionApplied?: (tokenId: string, chosenLemmaId: string | null) => void;
   } = $props();
 
   let payload = $state<LemmaPayload | null>(null);
   let loadError = $state<string | null>(null);
   let showAlternates = $state(false);
+  // T-6.2: opens the CorrectionModal layered on top of the popup.
+  let showCorrectionModal = $state(false);
   let optimisticStatus = $state<'unknown' | 'learning' | 'known' | 'ignored'>(
     untrack(() => token.status),
   );
@@ -572,6 +580,20 @@
       {/if}
     {/if}
 
+    <!-- T-6.2: "Fix" affordance — every popup gets it, even the
+         non-ambiguous ones (a learner may know the worker got the
+         lemma wrong on a token where the model wasn't unsure). -->
+    {#if isOwner}
+      <button
+        type="button"
+        class="fix-toggle"
+        onclick={() => (showCorrectionModal = true)}
+        title="Search the dictionary or mark this surface"
+      >
+        Fix this word
+      </button>
+    {/if}
+
     {#if token.isAmbiguous && token.candidates.length > 0}
       <button
         type="button"
@@ -611,6 +633,17 @@
     {/if}
   </div>
 </Sheet>
+
+<CorrectionModal
+  open={showCorrectionModal}
+  {token}
+  {language}
+  onClose={() => (showCorrectionModal = false)}
+  onApplied={(lemmaId) => {
+    onCorrectionApplied?.(token.id, lemmaId);
+    onClose();
+  }}
+/>
 
 <style>
   .sp-head {
@@ -878,6 +911,21 @@
     resize: vertical;
   }
 
+  .fix-toggle {
+    margin-top: 0.85rem;
+    margin-right: 0.4rem;
+    background: transparent;
+    border: 1px solid var(--rule, var(--color-border));
+    border-radius: 999px;
+    padding: 0.4rem 0.85rem;
+    font: inherit;
+    font-size: 0.78rem;
+    color: var(--ink-2, var(--color-fg));
+    cursor: pointer;
+  }
+  .fix-toggle:hover {
+    background: color-mix(in oklch, var(--ink, var(--color-fg)) 5%, transparent);
+  }
   .alt-toggle {
     margin-top: 0.85rem;
     background: transparent;

--- a/apps/web/src/routes/api/v1/me/parse-reports/+server.ts
+++ b/apps/web/src/routes/api/v1/me/parse-reports/+server.ts
@@ -1,0 +1,69 @@
+/**
+ * POST /api/v1/me/parse-reports (T-6.5 wiring; called by T-6.2's
+ * correction modal and T-6.3's new-lemma form).
+ *
+ * Files (or merges into) a parse_report. The user's optional
+ * "Also report to moderators" checkbox in the correction modal
+ * decides whether this fires alongside the per-user
+ * /api/v1/me/token-corrections write.
+ */
+import { error, json } from '@sveltejs/kit';
+import { z } from 'zod';
+
+import { requireUser } from '$lib/server/auth/require-user.js';
+import { fileParseReport } from '$lib/server/parse-reports.js';
+import { isSupportedLanguage, type LanguageCode } from '@ciareader/shared-types';
+import { parseJson } from '../../auth/_helpers.js';
+import type { RequestHandler } from './$types';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const candidateSchema = z.object({
+  lemmaId: z.string().regex(UUID_RE).nullable(),
+  score: z.number(),
+  features: z.record(z.string()),
+});
+
+const bodySchema = z
+  .object({
+    tokenId: z.string().regex(UUID_RE).nullable().optional(),
+    language: z.string().refine(isSupportedLanguage, 'unsupported language'),
+    surfaceNfc: z.string().min(1).max(200),
+    contextSignature: z.string().max(64).optional(),
+    originalCandidates: z.array(candidateSchema).default([]),
+    correctedLemmaId: z.string().regex(UUID_RE).nullable().optional(),
+    correctionType: z.enum([
+      'pick_candidate',
+      'manual_lemma',
+      'new_lemma',
+      'mark_proper_noun',
+      'mark_foreign',
+      'mark_not_a_word',
+    ]),
+    note: z.string().max(2000).nullable().optional(),
+  })
+  .strict();
+
+export const POST: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  const body = await parseJson(event.request, bodySchema);
+
+  const { report, merged } = await fileParseReport({
+    reporterId: user.id,
+    tokenId: body.tokenId ?? null,
+    language: body.language as LanguageCode,
+    surfaceNfc: body.surfaceNfc,
+    contextSignature: body.contextSignature,
+    originalCandidates: body.originalCandidates ?? [],
+    correctedLemmaId: body.correctedLemmaId ?? null,
+    correctionType: body.correctionType,
+    note: body.note ?? null,
+  });
+  return json({ report, merged }, { status: merged ? 200 : 201 });
+};
+
+// Block anything other than POST so a bare GET on this URL gets a
+// useful 405 instead of SvelteKit's default route-not-found 404.
+export const fallback: RequestHandler = async () => {
+  throw error(405, 'Method not allowed');
+};

--- a/apps/web/src/routes/api/v1/me/parse-reports/parse-reports-server.test.ts
+++ b/apps/web/src/routes/api/v1/me/parse-reports/parse-reports-server.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fileParseReport = vi.fn();
+const requireUser = vi.fn();
+
+vi.mock('$lib/server/parse-reports.js', () => ({
+  fileParseReport: (...a: unknown[]) => fileParseReport(...a),
+}));
+vi.mock('$lib/server/auth/require-user.js', () => ({
+  requireUser: (...a: unknown[]) => requireUser(...a),
+}));
+
+type Post = (typeof import('./+server.js'))['POST'];
+
+const TOKEN = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const LEMMA = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+
+async function call(body: unknown) {
+  const { POST } = await import('./+server.js');
+  const event = {
+    request: new Request('http://x/api/v1/me/parse-reports', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+  } as unknown as Parameters<Post>[0];
+  try {
+    return (await POST(event)) as Response;
+  } catch (e) {
+    return e as { status: number };
+  }
+}
+
+beforeEach(() => {
+  fileParseReport.mockReset();
+  requireUser.mockReset();
+  requireUser.mockResolvedValue({ id: 'u1' });
+});
+
+afterEach(() => vi.resetModules());
+
+describe('POST /api/v1/me/parse-reports', () => {
+  it('files a fresh report and returns 201', async () => {
+    fileParseReport.mockResolvedValueOnce({
+      report: { id: 'pr-1' },
+      merged: false,
+    });
+    const res = (await call({
+      tokenId: TOKEN,
+      language: 'hi',
+      surfaceNfc: 'पाठ',
+      correctedLemmaId: LEMMA,
+      correctionType: 'manual_lemma',
+      originalCandidates: [],
+    })) as Response;
+    expect(res.status).toBe(201);
+    expect(fileParseReport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reporterId: 'u1',
+        language: 'hi',
+        surfaceNfc: 'पाठ',
+      }),
+    );
+  });
+
+  it('returns 200 (not 201) when the call merged into an existing report', async () => {
+    fileParseReport.mockResolvedValueOnce({
+      report: { id: 'pr-1', duplicateCount: 4 },
+      merged: true,
+    });
+    const res = (await call({
+      tokenId: TOKEN,
+      language: 'hi',
+      surfaceNfc: 'पाठ',
+      correctedLemmaId: LEMMA,
+      correctionType: 'manual_lemma',
+    })) as Response;
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects an unknown language with 400', async () => {
+    const r = (await call({
+      tokenId: TOKEN,
+      language: 'fr',
+      surfaceNfc: 'lapin',
+      correctionType: 'manual_lemma',
+      correctedLemmaId: LEMMA,
+    })) as { status: number };
+    expect(r.status).toBe(400);
+    expect(fileParseReport).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown correction type', async () => {
+    const r = (await call({
+      tokenId: TOKEN,
+      language: 'hi',
+      surfaceNfc: 'पाठ',
+      correctionType: 'invented',
+    })) as { status: number };
+    expect(r.status).toBe(400);
+  });
+});

--- a/apps/web/src/routes/reader/[textId]/+page.svelte
+++ b/apps/web/src/routes/reader/[textId]/+page.svelte
@@ -301,6 +301,7 @@
       chapters={data.chapters}
       chapterIdx={data.anchor.chapterIdx}
       textId={data.text.id}
+      language={data.text.language as LanguageCode}
       {showRomanization}
       isOwner={data.isOwner}
     />
@@ -309,6 +310,7 @@
       chapters={data.chapters}
       chapterIdx={data.anchor.chapterIdx}
       wordsPerPage={readerSettings.wordsPerPage}
+      language={data.text.language as LanguageCode}
       {showRomanization}
       isOwner={data.isOwner}
     />
@@ -317,6 +319,7 @@
       chapters={data.chapters}
       initialChapterIdx={data.anchor.chapterIdx}
       textId={data.text.id}
+      language={data.text.language as LanguageCode}
       {showRomanization}
       isOwner={data.isOwner}
     />


### PR DESCRIPTION
> Stacked on #226 (T-6.2a).

## Summary

\"Fix this word\" affordance on every WordPopup. Modal with three correction surfaces: candidate list, script-agnostic dictionary search via \`<ScriptAwareInput>\` + \`/api/v1/dictionary/:lang/lemmas\` (debounced 200ms), and quick \`mark_*\` buttons. Footer carries an \"Also report to moderators\" checkbox; default ON when the token has no candidates (= more likely a manual_lemma / new_lemma than a pick).

POST \`/api/v1/me/parse-reports\` added, wrapping \`fileParseReport\` from T-6.5 — returns 201 on fresh, 200 on merged-into-existing.

\`language\` now flows through ReaderPage / ReaderScroll / ReaderContinuous → ChapterBody → WordPopup so the modal can drive its dictionary search. \`onCorrectionApplied(tokenId, null)\` from \`mark_*\` corrections clears the override map so the next render falls through to the worker's (now-suppressed) primary.

Closes #56.

## Test plan
- 98 files / 795 tests pass; new \`parse-reports-server.test.ts\` covers fresh insert (201), dedup-merge (200), unsupported language (400), unknown correction type (400).
- typecheck + lint clean.