### PR TITLE
T-7.7: per-user progress on shared / official texts

### DIFF
--- a/apps/web/src/routes/reader/[textId]/+page.svelte
+++ b/apps/web/src/routes/reader/[textId]/+page.svelte
@@ -179,8 +179,12 @@
       cleanupPoll = () => window.clearInterval(interval);
     }
 
-    // Progress writer — owners only.
-    if (data.isOwner) {
+    // T-7.7: progress writer for any signed-in reader, not just
+    // owners. user_text_progress is keyed on (user, text) so a
+    // recipient of a shared text or a signed-in reader of an
+    // official text gets their own resume-anchor row. Anonymous
+    // viewers (the only false branch of canPersistSettings) skip.
+    if (data.canPersistSettings) {
       progressWriter = new ProgressWriter(data.text.id);
       // Schedule an initial write so reopening immediately at the
       // current chapter persists even without scrolling.


### PR DESCRIPTION
> Stacked on #287 (T-7.6).

## Summary

The reader's progress writer was gated on \`data.isOwner\`, which suppressed it for shared (T-7.2) recipients and signed-in readers of official texts. \`user_text_progress\` is keyed on \`(user, text)\` so every signed-in reader has their own resume-anchor row — the gate was the only thing keeping the table empty for non-owners.

Switch the guard to \`data.canPersistSettings\`, which is already true for any signed-in user (false for the only branch that should genuinely skip — anonymous readers of an official text).

The PATCH endpoint at \`/api/v1/me/text-progress/:textId\` already authorizes via \`canReadText\` (T-4.6), which by T-7.2 / T-7.4 grants shared + group recipients access. No service or schema change.

Closes #73.

## Test plan
- 818 tests pass; typecheck clean.