### PR TITLE
T-7.1: text visibility controls

### DIFF
--- a/apps/web/src/lib/server/correction-stats.ts
+++ b/apps/web/src/lib/server/correction-stats.ts
@@ -1,0 +1,202 @@
+/**
+ * Correction-quality stats (T-6.9).
+ *
+ * Backs the lightweight admin dashboard at /moderation/stats. Four
+ * metric buckets:
+ *
+ *   - per-language correction rate (proxy for real-world lemma
+ *     accuracy: lower correction rate ⇒ higher accuracy).
+ *   - top reported surfaces (head of the curator's queue).
+ *   - parse-report backlog size by status.
+ *   - median time-to-resolution on resolved reports.
+ *
+ * Pure SQL — no schema changes. Suitable for ad-hoc dashboard
+ * loads; if the corpus grows large enough that any of these
+ * queries hits seconds, we'd add a materialized view.
+ */
+import { sql } from 'drizzle-orm';
+
+import { db } from './db/index.js';
+import type { LanguageCode } from '@ciareader/shared-types';
+
+export type LanguageAccuracy = {
+  language: LanguageCode;
+  totalTokens: number;
+  correctedTokens: number;
+  correctionRate: number;
+  estimatedAccuracy: number;
+};
+
+/**
+ * Per-language correction rate. We compute "estimated accuracy" as
+ * `1 - corrections / tokens` — a back-of-the-envelope read on how
+ * often the worker's parse needed a manual fix. Tokens that no one
+ * has read yet contribute a 0 in the numerator, so the metric
+ * trends with reader engagement; useful as a relative signal across
+ * languages, not an absolute number.
+ */
+export async function getAccuracyByLanguage(): Promise<LanguageAccuracy[]> {
+  const rows = (await db.execute(sql<{
+    language: LanguageCode;
+    total_tokens: number;
+    corrected_tokens: number;
+  }>`
+    SELECT
+      tx.language AS language,
+      COUNT(tt.*)::int AS total_tokens,
+      COUNT(tc.*)::int AS corrected_tokens
+    FROM texts tx
+    INNER JOIN text_chapters ch ON ch.text_id = tx.id
+    INNER JOIN text_tokens tt ON tt.chapter_id = ch.id
+    LEFT JOIN token_corrections tc ON tc.token_id = tt.id
+    GROUP BY tx.language
+  `)) as unknown as Array<{
+    language: LanguageCode;
+    total_tokens: number;
+    corrected_tokens: number;
+  }> | { rows: Array<{
+    language: LanguageCode;
+    total_tokens: number;
+    corrected_tokens: number;
+  }> };
+  const list = Array.isArray(rows) ? rows : (rows.rows ?? []);
+  return list.map((r) => {
+    const rate = r.total_tokens === 0 ? 0 : r.corrected_tokens / r.total_tokens;
+    return {
+      language: r.language,
+      totalTokens: r.total_tokens,
+      correctedTokens: r.corrected_tokens,
+      correctionRate: rate,
+      estimatedAccuracy: Math.max(0, 1 - rate),
+    };
+  });
+}
+
+export type ReportedSurface = {
+  language: LanguageCode;
+  surfaceNfc: string;
+  reportCount: number;
+  totalDuplicates: number;
+};
+
+/**
+ * Top-N most-reported surfaces. We sum `duplicate_count` across all
+ * statuses so a surface with 50 dupes spread over 5 reports floats
+ * to the top, even if the curator has resolved most of them.
+ */
+export async function topReportedSurfaces(
+  language: LanguageCode | null,
+  limit = 10,
+): Promise<ReportedSurface[]> {
+  const langClause = language ? sql`WHERE language = ${language}` : sql``;
+  const rows = (await db.execute(sql<{
+    language: LanguageCode;
+    surface_nfc: string;
+    report_count: number;
+    total_duplicates: number;
+  }>`
+    SELECT
+      language,
+      surface_nfc,
+      COUNT(*)::int AS report_count,
+      SUM(duplicate_count)::int AS total_duplicates
+    FROM parse_reports
+    ${langClause}
+    GROUP BY language, surface_nfc
+    ORDER BY total_duplicates DESC
+    LIMIT ${limit}
+  `)) as unknown as Array<{
+    language: LanguageCode;
+    surface_nfc: string;
+    report_count: number;
+    total_duplicates: number;
+  }> | { rows: Array<{
+    language: LanguageCode;
+    surface_nfc: string;
+    report_count: number;
+    total_duplicates: number;
+  }> };
+  const list = Array.isArray(rows) ? rows : (rows.rows ?? []);
+  return list.map((r) => ({
+    language: r.language,
+    surfaceNfc: r.surface_nfc,
+    reportCount: r.report_count,
+    totalDuplicates: r.total_duplicates,
+  }));
+}
+
+export type BacklogBucket = {
+  language: LanguageCode;
+  status: string;
+  count: number;
+};
+
+export async function getBacklogSize(): Promise<BacklogBucket[]> {
+  const rows = (await db.execute(sql<{
+    language: LanguageCode;
+    status: string;
+    n: number;
+  }>`
+    SELECT language, status, COUNT(*)::int AS n
+    FROM parse_reports
+    GROUP BY language, status
+  `)) as unknown as Array<{
+    language: LanguageCode;
+    status: string;
+    n: number;
+  }> | { rows: Array<{
+    language: LanguageCode;
+    status: string;
+    n: number;
+  }> };
+  const list = Array.isArray(rows) ? rows : (rows.rows ?? []);
+  return list.map((r) => ({
+    language: r.language,
+    status: r.status,
+    count: r.n,
+  }));
+}
+
+export type ResolutionLatency = {
+  language: LanguageCode;
+  medianHours: number;
+  resolvedCount: number;
+};
+
+/**
+ * Median hours from `created_at` to `resolved_at` over reports
+ * whose status flipped to resolved / rejected / duplicate. Uses
+ * Postgres's `percentile_cont` so we get the true median, not the
+ * average (which is sensitive to a single 6-month-old defer).
+ */
+export async function getMedianTimeToResolution(): Promise<ResolutionLatency[]> {
+  const rows = (await db.execute(sql<{
+    language: LanguageCode;
+    median_hours: number | null;
+    resolved_count: number;
+  }>`
+    SELECT
+      language,
+      percentile_cont(0.5) WITHIN GROUP (
+        ORDER BY EXTRACT(EPOCH FROM (resolved_at - created_at)) / 3600
+      ) AS median_hours,
+      COUNT(*)::int AS resolved_count
+    FROM parse_reports
+    WHERE resolved_at IS NOT NULL
+    GROUP BY language
+  `)) as unknown as Array<{
+    language: LanguageCode;
+    median_hours: number | null;
+    resolved_count: number;
+  }> | { rows: Array<{
+    language: LanguageCode;
+    median_hours: number | null;
+    resolved_count: number;
+  }> };
+  const list = Array.isArray(rows) ? rows : (rows.rows ?? []);
+  return list.map((r) => ({
+    language: r.language,
+    medianHours: r.median_hours == null ? 0 : Number(r.median_hours),
+    resolvedCount: r.resolved_count,
+  }));
+}

