### PR TITLE
T-6.8: bulk reprocess-text endpoint

### DIFF
--- a/apps/web/src/lib/server/texts/bulk-reprocess.test.ts
+++ b/apps/web/src/lib/server/texts/bulk-reprocess.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const processTextNow = vi.fn();
+
+const rows: Array<Record<string, unknown>> = [];
+type ChainShape = {
+  from: ReturnType<typeof vi.fn>;
+  where: ReturnType<typeof vi.fn>;
+  limit: ReturnType<typeof vi.fn>;
+  $dynamic: ReturnType<typeof vi.fn>;
+};
+const chain: ChainShape = {
+  from: vi.fn(() => chain),
+  where: vi.fn(() => chain),
+  limit: vi.fn(() => rows),
+  $dynamic: vi.fn(() => chain),
+};
+
+const fakeDb = {
+  select: vi.fn(() => chain),
+};
+
+vi.mock('../db/index.js', () => ({
+  db: fakeDb,
+  schema: {
+    texts: {
+      id: 'texts.id',
+      language: 'texts.language',
+      status: 'texts.status',
+    },
+  },
+}));
+
+vi.mock('./in-process-dispatcher.js', () => ({
+  processTextNow: (...a: unknown[]) => processTextNow(...a),
+}));
+
+const { bulkReprocessTexts } = await import('./bulk-reprocess.js');
+
+beforeEach(() => {
+  rows.length = 0;
+  for (const fn of Object.values(chain))
+    (fn as ReturnType<typeof vi.fn>).mockClear();
+  fakeDb.select.mockClear();
+  processTextNow.mockReset();
+  processTextNow.mockResolvedValue(0);
+});
+
+describe('bulkReprocessTexts', () => {
+  it('dispatches every matching text', async () => {
+    rows.push({ id: 'tx-1' }, { id: 'tx-2' });
+    const r = await bulkReprocessTexts({ language: 'hi' });
+    expect(r.dispatched).toBe(2);
+    expect(r.textIds).toEqual(['tx-1', 'tx-2']);
+    expect(processTextNow).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns 0 when no texts match', async () => {
+    const r = await bulkReprocessTexts({});
+    expect(r.dispatched).toBe(0);
+    expect(processTextNow).not.toHaveBeenCalled();
+  });
+
+  it('caps the dispatch count at the requested limit', async () => {
+    const r = await bulkReprocessTexts({ limit: 1 });
+    // We can't easily assert the SQL `.limit()` arg here, but we
+    // verify the call passes through to the chain.
+    expect(chain.limit).toHaveBeenCalledWith(1);
+    expect(r.matched).toBe(0);
+  });
+
+  it('filters by language when provided', async () => {
+    rows.push({ id: 'tx-1' });
+    await bulkReprocessTexts({ language: 'mr' });
+    // Single composite WHERE was issued.
+    expect(chain.where).toHaveBeenCalledOnce();
+  });
+
+  it('filters by status array when provided', async () => {
+    rows.push({ id: 'tx-1' });
+    await bulkReprocessTexts({ statuses: ['ready', 'failed'] });
+    expect(chain.where).toHaveBeenCalledOnce();
+  });
+
+  it('swallows dispatcher errors without rejecting the bulk call', async () => {
+    rows.push({ id: 'tx-explode' });
+    processTextNow.mockRejectedValueOnce(new Error('dispatcher down'));
+    const r = await bulkReprocessTexts({});
+    expect(r.dispatched).toBe(1);
+  });
+});

