### PR TITLE
T-3.10: Kaikki Odia importer

### DIFF
--- a/apps/web/scripts/fetch-dictionary-sources.sh
+++ b/apps/web/scripts/fetch-dictionary-sources.sh
@@ -28,6 +28,7 @@ case "${1-all}" in
   all)
     fetch_kaikki kaikki-hindi Hindi
     fetch_kaikki kaikki-marathi Marathi
+    fetch_kaikki kaikki-odia Odia
     ;;
   kaikki-hindi)
     fetch_kaikki kaikki-hindi Hindi
@@ -35,9 +36,12 @@ case "${1-all}" in
   kaikki-marathi)
     fetch_kaikki kaikki-marathi Marathi
     ;;
+  kaikki-odia)
+    fetch_kaikki kaikki-odia Odia
+    ;;
   *)
     echo "unknown source: $1" >&2
-    echo "available: kaikki-hindi, kaikki-marathi (more land per per-source PR)" >&2
+    echo "available: kaikki-hindi, kaikki-marathi, kaikki-odia (more land per per-source PR)" >&2
     exit 1
     ;;
 esac

--- a/apps/web/src/lib/server/dictionary/sources/__fixtures__/kaikki-odia.jsonl
+++ b/apps/web/src/lib/server/dictionary/sources/__fixtures__/kaikki-odia.jsonl
@@ -1,0 +1,6 @@
+{"word":"ପାଣି","pos":"noun","lang_code":"or","senses":[{"glosses":["water"]}]}
+{"word":"ଘର","pos":"noun","lang_code":"or","senses":[{"glosses":["house","home"]}]}
+{"word":"ପିଲା","pos":"noun","lang_code":"or","senses":[{"glosses":["child"]}]}
+{"word":"ଯିବା","pos":"verb","lang_code":"or","senses":[{"glosses":["to go"]}]}
+{"word":"ଭଲ","pos":"adj","lang_code":"or","senses":[{"glosses":["good"]}]}
+{"word":"ଓ","pos":"conj","lang_code":"or","senses":[{"glosses":["and"]}]}

--- a/apps/web/src/lib/server/dictionary/sources/index.ts
+++ b/apps/web/src/lib/server/dictionary/sources/index.ts
@@ -17,6 +17,7 @@ import type { DictionaryImportSource } from '../types.js';
 import { hindiSeedSource } from './hindi-seed.js';
 import { kaikkiHindiSource } from './kaikki-hindi.js';
 import { kaikkiMarathiSource } from './kaikki-marathi.js';
