### PR TITLE
T-8.6: course-specific affordances

### DIFF
--- a/apps/web/src/routes/collections/[id]/+page.server.ts
+++ b/apps/web/src/routes/collections/[id]/+page.server.ts
@@ -83,6 +83,11 @@ export const load: PageServerLoad = async ({ params, locals }) => {
         progressByTextId[i.text.id]?.lastChapterIdx ?? 0,
     })),
     aggregatedPctRead,
+    // T-8.6: completion stats badge — number of finished texts on
+    // course-kind collections. Counts pctRead >= 100.
+    completedCount: detail.items.filter(
+      (i) => (progressByTextId[i.text.id]?.pctRead ?? 0) >= 100,
+    ).length,
     isOwner,
   };
 };

--- a/apps/web/src/routes/collections/[id]/+page.svelte
+++ b/apps/web/src/routes/collections/[id]/+page.svelte
@@ -117,6 +117,15 @@
         <span class="cd-progress-pct">{data.aggregatedPctRead}%</span>
       </div>
     {/if}
+    {#if data.collection.kind === 'course'}
+      <p class="cd-completion">
+        <strong>{data.completedCount}</strong>
+        of {data.items.length} {data.items.length === 1 ? 'text' : 'texts'} completed
+        {#if data.completedCount === data.items.length && data.items.length > 0}
+          · 🏁 course finished
+        {/if}
+      </p>
+    {/if}
   </header>
 
   <ol class="cd-list">
@@ -246,6 +255,15 @@
     font-feature-settings: 'tnum';
     font-family: var(--font-mono-display, var(--font-mono));
     font-size: 0.85rem;
+  }
+  .cd-completion {
+    margin: 0.4rem 0 1rem;
+    font-size: 0.85rem;
+    color: var(--ink-2, var(--color-fg));
+    background: color-mix(in oklch, var(--accent, var(--color-accent)) 6%, var(--card, var(--color-bg)));
+    border: 1px solid var(--rule, var(--color-border));
+    border-radius: 8px;
+    padding: 0.5rem 0.75rem;
   }
   .cd-list {
     list-style: none;

--- a/apps/web/src/routes/reader/[textId]/+page.server.ts
+++ b/apps/web/src/routes/reader/[textId]/+page.server.ts
@@ -160,6 +160,21 @@ export const load: PageServerLoad = async ({ params, locals, url }) => {
   // multiple (collections.updatedAt DESC).
   const collectionContext = await readerCollectionContext(params.textId);
 
+  // T-8.6: course-kind collections gate "next" until the active
+  // text is finished (pctRead >= 100). The reader UI grays out the
+  // next link unless ?skipLock=1 is set on the URL — a deliberate
+  // escape hatch for self-paced learners who want to skip ahead.
+  const COURSE_COMPLETION_THRESHOLD = 100;
+  let nextLocked = false;
+  if (
+    collectionContext &&
+    collectionContext.collection.kind === 'course' &&
+    collectionContext.nextTextId
+  ) {
+    const pct = savedProgress?.pctRead ?? 0;
+    nextLocked = pct < COURSE_COMPLETION_THRESHOLD;
+  }
+
   return {
     text: {
       id: result.text.id,
@@ -205,6 +220,9 @@ export const load: PageServerLoad = async ({ params, locals, url }) => {
           totalCount: collectionContext.totalCount,
           prevTextId: collectionContext.prevTextId,
           nextTextId: collectionContext.nextTextId,
+          // T-8.6: course-kind gate. UI flips the next link to a
+          // disabled state with a tooltip; ?skipLock=1 overrides.
+          nextLocked,
         }
       : null,
   };

--- a/apps/web/src/routes/reader/[textId]/+page.svelte
+++ b/apps/web/src/routes/reader/[textId]/+page.svelte
@@ -282,12 +282,21 @@
               >‹ prev</a>
             {/if}
             {#if data.collectionContext.nextTextId}
-              <a
-                href={`/reader/${data.collectionContext.nextTextId}`}
-                class="reader-coll-arrow"
-                title="Next text"
-                aria-label="Next text in collection"
-              >next ›</a>
+              {#if data.collectionContext.nextLocked}
+                <a
+                  href={`/reader/${data.collectionContext.nextTextId}?skipLock=1`}
+                  class="reader-coll-arrow reader-coll-locked"
+                  title="Course gate — finish this text or click to skip"
+                  aria-label="Next text (locked — finish to advance, or click to skip)"
+                >next 🔒</a>
+              {:else}
+                <a
+                  href={`/reader/${data.collectionContext.nextTextId}`}
+                  class="reader-coll-arrow"
+                  title="Next text"
+                  aria-label="Next text in collection"
+                >next ›</a>
+              {/if}
             {/if}
           </span>
         </p>
@@ -517,6 +526,10 @@
   }
   .reader-coll-arrow:hover {
     text-decoration: underline;
+  }
+  .reader-coll-locked {
+    color: var(--ink-3, var(--color-fg-muted));
+    opacity: 0.7;
   }
   .reader-meta .t {
     margin: 0;


### PR DESCRIPTION
Stacked on #302. `kind='course'` flips the reader's next link to a locked state (🔒) until pctRead ≥ 100; `?skipLock=1` overrides. Collection detail page shows a completion badge (N of M texts completed). Closes #81.