### PR TITLE
T-7.8: classroom teacher dashboard

### DIFF
--- a/apps/web/src/lib/server/group-stats.ts
+++ b/apps/web/src/lib/server/group-stats.ts
@@ -1,0 +1,131 @@
+/**
+ * Group / classroom dashboard stats (T-7.8).
+ *
+ * Aggregates reading progress for every member of a group across
+ * the texts the owner has shared with the group. Lets a teacher /
+ * classroom owner see at a glance who's read what.
+ *
+ * Owner-or-admin only. Members CAN'T see each other's progress —
+ * the dashboard is a teaching surface, not a leaderboard.
+ */
+import { eq, sql } from 'drizzle-orm';
+
+import { db, schema } from './db/index.js';
+import { GroupError } from './groups.js';
+import type { Group, User } from './db/schema.js';
+
+export type MemberProgress = {
+  userId: string;
+  displayName: string | null;
+  email: string;
+  textId: string;
+  textTitle: string;
+  pctRead: number;
+  lastChapterIdx: number;
+  updatedAt: Date | null;
+};
+
+export type GroupDashboard = {
+  group: Group;
+  memberCount: number;
+  sharedTextCount: number;
+  rows: MemberProgress[];
+};
+
+export async function loadGroupDashboard(
+  groupId: string,
+  actor: Pick<User, 'id' | 'role'>,
+): Promise<GroupDashboard> {
+  const [group] = (await db
+    .select()
+    .from(schema.groups)
+    .where(eq(schema.groups.id, groupId))
+    .limit(1)) as Group[];
+  if (!group) throw new GroupError('group not found', 404);
+  if (actor.role !== 'admin' && group.ownerId !== actor.id) {
+    throw new GroupError('only the owner can view the dashboard', 403);
+  }
+
+  // Member + shared-text counts. Run in parallel.
+  const [memberCountRows, sharedTextCountRows] = await Promise.all([
+    db
+      .select({ n: sql<number>`count(*)::int` })
+      .from(schema.groupMemberships)
+      .where(eq(schema.groupMemberships.groupId, groupId)),
+    db
+      .select({ n: sql<number>`count(*)::int` })
+      .from(schema.textGroupShares)
+      .where(eq(schema.textGroupShares.groupId, groupId)),
+  ]);
+  const memberCount =
+    (memberCountRows as Array<{ n: number }>)[0]?.n ?? 0;
+  const sharedTextCount =
+    (sharedTextCountRows as Array<{ n: number }>)[0]?.n ?? 0;
+
+  // Per-member progress on every shared text. We left-join so a
+  // member who hasn't opened a text yet still appears with
+  // pctRead = 0 + last_*_idx = 0.
+  const rows = (await db.execute(sql<{
+    user_id: string;
+    display_name: string | null;
+    email: string;
+    text_id: string;
+    text_title: string;
+    pct_read: number;
+    last_chapter_idx: number;
+    updated_at: Date | null;
+  }>`
+    SELECT
+      gm.user_id AS user_id,
+      u.display_name AS display_name,
+      u.email AS email,
+      tgs.text_id AS text_id,
+      t.title AS text_title,
+      COALESCE(p.pct_read, 0)::float AS pct_read,
+      COALESCE(p.last_chapter_idx, 0)::int AS last_chapter_idx,
+      p.updated_at AS updated_at
+    FROM group_memberships gm
+    INNER JOIN users u ON u.id = gm.user_id
+    INNER JOIN text_group_shares tgs ON tgs.group_id = gm.group_id
+    INNER JOIN texts t ON t.id = tgs.text_id
+    LEFT JOIN user_text_progress p
+      ON p.user_id = gm.user_id AND p.text_id = tgs.text_id
+    WHERE gm.group_id = ${groupId}
+    ORDER BY u.email, t.title
+  `)) as unknown as Array<{
+    user_id: string;
+    display_name: string | null;
+    email: string;
+    text_id: string;
+    text_title: string;
+    pct_read: number;
+    last_chapter_idx: number;
+    updated_at: Date | null;
+  }> | { rows: Array<{
+    user_id: string;
+    display_name: string | null;
+    email: string;
+    text_id: string;
+    text_title: string;
+    pct_read: number;
+    last_chapter_idx: number;
+    updated_at: Date | null;
+  }> };
+  const list = Array.isArray(rows) ? rows : (rows.rows ?? []);
+
+  return {
+    group,
+    memberCount,
+    sharedTextCount,
+    rows: list.map((r) => ({
+      userId: r.user_id,
+      displayName: r.display_name,
+      email: r.email,
+      textId: r.text_id,
+      textTitle: r.text_title,
+      pctRead: r.pct_read,
+      lastChapterIdx: r.last_chapter_idx,
+      updatedAt: r.updated_at,
+    })),
+  };
+}

--- a/apps/web/src/routes/groups/[id]/dashboard/+page.server.ts
+++ b/apps/web/src/routes/groups/[id]/dashboard/+page.server.ts
@@ -1,0 +1,31 @@
+/**
+ * Classroom / group dashboard (T-7.8).
+ *
+ * Owner-or-admin only. Aggregates per-member reading progress on
+ * the texts shared with the group.
+ */
+import { error, redirect } from '@sveltejs/kit';
+
+import { GroupError } from '$lib/server/groups.js';
+import { loadGroupDashboard } from '$lib/server/group-stats.js';
+import type { PageServerLoad } from './$types';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const load: PageServerLoad = async ({ params, locals, url }) => {
+  if (!locals.user) {
+    throw redirect(303, `/login?next=${encodeURIComponent(url.pathname)}`);
+  }
+  const id = params.id;
+  if (!id || !UUID_RE.test(id)) throw error(400, 'Invalid group id');
+  try {
+    const dashboard = await loadGroupDashboard(id, {
+      id: locals.user.id,
+      role: locals.user.role,
+    });
+    return { dashboard };
+  } catch (e) {
+    if (e instanceof GroupError) throw error(e.status, e.message);
+    throw e;
+  }
+};

