### PR TITLE
Move sidebar toggle to top of viewport

### DIFF
--- a/apps/web/src/lib/components/shell/AppShell.svelte
+++ b/apps/web/src/lib/components/shell/AppShell.svelte
@@ -610,7 +610,7 @@
    * button at the top-left as a simple immersive-toggle there. */
   .rail-toggle {
     position: fixed;
-    top: 50%;
+    top: 1rem;
     left: 0;
     width: 22px;
     height: 44px;
@@ -624,7 +624,6 @@
     cursor: pointer;
     z-index: 30;
     box-shadow: 2px 0 8px rgba(0, 0, 0, 0.08);
-    transform: translateY(-50%);
     transition:
       left 200ms cubic-bezier(0.2, 0, 0, 1),
       background 150ms ease,


### PR DESCRIPTION
## Summary
- The rail expand/collapse button was vertically centered, where it overlapped mid-screen content like word popups and the dictionary panel.
- Pinned it near the top of the viewport (`top: 1rem`) so it stays out of the reading area in both expanded and collapsed states.

## Test plan
- [ ] Visit any page on desktop — toggle button sits near the top-left, flush against the rail's right edge when expanded.
- [ ] Collapse the rail — button remains at the top-left (snaps to viewport edge), still clickable.
- [ ] Open a reader page and click a word — the popup no longer collides with the toggle button.