### PR TITLE
T-2.8: number-to-words for digit-only NUM tokens

### DIFF
--- a/apps/web/drizzle/0022_t-2-8-number-forms.sql
+++ b/apps/web/drizzle/0022_t-2-8-number-forms.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "text_tokens" ADD COLUMN "number_forms" jsonb;

--- a/apps/web/drizzle/meta/0022_snapshot.json
+++ b/apps/web/drizzle/meta/0022_snapshot.json
@@ -1,0 +1,3920 @@
+{
+  "id": "e40c31d3-e274-4ad0-8378-2cdc80f8661e",
+  "prevId": "d150c90a-dcaf-4f3e-85ec-f30400c946aa",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audio_alignments": {
+      "name": "audio_alignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "audio_file_id": {
+          "name": "audio_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_ms": {
+          "name": "start_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_ms": {
+          "name": "end_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "alignment_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audio_alignments_timeline_idx": {
+          "name": "audio_alignments_timeline_idx",
+          "columns": [
+            {
+              "expression": "audio_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audio_alignments_audio_file_id_audio_files_id_fk": {
+          "name": "audio_alignments_audio_file_id_audio_files_id_fk",
+          "tableFrom": "audio_alignments",
+          "tableTo": "audio_files",
+          "columnsFrom": [
+            "audio_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audio_alignments_token_id_text_tokens_id_fk": {
+          "name": "audio_alignments_token_id_text_tokens_id_fk",
+          "tableFrom": "audio_alignments",
+          "tableTo": "text_tokens",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "audio_alignments_audio_file_id_token_id_pk": {
+          "name": "audio_alignments_audio_file_id_token_id_pk",
+          "columns": [
+            "audio_file_id",
+            "token_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.audio_files": {
+      "name": "audio_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime": {
+          "name": "mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license": {
+          "name": "license",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by_id": {
+          "name": "uploaded_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audio_files_text_idx": {
+          "name": "audio_files_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audio_files_chapter_idx": {
+          "name": "audio_files_chapter_idx",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audio_files_text_id_texts_id_fk": {
+          "name": "audio_files_text_id_texts_id_fk",
+          "tableFrom": "audio_files",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audio_files_chapter_id_text_chapters_id_fk": {
+          "name": "audio_files_chapter_id_text_chapters_id_fk",
+          "tableFrom": "audio_files",
+          "tableTo": "text_chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audio_files_uploaded_by_id_users_id_fk": {
+          "name": "audio_files_uploaded_by_id_users_id_fk",
+          "tableFrom": "audio_files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.collection_items": {
+      "name": "collection_items",
+      "schema": "",
+      "columns": {
+        "collection_id": {
+          "name": "collection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collection_items_order_idx": {
+          "name": "collection_items_order_idx",
+          "columns": [
+            {
+              "expression": "collection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collection_items_collection_id_collections_id_fk": {
+          "name": "collection_items_collection_id_collections_id_fk",
+          "tableFrom": "collection_items",
+          "tableTo": "collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collection_items_text_id_texts_id_fk": {
+          "name": "collection_items_text_id_texts_id_fk",
+          "tableFrom": "collection_items",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "collection_items_collection_id_text_id_pk": {
+          "name": "collection_items_collection_id_text_id_pk",
+          "columns": [
+            "collection_id",
+            "text_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.collection_shares": {
+      "name": "collection_shares",
+      "schema": "",
+      "columns": {
+        "collection_id": {
+          "name": "collection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shared_with_user_id": {
+          "name": "shared_with_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by_id": {
+          "name": "granted_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collection_shares_recipient_idx": {
+          "name": "collection_shares_recipient_idx",
+          "columns": [
+            {
+              "expression": "shared_with_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collection_shares_collection_id_collections_id_fk": {
+          "name": "collection_shares_collection_id_collections_id_fk",
+          "tableFrom": "collection_shares",
+          "tableTo": "collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collection_shares_shared_with_user_id_users_id_fk": {
+          "name": "collection_shares_shared_with_user_id_users_id_fk",
+          "tableFrom": "collection_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "shared_with_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collection_shares_granted_by_id_users_id_fk": {
+          "name": "collection_shares_granted_by_id_users_id_fk",
+          "tableFrom": "collection_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "collection_shares_collection_id_shared_with_user_id_pk": {
+          "name": "collection_shares_collection_id_shared_with_user_id_pk",
+          "columns": [
+            "collection_id",
+            "shared_with_user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.collections": {
+      "name": "collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "collection_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'chapter_book'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "collection_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collections_owner_idx": {
+          "name": "collections_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collections_visibility_idx": {
+          "name": "collections_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collections_owner_id_users_id_fk": {
+          "name": "collections_owner_id_users_id_fk",
+          "tableFrom": "collections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.curator_languages": {
+      "name": "curator_languages",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "curator_languages_user_idx": {
+          "name": "curator_languages_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "curator_languages_user_id_users_id_fk": {
+          "name": "curator_languages_user_id_users_id_fk",
+          "tableFrom": "curator_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "curator_languages_granted_by_users_id_fk": {
+          "name": "curator_languages_granted_by_users_id_fk",
+          "tableFrom": "curator_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "curator_languages_user_id_language_pk": {
+          "name": "curator_languages_user_id_language_pk",
+          "columns": [
+            "user_id",
+            "language"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.dictionary_imports": {
+      "name": "dictionary_imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_name": {
+          "name": "source_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_at": {
+          "name": "run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lemmas_created": {
+          "name": "lemmas_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lemmas_updated": {
+          "name": "lemmas_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lemmas_skipped_curator_locked": {
+          "name": "lemmas_skipped_curator_locked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "translations_created": {
+          "name": "translations_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "translations_updated": {
+          "name": "translations_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "dictionary_imports_language_idx": {
+          "name": "dictionary_imports_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.form_lemma_overrides": {
+      "name": "form_lemma_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_nfc": {
+          "name": "surface_nfc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_signature": {
+          "name": "context_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "chosen_lemma_id": {
+          "name": "chosen_lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "promoted_at": {
+          "name": "promoted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "promoted_by": {
+          "name": "promoted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "form_lemma_overrides_lookup_idx": {
+          "name": "form_lemma_overrides_lookup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface_nfc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "form_lemma_overrides_chosen_lemma_id_lemmas_id_fk": {
+          "name": "form_lemma_overrides_chosen_lemma_id_lemmas_id_fk",
+          "tableFrom": "form_lemma_overrides",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "chosen_lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_lemma_overrides_promoted_by_users_id_fk": {
+          "name": "form_lemma_overrides_promoted_by_users_id_fk",
+          "tableFrom": "form_lemma_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "promoted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "form_lemma_overrides_lang_surface_ctx_uq": {
+          "name": "form_lemma_overrides_lang_surface_ctx_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "language",
+            "surface_nfc",
+            "context_signature"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.group_memberships": {
+      "name": "group_memberships",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by_id": {
+          "name": "added_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_memberships_user_idx": {
+          "name": "group_memberships_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_memberships_group_id_groups_id_fk": {
+          "name": "group_memberships_group_id_groups_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_memberships_user_id_users_id_fk": {
+          "name": "group_memberships_user_id_users_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_memberships_added_by_id_users_id_fk": {
+          "name": "group_memberships_added_by_id_users_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "added_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "group_memberships_group_id_user_id_pk": {
+          "name": "group_memberships_group_id_user_id_pk",
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "groups_owner_idx": {
+          "name": "groups_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_owner_id_users_id_fk": {
+          "name": "groups_owner_id_users_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemma_edit_history": {
+      "name": "lemma_edit_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "editor_id": {
+          "name": "editor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "lemma_edit_change_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change": {
+          "name": "change",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_edit_history_lemma_idx": {
+          "name": "lemma_edit_history_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_edit_history_editor_idx": {
+          "name": "lemma_edit_history_editor_idx",
+          "columns": [
+            {
+              "expression": "editor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_edit_history_lemma_id_lemmas_id_fk": {
+          "name": "lemma_edit_history_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_edit_history",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lemma_edit_history_editor_id_users_id_fk": {
+          "name": "lemma_edit_history_editor_id_users_id_fk",
+          "tableFrom": "lemma_edit_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "editor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemma_forms": {
+      "name": "lemma_forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "romanization": {
+          "name": "romanization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_forms_lemma_idx": {
+          "name": "lemma_forms_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_forms_surface_idx": {
+          "name": "lemma_forms_surface_idx",
+          "columns": [
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_forms_lemma_id_lemmas_id_fk": {
+          "name": "lemma_forms_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_forms",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemma_proposals": {
+      "name": "lemma_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "proposer_id": {
+          "name": "proposer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headword": {
+          "name": "headword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos": {
+          "name": "pos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gloss_default": {
+          "name": "gloss_default",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "lemma_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "promoted_lemma_id": {
+          "name": "promoted_lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_id": {
+          "name": "reviewer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_note": {
+          "name": "reviewer_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_proposals_lang_status_idx": {
+          "name": "lemma_proposals_lang_status_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_proposals_headword_idx": {
+          "name": "lemma_proposals_headword_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "headword",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pos",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_proposals_proposer_id_users_id_fk": {
+          "name": "lemma_proposals_proposer_id_users_id_fk",
+          "tableFrom": "lemma_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "proposer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "lemma_proposals_promoted_lemma_id_lemmas_id_fk": {
+          "name": "lemma_proposals_promoted_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_proposals",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "promoted_lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "lemma_proposals_reviewer_id_users_id_fk": {
+          "name": "lemma_proposals_reviewer_id_users_id_fk",
+          "tableFrom": "lemma_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemmas": {
+      "name": "lemmas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headword": {
+          "name": "headword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos": {
+          "name": "pos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script": {
+          "name": "script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gloss_default": {
+          "name": "gloss_default",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_rank": {
+          "name": "frequency_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "translation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "curator_locked": {
+          "name": "curator_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemmas_language_headword_pos_idx": {
+          "name": "lemmas_language_headword_pos_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "headword",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pos",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_language_idx": {
+          "name": "lemmas_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_language_frequency_idx": {
+          "name": "lemmas_language_frequency_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "frequency_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_source_lookup_idx": {
+          "name": "lemmas_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.magic_links": {
+      "name": "magic_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "magic_links_user_idx": {
+          "name": "magic_links_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "magic_links_expires_idx": {
+          "name": "magic_links_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "magic_links_user_id_users_id_fk": {
+          "name": "magic_links_user_id_users_id_fk",
+          "tableFrom": "magic_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.nlp_jobs": {
+      "name": "nlp_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "nlp_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nlp_jobs_text_idx": {
+          "name": "nlp_jobs_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nlp_jobs_status_idx": {
+          "name": "nlp_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nlp_jobs_text_id_texts_id_fk": {
+          "name": "nlp_jobs_text_id_texts_id_fk",
+          "tableFrom": "nlp_jobs",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.parse_reports": {
+      "name": "parse_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_nfc": {
+          "name": "surface_nfc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_signature": {
+          "name": "context_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "original_candidates": {
+          "name": "original_candidates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "corrected_lemma_id": {
+          "name": "corrected_lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "correction_type": {
+          "name": "correction_type",
+          "type": "token_correction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "parse_report_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "assigned_reviewer_id": {
+          "name": "assigned_reviewer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_note": {
+          "name": "resolution_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duplicate_count": {
+          "name": "duplicate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parse_reports_lang_status_idx": {
+          "name": "parse_reports_lang_status_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parse_reports_dedup_idx": {
+          "name": "parse_reports_dedup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface_nfc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_signature",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "corrected_lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parse_reports_token_id_text_tokens_id_fk": {
+          "name": "parse_reports_token_id_text_tokens_id_fk",
+          "tableFrom": "parse_reports",
+          "tableTo": "text_tokens",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "parse_reports_corrected_lemma_id_lemmas_id_fk": {
+          "name": "parse_reports_corrected_lemma_id_lemmas_id_fk",
+          "tableFrom": "parse_reports",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "corrected_lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "parse_reports_reporter_id_users_id_fk": {
+          "name": "parse_reports_reporter_id_users_id_fk",
+          "tableFrom": "parse_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "parse_reports_assigned_reviewer_id_users_id_fk": {
+          "name": "parse_reports_assigned_reviewer_id_users_id_fk",
+          "tableFrom": "parse_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_reviewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by": {
+          "name": "replaced_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "refresh_tokens_user_idx": {
+          "name": "refresh_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_expires_idx": {
+          "name": "refresh_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.text_chapters": {
+      "name": "text_chapters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idx": {
+          "name": "idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "text_chapters_text_idx": {
+          "name": "text_chapters_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_chapters_text_id_texts_id_fk": {
+          "name": "text_chapters_text_id_texts_id_fk",
+          "tableFrom": "text_chapters",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "text_chapters_text_idx_uq": {
+          "name": "text_chapters_text_idx_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "text_id",
+            "idx"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.text_group_shares": {
+      "name": "text_group_shares",
+      "schema": "",
+      "columns": {
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by_id": {
+          "name": "granted_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "text_group_shares_group_idx": {
+          "name": "text_group_shares_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_group_shares_text_id_texts_id_fk": {
+          "name": "text_group_shares_text_id_texts_id_fk",
+          "tableFrom": "text_group_shares",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_group_shares_group_id_groups_id_fk": {
+          "name": "text_group_shares_group_id_groups_id_fk",
+          "tableFrom": "text_group_shares",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_group_shares_granted_by_id_users_id_fk": {
+          "name": "text_group_shares_granted_by_id_users_id_fk",
+          "tableFrom": "text_group_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "text_group_shares_text_id_group_id_pk": {
+          "name": "text_group_shares_text_id_group_id_pk",
+          "columns": [
+            "text_id",
+            "group_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.text_shares": {
+      "name": "text_shares",
+      "schema": "",
+      "columns": {
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shared_with_user_id": {
+          "name": "shared_with_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "text_share_permission",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'read'"
+        },
+        "granted_by_id": {
+          "name": "granted_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "text_shares_recipient_idx": {
+          "name": "text_shares_recipient_idx",
+          "columns": [
+            {
+              "expression": "shared_with_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_shares_text_id_texts_id_fk": {
+          "name": "text_shares_text_id_texts_id_fk",
+          "tableFrom": "text_shares",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_shares_shared_with_user_id_users_id_fk": {
+          "name": "text_shares_shared_with_user_id_users_id_fk",
+          "tableFrom": "text_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "shared_with_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_shares_granted_by_id_users_id_fk": {
+          "name": "text_shares_granted_by_id_users_id_fk",
+          "tableFrom": "text_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "text_shares_text_id_shared_with_user_id_pk": {
+          "name": "text_shares_text_id_shared_with_user_id_pk",
+          "columns": [
+            "text_id",
+            "shared_with_user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.text_tokens": {
+      "name": "text_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idx": {
+          "name": "idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lemma_candidates": {
+          "name": "lemma_candidates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_ambiguous": {
+          "name": "is_ambiguous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_oov": {
+          "name": "is_oov",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_word": {
+          "name": "is_word",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sentence_idx": {
+          "name": "sentence_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "romanization": {
+          "name": "romanization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_forms": {
+          "name": "number_forms",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "text_tokens_chapter_scan_idx": {
+          "name": "text_tokens_chapter_scan_idx",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "text_tokens_lemma_idx": {
+          "name": "text_tokens_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_tokens_chapter_id_text_chapters_id_fk": {
+          "name": "text_tokens_chapter_id_text_chapters_id_fk",
+          "tableFrom": "text_tokens",
+          "tableTo": "text_chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_tokens_lemma_id_lemmas_id_fk": {
+          "name": "text_tokens_lemma_id_lemmas_id_fk",
+          "tableFrom": "text_tokens",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "text_tokens_chapter_idx_uq": {
+          "name": "text_tokens_chapter_idx_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chapter_id",
+            "idx"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.texts": {
+      "name": "texts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "status_error": {
+          "name": "status_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "texts_owner_idx": {
+          "name": "texts_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "texts_visibility_idx": {
+          "name": "texts_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "texts_owner_id_users_id_fk": {
+          "name": "texts_owner_id_users_id_fk",
+          "tableFrom": "texts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.token_corrections": {
+      "name": "token_corrections",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "token_correction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chosen_lemma_id": {
+          "name": "chosen_lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "token_corrections_token_idx": {
+          "name": "token_corrections_token_idx",
+          "columns": [
+            {
+              "expression": "token_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "token_corrections_chosen_lemma_idx": {
+          "name": "token_corrections_chosen_lemma_idx",
+          "columns": [
+            {
+              "expression": "chosen_lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "token_corrections_user_id_users_id_fk": {
+          "name": "token_corrections_user_id_users_id_fk",
+          "tableFrom": "token_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "token_corrections_token_id_text_tokens_id_fk": {
+          "name": "token_corrections_token_id_text_tokens_id_fk",
+          "tableFrom": "token_corrections",
+          "tableTo": "text_tokens",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "token_corrections_chosen_lemma_id_lemmas_id_fk": {
+          "name": "token_corrections_chosen_lemma_id_lemmas_id_fk",
+          "tableFrom": "token_corrections",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "chosen_lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "token_corrections_user_id_token_id_pk": {
+          "name": "token_corrections_user_id_token_id_pk",
+          "columns": [
+            "user_id",
+            "token_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.translations": {
+      "name": "translations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "translation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_translation_id": {
+          "name": "parent_translation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_language": {
+          "name": "target_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_rank": {
+          "name": "display_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "translations_lemma_idx": {
+          "name": "translations_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translations_submitted_by_idx": {
+          "name": "translations_submitted_by_idx",
+          "columns": [
+            {
+              "expression": "submitted_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translations_source_lookup_idx": {
+          "name": "translations_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "translations_lemma_id_lemmas_id_fk": {
+          "name": "translations_lemma_id_lemmas_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "translations_submitted_by_users_id_fk": {
+          "name": "translations_submitted_by_users_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "translations_parent_translation_id_translations_id_fk": {
+          "name": "translations_parent_translation_id_translations_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "translations",
+          "columnsFrom": [
+            "parent_translation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_known_lemmas": {
+      "name": "user_known_lemmas",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "known_lemma_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'learning'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_known_lemmas_user_idx": {
+          "name": "user_known_lemmas_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_known_lemmas_user_id_users_id_fk": {
+          "name": "user_known_lemmas_user_id_users_id_fk",
+          "tableFrom": "user_known_lemmas",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_known_lemmas_lemma_id_lemmas_id_fk": {
+          "name": "user_known_lemmas_lemma_id_lemmas_id_fk",
+          "tableFrom": "user_known_lemmas",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_known_lemmas_user_id_lemma_id_pk": {
+          "name": "user_known_lemmas_user_id_lemma_id_pk",
+          "columns": [
+            "user_id",
+            "lemma_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_languages": {
+      "name": "user_languages",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script_preference": {
+          "name": "script_preference",
+          "type": "script_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "romanization_scheme": {
+          "name": "romanization_scheme",
+          "type": "romanization_scheme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'iso15919'"
+        },
+        "known_words_count_cache": {
+          "name": "known_words_count_cache",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reader_layout_mode": {
+          "name": "reader_layout_mode",
+          "type": "reader_layout_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'page'"
+        },
+        "words_per_page": {
+          "name": "words_per_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 250
+        },
+        "font_family": {
+          "name": "font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_size": {
+          "name": "font_size",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 18
+        },
+        "line_spacing": {
+          "name": "line_spacing",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1.6
+        },
+        "highlight_style": {
+          "name": "highlight_style",
+          "type": "highlight_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'background'"
+        },
+        "reading_width": {
+          "name": "reading_width",
+          "type": "reading_width",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "baseline": {
+          "name": "baseline",
+          "type": "language_baseline",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_languages_user_id_users_id_fk": {
+          "name": "user_languages_user_id_users_id_fk",
+          "tableFrom": "user_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_languages_user_id_language_pk": {
+          "name": "user_languages_user_id_language_pk",
+          "columns": [
+            "user_id",
+            "language"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_text_progress": {
+      "name": "user_text_progress",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_chapter_idx": {
+          "name": "last_chapter_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_token_idx": {
+          "name": "last_token_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pct_read": {
+          "name": "pct_read",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_text_progress_user_idx": {
+          "name": "user_text_progress_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_text_progress_user_id_users_id_fk": {
+          "name": "user_text_progress_user_id_users_id_fk",
+          "tableFrom": "user_text_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_text_progress_text_id_texts_id_fk": {
+          "name": "user_text_progress_text_id_texts_id_fk",
+          "tableFrom": "user_text_progress",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_text_progress_user_id_text_id_pk": {
+          "name": "user_text_progress_user_id_text_id_pk",
+          "columns": [
+            "user_id",
+            "text_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_preference": {
+          "name": "theme_preference",
+          "type": "theme_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarded_at": {
+          "name": "onboarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    }
+  },
+  "enums": {
+    "public.alignment_source": {
+      "name": "alignment_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "imported",
+        "whisper"
+      ]
+    },
+    "public.collection_kind": {
+      "name": "collection_kind",
+      "schema": "public",
+      "values": [
+        "chapter_book",
+        "course",
+        "anthology"
+      ]
+    },
+    "public.collection_visibility": {
+      "name": "collection_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "shared",
+        "official"
+      ]
+    },
+    "public.highlight_style": {
+      "name": "highlight_style",
+      "schema": "public",
+      "values": [
+        "underline",
+        "background",
+        "colored_text"
+      ]
+    },
+    "public.known_lemma_status": {
+      "name": "known_lemma_status",
+      "schema": "public",
+      "values": [
+        "unknown",
+        "learning",
+        "known",
+        "ignored"
+      ]
+    },
+    "public.language": {
+      "name": "language",
+      "schema": "public",
+      "values": [
+        "hi",
+        "mr",
+        "or"
+      ]
+    },
+    "public.language_baseline": {
+      "name": "language_baseline",
+      "schema": "public",
+      "values": [
+        "none",
+        "beginner",
+        "intermediate"
+      ]
+    },
+    "public.lemma_edit_change_type": {
+      "name": "lemma_edit_change_type",
+      "schema": "public",
+      "values": [
+        "lemma_update",
+        "lemma_unlock",
+        "lemma_lock",
+        "translation_insert",
+        "translation_update",
+        "translation_hide",
+        "translation_unhide",
+        "form_insert",
+        "form_delete",
+        "lemma_merge",
+        "lemma_split",
+        "translation_reorder"
+      ]
+    },
+    "public.lemma_proposal_status": {
+      "name": "lemma_proposal_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.nlp_job_status": {
+      "name": "nlp_job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.parse_report_status": {
+      "name": "parse_report_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "triaged",
+        "resolved",
+        "rejected",
+        "duplicate",
+        "deferred"
+      ]
+    },
+    "public.reader_layout_mode": {
+      "name": "reader_layout_mode",
+      "schema": "public",
+      "values": [
+        "page",
+        "paged_scroll",
+        "continuous"
+      ]
+    },
+    "public.reading_width": {
+      "name": "reading_width",
+      "schema": "public",
+      "values": [
+        "narrow",
+        "medium",
+        "wide"
+      ]
+    },
+    "public.romanization_scheme": {
+      "name": "romanization_scheme",
+      "schema": "public",
+      "values": [
+        "iso15919",
+        "iast",
+        "hunterian",
+        "itrans"
+      ]
+    },
+    "public.script_preference": {
+      "name": "script_preference",
+      "schema": "public",
+      "values": [
+        "native",
+        "native_with_romanization",
+        "romanization_only"
+      ]
+    },
+    "public.text_share_permission": {
+      "name": "text_share_permission",
+      "schema": "public",
+      "values": [
+        "read"
+      ]
+    },
+    "public.text_source_type": {
+      "name": "text_source_type",
+      "schema": "public",
+      "values": [
+        "paste",
+        "txt",
+        "epub"
+      ]
+    },
+    "public.text_status": {
+      "name": "text_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.text_visibility": {
+      "name": "text_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "shared",
+        "official"
+      ]
+    },
+    "public.theme_preference": {
+      "name": "theme_preference",
+      "schema": "public",
+      "values": [
+        "system",
+        "light",
+        "dark"
+      ]
+    },
+    "public.token_correction_type": {
+      "name": "token_correction_type",
+      "schema": "public",
+      "values": [
+        "pick_candidate",
+        "manual_lemma",
+        "new_lemma",
+        "mark_proper_noun",
+        "mark_foreign",
+        "mark_not_a_word"
+      ]
+    },
+    "public.translation_source": {
+      "name": "translation_source",
+      "schema": "public",
+      "values": [
+        "official_dictionary",
+        "curator",
+        "user"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "curator",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1777462786288,
       "tag": "0021_empty_silk_fever",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1777463299320,
+      "tag": "0022_t-2-8-number-forms",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/src/lib/components/reader/WordPopup.svelte
+++ b/apps/web/src/lib/components/reader/WordPopup.svelte
@@ -437,27 +437,59 @@
           ×
         </button>
         <h2 class="sp-word">{token.surface}</h2>
-      {#if token.romanization}
-        <p class="sp-roman">{token.romanization}</p>
-      {/if}
-      {#if payload}
-        <p class="sp-row">
-          <span class="k">Lemma</span>
-          <span class="v">{payload.lemma.headword}</span>
-        </p>
-        <p class="sp-row">
-          <span class="k">Part of speech</span>
-          <span class="v">{payload.lemma.pos}</span>
-        </p>
-      {:else if token.isOov}
-        <p class="muted">No dictionary match</p>
-      {:else if loadError}
-        <p class="err">{loadError}</p>
-      {:else if token.lemmaId}
-        <p class="muted">Loading…</p>
+      {#if token.numberForms}
+        <!-- T-2.8: digit-only NUM token. Show all three native-script
+             digit renderings, then the spelled-out form + ISO 15919
+             romanization for each MVP language. The lemma / translation
+             / status panes are skipped — numbers aren't lemmas to learn. -->
+        <div class="num-block" data-testid="number-forms">
+          <div class="num-digits">
+            <span>{token.numberForms.digitsLatin}</span>
+            <span>{token.numberForms.digitsDeva}</span>
+            <span>{token.numberForms.digitsOrya}</span>
+          </div>
+          <ul class="num-langs">
+            <li>
+              <span class="num-lang">Hindi</span>
+              <span class="num-spelled">{token.numberForms.hi.spelled}</span>
+              <span class="num-roman">{token.numberForms.hi.romanized}</span>
+            </li>
+            <li>
+              <span class="num-lang">Marathi</span>
+              <span class="num-spelled">{token.numberForms.mr.spelled}</span>
+              <span class="num-roman">{token.numberForms.mr.romanized}</span>
+            </li>
+            <li>
+              <span class="num-lang">Odia</span>
+              <span class="num-spelled">{token.numberForms.odia.spelled}</span>
+              <span class="num-roman">{token.numberForms.odia.romanized}</span>
+            </li>
+          </ul>
+        </div>
+      {:else}
+        {#if token.romanization}
+          <p class="sp-roman">{token.romanization}</p>
+        {/if}
+        {#if payload}
+          <p class="sp-row">
+            <span class="k">Lemma</span>
+            <span class="v">{payload.lemma.headword}</span>
+          </p>
+          <p class="sp-row">
+            <span class="k">Part of speech</span>
+            <span class="v">{payload.lemma.pos}</span>
+          </p>
+        {:else if token.isOov}
+          <p class="muted">No dictionary match</p>
+        {:else if loadError}
+          <p class="err">{loadError}</p>
+        {:else if token.lemmaId}
+          <p class="muted">Loading…</p>
+        {/if}
       {/if}
     </header>
 
+    {#if !token.numberForms}
     {#if isOwner && token.lemmaId}
       <div class="sp-status" role="group" aria-label="Mark status">
         <button
@@ -670,6 +702,7 @@
           <p class="err small" role="alert">{pickError}</p>
         {/if}
       {/if}
+    {/if}
     {/if}
     </div>
   {/if}
@@ -1070,5 +1103,61 @@
   .alt-pick:disabled {
     opacity: 0.6;
     cursor: progress;
+  }
+
+  /* T-2.8: number-only token block. */
+  .num-block {
+    display: flex;
+    flex-direction: column;
+    gap: 0.7rem;
+    margin-top: 0.4rem;
+  }
+  .num-digits {
+    display: flex;
+    align-items: baseline;
+    gap: 0.85rem;
+    font-family: var(--font-serif-dev, var(--font-serif));
+    font-size: 1.25rem;
+    color: var(--ink-2, var(--color-fg));
+    padding-bottom: 0.55rem;
+    border-bottom: 1px solid var(--rule-2, var(--color-border));
+  }
+  .num-langs {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.5rem;
+  }
+  .num-langs li {
+    display: grid;
+    grid-template-columns: 4.5rem 1fr;
+    grid-template-rows: auto auto;
+    column-gap: 0.65rem;
+    row-gap: 0.1rem;
+    align-items: baseline;
+  }
+  .num-lang {
+    grid-column: 1;
+    grid-row: 1 / span 2;
+    font-size: 0.66rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--ink-3, var(--color-fg-muted));
+    align-self: center;
+  }
+  .num-spelled {
+    grid-column: 2;
+    grid-row: 1;
+    font-family: var(--font-serif-dev, var(--font-serif));
+    font-size: 1rem;
+    color: var(--ink, var(--color-fg));
+  }
+  .num-roman {
+    grid-column: 2;
+    grid-row: 2;
+    font-family: var(--font-mono-display, var(--font-mono));
+    font-size: 0.78rem;
+    color: var(--ink-3, var(--color-fg-muted));
   }
 </style>

--- a/apps/web/src/lib/components/reader/WordPopup.test.ts
+++ b/apps/web/src/lib/components/reader/WordPopup.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { cleanup, render } from '@testing-library/svelte';
+
+import WordPopup from './WordPopup.svelte';
+import type { ServerToken, ServerNumberForms } from './types.js';
+
+beforeAll(() => {
+  // jsdom doesn't ship matchMedia; the popup uses it to switch between
+  // mobile-sheet and desktop-static layouts. Stub a minimal "always
+  // mobile" matcher so the $effect doesn't throw.
+  if (!window.matchMedia) {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: (query: string) => ({
+        matches: false,
+        media: query,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+        onchange: null,
+      }),
+    });
+  }
+});
+
+afterEach(() => {
+  cleanup();
+  // Belt + braces: clear any portaled popup the cleanup didn't.
+  document.body
+    .querySelectorAll('[data-testid="word-popup"], [data-testid="word-popup-empty"]')
+    .forEach((el) => el.remove());
+});
+
+function makeNumberForms(): ServerNumberForms {
+  return {
+    value: 123,
+    digitsLatin: '123',
+    digitsDeva: '१२३',
+    digitsOrya: '୧୨୩',
+    hi: { spelled: 'एक सौ तेईस', romanized: 'ek sau teīs' },
+    mr: { spelled: 'एकशे तेवीस', romanized: 'ēkaśē tēvīsa' },
+    odia: { spelled: 'ଏକ ଶହ ତେଇଶ', romanized: 'ēka śaha tēiśa' },
+  };
+}
+
+function makeToken(overrides: Partial<ServerToken> = {}): ServerToken {
+  return {
+    id: 't1',
+    idx: 0,
+    surface: '123',
+    isWord: true,
+    isAmbiguous: false,
+    isOov: false,
+    lemmaId: null,
+    romanization: null,
+    glossDefault: null,
+    candidates: [],
+    numberForms: null,
+    status: 'unknown',
+    ...overrides,
+  };
+}
+
+describe('WordPopup — number-only token block (T-2.8)', () => {
+  it('renders all three native-script digit forms', () => {
+    render(WordPopup, {
+      token: makeToken({ numberForms: makeNumberForms() }),
+      language: 'hi',
+      isOwner: true,
+      onClose: vi.fn(),
+    });
+    // Sheet portals to <body>, so query document.body rather than the
+    // testing-library container.
+    const block = document.body.querySelector('[data-testid="number-forms"]');
+    expect(block).not.toBeNull();
+    const digits = block!.querySelector('.num-digits')!.textContent ?? '';
+    expect(digits).toContain('123');
+    expect(digits).toContain('१२३');
+    expect(digits).toContain('୧୨୩');
+  });
+
+  it('renders the spelled-out form + romanization for each MVP language', () => {
+    render(WordPopup, {
+      token: makeToken({ numberForms: makeNumberForms() }),
+      language: 'hi',
+      isOwner: true,
+      onClose: vi.fn(),
+    });
+    const langs = Array.from(
+      document.body.querySelectorAll('.num-langs li'),
+    ) as HTMLLIElement[];
+    expect(langs).toHaveLength(3);
+    const text = langs.map((li) => li.textContent ?? '').join('|');
+    expect(text).toContain('Hindi');
+    expect(text).toContain('एक सौ तेईस');
+    expect(text).toContain('ek sau teīs');
+    expect(text).toContain('Marathi');
+    expect(text).toContain('एकशे तेवीस');
+    expect(text).toContain('Odia');
+    expect(text).toContain('ଏକ ଶହ ତେଇଶ');
+  });
+
+  it('hides the status / translations / fix affordances for number tokens', () => {
+    // Pass a non-null lemmaId to force the number branch to suppress
+    // the status group explicitly (rather than relying on the absent-
+    // lemma path that already hides it).
+    render(WordPopup, {
+      token: makeToken({
+        lemmaId: 'should-not-matter',
+        numberForms: makeNumberForms(),
+      }),
+      language: 'hi',
+      isOwner: true,
+      onClose: vi.fn(),
+    });
+    expect(document.body.querySelector('.sp-status')).toBeNull();
+    expect(document.body.querySelector('.translations')).toBeNull();
+    expect(document.body.querySelector('.add-toggle')).toBeNull();
+    expect(document.body.querySelector('.fix-toggle')).toBeNull();
+  });
+
+  it('renders the existing lemma popup when numberForms is null', () => {
+    render(WordPopup, {
+      token: makeToken({ surface: 'पाठ', lemmaId: 'lem-1' }),
+      language: 'hi',
+      isOwner: true,
+      onClose: vi.fn(),
+    });
+    expect(
+      document.body.querySelector('[data-testid="number-forms"]'),
+    ).toBeNull();
+    expect(
+      document.body.querySelector('[data-testid="word-popup"]'),
+    ).not.toBeNull();
+  });
+});

--- a/apps/web/src/lib/components/reader/WordTooltip.test.ts
+++ b/apps/web/src/lib/components/reader/WordTooltip.test.ts
@@ -26,6 +26,7 @@ function makeToken(overrides: Partial<ServerToken> = {}): ServerToken {
     romanization: 'prabhāt',
     glossDefault: null,
     candidates: [],
+    numberForms: null,
     status: 'unknown',
     ...overrides,
   };

--- a/apps/web/src/lib/components/reader/lazy-tokens.test.ts
+++ b/apps/web/src/lib/components/reader/lazy-tokens.test.ts
@@ -19,6 +19,7 @@ function fakeTokens(n: number): ServerToken[] {
     romanization: null,
     glossDefault: null,
     candidates: [],
+    numberForms: null,
     status: 'unknown',
   }));
 }

--- a/apps/web/src/lib/components/reader/types.ts
+++ b/apps/web/src/lib/components/reader/types.ts
@@ -21,6 +21,26 @@ export type ServerCandidate = {
   features: Record<string, string>;
 };
 
+/** T-2.8: per-language spelled-out + ISO 15919 romanization for a
+ *  digit-only NUM token. Mirrors `RenderedNumberForms` in
+ *  `$lib/server/texts/tokens.ts`. */
+export type ServerNumberLanguageForm = {
+  spelled: string;
+  romanized: string;
+};
+
+export type ServerNumberForms = {
+  value: number;
+  digitsLatin: string;
+  digitsDeva: string;
+  digitsOrya: string;
+  hi: ServerNumberLanguageForm;
+  mr: ServerNumberLanguageForm;
+  /** Odia rendering. Field is `odia`, not ISO 639-1 `or`, because
+   *  `or` is a reserved keyword on the Python side. */
+  odia: ServerNumberLanguageForm;
+};
+
 /** Per-token row from the NLP worker (T-5.2). When present, the
  *  component renders these spans directly; when null, it falls back
  *  to client-side whitespace tokenization. */
@@ -40,6 +60,11 @@ export type ServerToken = {
    *  Empty array when the worker scored only one viable candidate
    *  or hasn't run yet. */
   candidates: ServerCandidate[];
+  /** T-2.8: digit-only NUM tokens (e.g. "123" / "१२३" / "୧୨୩")
+   *  carry a per-language spelled-out form + ISO-15919 romanization.
+   *  Null on every other token. The popup uses this to replace the
+   *  lemma/translation block with the three written-out renderings. */
+  numberForms: ServerNumberForms | null;
   status: 'known' | 'learning' | 'ignored' | 'unknown';
 };
 

--- a/apps/web/src/lib/server/db/schema.ts
+++ b/apps/web/src/lib/server/db/schema.ts
@@ -804,6 +804,21 @@ export const textTokens = pgTable(
     isWord: boolean('is_word').notNull().default(true),
     sentenceIdx: integer('sentence_idx').notNull().default(0),
     romanization: text('romanization'),
+    /** T-2.8: digit-only NUM tokens carry a per-language spelled-out
+     *  + ISO-15919 romanization payload so the reader pop-up can show
+     *  e.g. "123 → एक सौ तेईस / ek sau teīs" without re-deriving on
+     *  the client. Null on every other token. The shape mirrors
+     *  `NumberForms` in the Python NLP service (services/nlp/app/numbers.py)
+     *  and is delivered verbatim by the in-process dispatcher. */
+    numberForms: jsonb('number_forms').$type<{
+      value: number;
+      digits_latin: string;
+      digits_deva: string;
+      digits_orya: string;
+      hi: { spelled: string; romanized: string };
+      mr: { spelled: string; romanized: string };
+      odia: { spelled: string; romanized: string };
+    } | null>(),
   },
   (t) => ({
     chapterIdx: unique('text_tokens_chapter_idx_uq').on(t.chapterId, t.idx),

--- a/apps/web/src/lib/server/nlp-client.ts
+++ b/apps/web/src/lib/server/nlp-client.ts
@@ -7,6 +7,26 @@ export interface LemmaCandidate {
   features: Record<string, string>;
 }
 
+export interface NumberLanguageForm {
+  spelled: string;
+  romanized: string;
+}
+
+/** Per-token number-form payload populated by the NLP service for
+ *  digit-only NUM tokens (T-2.8). Null on every other token. */
+export interface NumberForms {
+  value: number;
+  digits_latin: string;
+  digits_deva: string;
+  digits_orya: string;
+  hi: NumberLanguageForm;
+  mr: NumberLanguageForm;
+  // Wire field is `odia`, not the ISO 639-1 `or`, because `or` is a
+  // reserved Python keyword and can't be an attribute name on the
+  // server-side Pydantic model. The TypeScript mirror matches.
+  odia: NumberLanguageForm;
+}
+
 export interface NlpToken {
   idx: number;
   surface: string;
@@ -15,6 +35,7 @@ export interface NlpToken {
   is_ambiguous: boolean;
   is_oov: boolean;
   romanization: string | null;
+  number_forms: NumberForms | null;
 }
 
 export interface ProcessResponse {

--- a/apps/web/src/lib/server/texts/in-process-dispatcher.test.ts
+++ b/apps/web/src/lib/server/texts/in-process-dispatcher.test.ts
@@ -163,6 +163,7 @@ describe('processTextNow', () => {
           is_oov: true,
           romanization: null,
           candidates: [],
+          number_forms: null,
         },
       ],
     });

--- a/apps/web/src/lib/server/texts/in-process-dispatcher.ts
+++ b/apps/web/src/lib/server/texts/in-process-dispatcher.ts
@@ -270,6 +270,7 @@ async function processChapter(
       isWord: t.is_word,
       sentenceIdx: 0,
       romanization: t.romanization,
+      numberForms: t.number_forms,
     };
   }) satisfies Array<Omit<TextToken, 'id'>>;
   if (rows.length === 0) return 0;

--- a/apps/web/src/lib/server/texts/tokens.test.ts
+++ b/apps/web/src/lib/server/texts/tokens.test.ts
@@ -73,6 +73,7 @@ function tokenRow(overrides: Record<string, unknown> = {}) {
     isWord: true,
     sentenceIdx: 0,
     romanization: null,
+    numberForms: null,
     ...overrides,
   };
 }

--- a/apps/web/src/lib/server/texts/tokens.ts
+++ b/apps/web/src/lib/server/texts/tokens.ts
@@ -39,6 +39,27 @@ export type RenderedCandidate = {
   features: Record<string, string>;
 };
 
+/** T-2.8: per-language spelled-out + ISO 15919 romanization for a
+ *  digit-only NUM token. Keyed on language for symmetry with the wire
+ *  shape; `or` is the ISO 639-1 code for Odia. */
+export type RenderedNumberLanguageForm = {
+  spelled: string;
+  romanized: string;
+};
+
+export type RenderedNumberForms = {
+  value: number;
+  digitsLatin: string;
+  digitsDeva: string;
+  digitsOrya: string;
+  hi: RenderedNumberLanguageForm;
+  mr: RenderedNumberLanguageForm;
+  /** Odia rendering. Field is `odia` rather than the ISO 639-1 `or`
+   *  because `or` is a reserved Python keyword on the server-side
+   *  Pydantic model that emits this payload. */
+  odia: RenderedNumberLanguageForm;
+};
+
 export type RenderedToken = {
   id: string;
   idx: number;
@@ -58,6 +79,9 @@ export type RenderedToken = {
    *  (or when the worker hasn't run). The popup hides the
    *  alternate-meanings affordance when this is empty. */
   candidates: RenderedCandidate[];
+  /** T-2.8: digit-only NUM tokens carry a per-language spelled-out
+   *  form + romanization. Null on every other token. */
+  numberForms: RenderedNumberForms | null;
   status: 'known' | 'learning' | 'ignored' | 'unknown';
 };
 
@@ -325,6 +349,19 @@ export async function loadChapterTokens(
     }
     candidates.sort((a, b) => b.score - a.score);
 
+    const nf = t.numberForms;
+    const renderedNumberForms: RenderedNumberForms | null = nf
+      ? {
+          value: nf.value,
+          digitsLatin: nf.digits_latin,
+          digitsDeva: nf.digits_deva,
+          digitsOrya: nf.digits_orya,
+          hi: nf.hi,
+          mr: nf.mr,
+          odia: nf.odia,
+        }
+      : null;
+
     return {
       id: t.id,
       idx: t.idx,
@@ -341,6 +378,7 @@ export async function loadChapterTokens(
         ? glossByLemma.get(effectiveLemmaId) ?? null
         : null,
       candidates,
+      numberForms: renderedNumberForms,
       status,
     };
   });

--- a/apps/web/src/routes/api/v1/smoke/smoke.test.ts
+++ b/apps/web/src/routes/api/v1/smoke/smoke.test.ts
@@ -36,6 +36,7 @@ describe('GET /api/v1/smoke', () => {
           is_ambiguous: false,
           is_oov: false,
           romanization: null,
+          number_forms: null,
         },
       ],
     });

--- a/apps/web/src/routes/reader/[textId]/page-server.test.ts
+++ b/apps/web/src/routes/reader/[textId]/page-server.test.ts
@@ -331,6 +331,8 @@ describe('/reader/[textId] loader', () => {
       lemmaId: 'lem-1',
       romanization: null,
       glossDefault: null,
+      candidates: [],
+      numberForms: null,
       status: 'unknown' as const,
     });
     loadChapterTokens.mockResolvedValueOnce([tokenRow('t0', 0)]);

--- a/services/nlp/app/numbers.py
+++ b/services/nlp/app/numbers.py
@@ -1,0 +1,611 @@
+"""Number-to-words for digit-only NUM tokens (T-2.8).
+
+The reader pop-up calls :func:`number_forms` whenever it receives a
+token whose surface is purely digits (Latin ``0–9``, Devanagari
+``०–९``, or Odia ``୦–୯`` — all from one script). The result is a
+:class:`NumberForms` struct with the integer value, all three native-
+script digit renderings, and the spelled-out form + ISO 15919
+romanization in each of the three MVP languages (Hindi, Marathi, Odia).
+
+Range
+=====
+Non-negative integers from 0 through 10⁷ (one crore) inclusive. Numbers
+larger than that, signed numbers, and decimals fall through (T-2.8a
+will lift those last two).
+
+Linguistic notes
+================
+The 0–99 forms in all three languages are highly irregular and were
+hand-curated for this module. Curator review is part of T-2.8 sign-off
+— typos in the rare 50–99 range (especially Marathi ``सत्त्याहत्तर``-style
+sandhi clusters) are exactly the sort of thing easy to miss in code
+review and obvious to a native reader. The base-100 / base-1k / lakh /
+crore composition rules are language-specific:
+
+* **Hindi** uses ``<digit> सौ <remainder>``: ``एक सौ तेईस``.
+* **Marathi** fuses the hundreds digit and the hundred word into one
+  token: ``एकशे तेवीस``. ``शंभर`` is colloquial for 100 alone, but
+  ``एकशे`` keeps the decomposition grammar consistent so 100 and 105
+  read as ``एकशे`` / ``एकशे पाच`` rather than alternating registers.
+* **Odia** uses ``<digit> ଶହ <remainder>``: ``ଏକ ଶହ ତେଇଶ``.
+
+All three languages stack lakh (10⁵) and crore (10⁷) above the base-1k
+unit — a Western "million" reads as ``दस लाख``, not as a separate word.
+
+Romanization is delegated to :func:`app.romanize.to_roman`, with the
+language hint (``"hi"`` / ``"mr"`` / ``"or"``) so Hindi gets schwa
+deletion and the ē/ō → e/o fold while Marathi and Odia keep the
+macrons. The output scheme is fixed at ISO 15919 — the reader's
+``romanization`` field is also ISO 15919, so the number block stays in
+the same scheme as the rest of the popup.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from app.romanize import to_roman
+from app.schemas import NumberForms, NumberLanguageForm
+
+# ----------------------------------------------------------------
+# Digit detection
+# ----------------------------------------------------------------
+
+_LATIN_DIGITS: str = "0123456789"
+_DEVA_DIGITS: str = "०१२३४५६७८९"  # ०-९
+_ORYA_DIGITS: str = "୦୧୨୩୪୫୬୭୮୯"  # ୦-୯
+
+DigitScript = Literal["latin", "deva", "orya"]
+
+_DIGIT_SETS: dict[DigitScript, str] = {
+    "latin": _LATIN_DIGITS,
+    "deva": _DEVA_DIGITS,
+    "orya": _ORYA_DIGITS,
+}
+
+#: Inclusive upper bound on values this module accepts. One crore.
+MAX_VALUE: int = 10_000_000
+
+
+def _classify_script(surface: str) -> DigitScript | None:
+    """Return the script tag if ``surface`` is non-empty and every
+    character is a digit from one (and only one) of the supported
+    scripts. Mixed-script and non-digit input returns ``None``.
+    """
+    if not surface:
+        return None
+    for name, digits in _DIGIT_SETS.items():
+        if all(c in digits for c in surface):
+            return name
+    return None
+
+
+def parse_digits(surface: str) -> int | None:
+    """Parse a digit-only token to an int.
+
+    Returns ``None`` for empty input, mixed-script input, signed
+    input, decimal input, or values exceeding :data:`MAX_VALUE`.
+    Accepts Latin, Devanagari, or Odia digits; all digits must come
+    from a single script.
+    """
+    script = _classify_script(surface)
+    if script is None:
+        return None
+    digits = _DIGIT_SETS[script]
+    value = 0
+    for c in surface:
+        value = value * 10 + digits.index(c)
+    if value > MAX_VALUE:
+        return None
+    return value
+
+
+def digits_in_script(n: int, script: DigitScript) -> str:
+    """Render an integer as a string of digits in the given script.
+
+    ``digits_in_script(123, "deva") == "१२३"``.
+    """
+    if n < 0 or n > MAX_VALUE:
+        raise ValueError(f"{n} out of range [0, {MAX_VALUE}]")
+    digits = _DIGIT_SETS[script]
+    if n == 0:
+        return digits[0]
+    out: list[str] = []
+    while n > 0:
+        out.append(digits[n % 10])
+        n //= 10
+    return "".join(reversed(out))
+
+
+# ----------------------------------------------------------------
+# Hindi
+# ----------------------------------------------------------------
+
+# fmt: off
+_HI_BELOW_100: tuple[str, ...] = (
+    "शून्य",        # 0
+    "एक",          # 1
+    "दो",           # 2
+    "तीन",         # 3
+    "चार",         # 4
+    "पाँच",         # 5
+    "छह",          # 6
+    "सात",         # 7
+    "आठ",          # 8
+    "नौ",           # 9
+    "दस",          # 10
+    "ग्यारह",       # 11
+    "बारह",        # 12
+    "तेरह",         # 13
+    "चौदह",        # 14
+    "पंद्रह",        # 15
+    "सोलह",        # 16
+    "सत्रह",        # 17
+    "अठारह",       # 18
+    "उन्नीस",       # 19
+    "बीस",         # 20
+    "इक्कीस",       # 21
+    "बाईस",        # 22
+    "तेईस",         # 23
+    "चौबीस",       # 24
+    "पच्चीस",       # 25
+    "छब्बीस",       # 26
+    "सत्ताईस",      # 27
+    "अट्ठाईस",      # 28
+    "उनतीस",       # 29
+    "तीस",         # 30
+    "इकतीस",       # 31
+    "बत्तीस",       # 32
+    "तैंतीस",        # 33
+    "चौंतीस",       # 34
+    "पैंतीस",        # 35
+    "छत्तीस",       # 36
+    "सैंतीस",        # 37
+    "अड़तीस",       # 38
+    "उनतालीस",     # 39
+    "चालीस",       # 40
+    "इकतालीस",     # 41
+    "बयालीस",      # 42
+    "तैंतालीस",      # 43
+    "चौवालीस",     # 44
+    "पैंतालीस",      # 45
+    "छियालीस",     # 46
+    "सैंतालीस",      # 47
+    "अड़तालीस",     # 48
+    "उनचास",       # 49
+    "पचास",        # 50
+    "इक्यावन",      # 51
+    "बावन",        # 52
+    "तिरेपन",       # 53
+    "चौवन",        # 54
+    "पचपन",        # 55
+    "छप्पन",        # 56
+    "सत्तावन",      # 57
+    "अट्ठावन",      # 58
+    "उनसठ",        # 59
+    "साठ",         # 60
+    "इकसठ",        # 61
+    "बासठ",        # 62
+    "तिरेसठ",       # 63
+    "चौंसठ",        # 64
+    "पैंसठ",         # 65
+    "छियासठ",      # 66
+    "सड़सठ",        # 67
+    "अड़सठ",        # 68
+    "उनहत्तर",      # 69
+    "सत्तर",         # 70
+    "इकहत्तर",      # 71
+    "बहत्तर",        # 72
+    "तिहत्तर",       # 73
+    "चौहत्तर",       # 74
+    "पचहत्तर",      # 75
+    "छिहत्तर",      # 76
+    "सतहत्तर",      # 77
+    "अठहत्तर",      # 78
+    "उन्यासी",       # 79
+    "अस्सी",        # 80
+    "इक्यासी",      # 81
+    "बयासी",        # 82
+    "तिरासी",       # 83
+    "चौरासी",       # 84
+    "पचासी",       # 85
+    "छियासी",      # 86
+    "सत्तासी",       # 87
+    "अट्ठासी",      # 88
+    "नवासी",       # 89
+    "नब्बे",         # 90
+    "इक्यानवे",     # 91
+    "बानवे",        # 92
+    "तिरानवे",      # 93
+    "चौरानवे",      # 94
+    "पचानवे",      # 95
+    "छियानवे",     # 96
+    "सत्तानवे",     # 97
+    "अट्ठानवे",     # 98
+    "निन्यानवे",    # 99
+)
+# fmt: on
+assert len(_HI_BELOW_100) == 100
+
+_HI_HUNDRED = "सौ"
+_HI_THOUSAND = "हज़ार"
+_HI_LAKH = "लाख"
+_HI_CRORE = "करोड़"
+
+
+def to_words_hi(n: int) -> str:
+    """Spell out ``n`` in Hindi (Devanagari)."""
+    if n < 0 or n > MAX_VALUE:
+        raise ValueError(f"{n} out of range [0, {MAX_VALUE}]")
+    if n < 100:
+        return _HI_BELOW_100[n]
+
+    parts: list[str] = []
+    crores, n = divmod(n, 10_000_000)
+    lakhs, n = divmod(n, 100_000)
+    thousands, n = divmod(n, 1_000)
+    hundreds, n = divmod(n, 100)
+    if crores:
+        parts.append(f"{_HI_BELOW_100[crores]} {_HI_CRORE}")
+    if lakhs:
+        parts.append(f"{_HI_BELOW_100[lakhs]} {_HI_LAKH}")
+    if thousands:
+        parts.append(f"{_HI_BELOW_100[thousands]} {_HI_THOUSAND}")
+    if hundreds:
+        parts.append(f"{_HI_BELOW_100[hundreds]} {_HI_HUNDRED}")
+    if n:
+        parts.append(_HI_BELOW_100[n])
+    return " ".join(parts)
+
+
+# ----------------------------------------------------------------
+# Marathi
+# ----------------------------------------------------------------
+
+# fmt: off
+_MR_BELOW_100: tuple[str, ...] = (
+    "शून्य",        # 0
+    "एक",          # 1
+    "दोन",         # 2
+    "तीन",         # 3
+    "चार",         # 4
+    "पाच",         # 5
+    "सहा",         # 6
+    "सात",         # 7
+    "आठ",          # 8
+    "नऊ",          # 9
+    "दहा",         # 10
+    "अकरा",        # 11
+    "बारा",         # 12
+    "तेरा",         # 13
+    "चौदा",        # 14
+    "पंधरा",        # 15
+    "सोळा",        # 16
+    "सतरा",        # 17
+    "अठरा",        # 18
+    "एकोणीस",      # 19
+    "वीस",          # 20
+    "एकवीस",       # 21
+    "बावीस",       # 22
+    "तेवीस",        # 23
+    "चोवीस",       # 24
+    "पंचवीस",      # 25
+    "सव्वीस",       # 26
+    "सत्तावीस",     # 27
+    "अठ्ठावीस",     # 28
+    "एकोणतीस",     # 29
+    "तीस",         # 30
+    "एकतीस",       # 31
+    "बत्तीस",        # 32
+    "तेहतीस",       # 33
+    "चौतीस",       # 34
+    "पस्तीस",       # 35
+    "छत्तीस",       # 36
+    "सदतीस",       # 37
+    "अडतीस",       # 38
+    "एकोणचाळीस",   # 39
+    "चाळीस",       # 40
+    "एक्केचाळीस",   # 41
+    "बेचाळीस",      # 42
+    "त्रेचाळीस",     # 43
+    "चव्वेचाळीस",   # 44
+    "पंचेचाळीस",    # 45
+    "सेहेचाळीस",    # 46
+    "सत्तेचाळीस",   # 47
+    "अठ्ठेचाळीस",   # 48
+    "एकोणपन्नास",  # 49
+    "पन्नास",       # 50
+    "एक्कावन्न",    # 51
+    "बावन्न",       # 52
+    "त्रेपन्न",       # 53
+    "चोपन्न",       # 54
+    "पंचावन्न",     # 55
+    "छप्पन्न",      # 56
+    "सत्तावन्न",    # 57
+    "अठ्ठावन्न",    # 58
+    "एकोणसाठ",    # 59
+    "साठ",         # 60
+    "एकसष्ठ",      # 61
+    "बासष्ठ",       # 62
+    "त्रेसष्ठ",       # 63
+    "चौसष्ठ",       # 64
+    "पासष्ठ",       # 65
+    "सहासष्ठ",     # 66
+    "सदुसष्ठ",      # 67
+    "अडुसष्ठ",      # 68
+    "एकोणसत्तर",   # 69
+    "सत्तर",        # 70
+    "एक्काहत्तर",   # 71
+    "बाहत्तर",      # 72
+    "त्र्याहत्तर",    # 73
+    "चौऱ्याहत्तर",  # 74
+    "पंच्याहत्तर",   # 75
+    "शहात्तर",      # 76
+    "सत्त्याहत्तर",  # 77
+    "अठ्ठ्याहत्तर",  # 78
+    "एकोणऐंशी",    # 79
+    "ऐंशी",         # 80
+    "एक्क्याऐंशी",  # 81
+    "ब्याऐंशी",      # 82
+    "त्र्याऐंशी",     # 83
+    "चौऱ्याऐंशी",   # 84
+    "पंच्याऐंशी",    # 85
+    "शहाऐंशी",      # 86
+    "सत्त्याऐंशी",   # 87
+    "अठ्ठ्याऐंशी",   # 88
+    "एकोणनव्वद",  # 89
+    "नव्वद",       # 90
+    "एक्क्याण्णव",  # 91
+    "ब्याण्णव",     # 92
+    "त्र्याण्णव",    # 93
+    "चौऱ्याण्णव",   # 94
+    "पंच्याण्णव",   # 95
+    "शहाण्णव",     # 96
+    "सत्त्याण्णव",  # 97
+    "अठ्ठ्याण्णव",  # 98
+    "नव्व्याण्णव",  # 99
+)
+# fmt: on
+assert len(_MR_BELOW_100) == 100
+
+# Marathi fuses the hundreds digit with the hundred-word: एकशे, दोनशे,
+# तीनशे, .... Index 0 is unused.
+_MR_HUNDREDS: tuple[str, ...] = (
+    "",  # unused
+    "एकशे",
+    "दोनशे",
+    "तीनशे",
+    "चारशे",
+    "पाचशे",
+    "सहाशे",
+    "सातशे",
+    "आठशे",
+    "नऊशे",
+)
+_MR_THOUSAND = "हजार"
+_MR_LAKH = "लाख"
+_MR_CRORE = "कोटी"
+
+
+def to_words_mr(n: int) -> str:
+    """Spell out ``n`` in Marathi (Devanagari)."""
+    if n < 0 or n > MAX_VALUE:
+        raise ValueError(f"{n} out of range [0, {MAX_VALUE}]")
+    if n < 100:
+        return _MR_BELOW_100[n]
+
+    parts: list[str] = []
+    crores, n = divmod(n, 10_000_000)
+    lakhs, n = divmod(n, 100_000)
+    thousands, n = divmod(n, 1_000)
+    hundreds, n = divmod(n, 100)
+    if crores:
+        parts.append(f"{_MR_BELOW_100[crores]} {_MR_CRORE}")
+    if lakhs:
+        parts.append(f"{_MR_BELOW_100[lakhs]} {_MR_LAKH}")
+    if thousands:
+        parts.append(f"{_MR_BELOW_100[thousands]} {_MR_THOUSAND}")
+    if hundreds:
+        parts.append(_MR_HUNDREDS[hundreds])
+    if n:
+        parts.append(_MR_BELOW_100[n])
+    return " ".join(parts)
+
+
+# ----------------------------------------------------------------
+# Odia
+# ----------------------------------------------------------------
+
+# fmt: off
+_OR_BELOW_100: tuple[str, ...] = (
+    "ଶୂନ୍ୟ",        # 0
+    "ଏକ",          # 1
+    "ଦୁଇ",         # 2
+    "ତିନି",         # 3
+    "ଚାରି",         # 4
+    "ପାଞ୍ଚ",        # 5
+    "ଛଅ",          # 6
+    "ସାତ",         # 7
+    "ଆଠ",          # 8
+    "ନଅ",          # 9
+    "ଦଶ",          # 10
+    "ଏଗାର",        # 11
+    "ବାର",         # 12
+    "ତେର",         # 13
+    "ଚଉଦ",         # 14
+    "ପନ୍ଦର",        # 15
+    "ଷୋହଳ",        # 16
+    "ସତର",         # 17
+    "ଅଠର",         # 18
+    "ଊଣେଇଶ",      # 19
+    "କୋଡ଼ିଏ",       # 20
+    "ଏକୋଇଶ",       # 21
+    "ବାଇଶ",        # 22
+    "ତେଇଶ",       # 23
+    "ଚବିଶ",         # 24
+    "ପଚିଶ",         # 25
+    "ଛବିଶ",         # 26
+    "ସତାଇଶ",      # 27
+    "ଅଠାଇଶ",      # 28
+    "ଅଣତିରିଶ",     # 29
+    "ତିରିଶ",         # 30
+    "ଏକତିରିଶ",     # 31
+    "ବତିଶ",        # 32
+    "ତେତିଶ",       # 33
+    "ଚଉତିରିଶ",     # 34
+    "ପଞ୍ଚତିରିଶ",    # 35
+    "ଛତିଶ",        # 36
+    "ସଡ଼େଇତିରିଶ",   # 37
+    "ଅଠତିରିଶ",     # 38
+    "ଅଣଚାଳିଶ",     # 39
+    "ଚାଳିଶ",       # 40
+    "ଏକଚାଳିଶ",     # 41
+    "ବୟାଳିଶ",      # 42
+    "ତେୟାଳିଶ",     # 43
+    "ଚଉରାଳିଶ",     # 44
+    "ପଞ୍ଚଚାଳିଶ",   # 45
+    "ଛୟାଳିଶ",      # 46
+    "ସତଚାଳିଶ",     # 47
+    "ଅଠଚାଳିଶ",     # 48
+    "ଅଣଚାଶ",       # 49
+    "ପଚାଶ",        # 50
+    "ଏକାବନ",       # 51
+    "ବାବନ",        # 52
+    "ତେପନ",        # 53
+    "ଚଉବନ",        # 54
+    "ପଞ୍ଚାବନ",     # 55
+    "ଛାବନ",        # 56
+    "ସତାବନ",      # 57
+    "ଅଠାବନ",      # 58
+    "ଅଣଷଠି",       # 59
+    "ଷାଠିଏ",        # 60
+    "ଏକଷଠି",       # 61
+    "ବାଷଠି",        # 62
+    "ତେଷଠି",       # 63
+    "ଚଉଷଠି",       # 64
+    "ପଞ୍ଚଷଠି",     # 65
+    "ଛଅଷଠି",       # 66
+    "ସତଷଠି",       # 67
+    "ଅଠଷଠି",       # 68
+    "ଅଣସତୁରୀ",     # 69
+    "ସତୁରୀ",        # 70
+    "ଏକସତୁରୀ",     # 71
+    "ବାସତୁରୀ",      # 72
+    "ତେସତୁରୀ",     # 73
+    "ଚଉସତୁରୀ",     # 74
+    "ପଞ୍ଚସତୁରୀ",   # 75
+    "ଛଅସତୁରୀ",     # 76
+    "ସତସତୁରୀ",     # 77
+    "ଅଠସତୁରୀ",     # 78
+    "ଅଣାଅଶୀ",      # 79
+    "ଅଶୀ",         # 80
+    "ଏକାଅଶୀ",      # 81
+    "ବୟାଅଶୀ",      # 82
+    "ତିରାଅଶୀ",      # 83
+    "ଚଉରାଅଶୀ",    # 84
+    "ପଞ୍ଚାଅଶୀ",    # 85
+    "ଛୟାଅଶୀ",      # 86
+    "ସତାଅଶୀ",     # 87
+    "ଅଠାଅଶୀ",     # 88
+    "ଅଣାନବେ",     # 89
+    "ନବେ",         # 90
+    "ଏକାନବେ",     # 91
+    "ବୟାନବେ",     # 92
+    "ତିରାନବେ",     # 93
+    "ଚଉରାନବେ",    # 94
+    "ପଞ୍ଚାନବେ",   # 95
+    "ଛୟାନବେ",     # 96
+    "ସତାନବେ",     # 97
+    "ଅଠାନବେ",     # 98
+    "ଅନେଶତ",      # 99
+)
+# fmt: on
+assert len(_OR_BELOW_100) == 100
+
+_OR_HUNDRED = "ଶହ"
+_OR_THOUSAND = "ହଜାର"
+_OR_LAKH = "ଲକ୍ଷ"
+_OR_CRORE = "କୋଟି"
+
+
+def to_words_or(n: int) -> str:
+    """Spell out ``n`` in Odia."""
+    if n < 0 or n > MAX_VALUE:
+        raise ValueError(f"{n} out of range [0, {MAX_VALUE}]")
+    if n < 100:
+        return _OR_BELOW_100[n]
+
+    parts: list[str] = []
+    crores, n = divmod(n, 10_000_000)
+    lakhs, n = divmod(n, 100_000)
+    thousands, n = divmod(n, 1_000)
+    hundreds, n = divmod(n, 100)
+    if crores:
+        parts.append(f"{_OR_BELOW_100[crores]} {_OR_CRORE}")
+    if lakhs:
+        parts.append(f"{_OR_BELOW_100[lakhs]} {_OR_LAKH}")
+    if thousands:
+        parts.append(f"{_OR_BELOW_100[thousands]} {_OR_THOUSAND}")
+    if hundreds:
+        parts.append(f"{_OR_BELOW_100[hundreds]} {_OR_HUNDRED}")
+    if n:
+        parts.append(_OR_BELOW_100[n])
+    return " ".join(parts)
+
+
+# ----------------------------------------------------------------
+# Public entry point
+# ----------------------------------------------------------------
+
+_LANG_TO_SCRIPT: dict[str, str] = {"hi": "Deva", "mr": "Deva", "or": "Orya"}
+
+
+def _romanize(spelled: str, language: str) -> str:
+    return to_roman(
+        spelled,
+        from_script=_LANG_TO_SCRIPT[language],
+        to_scheme="iso15919",
+        language=language,
+    )
+
+
+def _language_form(spelled: str, language: str) -> NumberLanguageForm:
+    return NumberLanguageForm(
+        spelled=spelled,
+        romanized=_romanize(spelled, language),
+    )
+
+
+def number_forms(surface: str) -> NumberForms | None:
+    """Build the per-language spelled-out + romanized struct for a
+    digit-only token, or ``None`` if the surface doesn't qualify.
+
+    Qualifying input: non-empty, all-digit, single-script (Latin /
+    Devanagari / Odia), value in ``[0, MAX_VALUE]``.
+    """
+    value = parse_digits(surface)
+    if value is None:
+        return None
+    return NumberForms(
+        value=value,
+        digits_latin=digits_in_script(value, "latin"),
+        digits_deva=digits_in_script(value, "deva"),
+        digits_orya=digits_in_script(value, "orya"),
+        hi=_language_form(to_words_hi(value), "hi"),
+        mr=_language_form(to_words_mr(value), "mr"),
+        # Wire field is ISO 639-1 ``or``; Python attribute is ``odia``
+        # (``or`` is a reserved keyword).
+        odia=_language_form(to_words_or(value), "or"),
+    )
+
+
+__all__ = [
+    "MAX_VALUE",
+    "DigitScript",
+    "digits_in_script",
+    "number_forms",
+    "parse_digits",
+    "to_words_hi",
+    "to_words_mr",
+    "to_words_or",
+]

--- a/services/nlp/app/pipelines/odia/__init__.py
+++ b/services/nlp/app/pipelines/odia/__init__.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
+from app.numbers import number_forms as _compute_number_forms
 from app.schemas import LemmaCandidate, Token
 
 from ..base import Pipeline, PipelineResult
@@ -129,6 +130,7 @@ class OdiaPipeline(Pipeline):
             is_ambiguous=len(analyses) >= 2,
             is_oov=is_oov,
             romanization=None,
+            number_forms=_compute_number_forms(surface),
         )
 
 

--- a/services/nlp/app/pipelines/stanza_ud.py
+++ b/services/nlp/app/pipelines/stanza_ud.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from typing import Any, Protocol
 
+from app.numbers import number_forms as _compute_number_forms
 from app.romanize import UnsupportedScriptError, to_roman
 from app.schemas import LemmaCandidate, Token
 
@@ -151,6 +152,7 @@ class StanzaUDPipeline(Pipeline):
                         is_ambiguous=False,
                         is_oov=is_oov,
                         romanization=self._romanize(surface) if is_word else None,
+                        number_forms=_compute_number_forms(surface),
                     )
                 )
                 idx += 1

--- a/services/nlp/app/schemas.py
+++ b/services/nlp/app/schemas.py
@@ -20,6 +20,36 @@ class LemmaCandidate(BaseModel):
     features: dict[str, str] = Field(default_factory=dict)
 
 
+class NumberLanguageForm(BaseModel):
+    """Per-language number rendering: native-script spelled-out form
+    plus its ISO 15919 romanization. Surfaced by :mod:`app.numbers` for
+    digit-only NUM tokens (T-2.8)."""
+
+    spelled: str
+    romanized: str
+
+
+class NumberForms(BaseModel):
+    """Per-token number-form payload for digit-only NUM surfaces. The
+    reader pop-up uses this to show the spelled-out form in all three
+    MVP languages so a learner can sound out a numeral without leaving
+    the page (T-2.8). ``None`` on the parent :class:`Token` for any
+    token that isn't a single-script digit run in ``[0, 10_000_000]``.
+    """
+
+    value: int
+    digits_latin: str
+    digits_deva: str
+    digits_orya: str
+    hi: NumberLanguageForm
+    mr: NumberLanguageForm
+    # The wire field uses ``odia`` instead of the ISO 639-1 code
+    # ``or`` because ``or`` is a reserved Python keyword and can't be
+    # an attribute name. The TypeScript mirror in
+    # ``apps/web/src/lib/server/nlp-client.ts`` matches.
+    odia: NumberLanguageForm
+
+
 class Token(BaseModel):
     idx: int
     surface: str
@@ -28,6 +58,7 @@ class Token(BaseModel):
     is_ambiguous: bool = False
     is_oov: bool = False
     romanization: str | None = None
+    number_forms: NumberForms | None = None
 
 
 class ProcessResponse(BaseModel):

--- a/services/nlp/tests/test_numbers.py
+++ b/services/nlp/tests/test_numbers.py
@@ -1,0 +1,328 @@
+"""Unit tests for :mod:`app.numbers` (T-2.8).
+
+The 0–99 spelled-out forms in three languages plus the base-100 / 1k /
+lakh / crore composition rules are easy to typo and hard to spot
+without a native reader, so we pin a sweep of reference values and let
+CI catch regressions.
+
+Reference values were cross-checked against published number tables
+(NCERT Hindi mathematics primers; Marathi BalBharti texts; Odia
+Govt.-of-Odisha textbooks) and curator review on the trickier 50–99
+sandhi forms is part of T-2.8 sign-off.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.numbers import (
+    MAX_VALUE,
+    digits_in_script,
+    number_forms,
+    parse_digits,
+    to_words_hi,
+    to_words_mr,
+    to_words_or,
+)
+from app.schemas import NumberForms
+
+# ----------------------------------------------------------------
+# parse_digits
+# ----------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "surface,expected",
+    [
+        ("0", 0),
+        ("9", 9),
+        ("10", 10),
+        ("123", 123),
+        ("9999999", 9_999_999),
+        ("10000000", 10_000_000),
+        # Devanagari digits
+        ("०", 0),
+        ("१२३", 123),
+        ("१०००", 1_000),
+        # Odia digits
+        ("୦", 0),
+        ("୧୨୩", 123),
+        ("୯୯୯", 999),
+    ],
+)
+def test_parse_digits_accepts_single_script(surface: str, expected: int) -> None:
+    assert parse_digits(surface) == expected
+
+
+@pytest.mark.parametrize(
+    "surface",
+    [
+        "",
+        "abc",
+        " ",
+        "12a",
+        # Mixed-script: not allowed.
+        "१23",
+        "1२3",
+        "1୨3",
+        "१୨३",
+        # Sign / decimal: T-2.8a.
+        "-1",
+        "+1",
+        "−1",
+        "1.5",
+        ".5",
+        "1.",
+        "1,000",
+        # Out of range.
+        "10000001",
+        "99999999",
+    ],
+)
+def test_parse_digits_rejects(surface: str) -> None:
+    assert parse_digits(surface) is None
+
+
+# ----------------------------------------------------------------
+# digits_in_script
+# ----------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "n,latin,deva,orya",
+    [
+        (0, "0", "०", "୦"),
+        (9, "9", "९", "୯"),
+        (10, "10", "१०", "୧୦"),
+        (123, "123", "१२३", "୧୨୩"),
+        (9_999_999, "9999999", "९९९९९९९", "୯୯୯୯୯୯୯"),
+        (10_000_000, "10000000", "१" + "०" * 7, "୧" + "୦" * 7),
+    ],
+)
+def test_digits_in_script(n: int, latin: str, deva: str, orya: str) -> None:
+    assert digits_in_script(n, "latin") == latin
+    assert digits_in_script(n, "deva") == deva
+    assert digits_in_script(n, "orya") == orya
+
+
+@pytest.mark.parametrize("n", [-1, MAX_VALUE + 1, 100_000_000])
+def test_digits_in_script_out_of_range(n: int) -> None:
+    with pytest.raises(ValueError):
+        digits_in_script(n, "latin")
+
+
+# ----------------------------------------------------------------
+# Hindi spelled-out — pinned reference values.
+# ----------------------------------------------------------------
+
+_HINDI_REFERENCE: list[tuple[int, str]] = [
+    (0, "शून्य"),
+    (1, "एक"),
+    (2, "दो"),
+    (3, "तीन"),
+    (5, "पाँच"),
+    (10, "दस"),
+    (11, "ग्यारह"),
+    (15, "पंद्रह"),
+    (19, "उन्नीस"),
+    (20, "बीस"),
+    (21, "इक्कीस"),
+    (30, "तीस"),
+    (50, "पचास"),
+    (99, "निन्यानवे"),
+    (100, "एक सौ"),
+    (101, "एक सौ एक"),
+    (123, "एक सौ तेईस"),
+    (500, "पाँच सौ"),
+    (999, "नौ सौ निन्यानवे"),
+    (1_000, "एक हज़ार"),
+    (1_234, "एक हज़ार दो सौ चौंतीस"),
+    (9_999, "नौ हज़ार नौ सौ निन्यानवे"),
+    (10_000, "दस हज़ार"),
+    (100_000, "एक लाख"),
+    (123_456, "एक लाख तेईस हज़ार चार सौ छप्पन"),
+    (1_000_000, "दस लाख"),
+    (9_999_999, "निन्यानवे लाख निन्यानवे हज़ार नौ सौ निन्यानवे"),
+    (10_000_000, "एक करोड़"),
+]
+
+
+@pytest.mark.parametrize("n,expected", _HINDI_REFERENCE)
+def test_to_words_hi_pinned(n: int, expected: str) -> None:
+    assert to_words_hi(n) == expected
+
+
+# ----------------------------------------------------------------
+# Marathi spelled-out — pinned reference values.
+# ----------------------------------------------------------------
+
+_MARATHI_REFERENCE: list[tuple[int, str]] = [
+    (0, "शून्य"),
+    (1, "एक"),
+    (2, "दोन"),
+    (5, "पाच"),
+    (9, "नऊ"),
+    (10, "दहा"),
+    (16, "सोळा"),
+    (19, "एकोणीस"),
+    (20, "वीस"),
+    (23, "तेवीस"),
+    (50, "पन्नास"),
+    (99, "नव्व्याण्णव"),
+    (100, "एकशे"),
+    (101, "एकशे एक"),
+    (123, "एकशे तेवीस"),
+    (200, "दोनशे"),
+    (500, "पाचशे"),
+    (1_000, "एक हजार"),
+    (1_234, "एक हजार दोनशे चौतीस"),
+    (10_000, "दहा हजार"),
+    (100_000, "एक लाख"),
+    (1_000_000, "दहा लाख"),
+    (10_000_000, "एक कोटी"),
+]
+
+
+@pytest.mark.parametrize("n,expected", _MARATHI_REFERENCE)
+def test_to_words_mr_pinned(n: int, expected: str) -> None:
+    assert to_words_mr(n) == expected
+
+
+# ----------------------------------------------------------------
+# Odia spelled-out — pinned reference values.
+# ----------------------------------------------------------------
+
+_ODIA_REFERENCE: list[tuple[int, str]] = [
+    (0, "ଶୂନ୍ୟ"),
+    (1, "ଏକ"),
+    (2, "ଦୁଇ"),
+    (5, "ପାଞ୍ଚ"),
+    (9, "ନଅ"),
+    (10, "ଦଶ"),
+    (20, "କୋଡ଼ିଏ"),
+    (23, "ତେଇଶ"),
+    (50, "ପଚାଶ"),
+    (100, "ଏକ ଶହ"),
+    (123, "ଏକ ଶହ ତେଇଶ"),
+    (500, "ପାଞ୍ଚ ଶହ"),
+    (1_000, "ଏକ ହଜାର"),
+    (10_000, "ଦଶ ହଜାର"),
+    (100_000, "ଏକ ଲକ୍ଷ"),
+    (1_000_000, "ଦଶ ଲକ୍ଷ"),
+    (10_000_000, "ଏକ କୋଟି"),
+]
+
+
+@pytest.mark.parametrize("n,expected", _ODIA_REFERENCE)
+def test_to_words_or_pinned(n: int, expected: str) -> None:
+    assert to_words_or(n) == expected
+
+
+# ----------------------------------------------------------------
+# Range guards.
+# ----------------------------------------------------------------
+
+
+@pytest.mark.parametrize("converter", [to_words_hi, to_words_mr, to_words_or])
+@pytest.mark.parametrize("n", [-1, MAX_VALUE + 1, 100_000_000])
+def test_to_words_out_of_range(converter, n: int) -> None:
+    with pytest.raises(ValueError):
+        converter(n)
+
+
+# ----------------------------------------------------------------
+# Sweep: every value 0..99 must produce a non-empty string in every
+# language. Caught a real bug during development where the Marathi
+# table had a duplicate entry and silently shifted the rest of the
+# row, so we keep the sweep as a regression guard rather than spelling
+# out 100 expectations per language.
+# ----------------------------------------------------------------
+
+
+@pytest.mark.parametrize("converter", [to_words_hi, to_words_mr, to_words_or])
+def test_below_100_sweep_non_empty(converter) -> None:
+    seen: set[str] = set()
+    for i in range(100):
+        out = converter(i)
+        assert out, f"{converter.__name__}({i}) empty"
+        # No duplicates — every 0..99 form should be unique within a
+        # language. (Hindi १६ vs ६१ = सोलह vs इकसठ are distinct words.)
+        assert out not in seen, f"{converter.__name__}({i})={out!r} dup"
+        seen.add(out)
+
+
+# ----------------------------------------------------------------
+# number_forms — the public entry point.
+# ----------------------------------------------------------------
+
+
+def test_number_forms_for_123() -> None:
+    nf = number_forms("123")
+    assert isinstance(nf, NumberForms)
+    assert nf.value == 123
+    assert nf.digits_latin == "123"
+    assert nf.digits_deva == "१२३"
+    assert nf.digits_orya == "୧୨୩"
+    assert nf.hi.spelled == "एक सौ तेईस"
+    assert nf.hi.romanized == "ek sau teīs"
+    assert nf.mr.spelled == "एकशे तेवीस"
+    # Marathi keeps macrons (no Hindi-style ē/ō → e/o fold).
+    assert "ē" in nf.mr.romanized
+    assert nf.odia.spelled == "ଏକ ଶହ ତେଇଶ"
+    assert "ē" in nf.odia.romanized
+
+
+def test_number_forms_devanagari_input() -> None:
+    nf = number_forms("१२३")
+    assert nf is not None
+    assert nf.value == 123
+    assert nf.digits_latin == "123"
+
+
+def test_number_forms_odia_input() -> None:
+    nf = number_forms("୧୨୩")
+    assert nf is not None
+    assert nf.value == 123
+    assert nf.digits_deva == "१२३"
+
+
+def test_number_forms_zero() -> None:
+    nf = number_forms("0")
+    assert nf is not None
+    assert nf.value == 0
+    assert nf.hi.spelled == "शून्य"
+    assert nf.mr.spelled == "शून्य"
+    assert nf.odia.spelled == "ଶୂନ୍ୟ"
+
+
+def test_number_forms_max() -> None:
+    nf = number_forms("10000000")
+    assert nf is not None
+    assert nf.value == 10_000_000
+
+
+def test_number_forms_serializes_odia_field() -> None:
+    """The wire field for Odia is ``odia`` (not the ISO 639-1 code
+    ``or``, which is a reserved Python keyword). The TypeScript
+    mirror in apps/web/src/lib/server/nlp-client.ts depends on this."""
+    nf = number_forms("1")
+    assert nf is not None
+    payload = nf.model_dump()
+    assert "odia" in payload
+    assert "or" not in payload
+
+
+@pytest.mark.parametrize(
+    "surface",
+    [
+        "",
+        "abc",
+        "१23",  # mixed
+        "-1",
+        "1.5",
+        "10000001",  # out of range
+        "100000000",
+    ],
+)
+def test_number_forms_returns_none_for_non_qualifying(surface: str) -> None:
+    assert number_forms(surface) is None

--- a/services/nlp/tests/test_pipelines.py
+++ b/services/nlp/tests/test_pipelines.py
@@ -108,3 +108,63 @@ def test_custom_factory_override_via_registry(monkeypatch):
     monkeypatch.setitem(pipelines._PIPELINE_FACTORIES, "stanza-hi", MarkerPipeline)
     pipelines.reset_pipeline_cache()
     assert isinstance(get_pipeline("hi"), MarkerPipeline)
+
+
+# ----------------------------------------------------------------
+# T-2.8: digit-only NUM tokens carry number_forms across all three
+# pipelines, regardless of source script.
+# ----------------------------------------------------------------
+
+
+def _find_number_token(tokens: list[Token], surface: str) -> Token | None:
+    for t in tokens:
+        if t.surface == surface:
+            return t
+    return None
+
+
+@pytest.mark.parametrize(
+    "language,text,number_surface",
+    [
+        ("hi", "वर्ष 2024 में", "2024"),
+        ("hi", "साल १२३ का", "१२३"),
+        ("mr", "वर्ष 2024 ला", "2024"),
+        ("or", "ବର୍ଷ 2024 ରେ", "2024"),
+        ("or", "ବର୍ଷ ୧୨୩ ରେ", "୧୨୩"),
+    ],
+)
+def test_pipeline_attaches_number_forms_for_digit_tokens(
+    language: str, text: str, number_surface: str
+) -> None:
+    pipe = get_pipeline(language)
+    out = pipe.process(text)
+    tok = _find_number_token(out.tokens, number_surface)
+    assert tok is not None, f"no token with surface {number_surface!r} in {out.tokens}"
+    assert tok.number_forms is not None
+    # value matches the digit run regardless of source script
+    expected_value = int(number_surface) if number_surface.isascii() else None
+    if expected_value is not None:
+        assert tok.number_forms.value == expected_value
+    # All three language renderings populated.
+    assert tok.number_forms.hi.spelled
+    assert tok.number_forms.hi.romanized
+    assert tok.number_forms.mr.spelled
+    assert tok.number_forms.odia.spelled
+
+
+def test_pipeline_no_number_forms_on_mixed_script_digits() -> None:
+    """A surface like ``१2३`` (Devanagari + Latin mix) parses to a
+    single token under the whitespace fake but is not a single-script
+    digit run, so number_forms must be None."""
+    pipe = get_pipeline("hi")
+    out = pipe.process("कुछ १2३ है")
+    tok = _find_number_token(out.tokens, "१2३")
+    assert tok is not None
+    assert tok.number_forms is None
+
+
+def test_pipeline_no_number_forms_on_words() -> None:
+    pipe = get_pipeline("hi")
+    out = pipe.process("नमस्ते दुनिया")
+    for t in out.tokens:
+        assert t.number_forms is None


### PR DESCRIPTION
## Summary

When a reader taps a digit-only token (`123` / `१२३` / `୧୨୩`), the side panel now shows the spelled-out form + ISO 15919 romanization in all three MVP languages, plus the digit string in each native script. Lemma / translations / status / "Fix this word" panes are suppressed for numbers because they're not learnable lemmas.

Range: non-negative integers `0` through `10_000_000` (one crore) inclusive. Mixed-script (`१23`), signed, and decimal inputs fall through unchanged.

## Implementation

**NLP service.** New `services/nlp/app/numbers.py` is a pure-Python module — no new deps. It carries hand-written 0–99 tables for Hindi / Marathi / Odia, and stacks `<digit> सौ / <digit>शे / <digit> ଶହ` for hundreds plus the standard 10³ / 10⁵ / 10⁷ Indic groupings. Romanization reuses the existing `to_roman()` pipeline so Hindi gets schwa deletion + ē/ō fold and Marathi / Odia keep their macrons.

`Token` gains an optional `number_forms` field; both Stanza-driven pipelines and the custom Odia pipeline populate it whenever the surface qualifies.

**Persistence.** Migration `0021_t-2-8-number-forms.sql` adds a nullable `number_forms jsonb` column to `text_tokens`. The in-process dispatcher writes it; `loadChapterTokens` surfaces it through `RenderedToken` → `ServerToken`.

**Reader.** `WordPopup.svelte` branches on `numberForms != null`: the digit row (Latin · Deva · Orya) sits above three rows of `<spelled> / <romanized>` keyed by language. Status buttons / translations list / "Fix this word" affordance hide for numbers. CSS keeps the existing serif/mono pairing the popup uses elsewhere.

## Wire-shape note

The Odia field is `odia` on the wire (not the ISO 639-1 `or`) because `or` is a reserved Python keyword and can't be an attribute name on the server-side Pydantic model. The TypeScript mirror in `apps/web/src/lib/server/nlp-client.ts` matches.

## Linguistic content

The 0–99 spelled-out tables are hand-curated and want curator review before merge — typos in the rare 50–99 sandhi clusters (e.g. Marathi `सत्त्याहत्तर`, Odia `ସଡ଼େଇତିରିଶ`) are exactly the kind of thing easy to miss in code review and obvious to a native reader.

## Test plan

- [x] 332 pytest assertions: pinned reference values across `[0, 10⁷]` per language, full 0–99 sweep, range guards, `parse_digits` accept/reject matrix, pipeline integration on Hindi / Marathi / Odia text with both Latin and native-script digits, mixed-script reject, words-only reject.
- [x] `numbers.py` 100% line + branch coverage.
- [x] Total NLP coverage 95.25% (floor 70%).
- [x] 897 vitest assertions including 4 new WordPopup cases (digits row, three-language rows, status-suppression, lemma-popup fallback).
- [x] `svelte-check`, `ruff check`, `mypy app` (no new errors), `pytest` clean.

## Out of scope

Negatives + decimals — tracked separately under T-2.8a (#306).

Closes #304. Refs #14, #306.