### PR TITLE
T-1.4: responsive shell with top nav + mobile bottom tab bar (#120)

### DIFF
--- a/apps/web/src/lib/components/shell/AppShell.svelte
+++ b/apps/web/src/lib/components/shell/AppShell.svelte
@@ -1,0 +1,159 @@
+<script lang="ts">
+  import { page } from '$app/stores';
+  import { TABS, getActiveTabId, visibleTabs, type Tab } from './tabs.js';
+  import type { Snippet } from 'svelte';
+
+  interface Props {
+    user: { id: string; displayName: string | null; email: string } | null;
+    children: Snippet;
+  }
+
+  let { user, children }: Props = $props();
+
+  const tabs = $derived<Tab[]>(visibleTabs(TABS, user !== null));
+  const activeId = $derived(getActiveTabId($page.url.pathname, tabs));
+</script>
+
+<div class="shell">
+  <header class="top-bar" aria-label="Primary">
+    <a class="brand" href="/" aria-label="CIA Reader home">
+      <span class="brand-mark">CIA</span>
+      <span class="brand-name">Reader</span>
+    </a>
+    <nav class="top-nav" aria-label="Primary navigation">
+      {#each tabs as tab (tab.id)}
+        <a
+          href={tab.href}
+          class="tab"
+          class:active={activeId === tab.id}
+          aria-current={activeId === tab.id ? 'page' : undefined}
+        >
+          {tab.label}
+        </a>
+      {/each}
+    </nav>
+    {#if user}
+      <span class="who" aria-label="Signed-in user">
+        {user.displayName ?? user.email}
+      </span>
+    {/if}
+  </header>
+
+  <main class="content">
+    {@render children()}
+  </main>
+
+  <nav class="bottom-nav" aria-label="Primary navigation">
+    {#each tabs as tab (tab.id)}
+      <a
+        href={tab.href}
+        class="tab"
+        class:active={activeId === tab.id}
+        aria-current={activeId === tab.id ? 'page' : undefined}
+      >
+        {tab.label}
+      </a>
+    {/each}
+  </nav>
+</div>
+
+<style>
+  .shell {
+    min-height: 100dvh;
+    display: flex;
+    flex-direction: column;
+  }
+  .top-bar {
+    display: flex;
+    align-items: center;
+    gap: var(--space-4);
+    padding: var(--space-3) var(--space-4);
+    border-bottom: 1px solid var(--color-border);
+    background: var(--color-surface-1);
+    position: sticky;
+    top: 0;
+    z-index: 10;
+  }
+  .brand {
+    display: inline-flex;
+    align-items: baseline;
+    gap: var(--space-2);
+    text-decoration: none;
+    color: inherit;
+    font-weight: 700;
+  }
+  .brand-mark {
+    color: var(--color-accent);
+    letter-spacing: 0.04em;
+  }
+  .brand-name {
+    color: var(--color-fg);
+  }
+  .top-nav {
+    display: flex;
+    gap: var(--space-2);
+    flex: 1;
+    margin-left: var(--space-4);
+  }
+  .who {
+    color: var(--color-fg-muted);
+    font-size: var(--font-size-sm);
+    white-space: nowrap;
+  }
+  .tab {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--space-2) var(--space-3);
+    border-radius: var(--radius-md);
+    min-height: var(--touch-target);
+    color: var(--color-fg-muted);
+    text-decoration: none;
+    font-size: var(--font-size-sm);
+  }
+  .tab:hover {
+    color: var(--color-fg);
+    background: var(--color-surface-2);
+  }
+  .tab.active {
+    color: var(--color-accent);
+    background: var(--color-surface-2);
+    font-weight: 600;
+  }
+  .content {
+    flex: 1;
+    display: block;
+    padding-bottom: calc(var(--touch-target) + var(--space-6));
+  }
+  .bottom-nav {
+    display: none;
+  }
+
+  /* Mobile: hide the top nav links (brand + who stay), show the bottom tab bar. */
+  @media (max-width: 640px) {
+    .top-nav {
+      display: none;
+    }
+    .bottom-nav {
+      display: grid;
+      grid-auto-flow: column;
+      grid-auto-columns: 1fr;
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      background: var(--color-surface-1);
+      border-top: 1px solid var(--color-border);
+      padding: var(--space-1) var(--space-2);
+      padding-bottom: calc(var(--space-1) + env(safe-area-inset-bottom, 0px));
+      z-index: 10;
+    }
+    .bottom-nav .tab {
+      padding: var(--space-2);
+      font-size: var(--font-size-xs);
+    }
+    .content {
+      padding-bottom: calc(var(--touch-target) * 1.5 + env(safe-area-inset-bottom, 0px));
+    }
+  }
+</style>

--- a/apps/web/src/lib/components/shell/tabs.test.ts
+++ b/apps/web/src/lib/components/shell/tabs.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { TABS, getActiveTabId, visibleTabs, type Tab } from './tabs.js';
+
+describe('visibleTabs', () => {
+  it('shows authenticated + any tabs to signed-in users', () => {
+    const shown = visibleTabs(TABS, true).map((t) => t.id);
+    expect(shown).toContain('home');
+    expect(shown).toContain('profile');
+    expect(shown).not.toContain('signin');
+  });
+
+  it('shows anonymous + any tabs to signed-out users', () => {
+    const shown = visibleTabs(TABS, false).map((t) => t.id);
+    expect(shown).toContain('home');
+    expect(shown).toContain('signin');
+    expect(shown).not.toContain('profile');
+  });
+});
+
+describe('getActiveTabId', () => {
+  it('matches the home tab only on the exact root path', () => {
+    expect(getActiveTabId('/', TABS)).toBe('home');
+    // A deeper path must not collapse back to 'home' just because every
+    // pathname starts with '/'.
+    expect(getActiveTabId('/profile', TABS)).not.toBe('home');
+  });
+
+  it('matches a tab on its exact path', () => {
+    expect(getActiveTabId('/profile', TABS)).toBe('profile');
+  });
+
+  it('matches a tab on a sub-path of its declared match', () => {
+    expect(getActiveTabId('/profile/languages', TABS)).toBe('profile');
+  });
+
+  it('returns null for a pathname no tab claims', () => {
+    expect(getActiveTabId('/nowhere', TABS)).toBeNull();
+  });
+
+  it('prefers the longer prefix when multiple tabs match', () => {
+    const custom: Tab[] = [
+      { id: 'root', label: 'Root', href: '/', auth: 'any', match: ['/'] },
+      { id: 'admin', label: 'Admin', href: '/admin', auth: 'any', match: ['/admin'] },
+      {
+        id: 'admin-reports',
+        label: 'Reports',
+        href: '/admin/reports',
+        auth: 'any',
+        match: ['/admin/reports'],
+      },
+    ];
+    expect(getActiveTabId('/admin/reports', custom)).toBe('admin-reports');
+    expect(getActiveTabId('/admin/something-else', custom)).toBe('admin');
+  });
+});

--- a/apps/web/src/lib/components/shell/tabs.ts
+++ b/apps/web/src/lib/components/shell/tabs.ts
@@ -1,0 +1,55 @@
+/**
+ * Definition of the top/bottom navigation tabs used by AppShell.
+ *
+ * A single source of truth — adding a new top-level destination (Library,
+ * Groups, Collections, …) means adding an entry here, not editing every
+ * layout file that references navigation.
+ *
+ * `auth`: 'any' shows to everyone, 'authenticated' only to signed-in users,
+ *          'anonymous' only to signed-out users.
+ */
+export type TabAuth = 'any' | 'authenticated' | 'anonymous';
+
+export interface Tab {
+  id: string;
+  label: string;
+  href: string;
+  auth: TabAuth;
+  /** Used for highlighting; a tab is active if the current pathname starts with any of these. */
+  match: string[];
+}
+
+export const TABS: readonly Tab[] = [
+  { id: 'home', label: 'Home', href: '/', auth: 'any', match: ['/'] },
+  {
+    id: 'profile',
+    label: 'Profile',
+    href: '/profile',
+    auth: 'authenticated',
+    match: ['/profile'],
+  },
+  { id: 'signin', label: 'Sign in', href: '/login', auth: 'anonymous', match: ['/login'] },
+];
+
+export function visibleTabs(tabs: readonly Tab[], isAuthenticated: boolean): Tab[] {
+  return tabs.filter((t) => {
+    if (t.auth === 'any') return true;
+    if (t.auth === 'authenticated') return isAuthenticated;
+    return !isAuthenticated;
+  });
+}
+
+export function getActiveTabId(pathname: string, tabs: readonly Tab[]): string | null {
+  // Exact '/' must not match every sub-route; special-case it. Other tabs
+  // use longest-prefix-wins so '/profile/edit' highlights the Profile tab.
+  let best: { id: string; len: number } | null = null;
+  for (const t of tabs) {
+    for (const m of t.match) {
+      const matches = m === '/' ? pathname === '/' : pathname === m || pathname.startsWith(`${m}/`);
+      if (matches && (best === null || m.length > best.len)) {
+        best = { id: t.id, len: m.length };
+      }
+    }
+  }
+  return best?.id ?? null;
+}

--- a/apps/web/src/routes/+layout.server.ts
+++ b/apps/web/src/routes/+layout.server.ts
@@ -1,0 +1,19 @@
+import type { LayoutServerLoad } from './$types';
+
+/**
+ * Layout-level loader so every page gets the current user without each
+ * +page.server.ts needing to re-pick it off locals. Kept to a small,
+ * serializable shape — anything touching secret fields must still go
+ * through requireUser on a per-route basis.
+ */
+export const load: LayoutServerLoad = ({ locals }) => {
+  if (!locals.user) return { user: null };
+  return {
+    user: {
+      id: locals.user.id,
+      email: locals.user.email,
+      displayName: locals.user.displayName,
+      role: locals.user.role,
+    },
+  };
+};

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
   import '$lib/styles/tokens.css';
-  let { children } = $props();
+  import AppShell from '$lib/components/shell/AppShell.svelte';
+  import type { LayoutData } from './$types';
+
+  let { data, children }: { data: LayoutData; children: import('svelte').Snippet } = $props();
 </script>
 
-{@render children()}
+<AppShell user={data.user}>
+  {@render children()}
+</AppShell>

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -3,7 +3,7 @@
   let { data }: { data: PageData } = $props();
 </script>
 
-<main>
+<div class="page">
   <h1>CIA Reader</h1>
   <p class="sub">Comparative Indo-Aryan — a LingQ-style reader for Hindi, Marathi, and Odia.</p>
 
@@ -55,10 +55,10 @@
       <a href="/api/v1/smoke">GET /api/v1/smoke</a> — end-to-end web → NLP round-trip.
     </p>
   </section>
-</main>
+</div>
 
 <style>
-  main {
+  .page {
     max-width: 48rem;
     margin: 0 auto;
     padding: 2rem 1.25rem;

--- a/apps/web/src/routes/layout-server.test.ts
+++ b/apps/web/src/routes/layout-server.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+
+import { load } from './+layout.server.js';
+
+type LoadEvent = Parameters<typeof load>[0];
+
+describe('root +layout.server.ts load', () => {
+  it('returns a null user when nobody is signed in', async () => {
+    const data = await load({ locals: {} } as unknown as LoadEvent);
+    expect(data).toEqual({ user: null });
+  });
+
+  it('serializes only the four public user fields when signed in', async () => {
+    const data = await load({
+      locals: {
+        user: {
+          id: 'u1',
+          email: 'a@b.c',
+          displayName: 'Alex',
+          role: 'user',
+          // Fields that must NOT leak via the layout loader — these live on
+          // the full User type but are not safe to send to every page.
+          passwordHash: 'secret',
+          themePreference: 'dark',
+        },
+      },
+    } as unknown as LoadEvent);
+    if (!data) throw new Error('load returned void');
+    expect(data.user).toEqual({
+      id: 'u1',
+      email: 'a@b.c',
+      displayName: 'Alex',
+      role: 'user',
+    });
+  });
+});

--- a/apps/web/src/routes/page-server.test.ts
+++ b/apps/web/src/routes/page-server.test.ts
@@ -20,10 +20,16 @@ describe('root +page.server.ts load', () => {
     vi.resetModules();
   });
 
+  async function callLoad(locals: Record<string, unknown>) {
+    const { load } = await import('./+page.server.js');
+    const data = await load({ locals } as unknown as Parameters<typeof load>[0]);
+    if (!data) throw new Error('load returned void');
+    return data;
+  }
+
   it("reports NLP 'ok' and lists supported languages when healthy", async () => {
     health.mockResolvedValue({ status: 'ok', languages: ['hi', 'mr', 'or'] });
-    const { load } = await import('./+page.server.js');
-    const data = await load({ locals: {} } as Parameters<typeof load>[0]);
+    const data = await callLoad({});
     expect(data.nlpStatus).toBe('ok');
     expect(data.nlpLanguages).toEqual(['hi', 'mr', 'or']);
     expect(data.languages.map((l: { code: string }) => l.code).sort()).toEqual(['hi', 'mr', 'or']);
@@ -36,20 +42,16 @@ describe('root +page.server.ts load', () => {
 
   it('pass-throughs the authenticated user when locals.user is set', async () => {
     health.mockResolvedValue({ status: 'ok', languages: ['hi', 'mr', 'or'] });
-    const { load } = await import('./+page.server.js');
-    const data = await load({
-      locals: {
-        user: { id: 'u1', email: 'a@b.c', displayName: 'Alex', role: 'user' },
-      },
-    } as unknown as Parameters<typeof load>[0]);
+    const data = await callLoad({
+      user: { id: 'u1', email: 'a@b.c', displayName: 'Alex', role: 'user' },
+    });
     expect(data.user).toMatchObject({ id: 'u1', email: 'a@b.c' });
   });
 
   it("reports NLP 'down' (not a thrown error) when the health check rejects", async () => {
     health.mockRejectedValue(new Error('connect ECONNREFUSED'));
     vi.spyOn(console, 'error').mockImplementation(() => {});
-    const { load } = await import('./+page.server.js');
-    const data = await load({ locals: {} } as Parameters<typeof load>[0]);
+    const data = await callLoad({});
     expect(data.nlpStatus).toBe('down');
     expect(data.nlpLanguages).toEqual([]);
   });

--- a/apps/web/src/routes/profile/+page.svelte
+++ b/apps/web/src/routes/profile/+page.svelte
@@ -22,7 +22,7 @@
   <title>Profile — CIA Reader</title>
 </svelte:head>
 
-<main>
+<div class="page">
   <h1>Profile</h1>
 
   <section>
@@ -112,10 +112,10 @@
       </form>
     {/each}
   </section>
-</main>
+</div>
 
 <style>
-  main {
+  .page {
     max-width: 48rem;
     margin: 0 auto;
     padding: 2rem 1.25rem;

--- a/apps/web/src/routes/profile/profile-server.test.ts
+++ b/apps/web/src/routes/profile/profile-server.test.ts
@@ -83,6 +83,7 @@ describe('profile +page.server.ts', () => {
           },
         },
       } as unknown as LoadEvent);
+      if (!data) throw new Error('load returned void');
       expect(data.user?.id).toBe('u1');
       expect(data.languages).toHaveLength(1);
       expect(data.languages[0]?.code).toBe('hi');


### PR DESCRIPTION
Introduces a single AppShell component used by every page via the root layout. Desktop: sticky top bar with horizontal tab links. Mobile (≤640px): the top-bar links collapse; a fixed bottom tab bar takes over, respecting safe-area-inset-bottom for notched devices. Every interactive tab hits the 44px touch-target token.

Navigation is defined in one place (tabs.ts):
  - TABS: declarative list with per-tab auth visibility (any / authenticated / anonymous) and longest-prefix match rules.
  - visibleTabs() filters by signed-in state.
  - getActiveTabId() picks the active tab via longest-prefix match, with '/' treated as exact so deeper paths don't all collapse to Home.

+layout.server.ts now serializes a minimal public-user shape (id, email, displayName, role) so the shell knows who's signed in without each page re-reading locals.user. Secret fields (password hash, refresh tokens) are deliberately stripped — test enforces this shape.

Tests cover the two pure helpers (tab visibility + active-tab matching) and the layout loader's output shape. Existing page/profile server tests updated for SvelteKit's widened PageData type inference triggered by the layout loader (the `data?` optional-chain narrowing requires explicit non-void assertion in test code).