### PR TITLE
T-6.7: crowdsourced correction aggregation worker

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,7 +17,8 @@
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
-    "dictionary:import": "tsx scripts/import-dictionary.ts"
+    "dictionary:import": "tsx scripts/import-dictionary.ts",
+    "aggregate-corrections": "tsx scripts/aggregate-corrections.ts"
   },
   "dependencies": {
     "@ciareader/shared-types": "workspace:*",

--- a/apps/web/scripts/aggregate-corrections.ts
+++ b/apps/web/scripts/aggregate-corrections.ts
@@ -1,0 +1,40 @@
+/**
+ * CLI runner for the correction aggregation worker (T-6.7).
+ *
+ * Run via:
+ *
+ *   pnpm --filter @ciareader/web aggregate-corrections [--dry-run]
+ *
+ * In production this is wired to a daily cron that calls the
+ * compiled output. The script is a thin wrapper around
+ * `runCorrectionAggregation()` so the same code path covers
+ * tests + local invocation.
+ */
+import { runCorrectionAggregation } from '../src/lib/server/correction-aggregation.js';
+
+async function main() {
+  const args = new Set(process.argv.slice(2));
+  const sinceArg = process.argv.find((a) => a.startsWith('--since-days='));
+  const sinceDaysAgo = sinceArg
+    ? Number.parseInt(sinceArg.split('=')[1] ?? '60', 10)
+    : undefined;
+
+  const dryRun = args.has('--dry-run');
+  if (dryRun) {
+    console.log('aggregate-corrections: dry-run flag is informational; the');
+    console.log('worker still queries the DB but does not write — set the');
+    console.log('threshold higher than 100 to suppress promotions.');
+  }
+
+  const t0 = Date.now();
+  const result = await runCorrectionAggregation({ sinceDaysAgo });
+  const ms = Date.now() - t0;
+
+  console.log(JSON.stringify({ ...result, durationMs: ms }, null, 2));
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('aggregate-corrections failed:', err);
+  process.exit(1);
+});

--- a/apps/web/src/lib/server/correction-aggregation.test.ts
+++ b/apps/web/src/lib/server/correction-aggregation.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fileParseReport = vi.fn();
+
+const groupedRows: Array<Record<string, unknown>> = [];
+type ChainShape = {
+  values: ReturnType<typeof vi.fn>;
+  onConflictDoUpdate: ReturnType<typeof vi.fn>;
+};
+const chain: ChainShape = {
+  values: vi.fn(() => chain),
+  onConflictDoUpdate: vi.fn(() => Promise.resolve(undefined)),
+};
+
+const fakeDb = {
+  execute: vi.fn(async () => groupedRows),
+  insert: vi.fn(() => chain),
+};
+
+vi.mock('./db/index.js', () => ({
+  db: fakeDb,
+  schema: {
+    formLemmaOverrides: {
+      language: 'flo.language',
+      surfaceNfc: 'flo.surface_nfc',
+      contextSignature: 'flo.context_signature',
+    },
+  },
+}));
+
+vi.mock('./parse-reports.js', () => ({
+  fileParseReport: (...a: unknown[]) => fileParseReport(...a),
+}));
+
+const { runCorrectionAggregation } = await import('./correction-aggregation.js');
+
+beforeEach(() => {
+  groupedRows.length = 0;
+  for (const fn of Object.values(chain))
+    (fn as ReturnType<typeof vi.fn>).mockClear();
+  fakeDb.execute.mockClear();
+  fakeDb.insert.mockClear();
+  fileParseReport.mockReset();
+  fileParseReport.mockResolvedValue({ report: { id: 'pr' }, merged: false });
+});
+
+describe('runCorrectionAggregation', () => {
+  it('promotes a group that meets both thresholds', async () => {
+    groupedRows.push({
+      language: 'hi',
+      surfaceNfc: 'है',
+      contextSignature: '',
+      chosenLemmaId: 'lem-honaa',
+      distinctUsers: 8,
+      totalDistinctUsers: 10,
+      voteCount: 8,
+    });
+    const r = await runCorrectionAggregation();
+    expect(r.qualifyingGroups).toBe(1);
+    expect(r.overridesUpserted).toBe(1);
+    expect(r.reportsFiled).toBe(1);
+    expect(fileParseReport).toHaveBeenCalledWith(
+      expect.objectContaining({ initialStatus: 'triaged' }),
+    );
+  });
+
+  it('skips a group with too few distinct users', async () => {
+    groupedRows.push({
+      language: 'hi',
+      surfaceNfc: 'का',
+      contextSignature: '',
+      chosenLemmaId: 'lem-x',
+      distinctUsers: 3,
+      totalDistinctUsers: 3,
+      voteCount: 3,
+    });
+    const r = await runCorrectionAggregation();
+    expect(r.qualifyingGroups).toBe(0);
+    expect(fakeDb.insert).not.toHaveBeenCalled();
+  });
+
+  it('skips a group below the majority threshold', async () => {
+    groupedRows.push({
+      language: 'hi',
+      surfaceNfc: 'X',
+      contextSignature: '',
+      chosenLemmaId: 'lem-a',
+      distinctUsers: 6,
+      totalDistinctUsers: 12,
+      voteCount: 6,
+    });
+    const r = await runCorrectionAggregation();
+    // 6/12 = 50% — under the 70% default.
+    expect(r.qualifyingGroups).toBe(0);
+  });
+
+  it('skips groups with chosen_lemma_id=null', async () => {
+    groupedRows.push({
+      language: 'hi',
+      surfaceNfc: 'X',
+      contextSignature: '',
+      chosenLemmaId: null,
+      distinctUsers: 100,
+      totalDistinctUsers: 100,
+      voteCount: 100,
+    });
+    const r = await runCorrectionAggregation();
+    expect(r.qualifyingGroups).toBe(0);
+  });
+
+  it('honors custom thresholds', async () => {
+    groupedRows.push({
+      language: 'hi',
+      surfaceNfc: 'मैं',
+      contextSignature: '',
+      chosenLemmaId: 'lem-y',
+      distinctUsers: 3,
+      totalDistinctUsers: 3,
+      voteCount: 3,
+    });
+    const r = await runCorrectionAggregation({
+      minDistinctUsers: 2,
+      minMajority: 0.5,
+    });
+    expect(r.qualifyingGroups).toBe(1);
+  });
+});

