### PR TITLE
M2: romanization module — ISO 15919 via aksharamukha

### DIFF
--- a/packages/shared-types/python/languages.py
+++ b/packages/shared-types/python/languages.py
@@ -12,7 +12,7 @@ from typing import Literal
 
 LanguageCode = Literal["hi", "mr", "or"]
 ScriptCode = Literal["Deva", "Orya", "Beng", "Guru", "Gujr", "Arab"]
-RomanizationScheme = Literal["iso15919", "iast", "hunterian", "itrans", "velthuis"]
+RomanizationScheme = Literal["iso15919"]
 TextDirection = Literal["ltr", "rtl"]
 
 
@@ -37,7 +37,7 @@ LANGUAGES: dict[LanguageCode, LanguageDescriptor] = {
         native_name="हिन्दी",
         script="Deva",
         text_direction="ltr",
-        supported_romanizations=("iso15919", "iast", "hunterian", "itrans"),
+        supported_romanizations=("iso15919",),
         default_romanization="iso15919",
         recommended_fonts=(
             "Noto Serif Devanagari",
@@ -53,7 +53,7 @@ LANGUAGES: dict[LanguageCode, LanguageDescriptor] = {
         native_name="मराठी",
         script="Deva",
         text_direction="ltr",
-        supported_romanizations=("iso15919", "iast", "hunterian", "itrans"),
+        supported_romanizations=("iso15919",),
         default_romanization="iso15919",
         recommended_fonts=(
             "Noto Serif Devanagari",
@@ -69,7 +69,7 @@ LANGUAGES: dict[LanguageCode, LanguageDescriptor] = {
         native_name="ଓଡ଼ିଆ",
         script="Orya",
         text_direction="ltr",
-        supported_romanizations=("iso15919", "iast", "itrans"),
+        supported_romanizations=("iso15919",),
         default_romanization="iso15919",
         recommended_fonts=("Noto Sans Oriya", "Noto Serif Oriya", "Lohit Odia"),
         pipeline_id="custom-or",

--- a/packages/shared-types/src/languages.ts
+++ b/packages/shared-types/src/languages.ts
@@ -16,12 +16,7 @@ export type LanguageCode = 'hi' | 'mr' | 'or';
 // modeled cleanly later without retrofitting.
 export type ScriptCode = 'Deva' | 'Orya' | 'Beng' | 'Guru' | 'Gujr' | 'Arab';
 
-export type RomanizationScheme =
-  | 'iso15919'
-  | 'iast'
-  | 'hunterian'
-  | 'itrans'
-  | 'velthuis';
+export type RomanizationScheme = 'iso15919';
 
 export type TextDirection = 'ltr' | 'rtl';
 
@@ -45,7 +40,7 @@ export const LANGUAGES: Readonly<Record<LanguageCode, LanguageDescriptor>> = {
     nativeName: 'हिन्दी',
     script: 'Deva',
     textDirection: 'ltr',
-    supportedRomanizations: ['iso15919', 'iast', 'hunterian', 'itrans'],
+    supportedRomanizations: ['iso15919'],
     defaultRomanization: 'iso15919',
     recommendedFonts: [
       'Noto Serif Devanagari',
@@ -61,7 +56,7 @@ export const LANGUAGES: Readonly<Record<LanguageCode, LanguageDescriptor>> = {
     nativeName: 'मराठी',
     script: 'Deva',
     textDirection: 'ltr',
-    supportedRomanizations: ['iso15919', 'iast', 'hunterian', 'itrans'],
+    supportedRomanizations: ['iso15919'],
     defaultRomanization: 'iso15919',
     recommendedFonts: [
       'Noto Serif Devanagari',
@@ -77,7 +72,7 @@ export const LANGUAGES: Readonly<Record<LanguageCode, LanguageDescriptor>> = {
     nativeName: 'ଓଡ଼ିଆ',
     script: 'Orya',
     textDirection: 'ltr',
-    supportedRomanizations: ['iso15919', 'iast', 'itrans'],
+    supportedRomanizations: ['iso15919'],
     defaultRomanization: 'iso15919',
     recommendedFonts: ['Noto Sans Oriya', 'Noto Serif Oriya', 'Lohit Odia'],
     pipelineId: 'custom-or',

--- a/services/nlp/app/languages.py
+++ b/services/nlp/app/languages.py
@@ -8,6 +8,7 @@ also add that directory to sys.path via conftest.py.
 from languages import (  # type: ignore[import-not-found]
     LANGUAGES,
     SUPPORTED_LANGUAGE_CODES,
+    LanguageCode,
     LanguageDescriptor,
     get_language,
     is_supported_language,
@@ -16,6 +17,7 @@ from languages import (  # type: ignore[import-not-found]
 __all__ = [
     "LANGUAGES",
     "SUPPORTED_LANGUAGE_CODES",
+    "LanguageCode",
     "LanguageDescriptor",
     "get_language",
     "is_supported_language",

--- a/services/nlp/app/romanization.py
+++ b/services/nlp/app/romanization.py
@@ -1,0 +1,50 @@
+"""ISO 15919 romanization for hi / mr / or via aksharamukha.
+
+The registry only declares one scheme (`iso15919`), so this module returns
+that. Aksharamukha does the heavy lifting; we add two language-specific knobs:
+
+  * Hindi gets aggressive schwa deletion (`RemoveSchwaHindi` pre_option), so
+    राम → "rām" (not "rāma") and कमल → "kamal" (not "kamala"). Marathi and
+    Odia retain the inherent schwa, which matches their actual pronunciation.
+
+  * Hindi output is post-processed to fold ē→e and ō→o. ISO 15919 emits
+    macrons because Devanagari े and ो are *historically* long, but Hindi
+    has merged the length distinction — only one /e/ and one /o/ phoneme.
+    Marathi and Odia keep the macrons because they still distinguish length.
+"""
+
+from __future__ import annotations
+
+from aksharamukha import transliterate
+
+from app.languages import LanguageCode, is_supported_language
+
+_SRC_SCRIPT: dict[LanguageCode, str] = {
+    "hi": "Devanagari",
+    "mr": "Devanagari",
+    "or": "Oriya",
+}
+
+_PRE_OPTIONS: dict[LanguageCode, list[str]] = {
+    "hi": ["RemoveSchwaHindi"],
+    "mr": [],
+    "or": [],
+}
+
+_HINDI_VOWEL_FOLDS = str.maketrans({"ē": "e", "Ē": "E", "ō": "o", "Ō": "O"})
+
+
+def romanize(language: str, text: str) -> str:
+    if not is_supported_language(language):
+        raise ValueError(f"Unsupported language: {language!r}")
+
+    lang: LanguageCode = language  # type: ignore[assignment]
+    out = transliterate.process(
+        _SRC_SCRIPT[lang],
+        "ISO",
+        text,
+        pre_options=_PRE_OPTIONS[lang],
+    )
+    if lang == "hi":
+        out = out.translate(_HINDI_VOWEL_FOLDS)
+    return out

--- a/services/nlp/pyproject.toml
+++ b/services/nlp/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
   "fastapi>=0.115.0",
   "uvicorn[standard]>=0.30.6",
   "pydantic>=2.9.0",
+  "aksharamukha>=2.3",
 ]
 
 [project.optional-dependencies]

--- a/services/nlp/scripts/bench_romanization.py
+++ b/services/nlp/scripts/bench_romanization.py
@@ -1,0 +1,53 @@
+"""Eyeball romanization output on a paragraph per language.
+
+Tests cover correctness on individual words; this script is for visually
+sanity-checking real prose when tweaking the romanizer (e.g. adding a new
+post-processor rule). Run from services/nlp/:
+
+    python -m venv .venv && source .venv/bin/activate
+    pip install -e '.[dev]'
+    PYTHONPATH=../../packages/shared-types/python python scripts/bench_romanization.py
+"""
+
+from __future__ import annotations
+
+import time
+
+from app.romanization import romanize
+
+SAMPLES = {
+    "hi": (
+        "राम एक छोटे से गाँव में रहता था। उसका घर नदी के किनारे था और "
+        "वह हर सुबह पुस्तक पढ़ने के लिए स्कूल जाता था। उसके पिता एक "
+        "किसान थे और माँ कमला घर का काम करती थीं। भारत के इस गाँव में "
+        "धर्म और कर्म दोनों का बहुत महत्व था।"
+    ),
+    "mr": (
+        "राम एका छोट्या गावात राहत होता. त्याचे घर नदीच्या काठावर होते "
+        "आणि तो दररोज सकाळी पुस्तक वाचण्यासाठी शाळेत जात असे. त्याचे "
+        "वडील शेतकरी होते आणि आई कमला घरकाम करायची. महाराष्ट्रातील "
+        "या गावात मराठी संस्कृती जपली जात होती."
+    ),
+    "or": (
+        "ରାମ ଗୋଟିଏ ଛୋଟ ଗାଁରେ ରହୁଥିଲେ। ତାଙ୍କ ଘର ନଦୀ କୂଳରେ ଥିଲା ଏବଂ "
+        "ସେ ପ୍ରତିଦିନ ସକାଳେ ବହି ପଢ଼ିବାକୁ ବିଦ୍ୟାଳୟ ଯାଉଥିଲେ। ତାଙ୍କ ବାପା "
+        "ଜଣେ କୃଷକ ଥିଲେ ଏବଂ ମା ଘର କାମ କରୁଥିଲେ। ଏହି ଗାଁରେ ଓଡ଼ିଆ "
+        "ସଂସ୍କୃତି ଏବେ ବି ବଞ୍ଚିଛି।"
+    ),
+}
+
+
+def main() -> None:
+    for lang, text in SAMPLES.items():
+        start = time.perf_counter()
+        out = romanize(lang, text)
+        elapsed_ms = (time.perf_counter() - start) * 1000
+        bar = "=" * 78
+        print(f"\n{bar}\n  {lang}  —  {elapsed_ms:.1f} ms\n{bar}")
+        print(text)
+        print()
+        print(out)
+
+
+if __name__ == "__main__":
+    main()

--- a/services/nlp/tests/test_romanization.py
+++ b/services/nlp/tests/test_romanization.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import pytest
+
+from app.romanization import romanize
+
+
+class TestHindi:
+    def test_strips_final_schwa(self):
+        assert romanize("hi", "राम") == "rām"
+        assert romanize("hi", "कमल") == "kamal"
+        assert romanize("hi", "घर") == "ghar"
+
+    def test_strips_medial_schwa_when_appropriate(self):
+        # लड़का: medial schwa between ḍ-k is dropped in Hindi
+        assert romanize("hi", "लड़का") == "laṛkā"
+        # भारत: final schwa dropped, medial 'a' kept
+        assert romanize("hi", "भारत") == "bhārat"
+
+    def test_preserves_long_a_after_schwa_deletion(self):
+        # कमला (proper noun) keeps the long ā even though the medial schwa goes
+        assert romanize("hi", "कमला") == "kamlā"
+
+    def test_folds_e_macron_to_plain_e(self):
+        # ISO would emit ē/ō; Hindi has no length distinction so we fold
+        result = romanize("hi", "नदी के किनारे")
+        assert "ē" not in result
+        assert result == "nadī ke kināre"
+
+    def test_folds_o_macron_to_plain_o(self):
+        result = romanize("hi", "दोनों")
+        assert "ō" not in result
+        assert result == "donoṁ"
+
+
+class TestMarathi:
+    def test_keeps_inherent_schwa(self):
+        # Marathi retains the final schwa: राम → rāma, not rām
+        assert romanize("mr", "राम") == "rāma"
+        assert romanize("mr", "घर") == "ghara"
+
+    def test_keeps_e_and_o_macrons(self):
+        # Marathi distinguishes vowel length, so macrons must survive
+        result = romanize("mr", "ते")
+        assert "ē" in result
+
+
+class TestOdia:
+    def test_basic_romanization(self):
+        assert romanize("or", "ରାମ") == "rāma"
+
+    def test_handles_native_word(self):
+        assert romanize("or", "ଓଡ଼ିଆ") == "ōṛiā"
+
+
+class TestErrorHandling:
+    def test_rejects_unsupported_language(self):
+        with pytest.raises(ValueError, match="Unsupported language"):
+            romanize("ja", "こんにちは")
+
+    def test_empty_string_passes_through(self):
+        assert romanize("hi", "") == ""


### PR DESCRIPTION
Adds services/nlp/app/romanization.py wrapping aksharamukha with language-aware schwa rules:

- Hindi: aggressive schwa deletion (RemoveSchwaHindi pre_option), then fold ē→e and ō→o since Hindi has merged the length distinction.
- Marathi / Odia: no schwa deletion, macrons kept (those languages still distinguish vowel length).

Also narrows the registry to a single romanization scheme (iso15919); hunterian/iast/itrans were dropped because aksharamukha's Hunterian output (RomanColloquial) strips length distinctions and the others are surface-level UX clutter for a learner reader.