### PR TITLE
Reader: static rail, hover fall-through, full-width top bar

### DIFF
--- a/apps/web/src/lib/components/overlay/Sheet.svelte
+++ b/apps/web/src/lib/components/overlay/Sheet.svelte
@@ -120,12 +120,20 @@
     position: fixed;
     inset: 0;
     z-index: 40;
-    /* Default: transparent — only sheets that opt in via dimmed=true
-     * paint the scrim. Click capture works either way. */
+    /* Undimmed: events pass straight through to the page behind so
+     * hover tooltips on the reader still fire while the sheet is
+     * locked open. The .sheet itself opts back into pointer events.
+     * Dimmed sheets keep the modal contract (backdrop catches
+     * outside clicks → close). */
+    pointer-events: none;
   }
   .sheet-back.dimmed {
     background: rgba(20, 16, 10, 0.42);
     backdrop-filter: blur(4px);
+    pointer-events: auto;
+  }
+  .sheet {
+    pointer-events: auto;
   }
   /* The bottom sheet on narrow viewports occludes the lower part of
    * the page even when `dimmed=false`. We still want a subtle

--- a/apps/web/src/lib/components/overlay/Sheet.test.ts
+++ b/apps/web/src/lib/components/overlay/Sheet.test.ts
@@ -38,16 +38,23 @@ describe('Sheet — dimmed prop (T-5.17)', () => {
     expect(back!.classList.contains('dimmed')).toBe(false);
   });
 
-  it('keeps the backdrop element so click-outside-to-close still works when dimmed=false', async () => {
+  // The .dimmed class is what gates pointer-events in CSS:
+  //   .sheet-back            { pointer-events: none; }
+  //   .sheet-back.dimmed     { pointer-events: auto; }
+  // jsdom doesn't compute Svelte-scoped CSS rules so we assert the
+  // class state instead and let manual / preview verification cover
+  // the pixel-level behavior.
+  it('keeps the dimmed backdrop interactive so click-outside-to-close works in modal mode', async () => {
     let closed = 0;
     render(Sheet, {
       open: true,
-      dimmed: false,
+      dimmed: true,
       onClose: () => {
         closed += 1;
       },
     });
     const back = document.body.querySelector('.sheet-back') as HTMLElement;
+    expect(back.classList.contains('dimmed')).toBe(true);
     await fireEvent.click(back);
     expect(closed).toBe(1);
   });

--- a/apps/web/src/lib/components/reader/ReaderPage.svelte
+++ b/apps/web/src/lib/components/reader/ReaderPage.svelte
@@ -272,15 +272,16 @@
     }
   }
 
-  /* The "window" is the clipping mask. It's exactly one column wide
-     (max 40rem so reading stays comfortable on big screens), and its
-     overflow:hidden is what hides the off-page columns sitting to its
-     right. The track inside (translateX target) carries the content,
-     and the content's overflow extends past the window horizontally. */
+  /* The "window" is the clipping mask. It fills the remaining width
+     of the reader chrome (the rail is static on desktop, so the
+     reader column already gets a sensible max width from the
+     viewport - rail). Its overflow:hidden is what hides the off-page
+     columns sitting to its right. The track inside (translateX
+     target) carries the content, and the content's overflow extends
+     past the window horizontally. */
   .reader-page-window {
     flex: 1;
     width: 100%;
-    max-width: 40rem;
     height: 100%;
     overflow: hidden;
     position: relative;

--- a/apps/web/src/lib/components/reader/WordPopup.svelte
+++ b/apps/web/src/lib/components/reader/WordPopup.svelte
@@ -345,6 +345,15 @@
 <Sheet open={true} onClose={onClose} title="" dimmed={false}>
   <div data-testid="word-popup">
     <header class="sp-head">
+      <button
+        type="button"
+        class="sp-close"
+        aria-label="Close"
+        title="Close"
+        onclick={onClose}
+      >
+        ×
+      </button>
       <h2 class="sp-word">{token.surface}</h2>
       {#if token.romanization}
         <p class="sp-roman">{token.romanization}</p>
@@ -550,7 +559,28 @@
 
 <style>
   .sp-head {
+    position: relative;
     margin-bottom: 0.85rem;
+  }
+  .sp-close {
+    position: absolute;
+    top: -0.25rem;
+    right: -0.25rem;
+    width: 28px;
+    height: 28px;
+    display: grid;
+    place-items: center;
+    border: 0;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--ink-3, var(--color-fg-muted));
+    font-size: 1.4rem;
+    line-height: 1;
+    cursor: pointer;
+  }
+  .sp-close:hover {
+    background: color-mix(in oklch, var(--ink, var(--color-fg)) 8%, transparent);
+    color: var(--ink, var(--color-fg));
   }
   .sp-word {
     margin: 0 0 0.25rem;

--- a/apps/web/src/lib/components/reader/WordTooltip.svelte
+++ b/apps/web/src/lib/components/reader/WordTooltip.svelte
@@ -95,7 +95,10 @@
 <style>
   .tip {
     position: fixed;
-    z-index: 30;
+    /* Above the side panel (z-index 40) so the tooltip shows even when
+     * the user is hovering a word that lives under where the panel
+     * sits — which is most of the right half of the reader. */
+    z-index: 50;
     background: var(--ink, #1f1a14);
     color: var(--paper, #fdfaf3);
     border-radius: 8px;

--- a/apps/web/src/lib/components/shell/AppShell.svelte
+++ b/apps/web/src/lib/components/shell/AppShell.svelte
@@ -600,14 +600,10 @@
   }
 
   /* —— Chevron / rail-toggle button (T-5.26) ————————————————
-   * Fixed-position so it stays clickable in both states. When the
-   * rail is open it sits flush inside the rail's right border (chevron
-   * points left, "collapse"); when the rail is hidden it snaps to the
-   * viewport's left edge (chevron points right, "expand"). High
-   * z-index so it floats over everything except the word side-panel.
-   *
-   * Mobile (<960px) doesn't have a rail to toggle into — keep the
-   * button at the top-left as a simple immersive-toggle there. */
+   * Mobile-only now. The rail is static on desktop, so there's
+   * nothing to expand/collapse there; on mobile we keep the toggle as
+   * an immersive-mode affordance (hides top-strip + bottom-nav for
+   * full-screen reading). Vertical tab on the viewport's left edge. */
   .rail-toggle {
     position: fixed;
     top: 50%;
@@ -626,18 +622,12 @@
     box-shadow: 2px 0 8px rgba(0, 0, 0, 0.08);
     transform: translateY(-50%);
     transition:
-      left 200ms cubic-bezier(0.2, 0, 0, 1),
       background 150ms ease,
       color 150ms ease;
   }
-  /* Expanded: dock against the rail's right border (rail is 232px). */
   @media (min-width: 960px) {
-    .rail-toggle[data-collapsed='0'] {
-      left: calc(232px - 22px);
-      border-radius: 8px 0 0 8px;
-      border-left: 1px solid var(--card-edge, var(--color-border));
-      border-right: 0;
-      box-shadow: -2px 0 8px rgba(0, 0, 0, 0.08);
+    .rail-toggle {
+      display: none;
     }
   }
   .rail-toggle:hover {
@@ -824,19 +814,13 @@
     text-decoration: underline;
   }
 
-  /* —— Immersive mode (T-5.16, retriggered by T-5.26) ——————————
-   * `data-reader-immersive="1"` on <html> hides the rail / top-strip
-   * / bottom-nav so the screen content occupies the whole viewport.
-   * Originally a reader-specific affordance; T-5.26 generalised it
-   * via a hamburger button on the shell. */
-  :global(html[data-reader-immersive='1']) .rail,
+  /* —— Immersive mode (mobile-only) ————————————————————————————
+   * `data-reader-immersive="1"` on <html> hides the mobile chrome
+   * (top-strip + bottom-nav) so the screen content occupies the
+   * whole viewport. Desktop's rail stays static regardless. */
   :global(html[data-reader-immersive='1']) .top-strip,
   :global(html[data-reader-immersive='1']) .bottom-nav {
     display: none;
-  }
-  :global(html[data-reader-immersive='1']) .shell {
-    grid-template-columns: 1fr;
-    grid-template-areas: 'content';
   }
   :global(html[data-reader-immersive='1']) .content {
     /* Bottom nav is gone — drop the safe-area padding too. */

--- a/apps/web/src/lib/components/shell/AppShell.svelte
+++ b/apps/web/src/lib/components/shell/AppShell.svelte
@@ -389,7 +389,10 @@
     text-overflow: ellipsis;
   }
 
-  /* —— Rail (desktop only) —— */
+  /* —— Rail (desktop only) ——
+     The rail sits below any page-level top bar via `--reader-top-h`,
+     a CSS var the reader sets to its top-bar height. Pages that don't
+     have a top bar leave the var unset and the rail goes top:0. */
   .rail {
     grid-area: rail;
     display: none;
@@ -403,8 +406,8 @@
       var(--paper-2, transparent)
     );
     position: sticky;
-    top: 0;
-    height: 100dvh;
+    top: var(--reader-top-h, 0px);
+    height: calc(100dvh - var(--reader-top-h, 0px));
   }
   @media (min-width: 960px) {
     .rail {

--- a/apps/web/src/routes/reader/[textId]/+page.svelte
+++ b/apps/web/src/routes/reader/[textId]/+page.svelte
@@ -114,6 +114,12 @@
   let progressWriter: ProgressWriter | null = null;
   let beforeUnloadHandler: (() => void) | null = null;
 
+  // The reader's top bar is a full-width fixed element. We measure
+  // its height into a `--reader-top-h` CSS variable so the AppShell
+  // rail and the reader body can both leave room for it without
+  // baking a fixed pixel value into either component.
+  let readerTopEl: HTMLElement | null = $state(null);
+
   onMount(() => {
     liveStatus = data.text.status;
 
@@ -180,12 +186,27 @@
       window.addEventListener('beforeunload', beforeUnloadHandler);
     }
 
+    // Track the .reader-top height so the rail can sit below it.
+    let topRO: ResizeObserver | null = null;
+    if (typeof ResizeObserver !== 'undefined' && readerTopEl) {
+      const apply = () => {
+        if (!readerTopEl) return;
+        const h = readerTopEl.getBoundingClientRect().height;
+        document.documentElement.style.setProperty('--reader-top-h', `${h}px`);
+      };
+      topRO = new ResizeObserver(apply);
+      topRO.observe(readerTopEl);
+      apply();
+    }
+
     return () => {
       cleanupPoll?.();
       window.removeEventListener('keydown', onKey);
       if (beforeUnloadHandler)
         window.removeEventListener('beforeunload', beforeUnloadHandler);
       void progressWriter?.flush();
+      topRO?.disconnect();
+      document.documentElement.style.removeProperty('--reader-top-h');
     };
   });
 
@@ -219,7 +240,7 @@
   data-hl={readerSettings.highlightStyle}
   style={readerStyle}
 >
-  <header class="reader-top">
+  <header class="reader-top" bind:this={readerTopEl}>
     <a class="reader-close" href="/library" aria-label="Close reader" title="Close reader">
       <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true">
         <path d="M6 6l12 12" />
@@ -341,10 +362,12 @@
     color: var(--ink, var(--color-fg));
     /* Fill the AppShell's content track so page mode can occupy the
        full vertical space (T-5.23). Children flex-stack vertically:
-       sticky top bar, fluid body, and progress foot. */
+       fluid body and progress foot — the top bar is fixed across the
+       whole viewport, so the body just needs the matching padding. */
     min-height: 100dvh;
     display: flex;
     flex-direction: column;
+    padding-top: var(--reader-top-h, 0px);
   }
   /* Page mode is meant to behave like a book — no vertical scroll;
      overflow stays inside the viewport, page arrows step through it.
@@ -356,10 +379,14 @@
     min-height: 0;
     overflow: hidden;
   }
+  /* Full-viewport top bar so the rail sits below it (rail reads the
+     same `--reader-top-h` variable to know how much room to leave). */
   .reader-top {
-    position: sticky;
+    position: fixed;
     top: 0;
-    z-index: 5;
+    left: 0;
+    right: 0;
+    z-index: 20;
     display: grid;
     grid-template-columns: 1fr;
     gap: 0.5rem 1rem;


### PR DESCRIPTION
## Summary

Three reader-shell changes that didn't make it into #217. Branched from latest main and re-applied; rail / tooltip / panel work all sits on top of the page-mode-horizontal flow that already shipped.

### Static rail on desktop
The chevron rail-toggle is now mobile-only. On desktop the rail is always visible — the collapse affordance was extra chrome to think about for little benefit. The reader window also drops its `max-width: 40rem` cap so the chapter text fills the rail-minus-arrows space instead of leaving a wide empty band.

- Rail-toggle button hidden via `@media (min-width: 960px) { display: none }`. On mobile it still toggles immersive (hide top-strip + bottom-nav).
- Removed `.rail` from the `data-reader-immersive` CSS rule + the matching `.shell` `grid-template-columns` override (rail can no longer be hidden on desktop).
- Removed `max-width: 40rem` from `.reader-page-window`.

### Hover tooltips fall through the side panel
The undimmed Sheet's backdrop covered the whole viewport with `pointer-events: auto`, so hovering a word with the side panel locked open hit `.sheet-back` instead of the token — no hover tooltip fired. Switch the backdrop to `pointer-events: none` in undimmed mode and opt `.sheet` itself back in so it still catches clicks. Click-outside-to-close stops working in undimmed mode as a side effect, so the WordPopup header gets an explicit close button. Dimmed sheets are unchanged.

WordTooltip's z-index also bumps from 30 → 50 so a tooltip rendered in the right half of the chapter (close to where the panel sits at z-index 40) shows over the panel instead of disappearing behind it.

### Full-width top bar with the rail tucked beneath
The reader's chapter title bar was a sticky header inside the right column, sitting beside the rail at the same y. Promote it to a fixed viewport-width strip across the very top, and have the rail sit beneath it.

- `.reader-top` becomes `position: fixed; top: 0; left: 0; right: 0; z-index: 20`.
- A ResizeObserver on `.reader-top` writes its rendered height to `--reader-top-h` on `<html>`. The reader page consumes it for `.reader { padding-top: var(--reader-top-h, 0px) }`. AppShell consumes it for the rail's sticky `top` and computed `height: calc(100dvh - var(--reader-top-h, 0px))`.
- Pages without a `.reader-top` leave the var unset and the rail goes back to `top: 0`.

## Test plan

- [x] `pnpm test` — 736 tests pass
- [x] `pnpm check` — 0 errors, 0 warnings
- [x] Desktop: rail is static, no toggle button, reader text spans full available width
- [x] Top bar spans `0..viewport-width`, z-index above rail; rail sits below at `top = top-bar height`
- [x] Hover a word while the side panel is open — tooltip appears for the hovered word, panel stays locked on the original
- [x] Close button in side-panel header dismisses the panel
- [ ] Mobile (<960px): toggle still appears and still hides top-strip + bottom-nav
- [ ] Esc still closes the side panel
- [ ] Resize window — column-width re-snaps; --reader-top-h tracks if top bar height changes