### PR TITLE
T-9.7: audio source attribution + licensing checkbox

### DIFF
--- a/apps/web/src/lib/components/reader/AudioPlayer.svelte
+++ b/apps/web/src/lib/components/reader/AudioPlayer.svelte
@@ -23,6 +23,7 @@
     mime: string;
     durationMs: number | null;
     attribution: string | null;
+    license: string | null;
   }
 
   import { untrack } from 'svelte';
@@ -171,8 +172,13 @@
     </select>
   </label>
 
-  {#if audio.attribution}
-    <span class="ap-attr" title="Audio source">{audio.attribution}</span>
+  {#if audio.attribution || audio.license}
+    <p class="ap-attr">
+      {#if audio.attribution}<span class="ap-attr-text">{audio.attribution}</span>{/if}
+      {#if audio.license}
+        <span class="ap-license" title="Audio license">{audio.license}</span>
+      {/if}
+    </p>
   {/if}
 </aside>
 
@@ -232,8 +238,21 @@
   }
   .ap-attr {
     grid-column: 1 / -1;
+    margin: 0;
     font-size: 0.66rem;
     color: var(--ink-4, var(--color-fg-subtle));
     text-align: center;
+    display: flex;
+    gap: 0.45rem;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+  .ap-license {
+    background: color-mix(in oklch, var(--ink, var(--color-fg)) 6%, transparent);
+    border-radius: 999px;
+    padding: 0.05rem 0.4rem;
+    font-family: var(--font-mono-display, var(--font-mono));
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
   }
 </style>

--- a/apps/web/src/lib/server/audio/audio.test.ts
+++ b/apps/web/src/lib/server/audio/audio.test.ts
@@ -1,0 +1,140 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fakePut = vi.fn();
+vi.mock('./storage.js', async () => {
+  const actual = await vi.importActual<typeof import('./storage.js')>(
+    './storage.js',
+  );
+  return {
+    ...actual,
+    getAudioStorage: () => ({
+      put: (...a: unknown[]) => fakePut(...a),
+      delete: vi.fn(),
+      urlFor: (k: string) => `/audio/${k}`,
+    }),
+  };
+});
+
+const rows: Array<Record<string, unknown>> = [];
+type ChainShape = {
+  from: ReturnType<typeof vi.fn>;
+  where: ReturnType<typeof vi.fn>;
+  limit: ReturnType<typeof vi.fn>;
+  values: ReturnType<typeof vi.fn>;
+  returning: ReturnType<typeof vi.fn>;
+  innerJoin: ReturnType<typeof vi.fn>;
+};
+const chain: ChainShape = {
+  from: vi.fn(() => chain),
+  where: vi.fn(() => chain),
+  limit: vi.fn(() => rows),
+  values: vi.fn(() => chain),
+  returning: vi.fn(() => rows),
+  innerJoin: vi.fn(() => chain),
+};
+const fakeDb = {
+  select: vi.fn(() => chain),
+  insert: vi.fn(() => chain),
+  delete: vi.fn(() => chain),
+};
+
+vi.mock('../db/index.js', () => ({
+  db: fakeDb,
+  schema: {
+    texts: { id: 't.id', ownerId: 't.owner_id' },
+    textChapters: { id: 'tc.id', textId: 'tc.text_id' },
+    audioFiles: { id: 'af.id', textId: 'af.text_id' },
+  },
+}));
+
+const { uploadAudio, AudioError } = await import('./audio.js');
+
+function reset() {
+  rows.length = 0;
+  for (const fn of Object.values(chain))
+    (fn as ReturnType<typeof vi.fn>).mockClear();
+  fakeDb.select.mockClear();
+  fakeDb.insert.mockClear();
+  fakePut.mockReset();
+}
+
+beforeEach(reset);
+
+const OWNER = { id: 'u1', role: 'user' as const };
+const ADMIN = { id: 'a1', role: 'admin' as const };
+const SMALL_BODY = new Uint8Array([0x49, 0x44, 0x33]); // ID3 header bytes
+
+describe('uploadAudio', () => {
+  it('rejects an unsupported mime with 415', async () => {
+    await expect(
+      uploadAudio({
+        textId: 'tx-1',
+        body: SMALL_BODY,
+        mime: 'video/mp4',
+        originalName: 'x.mp4',
+        uploader: OWNER,
+        acknowledgedRedistribution: true,
+      }),
+    ).rejects.toMatchObject({ status: 415 });
+  });
+
+  it('rejects an oversized body with 413', async () => {
+    await expect(
+      uploadAudio({
+        textId: 'tx-1',
+        body: new Uint8Array(200 * 1024 * 1024),
+        mime: 'audio/mpeg',
+        originalName: 'x.mp3',
+        uploader: OWNER,
+        acknowledgedRedistribution: true,
+      }),
+    ).rejects.toMatchObject({ status: 413 });
+  });
+
+  it('blocks non-admin owners who skip the redistribution checkbox (T-9.7)', async () => {
+    rows.push({
+      id: 'tx-1',
+      ownerId: OWNER.id,
+      language: 'hi',
+      title: 'x',
+      sourceType: 'paste',
+      status: 'ready',
+      visibility: 'private',
+    });
+    await expect(
+      uploadAudio({
+        textId: 'tx-1',
+        body: SMALL_BODY,
+        mime: 'audio/mpeg',
+        originalName: 'x.mp3',
+        uploader: OWNER,
+        // no acknowledgedRedistribution → 400.
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('lets admins skip the redistribution checkbox', async () => {
+    rows.push({
+      id: 'tx-1',
+      ownerId: 'someone-else',
+      language: 'hi',
+      title: 'x',
+      sourceType: 'paste',
+      status: 'ready',
+      visibility: 'private',
+    });
+    chain.returning.mockReturnValueOnce([{ id: 'audio-1' }]);
+    const r = await uploadAudio({
+      textId: 'tx-1',
+      body: SMALL_BODY,
+      mime: 'audio/mpeg',
+      originalName: 'x.mp3',
+      uploader: ADMIN,
+    });
+    expect(r.id).toBe('audio-1');
+    expect(fakePut).toHaveBeenCalledOnce();
+  });
+
+  void AudioError;
+});

--- a/apps/web/src/lib/server/audio/audio.ts
+++ b/apps/web/src/lib/server/audio/audio.ts
@@ -38,6 +38,10 @@ export type UploadAudioInput = {
   license?: string | null;
   durationMs?: number | null;
   uploader: Pick<User, 'id' | 'role'>;
+  /** T-9.7: redistribution-rights checkbox from the upload form.
+   *  Required for non-admin uploads — admins skip the check on
+   *  the assumption they're handling curator-vetted assets. */
+  acknowledgedRedistribution?: boolean;
 };
 
 export async function uploadAudio(
@@ -53,6 +57,17 @@ export async function uploadAudio(
   }
   if (!isAllowedAudioMime(input.mime)) {
     throw new AudioError(`Unsupported audio type ${input.mime}`, 415);
+  }
+  // T-9.7: redistribution-rights gate. Owner uploads must
+  // acknowledge the rights checkbox; admins bypass.
+  if (
+    input.uploader.role !== 'admin' &&
+    !input.acknowledgedRedistribution
+  ) {
+    throw new AudioError(
+      'You must confirm redistribution rights for this audio',
+      400,
+    );
   }
 
   // Verify the parent text exists and the uploader is the owner /

--- a/apps/web/src/routes/api/v1/texts/[id]/audio/+server.ts
+++ b/apps/web/src/routes/api/v1/texts/[id]/audio/+server.ts
@@ -49,6 +49,11 @@ export const POST: RequestHandler = async (event) => {
     typeof durationRaw === 'string' && durationRaw
       ? Number.parseInt(durationRaw, 10)
       : null;
+  // T-9.7: redistribution-rights checkbox. Form fields can come
+  // through as 'on' (checked checkbox), 'true', or '1'.
+  const ackRaw = form.get('acknowledgedRedistribution');
+  const acknowledgedRedistribution =
+    ackRaw === 'on' || ackRaw === 'true' || ackRaw === '1';
   try {
     const buf = new Uint8Array(await file.arrayBuffer());
     const audio = await uploadAudio({
@@ -67,6 +72,7 @@ export const POST: RequestHandler = async (event) => {
           ? durationMs
           : null,
       uploader: { id: user.id, role: user.role },
+      acknowledgedRedistribution,
     });
     return json({ audio }, { status: 201 });
   } catch (e) {

--- a/apps/web/src/routes/reader/[textId]/+page.server.ts
+++ b/apps/web/src/routes/reader/[textId]/+page.server.ts
@@ -243,6 +243,7 @@ export const load: PageServerLoad = async ({ params, locals, url }) => {
           mime: activeAudio.mime,
           durationMs: activeAudio.durationMs,
           attribution: activeAudio.attribution,
+          license: activeAudio.license,
         }
       : null,
   };


### PR DESCRIPTION
Stacked on #311. uploadAudio requires acknowledgedRedistribution=true for non-admin uploads (admins bypass). AudioPlayer renders attribution + license pill below the controls when set. Closes #89.