--- a/apps/web/src/lib/server/texts/bulk-reprocess.ts
+++ b/apps/web/src/lib/server/texts/bulk-reprocess.ts
@@ -1,0 +1,83 @@
+/**
+ * Bulk text reprocess service (T-6.8).
+ *
+ * After a large dictionary import or a batch of override updates,
+ * already-ingested texts may benefit from a fresh NLP pass. The
+ * single-text endpoint at `POST /api/v1/admin/texts/:id/reprocess`
+ * (T-4.4) handles individual recoveries; this service walks the
+ * whole library (filterable by language and status) and triggers
+ * re-processing on each.
+ *
+ * Synchronous-feeling but fire-and-forget per text: we call
+ * `processTextNow` on every match, but DON'T await each one — the
+ * dispatcher is async and the caller wants the count of dispatched
+ * jobs, not the eventual completion. A background process owns the
+ * actual work; the API is ack-only.
+ */
+import { and, eq, inArray } from 'drizzle-orm';
+
+import { db, schema } from '../db/index.js';
+import type { Text } from '../db/schema.js';
+import type { LanguageCode } from '@ciareader/shared-types';
+import { processTextNow } from './in-process-dispatcher.js';
+
+export type BulkReprocessFilter = {
+  language?: LanguageCode;
+  /** Filter by current text status. Common: 'ready' (re-run after
+   *  override updates), 'failed' (recover stuck imports). */
+  statuses?: Array<Text['status']>;
+  /** Cap on number of texts to re-process in one call. Defaults
+   *  to 500 — high enough for batch dictionary imports, low enough
+   *  that a stray invocation doesn't pin the worker for hours. */
+  limit?: number;
+};
+
+export type BulkReprocessResult = {
+  /** How many texts matched the filter. */
+  matched: number;
+  /** How many we actually dispatched (matched, capped to `limit`). */
+  dispatched: number;
+  textIds: string[];
+};
+
+export async function bulkReprocessTexts(
+  filter: BulkReprocessFilter,
+): Promise<BulkReprocessResult> {
+  const limit = Math.min(Math.max(1, filter.limit ?? 500), 5000);
+  const conditions = [];
+  if (filter.language) {
+    conditions.push(eq(schema.texts.language, filter.language));
+  }
+  if (filter.statuses && filter.statuses.length > 0) {
+    conditions.push(
+      inArray(
+        schema.texts.status,
+        filter.statuses as unknown as Text['status'][],
+      ),
+    );
+  }
+  let q = db.select({ id: schema.texts.id }).from(schema.texts).$dynamic();
+  if (conditions.length > 0) {
+    q = q.where(and(...(conditions as Parameters<typeof and>))) as typeof q;
+  }
+  const rows = (await q.limit(limit)) as Array<{ id: string }>;
+
+  const textIds = rows.map((r) => r.id);
+  // Fire-and-forget — the dispatcher writes status flips back to
+  // the texts row so the library / reader poll endpoints surface
+  // progress. We deliberately don't `await` so a 100-text batch
+  // doesn't tie up the request thread.
+  for (const id of textIds) {
+    void processTextNow(id).catch((err) => {
+      // Background failure: log + move on. The text's row will
+      // reflect the failure via markTextFailed in the dispatcher.
+      console.error(`bulkReprocessTexts: ${id} failed:`, err);
+    });
+  }
+
+  return {
+    matched: textIds.length,
+    dispatched: textIds.length,
+    textIds,
+  };
+}

--- a/apps/web/src/routes/api/v1/admin/texts/reprocess-batch/+server.ts
+++ b/apps/web/src/routes/api/v1/admin/texts/reprocess-batch/+server.ts
@@ -1,0 +1,44 @@
+/**
+ * POST /api/v1/admin/texts/reprocess-batch (T-6.8).
+ *
+ * Bulk variant of the per-text reprocess endpoint. Walks the
+ * library filtered by language + status and dispatches the NLP
+ * pipeline against each match. Admin-only. Returns the count +
+ * id list immediately — the actual processing runs in the
+ * background.
+ */
+import { error, json } from '@sveltejs/kit';
+import { z } from 'zod';
+
+import { requireUser } from '$lib/server/auth/require-user.js';
+import { isAdmin } from '$lib/server/dictionary/permissions.js';
+import { bulkReprocessTexts } from '$lib/server/texts/bulk-reprocess.js';
+import { isSupportedLanguage } from '@ciareader/shared-types';
+import { parseJson } from '../../../auth/_helpers.js';
+import type { LanguageCode } from '@ciareader/shared-types';
+import type { RequestHandler } from './$types';
+
+const bodySchema = z
+  .object({
+    language: z
+      .string()
+      .refine(isSupportedLanguage, 'unsupported language')
+      .optional(),
+    statuses: z
+      .array(z.enum(['pending', 'processing', 'ready', 'failed']))
+      .optional(),
+    limit: z.number().int().min(1).max(5000).optional(),
+  })
+  .strict();
+
+export const POST: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  if (!isAdmin({ role: user.role })) throw error(403, 'Admin role required');
+  const body = await parseJson(event.request, bodySchema);
+  const result = await bulkReprocessTexts({
+    language: body.language as LanguageCode | undefined,
+    statuses: body.statuses,
+    limit: body.limit,
+  });
+  return json(result, { status: 202 });
+};


### PR DESCRIPTION
## Summary

Single-text reprocess at \`POST /api/v1/admin/texts/:id/reprocess\` (T-4.4) covers individual recoveries. T-6.8 adds the bulk variant for after a batch dictionary import or override update:

\`POST /api/v1/admin/texts/reprocess-batch\`

Body: \`{ language?, statuses?, limit? }\`. Looks up matching texts and dispatches the in-process NLP pipeline against each. Response is 202 + dispatched count immediately; processing runs in the background. Cap at \`limit=5000\` (default 500). Admin-only.

Closes #64.

## Test plan
- New \`bulk-reprocess.test.ts\` covers happy path, no-match, limit, filters, dispatcher-error swallowing.
- typecheck + lint clean.