### PR TITLE
fix(reader): live preview + transparent settings sheet

### DIFF
--- a/apps/web/src/lib/components/reader/ReaderContinuous.svelte
+++ b/apps/web/src/lib/components/reader/ReaderContinuous.svelte
@@ -139,9 +139,13 @@
 
 <style>
   .reader-continuous {
-    max-width: 38rem;
+    max-width: var(--reader-col-width, 38rem);
     margin: 0 auto;
     padding: 1rem 1.25rem 4rem;
+    font-family: var(--reader-font-family, var(--font-serif-dev, var(--font-serif)));
+    font-size: var(--reader-font-size, 1.1rem);
+    line-height: var(--reader-line-height, 2);
+    color: var(--ink, var(--color-fg));
   }
   section {
     margin: 1.5rem 0;

--- a/apps/web/src/lib/components/reader/ReaderPage.svelte
+++ b/apps/web/src/lib/components/reader/ReaderPage.svelte
@@ -28,12 +28,20 @@
     textId,
     showRomanization = false,
     isOwner = false,
+    fontSize,
+    lineSpacing,
+    fontFamily,
+    readingWidth,
   }: {
     chapters: ChapterView[];
     chapterIdx: number;
     textId: string;
     showRomanization?: boolean;
     isOwner?: boolean;
+    fontSize?: number;
+    lineSpacing?: number;
+    fontFamily?: string | null;
+    readingWidth?: string;
   } = $props();
 
   const current = $derived(
@@ -177,11 +185,18 @@
     return () => ro.disconnect();
   });
 
-  // Re-measure when the chapter or romanization toggle changes — both
-  // mutate the content's natural size and we want pageCount to track.
+  // Re-measure when anything that mutates the content's natural size
+  // changes — chapter, romanization toggle, or any of the typography
+  // settings driven by CSS vars on the .reader root. ResizeObserver
+  // fires on box-size changes only, so font-size / line-height swaps
+  // (which only change scrollWidth) need an explicit nudge.
   $effect(() => {
     void chapterIdx;
     void showRomanization;
+    void fontSize;
+    void lineSpacing;
+    void fontFamily;
+    void readingWidth;
     measure();
   });
 </script>
@@ -282,6 +297,7 @@
   .reader-page-window {
     flex: 1;
     width: 100%;
+    max-width: var(--reader-col-width, 40rem);
     height: 100%;
     overflow: hidden;
     position: relative;
@@ -307,9 +323,9 @@
      the next — without it the browser tries to balance columns, which
      short-circuits the pagination. */
   .reader-page-content {
-    font-family: var(--font-serif-dev, var(--font-serif));
-    font-size: 1.1rem;
-    line-height: 2;
+    font-family: var(--reader-font-family, var(--font-serif-dev, var(--font-serif)));
+    font-size: var(--reader-font-size, 1.1rem);
+    line-height: var(--reader-line-height, 2);
     color: var(--ink, var(--color-fg));
     width: 100%;
     height: 100%;
@@ -317,11 +333,6 @@
     column-fill: auto;
     word-spacing: 0.03em;
     text-wrap: pretty;
-  }
-  @media (min-width: 768px) {
-    .reader-page-content {
-      font-size: 1.25rem;
-    }
   }
 
   .chapter-h {

--- a/apps/web/src/lib/components/reader/ReaderScroll.svelte
+++ b/apps/web/src/lib/components/reader/ReaderScroll.svelte
@@ -334,7 +334,7 @@
     padding: 0;
   }
   .reader-scroll-inner {
-    max-width: 40rem;
+    max-width: var(--reader-col-width, 40rem);
     margin: 0 auto;
     padding: 1.25rem 3rem 2rem;
   }
@@ -364,17 +364,12 @@
   }
   article {
     min-height: 50vh;
-    font-family: var(--font-serif-dev, var(--font-serif));
-    font-size: 1.1rem;
-    line-height: 2;
+    font-family: var(--reader-font-family, var(--font-serif-dev, var(--font-serif)));
+    font-size: var(--reader-font-size, 1.1rem);
+    line-height: var(--reader-line-height, 2);
     color: var(--ink, var(--color-fg));
     word-spacing: 0.03em;
     text-wrap: pretty;
-  }
-  @media (min-width: 768px) {
-    article {
-      font-size: 1.25rem;
-    }
   }
   .body {
     margin: 0 0 1rem;

--- a/apps/web/src/lib/components/reader/ReaderSettings.svelte
+++ b/apps/web/src/lib/components/reader/ReaderSettings.svelte
@@ -116,7 +116,7 @@
   }
 </script>
 