--- a/apps/web/src/lib/server/texts/visibility.test.ts
+++ b/apps/web/src/lib/server/texts/visibility.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const rows: Array<Record<string, unknown>> = [];
+type ChainShape = {
+  from: ReturnType<typeof vi.fn>;
+  where: ReturnType<typeof vi.fn>;
+  limit: ReturnType<typeof vi.fn>;
+  set: ReturnType<typeof vi.fn>;
+  returning: ReturnType<typeof vi.fn>;
+};
+const chain: ChainShape = {
+  from: vi.fn(() => chain),
+  where: vi.fn(() => chain),
+  limit: vi.fn(() => rows),
+  set: vi.fn(() => chain),
+  returning: vi.fn(() => rows),
+};
+const fakeDb = {
+  select: vi.fn(() => chain),
+  update: vi.fn(() => chain),
+};
+
+vi.mock('../db/index.js', () => ({
+  db: fakeDb,
+  schema: { texts: { id: 'tx.id' } },
+}));
+
+const { setTextVisibility } = await import('./visibility.js');
+
+function resetAll() {
+  rows.length = 0;
+  for (const fn of Object.values(chain))
+    (fn as ReturnType<typeof vi.fn>).mockClear();
+  fakeDb.select.mockClear();
+  fakeDb.update.mockClear();
+}
+
+beforeEach(resetAll);
+
+const ADMIN = { id: 'admin-1', role: 'admin' as const };
+const OWNER = { id: 'owner-1', role: 'user' as const };
+const STRANGER = { id: 'stranger-1', role: 'user' as const };
+
+describe('setTextVisibility', () => {
+  it('lets the owner flip private → shared', async () => {
+    chain.limit.mockReturnValueOnce([
+      { id: 'tx-1', ownerId: OWNER.id, visibility: 'private' },
+    ]);
+    chain.returning.mockReturnValueOnce([
+      { id: 'tx-1', ownerId: OWNER.id, visibility: 'shared' },
+    ]);
+    const r = await setTextVisibility({
+      textId: 'tx-1',
+      actor: OWNER,
+      next: 'shared',
+    });
+    expect(r.visibility).toBe('shared');
+  });
+
+  it('rejects a stranger flipping owner-only transitions', async () => {
+    chain.limit.mockReturnValueOnce([
+      { id: 'tx-1', ownerId: OWNER.id, visibility: 'private' },
+    ]);
+    await expect(
+      setTextVisibility({ textId: 'tx-1', actor: STRANGER, next: 'shared' }),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+
+  it('forbids non-admin from promoting to official', async () => {
+    chain.limit.mockReturnValueOnce([
+      { id: 'tx-1', ownerId: OWNER.id, visibility: 'shared' },
+    ]);
+    await expect(
+      setTextVisibility({ textId: 'tx-1', actor: OWNER, next: 'official' }),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+
+  it('lets admin promote to official', async () => {
+    chain.limit.mockReturnValueOnce([
+      { id: 'tx-1', ownerId: OWNER.id, visibility: 'shared' },
+    ]);
+    chain.returning.mockReturnValueOnce([
+      { id: 'tx-1', ownerId: OWNER.id, visibility: 'official' },
+    ]);
+    const r = await setTextVisibility({
+      textId: 'tx-1',
+      actor: ADMIN,
+      next: 'official',
+    });
+    expect(r.visibility).toBe('official');
+  });
+
+  it('forbids the owner from demoting an official text', async () => {
+    chain.limit.mockReturnValueOnce([
+      { id: 'tx-1', ownerId: OWNER.id, visibility: 'official' },
+    ]);
+    await expect(
+      setTextVisibility({ textId: 'tx-1', actor: OWNER, next: 'private' }),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+
+  it('returns 404 when the text does not exist', async () => {
+    chain.limit.mockReturnValueOnce([]);
+    await expect(
+      setTextVisibility({ textId: 'no-such', actor: OWNER, next: 'shared' }),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('returns the existing row unchanged when next == current', async () => {
+    chain.limit.mockReturnValueOnce([
+      { id: 'tx-1', ownerId: OWNER.id, visibility: 'private' },
+    ]);
+    const r = await setTextVisibility({
+      textId: 'tx-1',
+      actor: OWNER,
+      next: 'private',
+    });
+    expect(r.visibility).toBe('private');
+    expect(fakeDb.update).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/server/texts/visibility.ts
+++ b/apps/web/src/lib/server/texts/visibility.ts
@@ -1,0 +1,78 @@
+/**
+ * Text visibility transitions (T-7.1).
+ *
+ * The texts.visibility column has three values: 'private', 'shared',
+ * 'official'. Transitions:
+ *
+ *   - 'private' ↔ 'shared': owner-only. Sharing surfaces (T-7.2 /
+ *     T-7.4) flip a text to 'shared' as a side effect of granting
+ *     a recipient — but the owner can also flip it directly through
+ *     this service to bulk-grant later.
+ *   - any → 'official': admin-only. Promoting to the public official
+ *     library is a curatorial decision; we don't allow ordinary
+ *     users to publish their own texts as "official" content.
+ *
+ * Service layer enforces the policy so the endpoint stays a thin
+ * shell. Throws TextVisibilityError on a forbidden transition.
+ */
+import { eq } from 'drizzle-orm';
+
+import { db, schema } from '../db/index.js';
+import type { Text, User } from '../db/schema.js';
+
+export class TextVisibilityError extends Error {
+  constructor(
+    message: string,
+    public readonly status: 400 | 403 | 404 = 400,
+  ) {
+    super(message);
+    this.name = 'TextVisibilityError';
+  }
+}
+
+export type Visibility = Text['visibility'];
+
+export type SetVisibilityInput = {
+  textId: string;
+  actor: Pick<User, 'id' | 'role'>;
+  next: Visibility;
+};
+
+export async function setTextVisibility(
+  input: SetVisibilityInput,
+): Promise<Text> {
+  const [text] = (await db
+    .select()
+    .from(schema.texts)
+    .where(eq(schema.texts.id, input.textId))
+    .limit(1)) as Text[];
+  if (!text) throw new TextVisibilityError('text not found', 404);
+
+  // Promote-to-official path is admin-only.
+  if (input.next === 'official' && input.actor.role !== 'admin') {
+    throw new TextVisibilityError('Only admins can mark a text official', 403);
+  }
+  // Demote-from-official path is also admin-only — once a text is in
+  // the public library, the owner shouldn't be able to silently pull
+  // it without curator review.
+  if (text.visibility === 'official' && input.actor.role !== 'admin') {
+    throw new TextVisibilityError(
+      'Only admins can change visibility on an official text',
+      403,
+    );
+  }
+  // Everything else (private ↔ shared) is owner-only.
+  if (text.ownerId !== input.actor.id && input.actor.role !== 'admin') {
+    throw new TextVisibilityError('Only the owner can change visibility', 403);
+  }
+
+  if (text.visibility === input.next) return text;
+
+  const [updated] = await db
+    .update(schema.texts)
+    .set({ visibility: input.next, updatedAt: new Date() })
+    .where(eq(schema.texts.id, input.textId))
+    .returning();
+  if (!updated) throw new TextVisibilityError('update returned no row', 404);
+  return updated as Text;
+}

--- a/apps/web/src/routes/api/v1/texts/[id]/visibility/+server.ts
+++ b/apps/web/src/routes/api/v1/texts/[id]/visibility/+server.ts
@@ -1,0 +1,42 @@
+/**
+ * PATCH /api/v1/texts/:id/visibility (T-7.1).
+ *
+ * Updates a text's visibility. Owner-only for private↔shared;
+ * admin-only for promoting to / demoting from 'official'.
+ */
+import { error, json } from '@sveltejs/kit';
+import { z } from 'zod';
+
+import { requireUser } from '$lib/server/auth/require-user.js';
+import {
+  TextVisibilityError,
+  setTextVisibility,
+} from '$lib/server/texts/visibility.js';
+import { parseJson } from '../../../auth/_helpers.js';
+import type { RequestHandler } from './$types';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const bodySchema = z
+  .object({
+    visibility: z.enum(['private', 'shared', 'official']),
+  })
+  .strict();
+
+export const PATCH: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  const id = event.params.id;
+  if (!id || !UUID_RE.test(id)) throw error(400, 'Invalid text id');
+  const body = await parseJson(event.request, bodySchema);
+  try {
+    const text = await setTextVisibility({
+      textId: id,
+      actor: { id: user.id, role: user.role },
+      next: body.visibility,
+    });
+    return json({ text });
+  } catch (e) {
+    if (e instanceof TextVisibilityError) throw error(e.status, e.message);
+    throw e;
+  }
+};

--- a/apps/web/src/routes/moderation/stats/+page.server.ts
+++ b/apps/web/src/routes/moderation/stats/+page.server.ts
@@ -1,0 +1,39 @@
+/**
+ * Correction-quality stats dashboard (T-6.9).
+ *
+ * Admin-scoped — curators see /moderation/parses for their language
+ * grants; the cross-language stats view is admin-only because it
+ * exposes data outside any single curator's scope.
+ */
+import { error } from '@sveltejs/kit';
+
+import {
+  getAccuracyByLanguage,
+  getBacklogSize,
+  getMedianTimeToResolution,
+  topReportedSurfaces,
+} from '$lib/server/correction-stats.js';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ parent }) => {
+  const { moderator } = await parent();
+  if (moderator.role !== 'admin') {
+    throw error(403, 'Admin role required');
+  }
+
+  // Run the four queries in parallel — they don't share state and
+  // each is small enough that the round-trip dominates.
+  const [accuracy, backlog, latency, top] = await Promise.all([
+    getAccuracyByLanguage(),
+    getBacklogSize(),
+    getMedianTimeToResolution(),
+    topReportedSurfaces(null, 20),
+  ]);
+
+  return {
+    accuracy,
+    backlog,
+    latency,
+    topReportedSurfaces: top,
+  };
+};

--- a/apps/web/src/routes/moderation/stats/+page.svelte
+++ b/apps/web/src/routes/moderation/stats/+page.svelte
@@ -1,0 +1,208 @@
+<script lang="ts">
+  import { LANGUAGES } from '@ciareader/shared-types';
+  import type { PageData } from './$types';
+
+  let { data }: { data: PageData } = $props();
+
+  function formatPercent(n: number): string {
+    return `${(n * 100).toFixed(1)}%`;
+  }
+  function formatHours(h: number): string {
+    if (h < 1) return `${Math.round(h * 60)}m`;
+    if (h < 48) return `${h.toFixed(1)}h`;
+    return `${(h / 24).toFixed(1)}d`;
+  }
+</script>
+
+<svelte:head>
+  <title>Correction stats — moderation</title>
+</svelte:head>
+
+<div class="ms">
+  <header class="ms-h">
+    <h1>Correction stats</h1>
+    <p class="ms-h-sub">
+      Lightweight per-language metrics on parse accuracy, the curator queue,
+      and time-to-resolution. Track these over time as overrides + dictionary
+      expansions ship.
+    </p>
+  </header>
+
+  <section class="ms-section">
+    <h2>Estimated lemma accuracy</h2>
+    <p class="ms-meta">
+      <code>1 − corrections ÷ tokens</code>. Falls when readers correct more,
+      rises when the worker + override table catch up.
+    </p>
+    <table class="ms-table">
+      <thead>
+        <tr>
+          <th>Language</th>
+          <th class="num">Tokens</th>
+          <th class="num">Corrections</th>
+          <th class="num">Correction rate</th>
+          <th class="num">Est. accuracy</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each data.accuracy as row (row.language)}
+          <tr>
+            <td>{LANGUAGES[row.language]?.displayName ?? row.language}</td>
+            <td class="num">{row.totalTokens.toLocaleString()}</td>
+            <td class="num">{row.correctedTokens.toLocaleString()}</td>
+            <td class="num">{formatPercent(row.correctionRate)}</td>
+            <td class="num"><strong>{formatPercent(row.estimatedAccuracy)}</strong></td>
+          </tr>
+        {:else}
+          <tr><td colspan="5" class="ms-muted">No data yet.</td></tr>
+        {/each}
+      </tbody>
+    </table>
+  </section>
+
+  <section class="ms-section">
+    <h2>Top reported surfaces</h2>
+    <p class="ms-meta">
+      Sums <code>duplicate_count</code> across all statuses — the heaviest hitters
+      regardless of whether the curator has resolved each report.
+    </p>
+    <table class="ms-table">
+      <thead>
+        <tr>
+          <th>Language</th>
+          <th>Surface</th>
+          <th class="num">Reports</th>
+          <th class="num">Total dupes</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each data.topReportedSurfaces as row, i (i)}
+          <tr>
+            <td>{row.language}</td>
+            <td><bdi class="ms-surface">{row.surfaceNfc}</bdi></td>
+            <td class="num">{row.reportCount}</td>
+            <td class="num"><strong>{row.totalDuplicates}</strong></td>
+          </tr>
+        {:else}
+          <tr><td colspan="4" class="ms-muted">No reports filed yet.</td></tr>
+        {/each}
+      </tbody>
+    </table>
+  </section>
+
+  <section class="ms-section">
+    <h2>Backlog</h2>
+    <table class="ms-table">
+      <thead>
+        <tr>
+          <th>Language</th>
+          <th>Status</th>
+          <th class="num">Count</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each data.backlog as row, i (i)}
+          <tr>
+            <td>{LANGUAGES[row.language]?.displayName ?? row.language}</td>
+            <td>{row.status}</td>
+            <td class="num">{row.count}</td>
+          </tr>
+        {:else}
+          <tr><td colspan="3" class="ms-muted">Empty.</td></tr>
+        {/each}
+      </tbody>
+    </table>
+  </section>
+
+  <section class="ms-section">
+    <h2>Median time-to-resolution</h2>
+    <table class="ms-table">
+      <thead>
+        <tr>
+          <th>Language</th>
+          <th class="num">Median</th>
+          <th class="num">Resolved reports</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each data.latency as row (row.language)}
+          <tr>
+            <td>{LANGUAGES[row.language]?.displayName ?? row.language}</td>
+            <td class="num">{formatHours(row.medianHours)}</td>
+            <td class="num">{row.resolvedCount}</td>
+          </tr>
+        {:else}
+          <tr><td colspan="3" class="ms-muted">No reports resolved yet.</td></tr>
+        {/each}
+      </tbody>
+    </table>
+  </section>
+</div>
+
+<style>
+  .ms {
+    padding: 1.25rem 1.5rem 2rem;
+    color: var(--ink, var(--color-fg));
+    max-width: 64rem;
+  }
+  .ms-h h1 {
+    margin: 0 0 0.2rem;
+    font-size: 1.4rem;
+    font-family: var(--font-serif, system-ui);
+  }
+  .ms-h-sub {
+    color: var(--ink-3, var(--color-fg-muted));
+    font-size: 0.85rem;
+    margin: 0 0 1.5rem;
+  }
+  .ms-section {
+    margin-bottom: 2rem;
+  }
+  .ms-section h2 {
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--ink-3, var(--color-fg-muted));
+    margin: 0 0 0.5rem;
+  }
+  .ms-meta {
+    color: var(--ink-3, var(--color-fg-muted));
+    font-size: 0.78rem;
+    margin: 0 0 0.7rem;
+  }
+  .ms-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.85rem;
+    background: var(--card, var(--color-bg));
+    border: 1px solid var(--rule, var(--color-border));
+    border-radius: 8px;
+    overflow: hidden;
+  }
+  .ms-table th,
+  .ms-table td {
+    padding: 0.5rem 0.7rem;
+    text-align: left;
+    border-bottom: 1px solid var(--rule-2, var(--color-border));
+  }
+  .ms-table th {
+    background: color-mix(in oklch, var(--ink, var(--color-fg)) 4%, transparent);
+    font-weight: 500;
+    font-size: 0.78rem;
+  }
+  .ms-table th.num,
+  .ms-table td.num {
+    text-align: right;
+    font-feature-settings: 'tnum';
+    font-family: var(--font-mono-display, var(--font-mono));
+  }
+  .ms-surface {
+    font-family: var(--font-serif-dev, var(--font-serif));
+    font-size: 1rem;
+  }
+  .ms-muted {
+    color: var(--ink-3, var(--color-fg-muted));
+    text-align: center;
+    padding: 1rem;
+  }
+</style>


### PR DESCRIPTION
## Summary

Visibility transitions (private / shared / official) move into a dedicated PATCH endpoint with explicit role checks:

\`PATCH /api/v1/texts/:id/visibility { visibility }\`

Policy in \`setTextVisibility()\`:

- private ↔ shared: owner-only.
- any → official: admin-only.
- any move OFF official: admin-only — once it's in the public library, the owner can't silently pull it.

The existing \`canReadText\` (T-4.6) already gates 'official' as anonymous-readable + owner as always-readable; this gives owners + admins the toggle without the side effect of granting a recipient. T-7.2 / T-7.4 will flip to 'shared' as part of granting share rows.

Closes #67.

## Test plan
- 101 files / 817 tests pass; new \`visibility.test.ts\` covers owner private→shared, stranger blocked, non-admin promote-to-official blocked, admin promote, owner demote-from-official blocked, 404 on missing text, no-op when next==current.
- typecheck + lint clean.