### PR TITLE
Reader: static word panel on desktop, locked-word outline + tooltip

### DIFF
--- a/apps/web/src/lib/components/overlay/Sheet.svelte
+++ b/apps/web/src/lib/components/overlay/Sheet.svelte
@@ -46,8 +46,13 @@
   let trap: FocusTrap | null = null;
   let releaseScroll: (() => void) | null = null;
 
+  // Modal-ish behaviour (focus trap + body-scroll lock) only kicks in
+  // for dimmed sheets. Undimmed sheets are contextual side panels —
+  // the page behind stays interactive, so trapping focus inside the
+  // sheet or freezing the scroll position would actively get in the
+  // user's way.
   $effect(() => {
-    if (!open) {
+    if (!open || !dimmed) {
       trap?.deactivate();
       trap = null;
       releaseScroll?.();
@@ -160,15 +165,22 @@
       animation: slide-up 220ms cubic-bezier(0.2, 0, 0, 1);
     }
   }
-  /* Side-sheet layout (desktop / wide). */
+  /* Side-sheet layout (desktop / wide). The reader's word panel sits
+     below the page's top bar via `--reader-top-h`; pages without a
+     top bar leave the variable unset and the sheet hugs the top. */
   @media (min-width: 960px) {
     .sheet {
-      top: 0;
+      top: var(--reader-top-h, 0px);
       right: 0;
       bottom: 0;
       width: var(--sheet-width);
       box-shadow: -8px 0 32px rgba(0, 0, 0, 0.18);
       border-radius: 0;
+    }
+    /* Slide-in only animates for modal-style (dimmed) sheets. The
+       static word panel just appears in place — animating an
+       always-on column would feel jittery on every reload. */
+    .sheet-back.dimmed .sheet {
       animation: slide-in-right 220ms cubic-bezier(0.2, 0, 0, 1);
     }
   }

--- a/apps/web/src/lib/components/reader/ChapterBody.svelte
+++ b/apps/web/src/lib/components/reader/ChapterBody.svelte
@@ -118,16 +118,12 @@
 
   // Accepts both MouseEvent (mouseover) and FocusEvent (focusin) so
   // the tooltip surfaces for pointer hovers AND keyboard tabbing.
+  // We deliberately keep showing the tooltip for the locked word —
+  // the user might want a quick re-read of the gloss without taking
+  // their eyes off the chapter to read the side panel.
   function showHoverTooltip(event: Event) {
     const found = findToken(event.target as HTMLElement);
     if (!found) {
-      hoverToken = null;
-      hoverRect = null;
-      return;
-    }
-    // Skip the tooltip when the side panel is locked on the same
-    // word — redundant.
-    if (activeToken && activeToken.id === found.token.id) {
       hoverToken = null;
       hoverRect = null;
       return;
@@ -194,6 +190,7 @@
         {#each paragraph as token (token.id)}<TokenSpan
             {token}
             {showRomanization}
+            isAnchor={activeToken?.id === token.id}
           />{/each}
       </p>
     {/each}
@@ -212,15 +209,17 @@
   <WordTooltip token={hoverToken} anchorRect={hoverRect} />
 {/if}
 
-{#if activeToken && activeRect}
-  <WordPopup
-    token={activeToken}
-    anchorRect={activeRect}
-    {isOwner}
-    onClose={closePopup}
-    {onStatusChange}
-  />
-{/if}
+<!-- WordPopup mounts unconditionally so the side panel can stay
+     visible on desktop even before the user picks a word. The popup
+     itself decides whether to render its full body or an empty-state
+     prompt based on whether `token` is null. -->
+<WordPopup
+  token={activeToken}
+  anchorRect={activeRect ?? undefined}
+  {isOwner}
+  onClose={closePopup}
+  {onStatusChange}
+/>
 
 <style>
   /* Inherit font-size + line-height from the reader's content rule

--- a/apps/web/src/lib/components/reader/TokenSpan.svelte
+++ b/apps/web/src/lib/components/reader/TokenSpan.svelte
@@ -19,7 +19,15 @@
   let {
     token,
     showRomanization = false,
-  }: { token: ServerToken; showRomanization?: boolean } = $props();
+    isAnchor = false,
+  }: {
+    token: ServerToken;
+    showRomanization?: boolean;
+    /** True when this token is the one currently locked in the side
+     *  panel — gets an outline so the user remembers which word the
+     *  panel is bound to. */
+    isAnchor?: boolean;
+  } = $props();
 
   // OOV tokens get a distinct visual state (T-5.4a) — dashed
   // underline rather than the known/unknown highlight, so the user
@@ -30,6 +38,7 @@
     const classes: string[] = ['word'];
     if (token.isOov) classes.push('oov');
     if (token.isAmbiguous) classes.push('ambiguous');
+    if (isAnchor) classes.push('anchor');
     return classes.join(' ');
   });
 
@@ -89,5 +98,13 @@
     margin-left: 0.05em;
     vertical-align: super;
     font-size: 0.7em;
+  }
+  /* Anchor: the word currently locked in the side panel. Outline
+     instead of fill so the user can still see the underlying status
+     tint underneath. */
+  .word.anchor {
+    outline: 2px solid var(--accent, var(--color-accent));
+    outline-offset: 1px;
+    border-radius: 3px;
   }
 </style>

--- a/apps/web/src/lib/components/reader/WordPopup.svelte
+++ b/apps/web/src/lib/components/reader/WordPopup.svelte
@@ -55,13 +55,16 @@
   // anchorRect is accepted but unused — anchor positioning was used
   // before T-5.10 switched to Sheet. Kept on the prop signature for
   // backward compat with callers that still pass it.
+  // `token` is nullable now: the side panel renders unconditionally
+  // on desktop (static layout) and shows an empty-state prompt when
+  // the user hasn't picked a word yet.
   let {
     token,
     isOwner,
     onClose,
     onStatusChange,
   }: {
-    token: ServerToken;
+    token: ServerToken | null;
     anchorRect?: { top: number; left: number; bottom: number; right: number };
     isOwner: boolean;
     onClose: () => void;
@@ -75,9 +78,22 @@
   let loadError = $state<string | null>(null);
   let showAlternates = $state(false);
   let optimisticStatus = $state<'unknown' | 'learning' | 'known' | 'ignored'>(
-    untrack(() => token.status),
+    untrack(() => token?.status ?? 'unknown'),
   );
   let writeError = $state<string | null>(null);
+
+  // Desktop (>=960px) shows the panel as a static right column —
+  // always rendered. Mobile slides it up only when a word is active.
+  let isDesktop = $state(false);
+  $effect(() => {
+    if (typeof window === 'undefined') return;
+    const mq = window.matchMedia('(min-width: 960px)');
+    const apply = () => (isDesktop = mq.matches);
+    apply();
+    mq.addEventListener('change', apply);
+    return () => mq.removeEventListener('change', apply);
+  });
+  const sheetOpen = $derived(isDesktop || token !== null);
 
   // Re-fetch translations whenever the token prop changes. `$effect`
   // runs the body each time `token` (and thus `token.id` / `lemmaId`)
@@ -86,6 +102,12 @@
   // instead of leaving the old one stuck.
   $effect(() => {
     const t = token;
+    if (!t) {
+      payload = null;
+      loadError = null;
+      optimisticStatus = 'unknown';
+      return;
+    }
     optimisticStatus = t.status;
     if (!t.lemmaId) {
       payload = null;
@@ -116,7 +138,7 @@
   });
 
   function handleKeydown(e: KeyboardEvent) {
-    if (!isOwner || !token.lemmaId) return;
+    if (!isOwner || !token?.lemmaId) return;
     // T-5.21: skip the k/l/i shortcuts whenever the user is typing
     // into a form field — otherwise typing 'l' in the add-translation
     // textarea would silently flip the lemma to learning.
@@ -192,7 +214,7 @@
     body: string,
     parentTranslationId: string | null,
   ): Promise<PublicTranslation> {
-    if (!token.lemmaId) throw new Error('Missing lemma id');
+    if (!token || !token.lemmaId) throw new Error('Missing lemma id');
     const res = await fetch('/api/v1/translations', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -237,7 +259,7 @@
   }
 
   async function submitNewTranslation() {
-    if (!token.lemmaId) return;
+    if (!token || !token.lemmaId) return;
     const trimmed = newTranslationBody.trim();
     if (trimmed.length === 0) {
       addError = 'Translation cannot be empty.';
@@ -292,7 +314,7 @@
   }
 
   async function submitCustomize() {
-    if (!customizingId || !token.lemmaId) return;
+    if (!customizingId || !token || !token.lemmaId) return;
     const trimmed = customizeBody.trim();
     if (trimmed.length === 0) {
       customizeError = 'Translation cannot be empty.';
@@ -316,7 +338,7 @@
   async function markStatus(
     status: 'unknown' | 'learning' | 'known' | 'ignored',
   ) {
-    if (!token.lemmaId) return;
+    if (!token || !token.lemmaId) return;
     const lemmaId = token.lemmaId;
     const previous = optimisticStatus;
     optimisticStatus = status;
@@ -341,20 +363,27 @@
 <svelte:window onkeydown={handleKeydown} />
 
 <!-- T-5.17: dimmed=false so the reader paragraph remains readable
-     while a word is locked in the panel. -->
-<Sheet open={true} onClose={onClose} title="" dimmed={false}>
-  <div data-testid="word-popup">
-    <header class="sp-head">
-      <button
-        type="button"
-        class="sp-close"
-        aria-label="Close"
-        title="Close"
-        onclick={onClose}
-      >
-        ×
-      </button>
-      <h2 class="sp-word">{token.surface}</h2>
+     while a word is locked in the panel.
+     The panel is always open on desktop (static right column) and
+     conditional on mobile (slides up only when a word is picked). -->
+<Sheet open={sheetOpen} onClose={onClose} title="" dimmed={false}>
+  {#if !token}
+    <div class="sp-empty" data-testid="word-popup-empty">
+      <p>Click a word to see its definition.</p>
+    </div>
+  {:else}
+    <div data-testid="word-popup">
+      <header class="sp-head">
+        <button
+          type="button"
+          class="sp-close"
+          aria-label="Close"
+          title="Close"
+          onclick={onClose}
+        >
+          ×
+        </button>
+        <h2 class="sp-word">{token.surface}</h2>
       {#if token.romanization}
         <p class="sp-roman">{token.romanization}</p>
       {/if}
@@ -554,10 +583,18 @@
         </p>
       {/if}
     {/if}
-  </div>
+    </div>
+  {/if}
 </Sheet>
 
 <style>
+  .sp-empty {
+    color: var(--ink-3, var(--color-fg-muted));
+    font-size: 0.85rem;
+    font-style: italic;
+    text-align: center;
+    padding: 1.5rem 0.5rem;
+  }
   .sp-head {
     position: relative;
     margin-bottom: 0.85rem;

--- a/apps/web/src/lib/components/shell/AppShell.svelte
+++ b/apps/web/src/lib/components/shell/AppShell.svelte
@@ -389,10 +389,7 @@
     text-overflow: ellipsis;
   }
 
-  /* —— Rail (desktop only) ——
-     The rail sits below any page-level top bar via `--reader-top-h`,
-     a CSS var the reader sets to its top-bar height. Pages that don't
-     have a top bar leave the var unset and the rail goes top:0. */
+  /* —— Rail (desktop only) —— */
   .rail {
     grid-area: rail;
     display: none;
@@ -406,8 +403,8 @@
       var(--paper-2, transparent)
     );
     position: sticky;
-    top: var(--reader-top-h, 0px);
-    height: calc(100dvh - var(--reader-top-h, 0px));
+    top: 0;
+    height: 100dvh;
   }
   @media (min-width: 960px) {
     .rail {

--- a/apps/web/src/routes/reader/[textId]/+page.svelte
+++ b/apps/web/src/routes/reader/[textId]/+page.svelte
@@ -362,31 +362,34 @@
     color: var(--ink, var(--color-fg));
     /* Fill the AppShell's content track so page mode can occupy the
        full vertical space (T-5.23). Children flex-stack vertically:
-       fluid body and progress foot — the top bar is fixed across the
-       whole viewport, so the body just needs the matching padding. */
+       sticky top bar, fluid body, and progress foot. */
     min-height: 100dvh;
     display: flex;
     flex-direction: column;
-    padding-top: var(--reader-top-h, 0px);
+  }
+  /* The word side-panel is a permanent right column on desktop. Pad
+     the reader so its chapter, header, and progress strip never run
+     behind it. The panel width comes from Sheet's --sheet-width
+     (default 380px). */
+  @media (min-width: 960px) {
+    .reader {
+      padding-right: 380px;
+    }
   }
   /* Page mode is meant to behave like a book — no vertical scroll;
-     overflow stays inside the viewport, page arrows step through it.
-     Hard-cap the height so the inner flex chain (.reader-page-wrap →
-     .reader-page-viewport with overflow:hidden) actually constrains
-     the content, instead of letting min-height grow with it. */
+     overflow stays inside the viewport, page arrows step through it. */
   .reader[data-mode='page'] {
     height: 100dvh;
     min-height: 0;
     overflow: hidden;
   }
-  /* Full-viewport top bar so the rail sits below it (rail reads the
-     same `--reader-top-h` variable to know how much room to leave). */
+  /* The top bar lives inside the reader's right column (sticky inside
+     the AppShell content track, not over the rail). The right side
+     panel reads `--reader-top-h` to anchor below it. */
   .reader-top {
-    position: fixed;
+    position: sticky;
     top: 0;
-    left: 0;
-    right: 0;
-    z-index: 20;
+    z-index: 5;
     display: grid;
     grid-template-columns: 1fr;
     gap: 0.5rem 1rem;


### PR DESCRIPTION
The previous PR pass moved the LEFT rail down beneath the top bar. That was the wrong sidebar — the rail belongs at top:0; only the RIGHT word panel needed pushing down so it doesn't cover the chapter title + mode tabs. Revert the rail and full-width-top-bar changes.

The right panel now stays visible permanently on desktop (>=960px):
* WordPopup mounts unconditionally; `token` is nullable and an empty state ('Click a word to see its definition.') renders when no word is picked yet.
* sheetOpen = isDesktop || token !== null. Mobile keeps the slide-up on word click; desktop keeps the panel docked.
* Sheet's side-panel layout anchors below the top bar via the existing `--reader-top-h` variable, and skips the slide-in animation when undimmed (the column is always there — animating it would jitter on every page change).
* Sheet only locks scroll + traps focus when dimmed; an undimmed contextual side panel shouldn't freeze the page behind it.
* Reader gets `padding-right: 380px` on desktop so the chapter, header, and progress strip don't run behind the panel.

Hovering the locked word now still surfaces the tooltip — useful when the user wants a quick gloss read without taking their eyes off the chapter. The locked word also gets a 2px accent outline via a new `isAnchor` prop on TokenSpan so it stays findable while the panel is bound to it.