### PR TITLE
T-9.5: manual alignment editor

### DIFF
--- a/apps/web/src/lib/server/audio/import-export.test.ts
+++ b/apps/web/src/lib/server/audio/import-export.test.ts
@@ -1,0 +1,147 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+
+import {
+  AlignmentImportError,
+  matchWordsToTokens,
+  parseWebVtt,
+  parseWhisperJson,
+  toWebVtt,
+  toWhisperJson,
+} from './import-export.js';
+
+describe('parseWhisperJson', () => {
+  it('flattens segments × words into a single timing list', () => {
+    const out = parseWhisperJson({
+      segments: [
+        {
+          words: [
+            { word: 'hello', start: 0.0, end: 0.5 },
+            { word: 'world', start: 0.5, end: 1.0 },
+          ],
+        },
+        {
+          words: [{ word: 'next', start: 1.5, end: 2.0 }],
+        },
+      ],
+    });
+    expect(out).toHaveLength(3);
+    expect(out[2]?.word).toBe('next');
+  });
+
+  it('rejects a non-object payload', () => {
+    expect(() => parseWhisperJson(null)).toThrow(AlignmentImportError);
+  });
+
+  it('rejects a payload without segments', () => {
+    expect(() => parseWhisperJson({ words: [] })).toThrow(AlignmentImportError);
+  });
+
+  it('skips entries that are missing fields', () => {
+    const out = parseWhisperJson({
+      segments: [
+        {
+          words: [
+            { word: 'good', start: 0, end: 1 },
+            { word: 'bad', start: 'not a number' },
+            { start: 2, end: 3 },
+          ],
+        },
+      ],
+    });
+    expect(out).toHaveLength(1);
+  });
+});
+
+describe('parseWebVtt', () => {
+  it('parses well-formed WEBVTT cues into word timings', () => {
+    const vtt = `WEBVTT
+
+1
+00:00:00.000 --> 00:00:00.500
+hello
+
+2
+00:00:00.500 --> 00:00:01.000
+world
+`;
+    const out = parseWebVtt(vtt);
+    expect(out).toEqual([
+      { word: 'hello', start: 0, end: 0.5 },
+      { word: 'world', start: 0.5, end: 1 },
+    ]);
+  });
+
+  it('rejects a non-WEBVTT file', () => {
+    expect(() => parseWebVtt('not a vtt')).toThrow(AlignmentImportError);
+  });
+});
+
+describe('matchWordsToTokens', () => {
+  const tokens = [
+    { id: 't0', isWord: true },
+    { id: 't1', isWord: false },
+    { id: 't2', isWord: true },
+    { id: 't3', isWord: false },
+    { id: 't4', isWord: true },
+  ];
+
+  it('pairs imported words with isWord tokens by index', () => {
+    const r = matchWordsToTokens(
+      [
+        { word: 'a', start: 0, end: 0.5 },
+        { word: 'b', start: 0.5, end: 1 },
+        { word: 'c', start: 1, end: 1.5 },
+      ],
+      tokens,
+    );
+    expect(r.matched).toBe(3);
+    expect(r.alignments.map((a) => a.tokenId)).toEqual(['t0', 't2', 't4']);
+    expect(r.alignments[0]).toMatchObject({ startMs: 0, endMs: 500 });
+  });
+
+  it('truncates when more words than tokens', () => {
+    const r = matchWordsToTokens(
+      [
+        { word: 'a', start: 0, end: 1 },
+        { word: 'b', start: 1, end: 2 },
+        { word: 'c', start: 2, end: 3 },
+        { word: 'extra', start: 3, end: 4 },
+      ],
+      [
+        { id: 't0', isWord: true },
+        { id: 't1', isWord: true },
+      ],
+    );
+    expect(r.matched).toBe(2);
+    expect(r.imported).toBe(4);
+    expect(r.available).toBe(2);
+  });
+});
+
+describe('toWhisperJson + toWebVtt', () => {
+  const rows = [
+    { tokenId: 't0', startMs: 0, endMs: 500 },
+    { tokenId: 't2', startMs: 500, endMs: 1500 },
+  ];
+  const surfaces = new Map([
+    ['t0', 'hello'],
+    ['t2', 'world'],
+  ]);
+
+  it('emits Whisper-shaped JSON', () => {
+    const j = toWhisperJson(rows, surfaces);
+    expect(j.segments[0]?.words).toEqual([
+      { word: 'hello', start: 0, end: 0.5 },
+      { word: 'world', start: 0.5, end: 1.5 },
+    ]);
+  });
+
+  it('emits WebVTT round-trippable through parseWebVtt', () => {
+    const vtt = toWebVtt(rows, surfaces);
+    expect(vtt.startsWith('WEBVTT')).toBe(true);
+    const parsed = parseWebVtt(vtt);
+    expect(parsed[0]?.word).toBe('hello');
+    expect(parsed[1]?.start).toBeCloseTo(0.5);
+  });
+});

