### PR TITLE
T-8.3: reader next/prev-text awareness

### DIFF
--- a/apps/web/src/routes/reader/[textId]/+page.server.ts
+++ b/apps/web/src/routes/reader/[textId]/+page.server.ts
@@ -24,6 +24,7 @@ import { and, eq } from 'drizzle-orm';
 import { getReadableText } from '$lib/server/texts/upload.js';
 import { loadChapterTokens } from '$lib/server/texts/tokens.js';
 import { getTextProgress } from '$lib/server/texts/progress.js';
+import { readerCollectionContext } from '$lib/server/collections.js';
 import { db, schema } from '$lib/server/db/index.js';
 import type { LanguageCode } from '@ciareader/shared-types';
 import {
@@ -153,6 +154,12 @@ export const load: PageServerLoad = async ({ params, locals, url }) => {
     ? await loadChapterTokens(activeChapter.id, viewerId)
     : null;
 
+  // T-8.3: if this text is a member of a collection, surface the
+  // collection title + prev / next text ids in the reader chrome.
+  // Picks one collection deterministically when the text is in
+  // multiple (collections.updatedAt DESC).
+  const collectionContext = await readerCollectionContext(params.textId);
+
   return {
     text: {
       id: result.text.id,
@@ -189,5 +196,16 @@ export const load: PageServerLoad = async ({ params, locals, url }) => {
     // a session-only live preview.
     canPersistSettings: locals.user != null,
     isOwner: Boolean(locals.user && locals.user.id === result.text.ownerId),
+    collectionContext: collectionContext
+      ? {
+          collectionId: collectionContext.collection.id,
+          collectionTitle: collectionContext.collection.title,
+          collectionKind: collectionContext.collection.kind,
+          position: collectionContext.position,
+          totalCount: collectionContext.totalCount,
+          prevTextId: collectionContext.prevTextId,
+          nextTextId: collectionContext.nextTextId,
+        }
+      : null,
   };
 };

--- a/apps/web/src/routes/reader/[textId]/+page.svelte
+++ b/apps/web/src/routes/reader/[textId]/+page.svelte
@@ -264,6 +264,34 @@
       </svg>
     </a>
     <div class="reader-meta">
+      {#if data.collectionContext}
+        <p class="reader-coll-strip">
+          <a class="reader-coll-link" href={`/collections/${data.collectionContext.collectionId}`}>
+            {data.collectionContext.collectionTitle}
+          </a>
+          <span class="reader-coll-pos">
+            {data.collectionContext.position + 1}/{data.collectionContext.totalCount}
+          </span>
+          <span class="reader-coll-nav">
+            {#if data.collectionContext.prevTextId}
+              <a
+                href={`/reader/${data.collectionContext.prevTextId}`}
+                class="reader-coll-arrow"
+                title="Previous text"
+                aria-label="Previous text in collection"
+              >‹ prev</a>
+            {/if}
+            {#if data.collectionContext.nextTextId}
+              <a
+                href={`/reader/${data.collectionContext.nextTextId}`}
+                class="reader-coll-arrow"
+                title="Next text"
+                aria-label="Next text in collection"
+              >next ›</a>
+            {/if}
+          </span>
+        </p>
+      {/if}
       <h1 class="t">{data.text.title}</h1>
       <p class="a">
         <span class="badge">{data.text.language}</span>
@@ -453,6 +481,42 @@
   }
   .reader-meta {
     min-width: 0;
+  }
+  .reader-coll-strip {
+    margin: 0 0 0.25rem;
+    display: flex;
+    align-items: baseline;
+    gap: 0.55rem;
+    font-size: 0.7rem;
+    color: var(--ink-3, var(--color-fg-muted));
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    flex-wrap: wrap;
+  }
+  .reader-coll-link {
+    color: var(--ink-2, var(--color-fg));
+    text-decoration: none;
+    font-weight: 500;
+  }
+  .reader-coll-link:hover {
+    text-decoration: underline;
+  }
+  .reader-coll-pos {
+    font-family: var(--font-mono-display, var(--font-mono));
+    font-feature-settings: 'tnum';
+  }
+  .reader-coll-nav {
+    display: flex;
+    gap: 0.5rem;
+    margin-left: auto;
+  }
+  .reader-coll-arrow {
+    color: var(--accent, var(--color-accent));
+    text-decoration: none;
+    font-weight: 500;
+  }
+  .reader-coll-arrow:hover {
+    text-decoration: underline;
   }
   .reader-meta .t {
     margin: 0;

--- a/apps/web/src/routes/reader/[textId]/page-server.test.ts
+++ b/apps/web/src/routes/reader/[textId]/page-server.test.ts
@@ -43,6 +43,13 @@ vi.mock('$lib/server/texts/progress.js', async () => {
 // drizzle query chain to return whatever the test stages in
 // `userLanguagesRow`.
 let userLanguagesRow: Record<string, unknown> | null = null;
+// T-8.3: the loader now calls readerCollectionContext. Mock to
+// "no collection" so existing tests stay focused on the reader
+// surface; tests that care can override.
+vi.mock('$lib/server/collections.js', () => ({
+  readerCollectionContext: async () => null,
+}));
+
 vi.mock('$lib/server/db/index.js', () => {
   type ChainShape = {
     from: ReturnType<typeof vi.fn>;


### PR DESCRIPTION
Stacked on #298 (T-8.1). Reader chrome surfaces collection strip + prev/next text links when the active text is in a collection. Closes #78.