### PR TITLE
Reader: static word panel on desktop, locked-word outline + tooltip

### DIFF
--- a/apps/web/src/lib/components/overlay/Sheet.svelte
+++ b/apps/web/src/lib/components/overlay/Sheet.svelte
@@ -51,8 +51,13 @@
   // 0 on desktop / when no keyboard is visible.
   let kbInsetPx = $state(0);
 
+  // Modal-ish behaviour (focus trap + body-scroll lock) only kicks in
+  // for dimmed sheets. Undimmed sheets are contextual side panels —
+  // the page behind stays interactive, so trapping focus inside the
+  // sheet or freezing the scroll position would actively get in the
+  // user's way.
   $effect(() => {
-    if (!open) {
+    if (!open || !dimmed) {
       trap?.deactivate();
       trap = null;
       releaseScroll?.();
@@ -172,15 +177,22 @@
       transition: bottom 180ms ease-out;
     }
   }
-  /* Side-sheet layout (desktop / wide). */
+  /* Side-sheet layout (desktop / wide). The reader's word panel sits
+     below the page's top bar via `--reader-top-h`; pages without a
+     top bar leave the variable unset and the sheet hugs the top. */
   @media (min-width: 960px) {
     .sheet {
-      top: 0;
+      top: var(--reader-top-h, 0px);
       right: 0;
       bottom: 0;
       width: var(--sheet-width);
       box-shadow: -8px 0 32px rgba(0, 0, 0, 0.18);
       border-radius: 0;
+    }
+    /* Slide-in only animates for modal-style (dimmed) sheets. The
+       static word panel just appears in place — animating an
+       always-on column would feel jittery on every reload. */
+    .sheet-back.dimmed .sheet {
       animation: slide-in-right 220ms cubic-bezier(0.2, 0, 0, 1);
     }
   }

--- a/apps/web/src/lib/components/reader/ChapterBody.svelte
+++ b/apps/web/src/lib/components/reader/ChapterBody.svelte
@@ -160,16 +160,12 @@
 
   // Accepts both MouseEvent (mouseover) and FocusEvent (focusin) so
   // the tooltip surfaces for pointer hovers AND keyboard tabbing.
+  // We deliberately keep showing the tooltip for the locked word —
+  // the user might want a quick re-read of the gloss without taking
+  // their eyes off the chapter to read the side panel.
   function showHoverTooltip(event: Event) {
     const found = findToken(event.target as HTMLElement);
     if (!found) {
-      hoverToken = null;
-      hoverRect = null;
-      return;
-    }
-    // Skip the tooltip when the side panel is locked on the same
-    // word — redundant.
-    if (activeToken && activeToken.id === found.token.id) {
       hoverToken = null;
       hoverRect = null;
       return;
@@ -305,6 +301,7 @@
         {#each paragraph as token (token.id)}<TokenSpan
             {token}
             {showRomanization}
+            isAnchor={activeToken?.id === token.id}
           />{/each}
       </p>
     {/each}
@@ -323,17 +320,19 @@
   <WordTooltip token={hoverToken} anchorRect={hoverRect} />
 {/if}
 
-{#if activeToken && activeRect}
-  <WordPopup
-    token={activeToken}
-    anchorRect={activeRect}
-    {language}
-    {isOwner}
-    onClose={closePopup}
-    {onStatusChange}
-    {onCorrectionApplied}
-  />
-{/if}
+<!-- WordPopup mounts unconditionally so the side panel can stay
+     visible on desktop even before the user picks a word. The popup
+     itself decides whether to render its full body or an empty-state
+     prompt based on whether `token` is null. -->
+<WordPopup
+  token={activeToken}
+  anchorRect={activeRect ?? undefined}
+  {language}
+  {isOwner}
+  onClose={closePopup}
+  {onStatusChange}
+  {onCorrectionApplied}
+/>
 
 <CorrectionToast
   open={toastTokenId !== null}

--- a/apps/web/src/lib/components/reader/TokenSpan.svelte
+++ b/apps/web/src/lib/components/reader/TokenSpan.svelte
@@ -19,7 +19,15 @@
   let {
     token,
     showRomanization = false,
-  }: { token: ServerToken; showRomanization?: boolean } = $props();
+    isAnchor = false,
+  }: {
+    token: ServerToken;
+    showRomanization?: boolean;
+    /** True when this token is the one currently locked in the side
+     *  panel — gets an outline so the user remembers which word the
+     *  panel is bound to. */
+    isAnchor?: boolean;
+  } = $props();
 
   // OOV tokens get a distinct visual state (T-5.4a) — dashed
   // underline rather than the known/unknown highlight, so the user
@@ -30,6 +38,7 @@
     const classes: string[] = ['word'];
     if (token.isOov) classes.push('oov');
     if (token.isAmbiguous) classes.push('ambiguous');
+    if (isAnchor) classes.push('anchor');
     return classes.join(' ');
   });
 
@@ -89,5 +98,13 @@
     margin-left: 0.05em;
     vertical-align: super;
     font-size: 0.7em;
+  }
+  /* Anchor: the word currently locked in the side panel. Outline
+     instead of fill so the user can still see the underlying status
+     tint underneath. */
+  .word.anchor {
+    outline: 2px solid var(--accent, var(--color-accent));
+    outline-offset: 1px;
+    border-radius: 3px;
   }
 </style>

--- a/apps/web/src/lib/components/reader/WordPopup.svelte
+++ b/apps/web/src/lib/components/reader/WordPopup.svelte
@@ -57,6 +57,9 @@
   // anchorRect is accepted but unused — anchor positioning was used
   // before T-5.10 switched to Sheet. Kept on the prop signature for
   // backward compat with callers that still pass it.
+  // `token` is nullable now: the side panel renders unconditionally
+  // on desktop (static layout) and shows an empty-state prompt when
+  // the user hasn't picked a word yet.
   let {
     token,
     language,
@@ -65,7 +68,7 @@
     onStatusChange,
     onCorrectionApplied,
   }: {
-    token: ServerToken;
+    token: ServerToken | null;
     /** Drives the CorrectionModal's dictionary search + script
      *  selection. Required from T-6.2 forward. */
     language: LanguageCode;
@@ -87,7 +90,7 @@
   // T-6.2: opens the CorrectionModal layered on top of the popup.
   let showCorrectionModal = $state(false);
   let optimisticStatus = $state<'unknown' | 'learning' | 'known' | 'ignored'>(
-    untrack(() => token.status),
+    untrack(() => token?.status ?? 'unknown'),
   );
   let writeError = $state<string | null>(null);
   // T-6.1: tracks the in-flight candidate pick so the "This one"
@@ -96,6 +99,19 @@
   let pickingLemmaId = $state<string | null>(null);
   let pickError = $state<string | null>(null);
 
+  // Desktop (>=960px) shows the panel as a static right column —
+  // always rendered. Mobile slides it up only when a word is active.
+  let isDesktop = $state(false);
+  $effect(() => {
+    if (typeof window === 'undefined') return;
+    const mq = window.matchMedia('(min-width: 960px)');
+    const apply = () => (isDesktop = mq.matches);
+    apply();
+    mq.addEventListener('change', apply);
+    return () => mq.removeEventListener('change', apply);
+  });
+  const sheetOpen = $derived(isDesktop || token !== null);
+
   // Re-fetch translations whenever the token prop changes. `$effect`
   // runs the body each time `token` (and thus `token.id` / `lemmaId`)
   // changes — which happens when the parent rebinds the popup to a
@@ -103,6 +119,12 @@
   // instead of leaving the old one stuck.
   $effect(() => {
     const t = token;
+    if (!t) {
+      payload = null;
+      loadError = null;
+      optimisticStatus = 'unknown';
+      return;
+    }
     optimisticStatus = t.status;
     if (!t.lemmaId) {
       payload = null;
@@ -133,7 +155,7 @@
   });
 
   function handleKeydown(e: KeyboardEvent) {
-    if (!isOwner || !token.lemmaId) return;
+    if (!isOwner || !token?.lemmaId) return;
     // T-5.21: skip the k/l/i shortcuts whenever the user is typing
     // into a form field — otherwise typing 'l' in the add-translation
     // textarea would silently flip the lemma to learning.
@@ -209,7 +231,7 @@
     body: string,
     parentTranslationId: string | null,
   ): Promise<PublicTranslation> {
-    if (!token.lemmaId) throw new Error('Missing lemma id');
+    if (!token || !token.lemmaId) throw new Error('Missing lemma id');
     const res = await fetch('/api/v1/translations', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -254,7 +276,7 @@
   }
 
   async function submitNewTranslation() {
-    if (!token.lemmaId) return;
+    if (!token || !token.lemmaId) return;
     const trimmed = newTranslationBody.trim();
     if (trimmed.length === 0) {
       addError = 'Translation cannot be empty.';
@@ -309,7 +331,7 @@
   }
 
   async function submitCustomize() {
-    if (!customizingId || !token.lemmaId) return;
+    if (!customizingId || !token || !token.lemmaId) return;
     const trimmed = customizeBody.trim();
     if (trimmed.length === 0) {
       customizeError = 'Translation cannot be empty.';
@@ -336,6 +358,8 @@
   // lemma immediately; the server row backs the change for next
   // read (handled by T-6.4's loader join).
   async function pickCandidate(lemmaId: string) {
+    if (!token) return;
+    const tokenId = token.id;
     pickingLemmaId = lemmaId;
     pickError = null;
     try {
@@ -343,7 +367,7 @@
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({
-          tokenId: token.id,
+          tokenId,
           type: 'pick_candidate',
           chosenLemmaId: lemmaId,
         }),
@@ -352,7 +376,7 @@
         const text = await res.text().catch(() => '');
         throw new Error(text || `HTTP ${res.status}`);
       }
-      onCorrectionApplied?.(token.id, lemmaId);
+      onCorrectionApplied?.(tokenId, lemmaId);
       // Close the popup after a successful pick so the user lands
       // back on the reader; the parent's reactive state has already
       // re-rendered the token with the new lemma.
@@ -367,7 +391,7 @@
   async function markStatus(
     status: 'unknown' | 'learning' | 'known' | 'ignored',
   ) {
-    if (!token.lemmaId) return;
+    if (!token || !token.lemmaId) return;
     const lemmaId = token.lemmaId;
     const previous = optimisticStatus;
     optimisticStatus = status;
@@ -392,20 +416,27 @@
 <svelte:window onkeydown={handleKeydown} />
 
 <!-- T-5.17: dimmed=false so the reader paragraph remains readable
-     while a word is locked in the panel. -->
-<Sheet open={true} onClose={onClose} title="" dimmed={false}>
-  <div data-testid="word-popup">
-    <header class="sp-head">
-      <button
-        type="button"
-        class="sp-close"
-        aria-label="Close"
-        title="Close"
-        onclick={onClose}
-      >
-        ×
-      </button>
-      <h2 class="sp-word">{token.surface}</h2>
+     while a word is locked in the panel.
+     The panel is always open on desktop (static right column) and
+     conditional on mobile (slides up only when a word is picked). -->
+<Sheet open={sheetOpen} onClose={onClose} title="" dimmed={false}>
+  {#if !token}
+    <div class="sp-empty" data-testid="word-popup-empty">
+      <p>Click a word to see its definition.</p>
+    </div>
+  {:else}
+    <div data-testid="word-popup">
+      <header class="sp-head">
+        <button
+          type="button"
+          class="sp-close"
+          aria-label="Close"
+          title="Close"
+          onclick={onClose}
+        >
+          ×
+        </button>
+        <h2 class="sp-word">{token.surface}</h2>
       {#if token.romanization}
         <p class="sp-roman">{token.romanization}</p>
       {/if}
@@ -640,21 +671,31 @@
         {/if}
       {/if}
     {/if}
-  </div>
+    </div>
+  {/if}
 </Sheet>
 
-<CorrectionModal
-  open={showCorrectionModal}
-  {token}
-  {language}
-  onClose={() => (showCorrectionModal = false)}
-  onApplied={(lemmaId) => {
-    onCorrectionApplied?.(token.id, lemmaId);
-    onClose();
-  }}
-/>
+{#if token}
+  <CorrectionModal
+    open={showCorrectionModal}
+    {token}
+    {language}
+    onClose={() => (showCorrectionModal = false)}
+    onApplied={(lemmaId) => {
+      onCorrectionApplied?.(token.id, lemmaId);
+      onClose();
+    }}
+  />
+{/if}
 
 <style>
+  .sp-empty {
+    color: var(--ink-3, var(--color-fg-muted));
+    font-size: 0.85rem;
+    font-style: italic;
+    text-align: center;
+    padding: 1.5rem 0.5rem;
+  }
   .sp-head {
     position: relative;
     margin-bottom: 0.85rem;

--- a/apps/web/src/lib/components/shell/AppShell.svelte
+++ b/apps/web/src/lib/components/shell/AppShell.svelte
@@ -427,10 +427,7 @@
     text-overflow: ellipsis;
   }
 
-  /* —— Rail (desktop only) ——
-     The rail sits below any page-level top bar via `--reader-top-h`,
-     a CSS var the reader sets to its top-bar height. Pages that don't
-     have a top bar leave the var unset and the rail goes top:0. */
+  /* —— Rail (desktop only) —— */
   .rail {
     grid-area: rail;
     display: none;
@@ -444,8 +441,8 @@
       var(--paper-2, transparent)
     );
     position: sticky;
-    top: var(--reader-top-h, 0px);
-    height: calc(100dvh - var(--reader-top-h, 0px));
+    top: 0;
+    height: 100dvh;
   }
   @media (min-width: 960px) {
     .rail {

--- a/apps/web/src/routes/reader/[textId]/+page.svelte
+++ b/apps/web/src/routes/reader/[textId]/+page.svelte
@@ -385,31 +385,34 @@
     color: var(--ink, var(--color-fg));
     /* Fill the AppShell's content track so page mode can occupy the
        full vertical space (T-5.23). Children flex-stack vertically:
-       fluid body and progress foot — the top bar is fixed across the
-       whole viewport, so the body just needs the matching padding. */
+       sticky top bar, fluid body, and progress foot. */
     min-height: 100dvh;
     display: flex;
     flex-direction: column;
-    padding-top: var(--reader-top-h, 0px);
+  }
+  /* The word side-panel is a permanent right column on desktop. Pad
+     the reader so its chapter, header, and progress strip never run
+     behind it. The panel width comes from Sheet's --sheet-width
+     (default 380px). */
+  @media (min-width: 960px) {
+    .reader {
+      padding-right: 380px;
+    }
   }
   /* Page mode is meant to behave like a book — no vertical scroll;
-     overflow stays inside the viewport, page arrows step through it.
-     Hard-cap the height so the inner flex chain (.reader-page-wrap →
-     .reader-page-viewport with overflow:hidden) actually constrains
-     the content, instead of letting min-height grow with it. */
+     overflow stays inside the viewport, page arrows step through it. */
   .reader[data-mode='page'] {
     height: 100dvh;
     min-height: 0;
     overflow: hidden;
   }
-  /* Full-viewport top bar so the rail sits below it (rail reads the
-     same `--reader-top-h` variable to know how much room to leave). */
+  /* The top bar lives inside the reader's right column (sticky inside
+     the AppShell content track, not over the rail). The right side
+     panel reads `--reader-top-h` to anchor below it. */
   .reader-top {
-    position: fixed;
+    position: sticky;
     top: 0;
-    left: 0;
-    right: 0;
-    z-index: 20;
+    z-index: 5;
     display: grid;
     grid-template-columns: 1fr;
     gap: 0.5rem 1rem;


### PR DESCRIPTION
## Summary

The previous round (#231) moved the **left** rail down beneath the top bar — that was the wrong sidebar. Only the **right** word panel needed pushing down so it doesn't cover the chapter title + mode tabs. This PR reverts the rail / full-width-top-bar bit and applies the change where it actually belongs.

While I was there, three follow-ups the user asked for:

### Static word panel on desktop
The word panel stays visible permanently on desktop (≥960px). When no word is picked yet, an empty-state prompt ("Click a word to see its definition.") sits in the panel; clicking a word swaps in the lemma + translations.

- `WordPopup` mounts unconditionally; `token` is nullable. Empty-state vs full body decided by `token === null`.
- `sheetOpen = isDesktop || token !== null`. Desktop = always open. Mobile = slide-up only on word click (current behavior).
- Sheet's side-panel layout anchors below the top bar via the existing `--reader-top-h` variable.
- Slide-in animation only fires for modal (dimmed) sheets — the static word panel just appears in place; animating an always-on column would jitter on every page change.
- Sheet only locks scroll + traps focus when dimmed. Undimmed contextual side panels shouldn't freeze the page behind them.
- Reader root gets `padding-right: 380px` on desktop so the chapter, header, and progress strip don't run behind the panel.

### Hover tooltip on the locked word
Previously suppressed (the panel already has the gloss, so the tooltip felt redundant). The user wants it back — useful for a quick re-read without taking eyes off the chapter. The `if (activeToken && activeToken.id === found.token.id) { hide }` branch in ChapterBody is gone.

### Outline around the clicked word
TokenSpan takes a new `isAnchor` boolean. ChapterBody passes `activeToken?.id === token.id` per token, so exactly one word at a time is outlined with a 2px accent ring while the panel is locked on it.

## Test plan

- [x] `pnpm test` — 810 tests pass
- [x] `pnpm check` — 0 errors, 0 warnings
- [x] Desktop: rail stays at top:0 (not pushed below the top bar). Word panel docks below the top bar at right; chapter content fills the middle band, never running behind the panel.
- [x] Click a word: panel rebinds, the word gets a 2px accent outline.
- [x] Hover the locked word: tooltip still shows.
- [x] Hover other words while panel locked: tooltip shows above the panel.
- [ ] Mobile (<960px): panel still slides up on word click, doesn't render until then.
- [ ] Click the × in the panel header: panel closes back to empty state on desktop, dismisses on mobile.
- [ ] Esc key closes panel.