### PR TITLE
T-3.14: tooltip-side sibling fallback for glossDefault

### DIFF
--- a/apps/web/src/lib/server/texts/tokens.test.ts
+++ b/apps/web/src/lib/server/texts/tokens.test.ts
@@ -116,15 +116,46 @@ describe('loadChapterTokens', () => {
     ]);
     stage([]); // user_known_lemmas
     stage([
-      { id: 'lem-a', glossDefault: 'morning' },
-      { id: 'lem-b', glossDefault: null },
+      { id: 'lem-a', language: 'hi', headword: 'सुबह', glossDefault: 'morning' },
+      { id: 'lem-b', language: 'hi', headword: 'rare', glossDefault: null },
     ]);
+    // T-3.14 sibling fallback: lem-b had no gloss, so the loader runs
+    // a sibling lookup. No sibling exists for "rare", so an empty
+    // result keeps the null gloss as-is.
+    stage([]); // sibling fallback — no rows
     const result = await loadChapterTokens('chap-1', 'user-1');
     expect(result![0]).toMatchObject({ id: 't1', glossDefault: 'morning' });
-    // Lemma row exists but the gloss column is null — should pass through.
+    // Lemma row exists but the gloss column is null AND no sibling has
+    // a gloss — should pass through as null.
     expect(result![1]).toMatchObject({ id: 't2', glossDefault: null });
     // Whitespace token has no lemma id; glossDefault defaults to null.
     expect(result![2]).toMatchObject({ id: 't3', glossDefault: null });
