### PR TITLE
T-7.5: shared-with-you library tab

### DIFF
--- a/apps/web/src/lib/server/texts/library.test.ts
+++ b/apps/web/src/lib/server/texts/library.test.ts
@@ -32,9 +32,17 @@ const selectFn = vi.fn(() => {
   return makeSelectChain();
 });
 
+// T-7.5: listSharedTexts uses db.execute(sql`…`) for the
+// shared-id union. Test stub returns the next staged result.
+const executeFn = vi.fn(async () => {
+  calls.push({ kind: 'select' });
+  return staged.shift() ?? [];
+});
+
 vi.mock('../db/index.js', () => ({
   db: {
     select: () => selectFn(),
+    execute: (...a: unknown[]) => executeFn(...(a as [])),
   },
   schema: {
     texts: {
@@ -117,12 +125,24 @@ describe('listOwnedTexts', () => {
 });
 
 describe('listSharedTexts', () => {
-  it('returns an empty page (M7 not yet wired)', async () => {
+  it('returns an empty page when the viewer has no share rows', async () => {
+    // Single SELECT against the share-tables UNION → no ids.
+    stage([]);
     const page = await listSharedTexts({ id: 'user-1' });
     expect(page.cards).toEqual([]);
     expect(page.totalCount).toBe(0);
-    // No DB hit at all in the stub.
-    expect(calls).toHaveLength(0);
+    // No follow-up SELECT against the texts table when the union
+    // returned 0 ids.
+    expect(calls).toHaveLength(1);
+  });
+
+  it('returns the texts the viewer has direct or group access to', async () => {
+    stage([{ id: 't1' }, { id: 't2' }]); // share-id union
+    stage([{ count: 2 }]); // count
+    stage([textRow({ id: 't1' }), textRow({ id: 't2' })]); // rows
+    const page = await listSharedTexts({ id: 'user-1' });
+    expect(page.totalCount).toBe(2);
+    expect(page.cards.map((c) => c.id)).toEqual(['t1', 't2']);
   });
 });
 

--- a/apps/web/src/lib/server/texts/library.ts
+++ b/apps/web/src/lib/server/texts/library.ts
@@ -106,16 +106,71 @@ export async function listOwnedTexts(
 }
 
 /**
- * Texts shared with the viewer (T-7.x). Until those sharing tables
- * land, we return an empty page so the library tab renders without a
- * special-case "M7 not implemented yet" branch in the UI.
+ * Texts shared with the viewer (T-7.5). Combines direct shares
+ * (text_shares) with group shares (text_group_shares ↔
+ * group_memberships). Excludes texts the viewer owns themselves —
+ * those land in "Your texts."
+ *
+ * Implementation: a UNION inside a subquery that surfaces every
+ * text id the viewer can read via either path; the outer SELECT
+ * pulls the canonical text rows and counts.
  */
 export async function listSharedTexts(
-  _viewer: Pick<User, 'id'>,
-  opts: { limit?: number; offset?: number } = {},
+  viewer: Pick<User, 'id'>,
+  opts: { limit?: number; offset?: number; language?: LanguageCode } = {},
 ): Promise<ListPage> {
   const { limit, offset } = clampPage(opts);
-  return { cards: [], totalCount: 0, limit, offset };
+  // Find the set of text ids visible to the viewer through sharing.
+  const idsRows = (await db.execute(sql<{ id: string }>`
+    SELECT DISTINCT id FROM (
+      SELECT text_id AS id FROM text_shares
+       WHERE shared_with_user_id = ${viewer.id}
+      UNION
+      SELECT tgs.text_id AS id
+        FROM text_group_shares tgs
+        INNER JOIN group_memberships gm ON gm.group_id = tgs.group_id
+       WHERE gm.user_id = ${viewer.id}
+    ) AS shared_ids
+  `)) as unknown as Array<{ id: string }> | { rows: Array<{ id: string }> };
+  const ids = (Array.isArray(idsRows) ? idsRows : (idsRows.rows ?? [])).map(
+    (r) => r.id,
+  );
+  if (ids.length === 0) {
+    return { cards: [], totalCount: 0, limit, offset };
+  }
+
+  const conditions = [
+    sql`${schema.texts.id} IN (${sql.join(
+      ids.map((id) => sql`${id}`),
+      sql`, `,
+    )})`,
+    sql`${schema.texts.ownerId} IS DISTINCT FROM ${viewer.id}`,
+  ];
+  if (opts.language) {
+    conditions.push(eq(schema.texts.language, opts.language));
+  }
+  const where = and(...conditions);
+
+  const countRows = (await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(schema.texts)
+    .where(where)) as Array<{ count: number }>;
+  const count = countRows[0]?.count ?? 0;
+
+  const rows = (await db
+    .select()
+    .from(schema.texts)
+    .where(where)
+    .orderBy(desc(schema.texts.createdAt))
+    .limit(limit)
+    .offset(offset)) as Text[];
+
+  return {
+    cards: rows.map(projectCard),
+    totalCount: count,
+    limit,
+    offset,
+  };
 }
 
 /**


### PR DESCRIPTION
> Stacked on #285 (T-7.4).

## Summary

\`listSharedTexts()\` previously returned an empty page; now it does the real query — UNION over \`text_shares\` (direct) and \`text_group_shares ⨝ group_memberships\` (group), excluding texts the viewer owns themselves.

The library page already had a "Shared with you" tab (T-4.5) rendering an empty state — this PR is what makes it actually populate.

Closes #71.

## Test plan
- 818 tests pass; new \`listSharedTexts\` cases cover empty + populated paths.
- typecheck + lint clean.