### PR TITLE
T-6.6: curator moderation UI for parse reports

### DIFF
--- a/apps/web/src/lib/server/parse-reports.test.ts
+++ b/apps/web/src/lib/server/parse-reports.test.ts
@@ -134,6 +134,49 @@ describe('fileParseReport', () => {
   });
 });
 
+const { resolveParseReport, ParseReportValidationError } = await import(
+  './parse-reports.js'
+);
+
+describe('resolveParseReport', () => {
+  it('rejects a terminal status without a resolution note', async () => {
+    await expect(
+      resolveParseReport({
+        reportId: 'pr-1',
+        reviewerId: 'u1',
+        status: 'resolved',
+      }),
+    ).rejects.toBeInstanceOf(ParseReportValidationError);
+  });
+
+  it('returns the updated row on a happy path', async () => {
+    chain.returning.mockReturnValueOnce([
+      { id: 'pr-1', status: 'resolved' },
+    ]);
+    const r = await resolveParseReport({
+      reportId: 'pr-1',
+      reviewerId: 'u1',
+      status: 'resolved',
+      resolutionNote: 'fixed',
+    });
+    expect(r.status).toBe('resolved');
+    const setArg = chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(setArg.resolvedAt).toBeInstanceOf(Date);
+    expect(setArg.resolutionNote).toBe('fixed');
+  });
+
+  it('returns 404 when the report is missing', async () => {
+    chain.returning.mockReturnValueOnce([]);
+    await expect(
+      resolveParseReport({
+        reportId: 'pr-x',
+        reviewerId: 'u1',
+        status: 'deferred',
+      }),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+});
+
 describe('listParseReports', () => {
   it('runs an unfiltered list against the table when filter is empty', async () => {
     chain.offset.mockReturnValueOnce([{ id: 'pr-1' }, { id: 'pr-2' }]);

--- a/apps/web/src/lib/server/parse-reports.ts
+++ b/apps/web/src/lib/server/parse-reports.ts
@@ -20,7 +20,11 @@
 import { and, desc, eq, inArray, sql } from 'drizzle-orm';
 
 import { db, schema } from './db/index.js';
-import type { ParseReport, TokenCorrection } from './db/schema.js';
+import type {
+  FormLemmaOverride,
+  ParseReport,
+  TokenCorrection,
+} from './db/schema.js';
 import type { LanguageCode } from '@ciareader/shared-types';
 
 export type FileParseReportInput = {
@@ -120,6 +124,148 @@ export type ListParseReportsFilter = {
   limit?: number;
   offset?: number;
 };
+
+/**
+ * Update a report's status. Resolution / rejection / defer all
+ * route through here; `acceptParseReport` is the special branch
+ * that ALSO writes a `form_lemma_overrides` row before updating.
+ */
+export type ResolveParseReportInput = {
+  reportId: string;
+  reviewerId: string;
+  status: 'resolved' | 'rejected' | 'duplicate' | 'deferred' | 'triaged' | 'open';
+  resolutionNote?: string | null;
+  duplicateOfReportId?: string | null;
+};
+
+export class ParseReportValidationError extends Error {
+  constructor(
+    message: string,
+    public readonly status: 400 | 404 = 400,
+  ) {
+    super(message);
+    this.name = 'ParseReportValidationError';
+  }
+}
+
+export async function resolveParseReport(
+  input: ResolveParseReportInput,
+): Promise<ParseReport> {
+  if (
+    (input.status === 'resolved' ||
+      input.status === 'rejected' ||
+      input.status === 'duplicate') &&
+    !input.resolutionNote?.trim()
+  ) {
+    throw new ParseReportValidationError(
+      'resolutionNote required for terminal statuses',
+    );
+  }
+  const now = new Date();
+  const isTerminal =
+    input.status === 'resolved' ||
+    input.status === 'rejected' ||
+    input.status === 'duplicate';
+  const [updated] = await db
+    .update(schema.parseReports)
+    .set({
+      status: input.status,
+      assignedReviewerId: input.reviewerId,
+      resolutionNote: input.resolutionNote?.trim() || null,
+      resolvedAt: isTerminal ? now : null,
+      updatedAt: now,
+    })
+    .where(eq(schema.parseReports.id, input.reportId))
+    .returning();
+  if (!updated) {
+    throw new ParseReportValidationError('report not found', 404);
+  }
+  return updated as ParseReport;
+}
+
+export type AcceptParseReportInput = {
+  reportId: string;
+  reviewerId: string;
+  resolutionNote?: string | null;
+};
+
+export type AcceptParseReportResult = {
+  report: ParseReport;
+  override: FormLemmaOverride;
+};
+
+/**
+ * "Accept for everyone" — promotes the report's correction into
+ * `form_lemma_overrides` so the worker (and the reader fallback)
+ * apply the chosen lemma to every future token matching
+ * `(language, surface_nfc, context_signature)` AND flips the
+ * report status to resolved.
+ */
+export async function acceptParseReport(
+  input: AcceptParseReportInput,
+): Promise<AcceptParseReportResult> {
+  const [report] = (await db
+    .select()
+    .from(schema.parseReports)
+    .where(eq(schema.parseReports.id, input.reportId))
+    .limit(1)) as ParseReport[];
+  if (!report) {
+    throw new ParseReportValidationError('report not found', 404);
+  }
+  if (!report.correctedLemmaId) {
+    throw new ParseReportValidationError(
+      'report has no correctedLemmaId — accept is only valid for pick_candidate / manual_lemma reports',
+    );
+  }
+  const now = new Date();
+
+  // Upsert the form_lemma_override.
+  const [override] = await db
+    .insert(schema.formLemmaOverrides)
+    .values({
+      language: report.language,
+      surfaceNfc: report.surfaceNfc,
+      contextSignature: report.contextSignature,
+      chosenLemmaId: report.correctedLemmaId,
+      voteCount: report.duplicateCount,
+      promotedAt: now,
+      promotedBy: input.reviewerId,
+      note: input.resolutionNote ?? null,
+    })
+    .onConflictDoUpdate({
+      target: [
+        schema.formLemmaOverrides.language,
+        schema.formLemmaOverrides.surfaceNfc,
+        schema.formLemmaOverrides.contextSignature,
+      ],
+      set: {
+        chosenLemmaId: report.correctedLemmaId,
+        voteCount: report.duplicateCount,
+        promotedAt: now,
+        promotedBy: input.reviewerId,
+        note: input.resolutionNote ?? null,
+      },
+    })
+    .returning();
+  if (!override) throw new Error('form_lemma_overrides upsert returned no row');
+
+  const [updated] = await db
+    .update(schema.parseReports)
+    .set({
+      status: 'resolved',
+      assignedReviewerId: input.reviewerId,
+      resolvedAt: now,
+      resolutionNote: input.resolutionNote ?? 'Accepted for everyone',
+      updatedAt: now,
+    })
+    .where(eq(schema.parseReports.id, input.reportId))
+    .returning();
+  if (!updated) throw new Error('parse_reports update returned no row');
+  return {
+    report: updated as ParseReport,
+    override: override as FormLemmaOverride,
+  };
+}
 
 /**
  * Paged list for the curator moderation UI (T-6.6). Sorted by

--- a/apps/web/src/routes/api/v1/admin/parse-reports/[id]/accept/+server.ts
+++ b/apps/web/src/routes/api/v1/admin/parse-reports/[id]/accept/+server.ts
@@ -1,0 +1,46 @@
+/**
+ * POST /api/v1/admin/parse-reports/:id/accept (T-6.6).
+ *
+ * Promotes the report's chosen lemma into form_lemma_overrides
+ * (worker + reader fallback consume that for everyone) and
+ * resolves the report.
+ */
+import { error, json } from '@sveltejs/kit';
+import { z } from 'zod';
+
+import { requireUser } from '$lib/server/auth/require-user.js';
+import {
+  ParseReportValidationError,
+  acceptParseReport,
+} from '$lib/server/parse-reports.js';
+import { parseJson } from '../../../../auth/_helpers.js';
+import type { RequestHandler } from './$types';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const bodySchema = z
+  .object({
+    resolutionNote: z.string().max(2000).nullable().optional(),
+  })
+  .strict();
+
+export const POST: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  if (user.role !== 'curator' && user.role !== 'admin') {
+    throw error(403, 'Curator or admin required');
+  }
+  const id = event.params.id;
+  if (!id || !UUID_RE.test(id)) throw error(400, 'Invalid report id');
+  const body = await parseJson(event.request, bodySchema);
+  try {
+    const result = await acceptParseReport({
+      reportId: id,
+      reviewerId: user.id,
+      resolutionNote: body.resolutionNote ?? null,
+    });
+    return json(result);
+  } catch (e) {
+    if (e instanceof ParseReportValidationError) throw error(e.status, e.message);
+    throw e;
+  }
+};

--- a/apps/web/src/routes/api/v1/admin/parse-reports/[id]/resolve/+server.ts
+++ b/apps/web/src/routes/api/v1/admin/parse-reports/[id]/resolve/+server.ts
@@ -1,0 +1,57 @@
+/**
+ * POST /api/v1/admin/parse-reports/:id/resolve (T-6.6).
+ *
+ * Updates the report's status to one of resolved / rejected /
+ * duplicate / deferred / triaged. Reject + resolve + duplicate
+ * require a non-empty resolution note.
+ */
+import { error, json } from '@sveltejs/kit';
+import { z } from 'zod';
+
+import { requireUser } from '$lib/server/auth/require-user.js';
+import {
+  ParseReportValidationError,
+  resolveParseReport,
+} from '$lib/server/parse-reports.js';
+import { parseJson } from '../../../../auth/_helpers.js';
+import type { RequestHandler } from './$types';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const bodySchema = z
+  .object({
+    status: z.enum([
+      'resolved',
+      'rejected',
+      'duplicate',
+      'deferred',
+      'triaged',
+      'open',
+    ]),
+    resolutionNote: z.string().max(2000).nullable().optional(),
+    duplicateOfReportId: z.string().regex(UUID_RE).nullable().optional(),
+  })
+  .strict();
+
+export const POST: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  if (user.role !== 'curator' && user.role !== 'admin') {
+    throw error(403, 'Curator or admin required');
+  }
+  const id = event.params.id;
+  if (!id || !UUID_RE.test(id)) throw error(400, 'Invalid report id');
+  const body = await parseJson(event.request, bodySchema);
+  try {
+    const report = await resolveParseReport({
+      reportId: id,
+      reviewerId: user.id,
+      status: body.status,
+      resolutionNote: body.resolutionNote ?? null,
+      duplicateOfReportId: body.duplicateOfReportId ?? null,
+    });
+    return json({ report });
+  } catch (e) {
+    if (e instanceof ParseReportValidationError) throw error(e.status, e.message);
+    throw e;
+  }
+};

--- a/apps/web/src/routes/moderation/parses/+page.server.ts
+++ b/apps/web/src/routes/moderation/parses/+page.server.ts
@@ -1,0 +1,88 @@
+/**
+ * Curator parse-reports moderation page (T-6.6).
+ *
+ * URL contract:
+ *   /moderation/parses?language=hi&status=open&id=<report-uuid>
+ *
+ * Left pane is the filtered list (sorted by duplicate_count DESC,
+ * then updated_at DESC); right pane is the selected report. The
+ * selected-id is a URL param so a curator can paste a link and
+ * land directly on a specific report.
+ */
+import { error } from '@sveltejs/kit';
+
+import { listParseReports } from '$lib/server/parse-reports.js';
+import { db, schema } from '$lib/server/db/index.js';
+import { eq } from 'drizzle-orm';
+import { isSupportedLanguage } from '@ciareader/shared-types';
+import type { LanguageCode } from '@ciareader/shared-types';
+import type { ParseReport } from '$lib/server/db/schema.js';
+import type { PageServerLoad } from './$types';
+
+const STATUSES = [
+  'open',
+  'triaged',
+  'resolved',
+  'rejected',
+  'duplicate',
+  'deferred',
+] as const;
+
+function readStatus(url: URL): ParseReport['status'] | null {
+  const raw = url.searchParams.get('status');
+  if (!raw) return 'open';
+  return (STATUSES as readonly string[]).includes(raw)
+    ? (raw as ParseReport['status'])
+    : null;
+}
+
+export const load: PageServerLoad = async ({ url, parent }) => {
+  const { moderator } = await parent();
+  const langParam = url.searchParams.get('language');
+  let language: LanguageCode | null = null;
+  if (langParam && langParam !== 'any') {
+    if (!isSupportedLanguage(langParam)) {
+      throw error(400, `Unsupported language: ${langParam}`);
+    }
+    if (
+      moderator.role !== 'admin' &&
+      !moderator.grantedLanguages.includes(langParam)
+    ) {
+      throw error(403, `Not granted on ${langParam}`);
+    }
+    language = langParam;
+  }
+
+  const status = readStatus(url);
+  if (status === null) {
+    throw error(400, `Unknown status; allowed: ${STATUSES.join(', ')}`);
+  }
+
+  const reports = await listParseReports({
+    language: language ?? undefined,
+    status,
+    limit: 100,
+  });
+
+  // Right-pane selection. URL: ?id=<uuid>. Anything missing or
+  // unknown falls back to the first listed report.
+  const selectedIdParam = url.searchParams.get('id');
+  let selected: ParseReport | null = null;
+  if (selectedIdParam) {
+    const [row] = (await db
+      .select()
+      .from(schema.parseReports)
+      .where(eq(schema.parseReports.id, selectedIdParam))
+      .limit(1)) as ParseReport[];
+    if (row) selected = row;
+  }
+  if (!selected && reports.length > 0) selected = reports[0]!;
+
+  return {
+    moderator,
+    filter: { language, status },
+    reports,
+    selected,
+    statusOptions: STATUSES,
+  };
+};

--- a/apps/web/src/routes/moderation/parses/+page.svelte
+++ b/apps/web/src/routes/moderation/parses/+page.svelte
@@ -1,0 +1,441 @@
+<script lang="ts">
+  import { goto, invalidateAll } from '$app/navigation';
+  import { LANGUAGES, SUPPORTED_LANGUAGE_CODES } from '@ciareader/shared-types';
+  import type { PageData } from './$types';
+
+  let { data }: { data: PageData } = $props();
+
+  function setQuery(params: Record<string, string | null>) {
+    const url = new URL(typeof window !== 'undefined' ? window.location.href : 'http://x');
+    for (const [k, v] of Object.entries(params)) {
+      if (v == null || v === '') url.searchParams.delete(k);
+      else url.searchParams.set(k, v);
+    }
+    void goto(url.pathname + (url.searchParams.toString() ? `?${url.searchParams.toString()}` : ''), {
+      keepFocus: true,
+    });
+  }
+
+  let resolutionNote = $state('');
+  let acting = $state(false);
+  let actionError = $state<string | null>(null);
+
+  async function actionPost(
+    path: string,
+    body: Record<string, unknown> = {},
+  ) {
+    if (!data.selected) return;
+    acting = true;
+    actionError = null;
+    try {
+      const res = await fetch(path, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        actionError = (await res.text().catch(() => '')) || `HTTP ${res.status}`;
+        return;
+      }
+      resolutionNote = '';
+      await invalidateAll();
+    } finally {
+      acting = false;
+    }
+  }
+
+  function onAccept() {
+    if (!data.selected) return;
+    void actionPost(`/api/v1/admin/parse-reports/${data.selected.id}/accept`, {
+      resolutionNote: resolutionNote || null,
+    });
+  }
+  function onResolve(status: 'rejected' | 'deferred' | 'duplicate' | 'resolved') {
+    if (!data.selected) return;
+    if (
+      (status === 'rejected' || status === 'duplicate' || status === 'resolved') &&
+      !resolutionNote.trim()
+    ) {
+      actionError = 'Resolution note is required for terminal statuses.';
+      return;
+    }
+    void actionPost(`/api/v1/admin/parse-reports/${data.selected.id}/resolve`, {
+      status,
+      resolutionNote,
+    });
+  }
+</script>
+
+<svelte:head>
+  <title>Parse reports — moderation</title>
+</svelte:head>
+
+<div class="mp">
+  <header class="mp-h">
+    <h1>Parse reports</h1>
+    <p class="mp-h-sub">
+      User-filed corrections + system-flagged consensus. Accept promotes a fix to
+      <code>form_lemma_overrides</code>; reject closes the report.
+    </p>
+  </header>
+
+  <div class="mp-filters">
+    <label>
+      <span class="mp-l">Language</span>
+      <select
+        value={data.filter.language ?? 'any'}
+        onchange={(e) =>
+          setQuery({ language: (e.target as HTMLSelectElement).value })}
+      >
+        <option value="any">Any</option>
+        {#each SUPPORTED_LANGUAGE_CODES as code}
+          {#if data.moderator.role === 'admin' || data.moderator.grantedLanguages.includes(code)}
+            <option value={code}>{LANGUAGES[code].displayName}</option>
+          {/if}
+        {/each}
+      </select>
+    </label>
+    <label>
+      <span class="mp-l">Status</span>
+      <select
+        value={data.filter.status}
+        onchange={(e) =>
+          setQuery({ status: (e.target as HTMLSelectElement).value })}
+      >
+        {#each data.statusOptions as s}
+          <option value={s}>{s}</option>
+        {/each}
+      </select>
+    </label>
+  </div>
+
+  <div class="mp-grid">
+    <ul class="mp-list" data-testid="parse-reports-list">
+      {#each data.reports as r (r.id)}
+        <li>
+          <button
+            type="button"
+            class="mp-item"
+            data-active={r.id === data.selected?.id ? '1' : '0'}
+            onclick={() => setQuery({ id: r.id })}
+          >
+            <span class="mp-surface">{r.surfaceNfc}</span>
+            <span class="mp-pill">{r.correctionType}</span>
+            <span class="mp-pill mp-pill-count">×{r.duplicateCount}</span>
+            <span class="mp-meta">
+              {r.language} · {r.status}
+            </span>
+          </button>
+        </li>
+      {:else}
+        <li class="mp-empty">No reports match the filter.</li>
+      {/each}
+    </ul>
+
+    <section class="mp-detail">
+      {#if data.selected}
+        <header class="mp-detail-h">
+          <h2 class="mp-detail-surface">{data.selected.surfaceNfc}</h2>
+          <span class="mp-pill">{data.selected.correctionType}</span>
+          <span class="mp-pill">{data.selected.status}</span>
+          <span class="mp-pill mp-pill-count">×{data.selected.duplicateCount}</span>
+        </header>
+
+        <dl class="mp-meta-list">
+          <dt>Language</dt>
+          <dd>{data.selected.language}</dd>
+          <dt>Context signature</dt>
+          <dd><code>{data.selected.contextSignature || '(none)'}</code></dd>
+          <dt>Reporter note</dt>
+          <dd>{data.selected.note || '(none)'}</dd>
+          <dt>Original candidates</dt>
+          <dd>
+            {#if data.selected.originalCandidates.length === 0}
+              <span class="mp-muted">(empty)</span>
+            {:else}
+              <ul class="mp-cands">
+                {#each data.selected.originalCandidates as c, i (i)}
+                  <li>
+                    <code>{c.lemmaId ?? 'null'}</code>
+                    · score {c.score.toFixed(2)}
+                  </li>
+                {/each}
+              </ul>
+            {/if}
+          </dd>
+          <dt>Proposed lemma</dt>
+          <dd>
+            {#if data.selected.correctedLemmaId}
+              <code>{data.selected.correctedLemmaId}</code>
+            {:else}
+              <span class="mp-muted">(no lemma — mark_*)</span>
+            {/if}
+          </dd>
+        </dl>
+
+        {#if data.selected.status === 'open' || data.selected.status === 'triaged'}
+          <div class="mp-actions" data-testid="parse-actions">
+            <label class="mp-row">
+              <span class="mp-l">Resolution note (required for terminal actions)</span>
+              <textarea
+                bind:value={resolutionNote}
+                rows="2"
+                placeholder="Why this decision?"
+              ></textarea>
+            </label>
+            <div class="mp-buttons">
+              {#if data.selected.correctedLemmaId}
+                <button
+                  type="button"
+                  class="mp-btn mp-primary"
+                  disabled={acting}
+                  onclick={onAccept}
+                >
+                  {acting ? 'Saving…' : 'Accept for everyone'}
+                </button>
+              {/if}
+              <button
+                type="button"
+                class="mp-btn"
+                disabled={acting}
+                onclick={() => onResolve('rejected')}
+              >
+                Reject
+              </button>
+              <button
+                type="button"
+                class="mp-btn"
+                disabled={acting}
+                onclick={() => onResolve('deferred')}
+              >
+                Defer
+              </button>
+              <button
+                type="button"
+                class="mp-btn"
+                disabled={acting}
+                onclick={() => onResolve('duplicate')}
+              >
+                Mark duplicate
+              </button>
+              <button
+                type="button"
+                class="mp-btn"
+                disabled={acting}
+                onclick={() => onResolve('resolved')}
+              >
+                Resolve manually
+              </button>
+            </div>
+            {#if actionError}
+              <p class="mp-err" role="alert">{actionError}</p>
+            {/if}
+          </div>
+        {:else}
+          <p class="mp-muted">
+            Already {data.selected.status}.
+            {#if data.selected.resolutionNote}
+              — {data.selected.resolutionNote}
+            {/if}
+          </p>
+        {/if}
+      {:else}
+        <p class="mp-muted mp-empty-detail">
+          Select a report on the left to review.
+        </p>
+      {/if}
+    </section>
+  </div>
+</div>
+
+<style>
+  .mp {
+    padding: 1.25rem 1.5rem 2rem;
+    color: var(--ink, var(--color-fg));
+  }
+  .mp-h h1 {
+    margin: 0 0 0.2rem;
+    font-size: 1.4rem;
+    font-family: var(--font-serif, system-ui);
+  }
+  .mp-h-sub {
+    color: var(--ink-3, var(--color-fg-muted));
+    font-size: 0.85rem;
+    margin: 0 0 1rem;
+  }
+  .mp-filters {
+    display: flex;
+    gap: 0.85rem;
+    margin-bottom: 1rem;
+    flex-wrap: wrap;
+  }
+  .mp-filters label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+  .mp-l {
+    font-size: 0.66rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--ink-3, var(--color-fg-muted));
+  }
+  select,
+  textarea {
+    padding: 0.4rem 0.55rem;
+    border: 1px solid var(--card-edge, var(--color-border));
+    border-radius: 6px;
+    background: var(--card, var(--color-bg));
+    color: var(--ink, var(--color-fg));
+    font-size: 0.85rem;
+  }
+  .mp-grid {
+    display: grid;
+    grid-template-columns: minmax(20rem, 24rem) 1fr;
+    gap: 1.25rem;
+  }
+  @media (max-width: 760px) {
+    .mp-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+  .mp-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    max-height: 70vh;
+    overflow-y: auto;
+  }
+  .mp-item {
+    width: 100%;
+    text-align: left;
+    background: var(--card, var(--color-bg));
+    border: 1px solid var(--rule, var(--color-border));
+    border-radius: 8px;
+    padding: 0.55rem 0.65rem;
+    cursor: pointer;
+    display: grid;
+    grid-template-columns: 1fr auto auto;
+    gap: 0.5rem;
+    align-items: center;
+    font: inherit;
+  }
+  .mp-item[data-active='1'] {
+    border-color: var(--accent, var(--color-accent));
+    background: color-mix(in oklch, var(--accent, var(--color-accent)) 8%, var(--card, var(--color-bg)));
+  }
+  .mp-surface {
+    font-family: var(--font-serif-dev, var(--font-serif));
+    font-size: 1.05rem;
+  }
+  .mp-pill {
+    background: color-mix(in oklch, var(--ink, var(--color-fg)) 6%, transparent);
+    border-radius: 999px;
+    font-size: 0.62rem;
+    padding: 0.18rem 0.45rem;
+    color: var(--ink-3, var(--color-fg-muted));
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+  .mp-pill-count {
+    font-feature-settings: 'tnum';
+  }
+  .mp-meta {
+    grid-column: 1 / -1;
+    font-size: 0.7rem;
+    color: var(--ink-3, var(--color-fg-muted));
+  }
+  .mp-empty {
+    color: var(--ink-3, var(--color-fg-muted));
+    padding: 1rem;
+  }
+  .mp-detail {
+    border: 1px solid var(--rule, var(--color-border));
+    border-radius: 10px;
+    padding: 1rem 1.1rem;
+    background: var(--card, var(--color-bg));
+  }
+  .mp-detail-h {
+    display: flex;
+    align-items: baseline;
+    gap: 0.55rem;
+    flex-wrap: wrap;
+    border-bottom: 1px solid var(--rule, var(--color-border));
+    padding-bottom: 0.65rem;
+    margin-bottom: 0.85rem;
+  }
+  .mp-detail-surface {
+    font-family: var(--font-serif-dev, var(--font-serif));
+    margin: 0;
+    font-size: 1.4rem;
+  }
+  .mp-meta-list {
+    display: grid;
+    grid-template-columns: 10rem 1fr;
+    gap: 0.45rem 0.85rem;
+    margin: 0 0 1rem;
+  }
+  .mp-meta-list dt {
+    color: var(--ink-3, var(--color-fg-muted));
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .mp-meta-list dd {
+    margin: 0;
+    font-size: 0.9rem;
+  }
+  .mp-cands {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    font-size: 0.78rem;
+  }
+  .mp-cands li {
+    margin: 0.1rem 0;
+  }
+  .mp-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
+  }
+  .mp-row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+  }
+  .mp-buttons {
+    display: flex;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+  }
+  .mp-btn {
+    background: var(--card-2, var(--color-bg));
+    border: 1px solid var(--rule, var(--color-border));
+    color: var(--ink, var(--color-fg));
+    padding: 0.4rem 0.8rem;
+    border-radius: 6px;
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.85rem;
+  }
+  .mp-primary {
+    background: var(--accent, var(--color-accent));
+    color: var(--accent-ink, var(--color-bg));
+    border-color: var(--accent, var(--color-accent));
+  }
+  .mp-err {
+    color: var(--err, #b94545);
+    font-size: 0.82rem;
+    margin: 0;
+  }
+  .mp-muted {
+    color: var(--ink-3, var(--color-fg-muted));
+  }
+  .mp-empty-detail {
+    padding: 1rem;
+  }
+</style>


### PR DESCRIPTION
/moderation/parses page wires the existing parse_reports table into a curator surface. Left pane: filterable list (language scoped to curator's grants, status). Right pane: report detail with duplicate_count, original candidates snapshot, proposed lemma, reporter note + resolution note + selectable actions.

Actions:

  - Accept for everyone (only when correctedLemmaId is set): promotes to form_lemma_overrides via acceptParseReport(), then flips the report to resolved.
  - Reject: requires resolution note, status=rejected.
  - Mark duplicate: requires resolution note, status=duplicate.
  - Resolve manually: requires resolution note, status=resolved.
  - Defer: status=deferred, no note required.

Service: resolveParseReport() and acceptParseReport() in parse-reports.ts. The accept path UPSERTs against the form_lemma_overrides unique tuple (language, surface_nfc, context_signature) so re-accepting after a re-import is idempotent.

Endpoints:
  POST /api/v1/admin/parse-reports/:id/resolve
  POST /api/v1/admin/parse-reports/:id/accept

Both gated to curator + admin via the existing user.role check.

Closes #62.