+  });
+
+  it('falls back to a sibling lemma\'s gloss when the linked lemma has none (T-3.14)', async () => {
+    // Common case: NLP tagged "पार्क" as PROPN with no gloss; the
+    // dictionary entry is under "पार्क/NOUN" with the actual gloss.
+    stage([tokenRow({ id: 't1', idx: 0, lemmaId: 'lem-propn' })]);
+    stage([]); // user_known_lemmas
+    stage([
+      { id: 'lem-propn', language: 'hi', headword: 'पार्क', glossDefault: null },
+    ]);
+    stage([
+      { language: 'hi', headword: 'पार्क', glossDefault: 'park' },
+    ]);
+    const result = await loadChapterTokens('chap-1', 'user-1');
+    expect(result![0]).toMatchObject({ id: 't1', glossDefault: 'park' });
+  });
+
+  it('skips the sibling fallback query entirely when every lemma has its own gloss (T-3.14)', async () => {
+    stage([tokenRow({ id: 't1', idx: 0, lemmaId: 'lem-a' })]);
+    stage([]); // user_known_lemmas
+    stage([{ id: 'lem-a', language: 'hi', headword: 'पानी', glossDefault: 'water' }]);
+    // No 4th stage — fallback query must not fire.
+    await loadChapterTokens('chap-1', 'user-1');
+    // 1 (tokens) + 1 (user_known_lemmas) + 1 (gloss lookup) = 3, no
+    // sibling fallback.
+    expect(selectFn).toHaveBeenCalledTimes(3);
   });
 
   it('handles anonymous viewers (no user_known_lemmas SELECT, every status=unknown)', async () => {

--- a/apps/web/src/lib/server/texts/tokens.ts
+++ b/apps/web/src/lib/server/texts/tokens.ts
@@ -11,7 +11,7 @@
  * client-side whitespace tokenizer in that case (still readable, just
  * no lemma colouring).
  */
-import { eq, inArray } from 'drizzle-orm';
+import { and, eq, inArray, isNotNull } from 'drizzle-orm';
 
 import { db, schema } from '../db/index.js';
 import type { TextToken, UserKnownLemma } from '../db/schema.js';
@@ -81,20 +81,86 @@ export async function loadChapterTokens(
   // T-5.18: pull each lemma's `glossDefault` so the hover tooltip can
   // surface a brief definition without a per-hover fetch. Cheap — a
   // single SELECT against an indexed primary key.
+  //
+  // T-3.14: also pull `language` and `headword` so we can fall back
+  // to a sibling lemma's gloss when the directly-linked one is empty.
+  // Common case: a token tagged PROPN (because it's part of a
+  // multi-word proper name) where the dictionary entry actually lives
+  // under NOUN. Pre-fix the tooltip said "No translations"; post-fix
+  // it shows the sibling NOUN's gloss. Mirrors the popup-side
+  // fallback in `getLemmaTranslations` so both surfaces stay in sync.
   const glossByLemma = new Map<string, string | null>();
+  const lemmaHeadwords: Array<{
+    id: string;
+    language: string;
+    headword: string;
+  }> = [];
   if (lemmaIds.length > 0) {
     const lemmaRows = (await db
       .select({
         id: schema.lemmas.id,
+        language: schema.lemmas.language,
+        headword: schema.lemmas.headword,
         glossDefault: schema.lemmas.glossDefault,
       })
       .from(schema.lemmas)
       .where(inArray(schema.lemmas.id, lemmaIds))) as Array<{
       id: string;
+      language: string;
+      headword: string;
       glossDefault: string | null;
     }>;
     for (const r of lemmaRows) {
       glossByLemma.set(r.id, r.glossDefault);
+      if (!r.glossDefault) {
+        lemmaHeadwords.push({
+          id: r.id,
+          language: r.language,
+          headword: r.headword,
+        });
+      }
+    }
+  }
+
+  // Sibling-fallback pass: for any chapter lemma whose own gloss is
+  // null, find another lemma with the same (language, headword) that
+  // has a non-null gloss and use it. We bucket by (language,
+  // headword) so the fallback query is one SELECT regardless of how
+  // many tokens are gloss-less, and we only run it when there's
+  // actually something to fix.
+  if (lemmaHeadwords.length > 0) {
+    const headwords = Array.from(new Set(lemmaHeadwords.map((l) => l.headword)));
+    const languages = Array.from(new Set(lemmaHeadwords.map((l) => l.language)));
+    const siblingRows = (await db
+      .select({
+        language: schema.lemmas.language,
+        headword: schema.lemmas.headword,
+        glossDefault: schema.lemmas.glossDefault,
+      })
+      .from(schema.lemmas)
+      .where(
+        and(
+          inArray(schema.lemmas.language, languages as ('hi' | 'mr' | 'or')[]),
+          inArray(schema.lemmas.headword, headwords),
+          isNotNull(schema.lemmas.glossDefault),
+        ),
+      )) as Array<{
+      language: string;
+      headword: string;
+      glossDefault: string | null;
+    }>;
+    const fallbackByKey = new Map<string, string>();
+    for (const r of siblingRows) {
+      if (!r.glossDefault) continue;
+      const key = `${r.language}\t${r.headword}`;
+      if (!fallbackByKey.has(key)) {
+        fallbackByKey.set(key, r.glossDefault);
+      }
+    }
+    for (const l of lemmaHeadwords) {
+      const key = `${l.language}\t${l.headword}`;
+      const fallback = fallbackByKey.get(key);
+      if (fallback) glossByLemma.set(l.id, fallback);
     }
   }
 


### PR DESCRIPTION
Companion to the popup-side fallback in this branch's prior commit. The hover tooltip is no-fetch by design — it reads the glossDefault that the chapter loader baked onto each token row. So the popup fallback alone wasn't enough: a tooltip over "पार्क" still said "No translations" because the token's glossDefault was the PROPN row's null, not the NOUN sibling's "park".

This applies the same sibling-fallback rule at the chapter-load layer:
- After fetching glossDefault for the token's lemma, identify any lemmas that came back null.
- One follow-up SELECT scoped to those (language, headword) pairs with WHERE gloss_default IS NOT NULL fills in the fallback.
- The follow-up only fires when there's actually something to fix — chapters where every linked lemma has its own gloss pay zero extra cost.

Tests
- Updated the existing T-5.18 test to stage the new sibling-lookup result + the new (language, headword) columns the loader now selects.
- Two new cases:
  - "falls back to a sibling lemma's gloss when the linked lemma has none" — exercises the पार्क/PROPN → पार्क/NOUN flow.
  - "skips the sibling fallback query entirely when every lemma has its own gloss" — guards the cost-when-not-needed property.

Refs #25.