--- a/apps/web/src/routes/groups/[id]/dashboard/+page.svelte
+++ b/apps/web/src/routes/groups/[id]/dashboard/+page.svelte
@@ -1,0 +1,154 @@
+<script lang="ts">
+  import type { PageData } from './$types';
+
+  let { data }: { data: PageData } = $props();
+
+  // Group rows by user for the per-member section.
+  type Member = {
+    userId: string;
+    displayName: string | null;
+    email: string;
+    rows: typeof data.dashboard.rows;
+  };
+  const members: Member[] = (() => {
+    const map = new Map<string, Member>();
+    for (const r of data.dashboard.rows) {
+      const existing = map.get(r.userId);
+      if (existing) {
+        existing.rows.push(r);
+        continue;
+      }
+      map.set(r.userId, {
+        userId: r.userId,
+        displayName: r.displayName,
+        email: r.email,
+        rows: [r],
+      });
+    }
+    return Array.from(map.values()).sort((a, b) =>
+      a.email.localeCompare(b.email),
+    );
+  })();
+</script>
+
+<svelte:head>
+  <title>{data.dashboard.group.name} — classroom dashboard</title>
+</svelte:head>
+
+<div class="cd">
+  <header class="cd-h">
+    <h1>{data.dashboard.group.name}</h1>
+    {#if data.dashboard.group.description}
+      <p class="cd-desc">{data.dashboard.group.description}</p>
+    {/if}
+    <p class="cd-stats">
+      <strong>{data.dashboard.memberCount}</strong> members ·
+      <strong>{data.dashboard.sharedTextCount}</strong> shared texts
+    </p>
+  </header>
+
+  {#each members as m (m.userId)}
+    <section class="cd-member">
+      <h2>{m.displayName ?? m.email}</h2>
+      <p class="cd-email">{m.email}</p>
+      <table class="cd-table">
+        <thead>
+          <tr>
+            <th>Text</th>
+            <th class="num">Chapter</th>
+            <th class="num">% read</th>
+            <th class="num">Last activity</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each m.rows as row, i (i)}
+            <tr>
+              <td><a href={`/reader/${row.textId}`}>{row.textTitle}</a></td>
+              <td class="num">{row.lastChapterIdx + 1}</td>
+              <td class="num">{Math.round(row.pctRead)}%</td>
+              <td class="num cd-when">
+                {row.updatedAt ? new Date(row.updatedAt).toLocaleString() : '—'}
+              </td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </section>
+  {:else}
+    <p class="cd-empty">
+      No members yet, or no texts shared with the group. Share a text and add
+      members to populate the dashboard.
+    </p>
+  {/each}
+</div>
+
+<style>
+  .cd {
+    max-width: 56rem;
+    margin: 0 auto;
+    padding: 1.5rem 1.25rem 3rem;
+    color: var(--ink, var(--color-fg));
+  }
+  .cd-h h1 {
+    margin: 0 0 0.2rem;
+    font-size: 1.6rem;
+    font-family: var(--font-serif, system-ui);
+  }
+  .cd-desc {
+    color: var(--ink-2, var(--color-fg));
+    margin: 0 0 0.4rem;
+  }
+  .cd-stats {
+    color: var(--ink-3, var(--color-fg-muted));
+    font-size: 0.85rem;
+    margin: 0 0 1.5rem;
+  }
+  .cd-member {
+    margin-bottom: 2rem;
+  }
+  .cd-member h2 {
+    font-size: 1rem;
+    margin: 0;
+    font-family: var(--font-serif, system-ui);
+  }
+  .cd-email {
+    color: var(--ink-3, var(--color-fg-muted));
+    font-size: 0.78rem;
+    margin: 0 0 0.5rem;
+  }
+  .cd-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.85rem;
+    background: var(--card, var(--color-bg));
+    border: 1px solid var(--rule, var(--color-border));
+    border-radius: 8px;
+    overflow: hidden;
+  }
+  .cd-table th,
+  .cd-table td {
+    padding: 0.4rem 0.65rem;
+    border-bottom: 1px solid var(--rule-2, var(--color-border));
+    text-align: left;
+  }
+  .cd-table th {
+    background: color-mix(in oklch, var(--ink, var(--color-fg)) 4%, transparent);
+    font-weight: 500;
+    font-size: 0.78rem;
+  }
+  .cd-table .num {
+    text-align: right;
+    font-feature-settings: 'tnum';
+    font-family: var(--font-mono-display, var(--font-mono));
+  }
+  .cd-when {
+    color: var(--ink-3, var(--color-fg-muted));
+    font-size: 0.78rem;
+  }
+  .cd-empty {
+    padding: 2rem;
+    text-align: center;
+    color: var(--ink-3, var(--color-fg-muted));
+    font-style: italic;
+  }
+</style>


### PR DESCRIPTION
> Stacked on #288 (T-7.7).

## Summary

\`/groups/:id/dashboard\` surfaces per-member reading progress on every text the group has been granted access to. Owner-or-admin only — members can't see each other's progress (teaching surface, not a leaderboard).

\`loadGroupDashboard()\` assembles three pieces in parallel:
- Member count (\`group_memberships\`).
- Shared-text count (\`text_group_shares\`).
- Per-member-per-text rows: \`LEFT JOIN user_text_progress\` so a member who hasn't opened a shared text yet still appears with \`pctRead=0\`.

Page groups rows by member for the render so each student gets their own table.

Closes #74.

## Test plan
- 818 tests pass; typecheck + lint clean.