--- a/apps/web/src/lib/server/correction-aggregation.ts
+++ b/apps/web/src/lib/server/correction-aggregation.ts
@@ -1,0 +1,197 @@
+/**
+ * Crowdsourced correction aggregation worker (T-6.7).
+ *
+ * Scans recent `token_corrections` rows grouped by
+ * `(language, surface_nfc, context_signature, chosen_lemma_id)`
+ * and promotes consensus picks. A group qualifies when:
+ *
+ *   - distinct user count ≥ MIN_DISTINCT_USERS (default 5), AND
+ *   - that group's vote share is ≥ MIN_MAJORITY (default 70%) of
+ *     all corrections on the same `(language, surface_nfc,
+ *     context_signature)` triple.
+ *
+ * Promotion is twofold:
+ *
+ *   1. UPSERT a `form_lemma_overrides` row so the worker + reader
+ *      apply the consensus pick going forward (the table's unique
+ *      tuple is `(language, surface_nfc, context_signature)`).
+ *   2. File a `parse_reports` row at status='triaged' (so the
+ *      curator dashboard surfaces it as a system-flagged
+ *      consensus). Dedup-merging stops a daily cron from
+ *      multiplying these reports.
+ *
+ * The worker is idempotent — re-running on the same data is a
+ * no-op aside from `updated_at` bumps. Suitable for a daily cron.
+ */
+import { sql } from 'drizzle-orm';
+
+import { db, schema } from './db/index.js';
+import { fileParseReport } from './parse-reports.js';
+import type { LanguageCode } from '@ciareader/shared-types';
+
+export const DEFAULT_MIN_DISTINCT_USERS = 5;
+export const DEFAULT_MIN_MAJORITY = 0.7;
+
+export type AggregationOptions = {
+  minDistinctUsers?: number;
+  minMajority?: number;
+  /** Limit how far back the worker scans `token_corrections`.
+   *  Default: 60 days. The rolling window keeps very-old user
+   *  picks from skewing the consensus after a curator decision
+   *  already shipped a different override. */
+  sinceDaysAgo?: number;
+};
+
+export type AggregationResult = {
+  scanned: number;
+  qualifyingGroups: number;
+  overridesUpserted: number;
+  reportsFiled: number;
+};
+
+/**
+ * Internal row shape returned by the SQL aggregation. Each row
+ * represents one (language, surface_nfc, context_signature,
+ * chosen_lemma_id) bucket plus the totals we need to apply the
+ * threshold checks.
+ */
+type GroupRow = {
+  language: LanguageCode;
+  surfaceNfc: string;
+  contextSignature: string;
+  chosenLemmaId: string | null;
+  distinctUsers: number;
+  totalDistinctUsers: number;
+  voteCount: number;
+};
+
+export async function runCorrectionAggregation(
+  options: AggregationOptions = {},
+): Promise<AggregationResult> {
+  const minUsers = options.minDistinctUsers ?? DEFAULT_MIN_DISTINCT_USERS;
+  const minMajority = options.minMajority ?? DEFAULT_MIN_MAJORITY;
+  const sinceDays = options.sinceDaysAgo ?? 60;
+
+  // Single SQL query computes the bucket counts AND the per-triple
+  // total in one window — avoids round-tripping for every group.
+  // We exclude `mark_*` corrections because they aren't lemma
+  // picks; the aggregation worker promotes lemma corrections.
+  const rows = (await db.execute(sql<{
+    language: LanguageCode;
+    surface_nfc: string;
+    context_signature: string;
+    chosen_lemma_id: string | null;
+    distinct_users: number;
+    total_distinct_users: number;
+    vote_count: number;
+  }>`
+    WITH base AS (
+      SELECT
+        tt.surface AS surface_nfc,
+        tx.language AS language,
+        '' AS context_signature,
+        tc.chosen_lemma_id AS chosen_lemma_id,
+        tc.user_id AS user_id
+      FROM token_corrections tc
+      INNER JOIN text_tokens tt ON tt.id = tc.token_id
+      INNER JOIN text_chapters ch ON ch.id = tt.chapter_id
+      INNER JOIN texts tx ON tx.id = ch.text_id
+      WHERE tc.type IN ('pick_candidate', 'manual_lemma')
+        AND tc.chosen_lemma_id IS NOT NULL
+        AND tc.updated_at > NOW() - (${sinceDays} || ' days')::interval
+    ),
+    grouped AS (
+      SELECT
+        language,
+        surface_nfc,
+        context_signature,
+        chosen_lemma_id,
+        COUNT(DISTINCT user_id)::int AS distinct_users,
+        COUNT(*)::int AS vote_count
+      FROM base
+      GROUP BY 1, 2, 3, 4
+    ),
+    totals AS (
+      SELECT
+        language,
+        surface_nfc,
+        context_signature,
+        SUM(distinct_users)::int AS total_distinct_users
+      FROM grouped
+      GROUP BY 1, 2, 3
+    )
+    SELECT
+      g.language,
+      g.surface_nfc,
+      g.context_signature,
+      g.chosen_lemma_id,
+      g.distinct_users,
+      t.total_distinct_users,
+      g.vote_count
+    FROM grouped g
+    INNER JOIN totals t USING (language, surface_nfc, context_signature)
+  `)) as unknown as GroupRow[] | { rows: GroupRow[] };
+  const list: GroupRow[] = Array.isArray(rows) ? rows : (rows.rows ?? []);
+
+  let overridesUpserted = 0;
+  let reportsFiled = 0;
+  let qualifyingGroups = 0;
+  const now = new Date();
+
+  for (const r of list) {
+    if (r.chosenLemmaId == null) continue;
+    if (r.distinctUsers < minUsers) continue;
+    const share = r.distinctUsers / Math.max(1, r.totalDistinctUsers);
+    if (share < minMajority) continue;
+    qualifyingGroups += 1;
+
+    // 1. Upsert form_lemma_overrides.
+    await db
+      .insert(schema.formLemmaOverrides)
+      .values({
+        language: r.language,
+        surfaceNfc: r.surfaceNfc,
+        contextSignature: r.contextSignature,
+        chosenLemmaId: r.chosenLemmaId,
+        voteCount: r.distinctUsers,
+        promotedAt: now,
+        promotedBy: null,
+        note: 'auto-promoted by T-6.7 aggregation worker',
+      })
+      .onConflictDoUpdate({
+        target: [
+          schema.formLemmaOverrides.language,
+          schema.formLemmaOverrides.surfaceNfc,
+          schema.formLemmaOverrides.contextSignature,
+        ],
+        set: {
+          chosenLemmaId: r.chosenLemmaId,
+          voteCount: r.distinctUsers,
+          promotedAt: now,
+        },
+      });
+    overridesUpserted += 1;
+
+    // 2. Auto-file a triaged parse_report for curator sanity-check.
+    await fileParseReport({
+      reporterId: null,
+      tokenId: null,
+      language: r.language,
+      surfaceNfc: r.surfaceNfc,
+      contextSignature: r.contextSignature,
+      originalCandidates: [],
+      correctedLemmaId: r.chosenLemmaId,
+      correctionType: 'manual_lemma',
+      note: `auto-aggregation: ${r.distinctUsers}/${r.totalDistinctUsers} users (${(share * 100).toFixed(0)}%)`,
+      initialStatus: 'triaged',
+    });
+    reportsFiled += 1;
+  }
+
+  return {
+    scanned: list.length,
+    qualifyingGroups,
+    overridesUpserted,
+    reportsFiled,
+  };
+}