-<Sheet {open} {onClose} title="Reader settings" width={400}>
+<Sheet {open} {onClose} title="Reader settings" width={400} dimmed={false}>
   <div class="rs" data-testid="reader-settings">
     <section>
       <h3>Layout</h3>

--- a/apps/web/src/lib/styles/tokens.css
+++ b/apps/web/src/lib/styles/tokens.css
@@ -374,3 +374,29 @@ html[data-hl='underline'] .word[data-s='5'] {
   text-decoration-color: var(--ink-4);
   text-decoration-thickness: 0.5px;
 }
+
+html[data-hl='colored_text'] .word[data-s='0'] {
+  background: transparent;
+  color: var(--accent);
+}
+html[data-hl='colored_text'] .word[data-s='1'] {
+  background: transparent;
+  color: oklch(0.55 0.11 80);
+}
+html[data-hl='colored_text'] .word[data-s='2'] {
+  background: transparent;
+  color: oklch(0.5 0.13 75);
+}
+html[data-hl='colored_text'] .word[data-s='3'] {
+  background: transparent;
+  color: oklch(0.45 0.15 70);
+}
+html[data-hl='colored_text'] .word[data-s='4'] {
+  color: var(--w-known-ink);
+}
+html[data-hl='colored_text'] .word[data-s='5'] {
+  color: var(--w-ignored-ink);
+  text-decoration: line-through;
+  text-decoration-color: var(--ink-4);
+  text-decoration-thickness: 0.5px;
+}

--- a/apps/web/src/routes/reader/[textId]/+page.svelte
+++ b/apps/web/src/routes/reader/[textId]/+page.svelte
@@ -73,6 +73,23 @@
       .join('; '),
   );
 
+  // tokens.css scopes the word-status highlight rules to
+  // `html[data-hl='…']` (set up-front by app.html so first paint is
+  // correct). Mirror the popover's choice onto <html> so a live change
+  // flips the rules immediately. The previous value is restored on
+  // unmount so the attribute reflects this language's setting only
+  // while the reader is on screen.
+  $effect(() => {
+    if (typeof document === 'undefined') return;
+    const html = document.documentElement;
+    const previous = html.getAttribute('data-hl');
+    html.setAttribute('data-hl', readerSettings.highlightStyle);
+    return () => {
+      if (previous == null) html.removeAttribute('data-hl');
+      else html.setAttribute('data-hl', previous);
+    };
+  });
+
   function shouldPoll(s: typeof data.text.status): boolean {
     return s === 'pending' || s === 'processing';
   }
@@ -237,7 +254,6 @@
 <div
   class="reader"
   data-mode={data.mode}
-  data-hl={readerSettings.highlightStyle}
   style={readerStyle}
 >
   <header class="reader-top" bind:this={readerTopEl}>
@@ -324,6 +340,10 @@
       textId={data.text.id}
       {showRomanization}
       isOwner={data.isOwner}
+      fontSize={readerSettings.fontSize}
+      lineSpacing={readerSettings.lineSpacing}
+      fontFamily={readerSettings.fontFamily}
+      readingWidth={readerSettings.readingWidth}
     />
   {:else if data.mode === 'paged_scroll'}
     <ReaderScroll


### PR DESCRIPTION
## Summary
- The reader settings popover (T-5.1b) wasn't actually a live preview — the dark Sheet scrim covered the text, and none of the typography / width / highlight settings were wired through to the actual reader components.
- Drop the scrim on the settings sheet and wire CSS variables + `data-hl` through to ReaderPage / ReaderScroll / ReaderContinuous so every popover knob updates the text immediately.
- Add the missing CSS for the `colored_text` highlight option.

## Test plan
- [ ] Open a reader text, click the gear icon — paragraph text behind the popover stays at full opacity.
- [ ] Drag font-size and line-spacing sliders — text reflows as you drag in all three modes (Page, Scroll, Continuous).
- [ ] Switch reading width Narrow / Medium / Wide — column max-width updates live.
- [ ] Pick a font from the dropdown — body font face changes immediately.
- [ ] Switch highlight Tint / Underline / Color — known-word styling flips immediately, and "Color" actually does something now.
- [ ] In Page mode, change font-size — page count in the footer recalculates correctly (no stale columns).
- [ ] Close the reader — `<html data-hl>` reverts to the cookie-driven default.

Refs #45.