--- a/apps/web/src/lib/server/audio/import-export.ts
+++ b/apps/web/src/lib/server/audio/import-export.ts
@@ -1,0 +1,200 @@
+/**
+ * Alignment import / export (T-9.6).
+ *
+ * Two formats:
+ *
+ *   - Whisper word-timestamps JSON. Compatible with the JSON the
+ *     `whisper` Python CLI emits at `--word_timestamps True`:
+ *
+ *       {
+ *         "segments": [
+ *           {
+ *             "words": [
+ *               { "word": "hello", "start": 0.12, "end": 0.45 },
+ *               ...
+ *             ]
+ *           }
+ *         ]
+ *       }
+ *
+ *   - WebVTT per-word cues. Each cue is a single word with
+ *     start/end timestamps. WebVTT spec timestamp format
+ *     `HH:MM:SS.mmm`.
+ *
+ * Matching back to `text_tokens.id`: we rely on word-order. The
+ * importer takes the chapter's tokens in reading order, filters
+ * to `is_word=true`, and pairs with the imported word list by
+ * index. Any length mismatch is reported back so the caller
+ * can decide whether to truncate or reject. The whisper format's
+ * "word" string is informational; we don't fuzzy-match on it.
+ */
+import type { Alignment } from './types.js';
+
+export type WordTiming = {
+  /** Display surface from the source — purely informational. */
+  word: string;
+  /** Seconds. */
+  start: number;
+  end: number;
+};
+
+export type ImportFormat = 'whisper' | 'webvtt';
+
+export class AlignmentImportError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AlignmentImportError';
+  }
+}
+
+/**
+ * Parse a Whisper word-timestamps JSON document into a flat
+ * WordTiming[]. Returns the words in document order.
+ */
+export function parseWhisperJson(payload: unknown): WordTiming[] {
+  if (!payload || typeof payload !== 'object') {
+    throw new AlignmentImportError('not a JSON object');
+  }
+  const segments = (payload as { segments?: unknown }).segments;
+  if (!Array.isArray(segments)) {
+    throw new AlignmentImportError('missing segments array');
+  }
+  const out: WordTiming[] = [];
+  for (const seg of segments) {
+    const words = (seg as { words?: unknown }).words;
+    if (!Array.isArray(words)) continue;
+    for (const w of words) {
+      const word = (w as { word?: unknown }).word;
+      const start = (w as { start?: unknown }).start;
+      const end = (w as { end?: unknown }).end;
+      if (
+        typeof word !== 'string' ||
+        typeof start !== 'number' ||
+        typeof end !== 'number'
+      ) {
+        continue;
+      }
+      out.push({ word: word.trim(), start, end });
+    }
+  }
+  return out;
+}
+
+const VTT_TIMESTAMP_RE =
+  /^(\d{2}):(\d{2}):(\d{2})\.(\d{3})\s+-->\s+(\d{2}):(\d{2}):(\d{2})\.(\d{3})/;
+
+function vttToSeconds(h: string, m: string, s: string, ms: string): number {
+  return (
+    Number.parseInt(h, 10) * 3600 +
+    Number.parseInt(m, 10) * 60 +
+    Number.parseInt(s, 10) +
+    Number.parseInt(ms, 10) / 1000
+  );
+}
+
+/**
+ * Parse a WebVTT document into a flat WordTiming[]. Each cue
+ * becomes one word; the cue's payload (lines after the
+ * timestamp) is the word string. Cues without a recognisable
+ * timestamp are skipped quietly.
+ */
+export function parseWebVtt(text: string): WordTiming[] {
+  const lines = text.split(/\r?\n/);
+  if (lines.length === 0 || !lines[0]!.startsWith('WEBVTT')) {
+    throw new AlignmentImportError('not a WEBVTT file');
+  }
+  const out: WordTiming[] = [];
+  for (let i = 1; i < lines.length; i++) {
+    const m = VTT_TIMESTAMP_RE.exec(lines[i]!);
+    if (!m) continue;
+    const start = vttToSeconds(m[1]!, m[2]!, m[3]!, m[4]!);
+    const end = vttToSeconds(m[5]!, m[6]!, m[7]!, m[8]!);
+    // Cue payload is the first non-empty line after the timestamp.
+    let payload = '';
+    for (let j = i + 1; j < lines.length; j++) {
+      const line = lines[j]!.trim();
+      if (line === '') break;
+      payload = payload ? `${payload} ${line}` : line;
+    }
+    if (payload) out.push({ word: payload.trim(), start, end });
+  }
+  return out;
+}
+
+/**
+ * Pair imported word timings with the chapter's actual text_token
+ * ids by reading-order index over isWord tokens. Returns the
+ * per-token alignment list ready to PUT to the alignments
+ * endpoint.
+ */
+export function matchWordsToTokens(
+  words: WordTiming[],
+  tokens: Array<{ id: string; isWord: boolean }>,
+): {
+  alignments: Alignment[];
+  matched: number;
+  imported: number;
+  available: number;
+} {
+  const wordTokens = tokens.filter((t) => t.isWord);
+  const n = Math.min(words.length, wordTokens.length);
+  const alignments: Alignment[] = [];
+  for (let i = 0; i < n; i++) {
+    const w = words[i]!;
+    const t = wordTokens[i]!;
+    alignments.push({
+      tokenId: t.id,
+      startMs: Math.max(0, Math.round(w.start * 1000)),
+      endMs: Math.max(0, Math.round(w.end * 1000)),
+    });
+  }
+  return {
+    alignments,
+    matched: n,
+    imported: words.length,
+    available: wordTokens.length,
+  };
+}
+
+/**
+ * Convert in-DB alignments + per-token surfaces to a Whisper-
+ * shaped JSON document for export.
+ */
+export function toWhisperJson(
+  rows: Array<{ tokenId: string; startMs: number; endMs: number }>,
+  surfaceById: Map<string, string>,
+): { segments: Array<{ words: WordTiming[] }> } {
+  const words: WordTiming[] = rows.map((r) => ({
+    word: surfaceById.get(r.tokenId) ?? '',
+    start: r.startMs / 1000,
+    end: r.endMs / 1000,
+  }));
+  return { segments: [{ words }] };
+}
+
+function formatVttTimestamp(ms: number): string {
+  const total = Math.max(0, Math.round(ms));
+  const h = Math.floor(total / 3_600_000);
+  const m = Math.floor((total % 3_600_000) / 60_000);
+  const s = Math.floor((total % 60_000) / 1000);
+  const millis = total % 1000;
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}.${String(millis).padStart(3, '0')}`;
+}
+
+export function toWebVtt(
+  rows: Array<{ tokenId: string; startMs: number; endMs: number }>,
+  surfaceById: Map<string, string>,
+): string {
+  const lines: string[] = ['WEBVTT', ''];
+  for (let i = 0; i < rows.length; i++) {
+    const r = rows[i]!;
+    const surface = surfaceById.get(r.tokenId) ?? '';
+    lines.push(String(i + 1));
+    lines.push(
+      `${formatVttTimestamp(r.startMs)} --> ${formatVttTimestamp(r.endMs)}`,
+    );
+    lines.push(surface);
+    lines.push('');
+  }
+  return lines.join('\n');
+}

--- a/apps/web/src/lib/server/audio/sentence-tokens.test.ts
+++ b/apps/web/src/lib/server/audio/sentence-tokens.test.ts
@@ -1,0 +1,53 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+
+import {
+  interpolateSentenceMarks,
+  type SentenceTokens,
+} from './sentence-tokens.js';
+
+const SENTENCES: SentenceTokens[] = [
+  {
+    sentenceIdx: 0,
+    tokens: [
+      { id: 't0', surface: 'hello', isWord: true },
+      { id: 't1', surface: ' ', isWord: false },
+      { id: 't2', surface: 'world', isWord: true },
+      { id: 't3', surface: '.', isWord: false },
+    ],
+  },
+  {
+    sentenceIdx: 1,
+    tokens: [
+      { id: 't4', surface: 'next', isWord: true },
+      { id: 't5', surface: '.', isWord: false },
+    ],
+  },
+];
+
+describe('interpolateSentenceMarks', () => {
+  it('emits a row per word token, skipping punctuation', () => {
+    const out = interpolateSentenceMarks(SENTENCES, [
+      { sentenceIdx: 0, startMs: 0, endMs: 1000 },
+    ]);
+    expect(out).toHaveLength(2);
+    expect(out.map((r) => r.tokenId)).toEqual(['t0', 't2']);
+    expect(out[0]).toMatchObject({ startMs: 0, endMs: 500 });
+    expect(out[1]).toMatchObject({ startMs: 500, endMs: 1000 });
+  });
+
+  it('skips a sentence that has no mark', () => {
+    const out = interpolateSentenceMarks(SENTENCES, [
+      { sentenceIdx: 1, startMs: 2000, endMs: 3000 },
+    ]);
+    expect(out.map((r) => r.tokenId)).toEqual(['t4']);
+  });
+
+  it('handles a degenerate sentence with no words', () => {
+    const out = interpolateSentenceMarks(
+      [{ sentenceIdx: 7, tokens: [{ id: 'x', surface: '.', isWord: false }] }],
+      [{ sentenceIdx: 7, startMs: 0, endMs: 100 }],
+    );
+    expect(out).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/server/audio/sentence-tokens.ts
+++ b/apps/web/src/lib/server/audio/sentence-tokens.ts
@@ -1,0 +1,94 @@
+/**
+ * Sentence-grouped token loader for the alignment editor (T-9.5).
+ *
+ * The editor walks the chapter one sentence at a time and lets the
+ * owner press-and-hold to mark each sentence's start/end ms during
+ * playback. The grouping comes off `text_tokens.sentence_idx`,
+ * written by the NLP worker (T-2.6).
+ */
+import { asc, eq } from 'drizzle-orm';
+
+import { db, schema } from '../db/index.js';
+import type { TextToken } from '../db/schema.js';
+
+export type SentenceTokens = {
+  sentenceIdx: number;
+  tokens: Array<{ id: string; surface: string; isWord: boolean }>;
+};
+
+export async function loadSentenceTokensForAudio(
+  audioFileId: string,
+): Promise<SentenceTokens[]> {
+  const [audio] = (await db
+    .select({
+      textId: schema.audioFiles.textId,
+      chapterId: schema.audioFiles.chapterId,
+    })
+    .from(schema.audioFiles)
+    .where(eq(schema.audioFiles.id, audioFileId))
+    .limit(1)) as Array<{ textId: string; chapterId: string | null }>;
+  if (!audio) return [];
+
+  // For chapter-bound audio we walk just that chapter's tokens; for
+  // whole-text audio we'd have to walk every chapter — out of scope
+  // for the manual editor (whole-text audio is rare; the importer
+  // path is the realistic surface for that).
+  if (!audio.chapterId) return [];
+
+  const tokens = (await db
+    .select()
+    .from(schema.textTokens)
+    .where(eq(schema.textTokens.chapterId, audio.chapterId))
+    .orderBy(asc(schema.textTokens.idx))) as TextToken[];
+
+  // Group on sentence_idx, preserving reading order.
+  const out: SentenceTokens[] = [];
+  let cur: SentenceTokens | null = null;
+  for (const t of tokens) {
+    if (!cur || cur.sentenceIdx !== t.sentenceIdx) {
+      cur = { sentenceIdx: t.sentenceIdx, tokens: [] };
+      out.push(cur);
+    }
+    cur.tokens.push({ id: t.id, surface: t.surface, isWord: t.isWord });
+  }
+  return out;
+}
+
+export type SentenceMark = {
+  sentenceIdx: number;
+  startMs: number;
+  endMs: number;
+};
+
+/**
+ * Linearly interpolate per-token timing across each sentence's
+ * marked (startMs, endMs) range. Each word in a sentence gets an
+ * equal slice; non-word tokens (punctuation / whitespace) are
+ * skipped — the alignment table is per-token but the highlighter
+ * only paints `isWord` spans anyway, so emitting rows for
+ * punctuation just bloats the table.
+ *
+ * Pure function — unit-tested without the DB.
+ */
+export function interpolateSentenceMarks(
+  sentences: SentenceTokens[],
+  marks: SentenceMark[],
+): Array<{ tokenId: string; startMs: number; endMs: number }> {
+  const marksBySentence = new Map<number, SentenceMark>();
+  for (const m of marks) marksBySentence.set(m.sentenceIdx, m);
+  const out: Array<{ tokenId: string; startMs: number; endMs: number }> = [];
+  for (const s of sentences) {
+    const mark = marksBySentence.get(s.sentenceIdx);
+    if (!mark) continue;
+    const wordTokens = s.tokens.filter((t) => t.isWord);
+    if (wordTokens.length === 0) continue;
+    const span = Math.max(0, mark.endMs - mark.startMs);
+    const slice = span / wordTokens.length;
+    for (let i = 0; i < wordTokens.length; i++) {
+      const start = Math.round(mark.startMs + slice * i);
+      const end = Math.round(mark.startMs + slice * (i + 1));
+      out.push({ tokenId: wordTokens[i]!.id, startMs: start, endMs: end });
+    }
+  }
+  return out;
+}

--- a/apps/web/src/lib/server/audio/types.ts
+++ b/apps/web/src/lib/server/audio/types.ts
@@ -1,0 +1,6 @@
+/** Shared shape used across the audio service tier. */
+export type Alignment = {
+  tokenId: string;
+  startMs: number;
+  endMs: number;
+};

--- a/apps/web/src/routes/api/v1/audio/[id]/alignments/export/+server.ts
+++ b/apps/web/src/routes/api/v1/audio/[id]/alignments/export/+server.ts
@@ -1,0 +1,59 @@
+/**
+ * GET /api/v1/audio/:id/alignments/export?format=whisper|webvtt
+ * (T-9.6).
+ */
+import { error } from '@sveltejs/kit';
+import { inArray } from 'drizzle-orm';
+
+import { listAlignments } from '$lib/server/audio/alignments.js';
+import {
+  toWebVtt,
+  toWhisperJson,
+} from '$lib/server/audio/import-export.js';
+import { db, schema } from '$lib/server/db/index.js';
+import type { RequestHandler } from './$types';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const GET: RequestHandler = async ({ params, url }) => {
+  const id = params.id;
+  if (!id || !UUID_RE.test(id)) throw error(400, 'Invalid audio id');
+  const format = url.searchParams.get('format') ?? 'whisper';
+  if (format !== 'whisper' && format !== 'webvtt') {
+    throw error(400, 'format must be "whisper" or "webvtt"');
+  }
+  const rows = await listAlignments(id);
+  // Pull each token's surface so the export carries human-readable
+  // word strings; otherwise we'd emit empty `word` fields.
+  const tokenIds = rows.map((r) => r.tokenId);
+  const surfaces = new Map<string, string>();
+  if (tokenIds.length > 0) {
+    const surf = (await db
+      .select({
+        id: schema.textTokens.id,
+        surface: schema.textTokens.surface,
+      })
+      .from(schema.textTokens)
+      .where(inArray(schema.textTokens.id, tokenIds))) as Array<{
+      id: string;
+      surface: string;
+    }>;
+    for (const r of surf) surfaces.set(r.id, r.surface);
+  }
+
+  if (format === 'whisper') {
+    return new Response(JSON.stringify(toWhisperJson(rows, surfaces), null, 2), {
+      headers: {
+        'content-type': 'application/json',
+        'content-disposition': `attachment; filename="alignment-${id}.json"`,
+      },
+    });
+  }
+  const vtt = toWebVtt(rows, surfaces);
+  return new Response(vtt, {
+    headers: {
+      'content-type': 'text/vtt; charset=utf-8',
+      'content-disposition': `attachment; filename="alignment-${id}.vtt"`,
+    },
+  });
+};

--- a/apps/web/src/routes/api/v1/audio/[id]/alignments/import/+server.ts
+++ b/apps/web/src/routes/api/v1/audio/[id]/alignments/import/+server.ts
@@ -1,0 +1,99 @@
+/**
+ * POST /api/v1/audio/:id/alignments/import (T-9.6).
+ *
+ * Body: { format: 'whisper' | 'webvtt', payload: <string|object> }.
+ * Maps imported word timings to text_tokens by reading-order index
+ * (isWord-only) and replaces the alignment set in one call.
+ */
+import { error, json } from '@sveltejs/kit';
+import { asc, eq } from 'drizzle-orm';
+
+import { requireUser } from '$lib/server/auth/require-user.js';
+import {
+  AlignmentError,
+  replaceAlignments,
+} from '$lib/server/audio/alignments.js';
+import {
+  AlignmentImportError,
+  matchWordsToTokens,
+  parseWebVtt,
+  parseWhisperJson,
+} from '$lib/server/audio/import-export.js';
+import { db, schema } from '$lib/server/db/index.js';
+import type { TextToken } from '$lib/server/db/schema.js';
+import type { RequestHandler } from './$types';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const POST: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  const id = event.params.id;
+  if (!id || !UUID_RE.test(id)) throw error(400, 'Invalid audio id');
+  const body = (await event.request.json()) as {
+    format?: string;
+    payload?: unknown;
+  };
+  if (body.format !== 'whisper' && body.format !== 'webvtt') {
+    throw error(400, 'format must be "whisper" or "webvtt"');
+  }
+
+  // Resolve the audio's chapter so we know which token order to
+  // pair against. Whole-text audio is out of scope here (matches
+  // the manual editor's chapter-bound contract).
+  const [audio] = (await db
+    .select({
+      audioId: schema.audioFiles.id,
+      chapterId: schema.audioFiles.chapterId,
+    })
+    .from(schema.audioFiles)
+    .where(eq(schema.audioFiles.id, id))
+    .limit(1)) as Array<{ audioId: string; chapterId: string | null }>;
+  if (!audio) throw error(404, 'Audio not found');
+  if (!audio.chapterId) {
+    throw error(
+      400,
+      'Import is only supported for chapter-bound audio at this layer',
+    );
+  }
+
+  const tokens = (await db
+    .select({
+      id: schema.textTokens.id,
+      isWord: schema.textTokens.isWord,
+    })
+    .from(schema.textTokens)
+    .where(eq(schema.textTokens.chapterId, audio.chapterId))
+    .orderBy(asc(schema.textTokens.idx))) as Array<
+    Pick<TextToken, 'id' | 'isWord'>
+  >;
+
+  let words;
+  try {
+    words =
+      body.format === 'whisper'
+        ? parseWhisperJson(body.payload)
+        : parseWebVtt(String(body.payload ?? ''));
+  } catch (e) {
+    if (e instanceof AlignmentImportError) throw error(400, e.message);
+    throw e;
+  }
+
+  const matched = matchWordsToTokens(words, tokens);
+  try {
+    const written = await replaceAlignments({
+      audioFileId: id,
+      alignments: matched.alignments,
+      source: 'imported',
+      actor: { id: user.id, role: user.role },
+    });
+    return json({
+      ok: true,
+      written,
+      imported: matched.imported,
+      available: matched.available,
+    });
+  } catch (e) {
+    if (e instanceof AlignmentError) throw error(e.status, e.message);
+    throw e;
+  }
+};

--- a/apps/web/src/routes/audio/[id]/align/+page.server.ts
+++ b/apps/web/src/routes/audio/[id]/align/+page.server.ts
@@ -1,0 +1,50 @@
+/**
+ * Manual alignment editor (T-9.5) loader.
+ *
+ * Owner-or-admin only. Loads the audio file's URL + the chapter's
+ * tokens grouped by sentence so the page can walk one sentence at
+ * a time during playback.
+ */
+import { error, redirect } from '@sveltejs/kit';
+import { eq } from 'drizzle-orm';
+
+import { db, schema } from '$lib/server/db/index.js';
+import { loadSentenceTokensForAudio } from '$lib/server/audio/sentence-tokens.js';
+import { getAudioStorage } from '$lib/server/audio/storage.js';
+import type { AudioFile, Text } from '$lib/server/db/schema.js';
+import type { PageServerLoad } from './$types';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const load: PageServerLoad = async ({ params, locals, url }) => {
+  if (!locals.user) {
+    throw redirect(303, `/login?next=${encodeURIComponent(url.pathname)}`);
+  }
+  const id = params.id;
+  if (!id || !UUID_RE.test(id)) throw error(400, 'Invalid audio id');
+
+  const [hit] = (await db
+    .select({
+      audio: schema.audioFiles,
+      ownerId: schema.texts.ownerId,
+    })
+    .from(schema.audioFiles)
+    .innerJoin(schema.texts, eq(schema.texts.id, schema.audioFiles.textId))
+    .where(eq(schema.audioFiles.id, id))
+    .limit(1)) as Array<{ audio: AudioFile; ownerId: Text['ownerId'] }>;
+  if (!hit) throw error(404, 'Audio not found');
+  if (locals.user.role !== 'admin' && hit.ownerId !== locals.user.id) {
+    throw error(403, 'Only the owner can edit alignments');
+  }
+
+  const sentences = await loadSentenceTokensForAudio(id);
+  return {
+    audio: {
+      id: hit.audio.id,
+      url: getAudioStorage().urlFor(hit.audio.storageKey),
+      mime: hit.audio.mime,
+      durationMs: hit.audio.durationMs,
+    },
+    sentences,
+  };
+};

--- a/apps/web/src/routes/audio/[id]/align/+page.svelte
+++ b/apps/web/src/routes/audio/[id]/align/+page.svelte
@@ -1,0 +1,277 @@
+<script lang="ts">
+  import type { PageData } from './$types';
+
+  let { data }: { data: PageData } = $props();
+
+  type Mark = { startMs: number; endMs: number };
+  let audioEl: HTMLAudioElement | null = $state(null);
+  let active = $state(0); // current sentence index
+  let isPlaying = $state(false);
+  let pressStart = $state<number | null>(null); // ms when current press started
+  let marks = $state<Map<number, Mark>>(new Map());
+
+  let saving = $state(false);
+  let saveError = $state<string | null>(null);
+  let saveOk = $state(false);
+
+  function nowMs(): number {
+    return audioEl ? Math.round(audioEl.currentTime * 1000) : 0;
+  }
+
+  function press() {
+    if (!audioEl || pressStart != null) return;
+    pressStart = nowMs();
+  }
+  function release() {
+    if (pressStart == null) return;
+    const startMs = pressStart;
+    const endMs = nowMs();
+    pressStart = null;
+    if (endMs <= startMs) return;
+    const sentenceIdx = data.sentences[active]?.sentenceIdx;
+    if (sentenceIdx === undefined) return;
+    const next = new Map(marks);
+    next.set(sentenceIdx, { startMs, endMs });
+    marks = next;
+    if (active < data.sentences.length - 1) active += 1;
+  }
+
+  function onKey(e: KeyboardEvent) {
+    if (e.target instanceof HTMLElement) {
+      const tag = e.target.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+    }
+    if (e.code === 'Space') {
+      e.preventDefault();
+      if (e.repeat) return;
+      press();
+    }
+  }
+  function onKeyUp(e: KeyboardEvent) {
+    if (e.code === 'Space') {
+      e.preventDefault();
+      release();
+    }
+  }
+
+  function togglePlay() {
+    if (!audioEl) return;
+    if (audioEl.paused) void audioEl.play();
+    else audioEl.pause();
+  }
+
+  async function save() {
+    saving = true;
+    saveError = null;
+    saveOk = false;
+    try {
+      const { interpolateSentenceMarks } = await import(
+        '$lib/server/audio/sentence-tokens.js'
+      );
+      // Browser-side import works because the helper is pure (no
+      // server-only deps). We pass the loader-provided sentences +
+      // the user's marks straight through.
+      const flat = Array.from(marks.entries()).map(([sentenceIdx, m]) => ({
+        sentenceIdx,
+        startMs: m.startMs,
+        endMs: m.endMs,
+      }));
+      const alignments = interpolateSentenceMarks(
+        data.sentences,
+        flat,
+      );
+      const res = await fetch(`/api/v1/audio/${data.audio.id}/alignments`, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ source: 'manual', alignments }),
+      });
+      if (!res.ok) {
+        saveError = (await res.text().catch(() => '')) || `HTTP ${res.status}`;
+        return;
+      }
+      saveOk = true;
+    } finally {
+      saving = false;
+    }
+  }
+</script>
+
+<svelte:head>
+  <title>Align audio — CIA Reader</title>
+</svelte:head>
+
+<svelte:window onkeydown={onKey} onkeyup={onKeyUp} />
+
+<div class="ae">
+  <header><h1>Align audio</h1></header>
+
+  <audio
+    bind:this={audioEl}
+    src={data.audio.url}
+    controls
+    preload="metadata"
+    onplay={() => (isPlaying = true)}
+    onpause={() => (isPlaying = false)}
+  ></audio>
+
+  <p class="ae-hint">
+    Press &amp; hold <kbd>Space</kbd> while a sentence is being spoken.
+    Release at the end. The next sentence advances automatically.
+    Per-word timings are linearly interpolated within each sentence.
+  </p>
+
+  <ol class="ae-sentences">
+    {#each data.sentences as s, i (s.sentenceIdx)}
+      <li
+        class="ae-sentence"
+        data-active={i === active ? '1' : '0'}
+        data-marked={marks.has(s.sentenceIdx) ? '1' : '0'}
+      >
+        <span class="ae-pos">{i + 1}</span>
+        <p class="ae-body">
+          {#each s.tokens as t (t.id)}<span>{t.surface}</span>{/each}
+        </p>
+        {#if marks.get(s.sentenceIdx)}
+          {@const m = marks.get(s.sentenceIdx)!}
+          <span class="ae-mark">
+            {(m.startMs / 1000).toFixed(2)}s → {(m.endMs / 1000).toFixed(2)}s
+          </span>
+        {/if}
+      </li>
+    {/each}
+  </ol>
+
+  <footer class="ae-foot">
+    <button type="button" onclick={togglePlay}>
+      {isPlaying ? 'Pause' : 'Play'}
+    </button>
+    <button type="button" disabled={marks.size === 0} onclick={() => (marks = new Map())}>
+      Clear marks
+    </button>
+    <button type="button" class="ae-save" disabled={saving || marks.size === 0} onclick={save}>
+      {saving ? 'Saving…' : `Save ${marks.size} sentence${marks.size === 1 ? '' : 's'}`}
+    </button>
+    {#if saveOk}
+      <span class="ae-ok">Saved.</span>
+    {/if}
+    {#if saveError}
+      <span class="ae-err" role="alert">{saveError}</span>
+    {/if}
+  </footer>
+
+  <p class="ae-back">
+    <button type="button" class="ae-link" onclick={() => window.history.back()}>← back</button>
+  </p>
+</div>
+
+<style>
+  .ae {
+    max-width: 48rem;
+    margin: 0 auto;
+    padding: 1.5rem 1.25rem 3rem;
+    color: var(--ink, var(--color-fg));
+  }
+  .ae h1 {
+    margin: 0 0 1rem;
+    font-family: var(--font-serif, system-ui);
+  }
+  audio {
+    width: 100%;
+    margin-bottom: 0.5rem;
+  }
+  .ae-hint {
+    color: var(--ink-3, var(--color-fg-muted));
+    font-size: 0.85rem;
+    margin: 0 0 1rem;
+  }
+  kbd {
+    background: var(--card, var(--color-bg));
+    border: 1px solid var(--card-edge, var(--color-border));
+    border-radius: 4px;
+    padding: 0.05rem 0.35rem;
+    font-family: var(--font-mono-display, var(--font-mono));
+    font-size: 0.78rem;
+  }
+  .ae-sentences {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
+  }
+  .ae-sentence {
+    display: grid;
+    grid-template-columns: 2rem 1fr auto;
+    gap: 0.55rem;
+    align-items: baseline;
+    padding: 0.55rem 0.65rem;
+    border: 1px solid var(--rule, var(--color-border));
+    border-radius: 8px;
+    background: var(--card, var(--color-bg));
+  }
+  .ae-sentence[data-active='1'] {
+    border-color: var(--accent, var(--color-accent));
+    box-shadow: 0 0 0 1px var(--accent, var(--color-accent));
+  }
+  .ae-sentence[data-marked='1'] {
+    background: color-mix(in oklch, var(--accent, var(--color-accent)) 6%, var(--card, var(--color-bg)));
+  }
+  .ae-pos {
+    font-family: var(--font-mono-display, var(--font-mono));
+    color: var(--ink-3, var(--color-fg-muted));
+    font-size: 0.8rem;
+    text-align: right;
+  }
+  .ae-body {
+    margin: 0;
+    font-family: var(--font-serif-dev, var(--font-serif));
+  }
+  .ae-mark {
+    font-family: var(--font-mono-display, var(--font-mono));
+    font-size: 0.75rem;
+    color: var(--ink-3, var(--color-fg-muted));
+  }
+  .ae-foot {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    margin-top: 1rem;
+  }
+  .ae-foot button {
+    background: var(--card, var(--color-bg));
+    border: 1px solid var(--rule, var(--color-border));
+    border-radius: 6px;
+    padding: 0.4rem 0.8rem;
+    font: inherit;
+    cursor: pointer;
+    color: var(--ink, var(--color-fg));
+  }
+  .ae-save {
+    background: var(--accent, var(--color-accent)) !important;
+    color: var(--accent-ink, var(--color-bg)) !important;
+    border-color: var(--accent, var(--color-accent)) !important;
+  }
+  .ae-foot button:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+  .ae-ok {
+    color: var(--accent, var(--color-accent));
+    font-size: 0.85rem;
+  }
+  .ae-err {
+    color: var(--err, #b94545);
+    font-size: 0.85rem;
+  }
+  .ae-back {
+    margin-top: 1rem;
+  }
+  .ae-link {
+    background: none;
+    border: 0;
+    color: var(--accent, var(--color-accent));
+    cursor: pointer;
+    font: inherit;
+  }
+</style>


### PR DESCRIPTION
Stacked on #309. /audio/:id/align — sentence-by-sentence press-and-hold editor; `interpolateSentenceMarks` linearly distributes per-word timings within each marked range. Saves through the existing PUT /api/v1/audio/:id/alignments endpoint with source='manual'. Closes #87.