### PR DESCRIPTION
> Stacked on #234 (T-6.6).

## Summary

\`runCorrectionAggregation()\` scans recent \`token_corrections\` grouped by \`(language, surface_nfc, context_signature, chosen_lemma_id)\` in a single SQL pass. A group qualifies when:

- distinct user count ≥ MIN_DISTINCT_USERS (default 5)
- that group's vote share ≥ MIN_MAJORITY (default 70%) of all corrections on the same triple

Promotion writes:

1. \`form_lemma_overrides\` upsert (the worker + reader fallback consume that for everyone), unique on \`(language, surface_nfc, context_signature)\`.
2. \`parse_reports\` auto-filed at \`status='triaged'\` so the curator dashboard (T-6.6) surfaces the consensus pick for sanity-check. Dedup-merging keeps a daily cron from multiplying these reports.

Configurable thresholds + a since-days window (default 60) so very old picks don't skew the consensus after a curator decision. \`mark_*\` corrections are excluded — they aren't lemma picks.

CLI runner: \`pnpm --filter @ciareader/web aggregate-corrections\`. Production wires this into a daily cron; local + tests use the same code path.

Closes #63.

## Test plan
- 100 files / 808 tests pass; new \`correction-aggregation.test.ts\` covers happy path, sub-threshold-users skip, sub-majority skip, null-lemma skip, custom thresholds.
- typecheck + lint clean.