### PR TITLE
T-7.4: share-with-group flow

### DIFF
--- a/apps/web/src/lib/server/texts/sharing.ts
+++ b/apps/web/src/lib/server/texts/sharing.ts
@@ -13,7 +13,12 @@
 import { and, eq } from 'drizzle-orm';
 
 import { db, schema } from '../db/index.js';
-import type { Text, TextShare, User } from '../db/schema.js';
+import type {
+  Text,
+  TextGroupShare,
+  TextShare,
+  User,
+} from '../db/schema.js';
 
 export class TextShareError extends Error {
   constructor(
@@ -129,6 +134,96 @@ export async function listTextShares(
     .select()
     .from(schema.textShares)
     .where(eq(schema.textShares.textId, textId))) as TextShare[];
+  return rows;
+}
+
+export type GroupShareInput = {
+  textId: string;
+  groupId: string;
+  actor: Pick<User, 'id' | 'role'>;
+};
+
+/**
+ * T-7.4: grant a group access to a text. Owner-or-admin only on
+ * the text. We don't require the actor to be a member of the
+ * target group — sharing TO a group is a one-way grant; they
+ * don't need to be inside the group to share with it.
+ */
+export async function grantTextGroupShare(
+  input: GroupShareInput,
+): Promise<TextGroupShare> {
+  const text = await loadText(input.textId);
+  if (!text) throw new TextShareError('text not found', 404);
+  if (!canManageShares(text, input.actor)) {
+    throw new TextShareError('only the owner can share', 403);
+  }
+  // Verify the group exists.
+  const [group] = (await db
+    .select({ id: schema.groups.id })
+    .from(schema.groups)
+    .where(eq(schema.groups.id, input.groupId))
+    .limit(1)) as Array<{ id: string }>;
+  if (!group) throw new TextShareError('group not found', 404);
+
+  const now = new Date();
+  const [row] = await db
+    .insert(schema.textGroupShares)
+    .values({
+      textId: input.textId,
+      groupId: input.groupId,
+      grantedById: input.actor.id,
+      createdAt: now,
+    })
+    .onConflictDoUpdate({
+      target: [
+        schema.textGroupShares.textId,
+        schema.textGroupShares.groupId,
+      ],
+      set: { grantedById: input.actor.id },
+    })
+    .returning();
+  if (!row) throw new TextShareError('insert returned no row');
+
+  if (text.visibility === 'private') {
+    await db
+      .update(schema.texts)
+      .set({ visibility: 'shared', updatedAt: now })
+      .where(eq(schema.texts.id, input.textId));
+  }
+  return row as TextGroupShare;
+}
+
+export async function revokeTextGroupShare(
+  input: GroupShareInput,
+): Promise<void> {
+  const text = await loadText(input.textId);
+  if (!text) throw new TextShareError('text not found', 404);
+  if (!canManageShares(text, input.actor)) {
+    throw new TextShareError('only the owner can revoke', 403);
+  }
+  await db
+    .delete(schema.textGroupShares)
+    .where(
+      and(
+        eq(schema.textGroupShares.textId, input.textId),
+        eq(schema.textGroupShares.groupId, input.groupId),
+      ),
+    );
+}
+
+export async function listTextGroupShares(
+  textId: string,
+  actor: Pick<User, 'id' | 'role'>,
+): Promise<TextGroupShare[]> {
+  const text = await loadText(textId);
+  if (!text) throw new TextShareError('text not found', 404);
+  if (!canManageShares(text, actor)) {
+    throw new TextShareError('only the owner can list group shares', 403);
+  }
+  const rows = (await db
+    .select()
+    .from(schema.textGroupShares)
+    .where(eq(schema.textGroupShares.textId, textId))) as TextGroupShare[];
   return rows;
 }
 

--- a/apps/web/src/routes/api/v1/texts/[id]/group-shares/+server.ts
+++ b/apps/web/src/routes/api/v1/texts/[id]/group-shares/+server.ts
@@ -1,0 +1,56 @@
+/**
+ * GET + POST /api/v1/texts/:id/group-shares (T-7.4).
+ *
+ * Owner / admin only. POST { groupId } — grant a group access.
+ */
+import { error, json } from '@sveltejs/kit';
+import { z } from 'zod';
+
+import { requireUser } from '$lib/server/auth/require-user.js';
+import {
+  TextShareError,
+  grantTextGroupShare,
+  listTextGroupShares,
+} from '$lib/server/texts/sharing.js';
+import { parseJson } from '../../../auth/_helpers.js';
+import type { RequestHandler } from './$types';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const postSchema = z
+  .object({ groupId: z.string().regex(UUID_RE) })
+  .strict();
+
+export const GET: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  const id = event.params.id;
+  if (!id || !UUID_RE.test(id)) throw error(400, 'Invalid text id');
+  try {
+    const shares = await listTextGroupShares(id, {
+      id: user.id,
+      role: user.role,
+    });
+    return json({ shares });
+  } catch (e) {
+    if (e instanceof TextShareError) throw error(e.status, e.message);
+    throw e;
+  }
+};
+
+export const POST: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  const id = event.params.id;
+  if (!id || !UUID_RE.test(id)) throw error(400, 'Invalid text id');
+  const body = await parseJson(event.request, postSchema);
+  try {
+    const share = await grantTextGroupShare({
+      textId: id,
+      groupId: body.groupId,
+      actor: { id: user.id, role: user.role },
+    });
+    return json({ share }, { status: 201 });
+  } catch (e) {
+    if (e instanceof TextShareError) throw error(e.status, e.message);
+    throw e;
+  }
+};

--- a/apps/web/src/routes/api/v1/texts/[id]/group-shares/[groupId]/+server.ts
+++ b/apps/web/src/routes/api/v1/texts/[id]/group-shares/[groupId]/+server.ts
@@ -1,0 +1,32 @@
+/**
+ * DELETE /api/v1/texts/:id/group-shares/:groupId (T-7.4).
+ */
+import { error, json } from '@sveltejs/kit';
+
+import { requireUser } from '$lib/server/auth/require-user.js';
+import {
+  TextShareError,
+  revokeTextGroupShare,
+} from '$lib/server/texts/sharing.js';
+import type { RequestHandler } from './$types';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const DELETE: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  const id = event.params.id;
+  const groupId = event.params.groupId;
+  if (!id || !UUID_RE.test(id)) throw error(400, 'Invalid text id');
+  if (!groupId || !UUID_RE.test(groupId)) throw error(400, 'Invalid group id');
+  try {
+    await revokeTextGroupShare({
+      textId: id,
+      groupId,
+      actor: { id: user.id, role: user.role },
+    });
+    return json({ ok: true });
+  } catch (e) {
+    if (e instanceof TextShareError) throw error(e.status, e.message);
+    throw e;
+  }
+};


### PR DESCRIPTION
> Stacked on #278 (T-7.3).

## Summary

Service + endpoints to grant a group access to a text, building on T-7.3's \`text_group_shares\` table.

\`grantTextGroupShare\` is owner-or-admin only on the text; it doesn't require the actor to be a member of the target group (sharing TO a group is a one-way grant). Promotes \`private → shared\` as a side effect. \`canReadText\` already consults \`viewerHasGroupShare\` from T-7.3, so the share takes effect for every member of the granted group immediately.

Endpoints: \`GET\` / \`POST /api/v1/texts/:id/group-shares\`, \`DELETE /api/v1/texts/:id/group-shares/:groupId\`.

Closes #70.

## Test plan
- 817 tests pass; typecheck + lint clean.