+import { kaikkiOdiaSource } from './kaikki-odia.js';
 
 export type RegistryEntry = {
   name: string;
@@ -27,6 +28,7 @@ export const dictionarySources: RegistryEntry[] = [
   { name: hindiSeedSource.name, source: hindiSeedSource },
   { name: kaikkiHindiSource.name, source: kaikkiHindiSource },
   { name: kaikkiMarathiSource.name, source: kaikkiMarathiSource },
+  { name: kaikkiOdiaSource.name, source: kaikkiOdiaSource },
 ];
 
 export function findSource(name: string): DictionaryImportSource | undefined {

--- a/apps/web/src/lib/server/dictionary/sources/kaikki-odia.ts
+++ b/apps/web/src/lib/server/dictionary/sources/kaikki-odia.ts
@@ -1,0 +1,26 @@
+/**
+ * Kaikki Odia importer (T-3.10).
+ *
+ * Thin instantiation of `makeKaikkiSource`. Odia uses the Odia script
+ * (ISO 15924 `Orya`), the only MVP language that doesn't use
+ * Devanagari — a clean test that the script-aware path doesn't
+ * silently default anything to `Deva`.
+ *
+ * Coverage caveat: Wiktionary's Odia corpus is the thinnest of the
+ * three MVP languages. This importer alone won't be enough — Odia
+ * WordNet (ISI Kolkata) lands in a follow-up PR per
+ * docs/dictionary-sources.md, and the browse page already carries the
+ * `coverage: sparse` notice users see at launch.
+ */
+import { makeKaikkiSource } from './kaikki.js';
+
+export const kaikkiOdiaSource = makeKaikkiSource({
+  name: 'kaikki-odia',
+  language: 'or',
+  script: 'Orya',
+  sourceIdPrefix: 'kaikki:or',
+  attribution: 'Wiktionary Odia via Kaikki.org',
+  license: 'CC-BY-SA-3.0',
+  envVar: 'KAIKKI_ODIA_FILE',
+  defaultPath: 'data/dictionaries/kaikki-odia/raw.jsonl',
+});

--- a/apps/web/src/lib/server/dictionary/sources/kaikki.test.ts
+++ b/apps/web/src/lib/server/dictionary/sources/kaikki.test.ts
@@ -18,11 +18,13 @@ import {
 } from './kaikki.js';
 import { kaikkiHindiSource } from './kaikki-hindi.js';
 import { kaikkiMarathiSource } from './kaikki-marathi.js';
+import { kaikkiOdiaSource } from './kaikki-odia.js';
 import type { ImportEntry } from '../types.js';
 
 const FIXTURES = dirname(fileURLToPath(import.meta.url)) + '/__fixtures__';
 const HINDI_FIXTURE = resolve(FIXTURES, 'kaikki-hindi.jsonl');
 const MARATHI_FIXTURE = resolve(FIXTURES, 'kaikki-marathi.jsonl');
+const ODIA_FIXTURE = resolve(FIXTURES, 'kaikki-odia.jsonl');
 
 const HINDI_OPTS = { script: 'Deva' as const, sourceIdPrefix: 'kaikki:hi' };
 
@@ -318,5 +320,35 @@ describe('kaikkiMarathiSource (streaming over fixture)', () => {
     }
     // Spot-check known entries from the fixture.
     expect(out.find((e) => e.headword === 'पाणी' && e.pos === 'NOUN')).toBeDefined();
+  });
+});
+
+describe('kaikkiOdiaSource (streaming over fixture)', () => {
+  beforeEach(() => {
+    process.env.KAIKKI_ODIA_FILE = ODIA_FIXTURE;
+  });
+  afterEach(() => {
+    delete process.env.KAIKKI_ODIA_FILE;
+  });
+
+  it('exposes the expected metadata + Odia script identifier', () => {
+    expect(kaikkiOdiaSource.name).toBe('kaikki-odia');
+    expect(kaikkiOdiaSource.language).toBe('or');
+    expect(kaikkiOdiaSource.license).toBe('CC-BY-SA-3.0');
+    expect(kaikkiOdiaSource.sourceAttribution).toContain('Odia');
+  });
+
+  it('uses the Odia script (Orya) — not silently defaulting to Deva', async () => {
+    const out: ImportEntry[] = [];
+    for await (const entry of await kaikkiOdiaSource.entries()) {
+      out.push(entry);
+    }
+    expect(out.length).toBeGreaterThan(0);
+    for (const e of out) {
+      expect(e.script).toBe('Orya');
+      expect(e.sourceId.startsWith('kaikki:or:')).toBe(true);
+    }
+    // Spot-check known entries from the fixture.
+    expect(out.find((e) => e.headword === 'ପାଣି' && e.pos === 'NOUN')).toBeDefined();
   });
 });

--- a/docs/dictionary-sources.md
+++ b/docs/dictionary-sources.md
@@ -45,6 +45,7 @@ launch.
 |---|---|---|---|
 | Odia WordNet | ISI Kolkata | Research use, distributable with attribution | Planned — the seed for T-2.3a's custom pipeline already draws from this |
 | OdiaNLP resources | Community / various | Mixed (MIT / CC-BY) | Planned — curated subset only, per-entry license check required |
+| [Wiktionary Odia (via Kaikki.org)](https://kaikki.org/dictionary/Odia/) | Wiktionary contributors | CC-BY-SA 3.0 | **Imported (T-3.10, 2026-04-28)** — fetched via `scripts/fetch-dictionary-sources.sh kaikki-odia`; the smallest Kaikki dump of the three MVP languages (~2k entries) but the first real Odia lexical data — proves the script-aware path works end-to-end with `Orya` |
 
 **Coverage: sparse.** Open-source Odia lexical coverage is materially thinner
 than Hindi or Marathi. We expect correspondingly more OOV tokens at launch


### PR DESCRIPTION
Third Kaikki source — completes the Kaikki coverage of MVP languages. Odia is the only MVP language not on Devanagari, so this also acts as a real exercise of the script-aware path with `Orya` (ISO 15924).

- sources/kaikki-odia.ts: thin instantiation of makeKaikkiSource
- sources/__fixtures__/kaikki-odia.jsonl: smoke fixture
- sources/kaikki.test.ts: + Odia smoke tests (script identifier, source_id prefix, fixture iteration). Now 26 tests in the file.
- scripts/fetch-dictionary-sources.sh: + kaikki-odia case

End-to-end verified against local Postgres with the real Kaikki dump (scripts/fetch-dictionary-sources.sh kaikki-odia → 3.5MB / 2,054 lines): 1,971 lemmas + 4,377 translations + 2,060 forms imported, idempotent.

Smallest of the three Kaikki dumps but the first real Odia lexical data in the project. Odia WordNet (ISI Kolkata) and OdiaNLP land in follow-up PRs to fill the long tail.

Refs #25, #192.