### PR TITLE
T-10.1: per-language stats page

### DIFF
--- a/apps/web/src/lib/server/learning-stats.ts
+++ b/apps/web/src/lib/server/learning-stats.ts
@@ -1,0 +1,240 @@
+/**
+ * Learning stats (T-10.1).
+ *
+ * Per-language: known / learning / encountered lemma counts plus a
+ * per-text breakdown with estimated comprehension. T-10.2's library
+ * card badge reads `estimatedComprehensionForText` directly so the
+ * grid lookup stays cheap.
+ *
+ * Estimated comprehension is the fraction of word-token occurrences
+ * whose lemma the user has marked 'known' — it answers "how much of
+ * this page would I already understand?" and changes meaningfully
+ * as the user marks words.
+ */
+import { sql } from 'drizzle-orm';
+
+import { db } from './db/index.js';
+import type { LanguageCode } from '@ciareader/shared-types';
+
+export type LanguageStats = {
+  knownCount: number;
+  learningCount: number;
+  ignoredCount: number;
+  /** Distinct lemmas seen at least once across the user's owned
+   *  texts in this language. */
+  encounteredCount: number;
+};
+
+function unwrapRows<T>(out: unknown): T[] {
+  if (Array.isArray(out)) return out as T[];
+  if (out && typeof out === 'object' && 'rows' in out) {
+    const rows = (out as { rows?: T[] }).rows;
+    if (Array.isArray(rows)) return rows;
+  }
+  return [];
+}
+
+export async function getLanguageStats(
+  userId: string,
+  language: LanguageCode,
+): Promise<LanguageStats> {
+  const counts = unwrapRows<{
+    known: number;
+    learning: number;
+    ignored: number;
+  }>(
+    await db.execute(sql`
+      SELECT
+        SUM(CASE WHEN ukl.status = 'known' THEN 1 ELSE 0 END)::int AS known,
+        SUM(CASE WHEN ukl.status = 'learning' THEN 1 ELSE 0 END)::int AS learning,
+        SUM(CASE WHEN ukl.status = 'ignored' THEN 1 ELSE 0 END)::int AS ignored
+      FROM user_known_lemmas ukl
+      INNER JOIN lemmas l ON l.id = ukl.lemma_id
+      WHERE ukl.user_id = ${userId}
+        AND l.language = ${language}
+    `),
+  );
+  const row = counts[0] ?? { known: 0, learning: 0, ignored: 0 };
+
+  // Distinct lemmas the user has *encountered* in their owned
+  // texts. Counts distinct lemma_id over text_tokens joined back to
+  // texts the user owns. Stays language-bound so cross-language
+  // shares (when M7 sharing lands) don't pollute the count.
+  const encountered = unwrapRows<{ n: number }>(
+    await db.execute(sql`
+      SELECT COUNT(DISTINCT tt.lemma_id)::int AS n
+      FROM text_tokens tt
+      INNER JOIN text_chapters ch ON ch.id = tt.chapter_id
+      INNER JOIN texts tx ON tx.id = ch.text_id
+      WHERE tx.owner_id = ${userId}
+        AND tx.language = ${language}
+        AND tt.lemma_id IS NOT NULL
+    `),
+  );
+  const encounteredCount = encountered[0]?.n ?? 0;
+
+  return {
+    knownCount: row.known ?? 0,
+    learningCount: row.learning ?? 0,
+    ignoredCount: row.ignored ?? 0,
+    encounteredCount,
+  };
+}
+
+export type TextStats = {
+  textId: string;
+  title: string;
+  language: LanguageCode;
+  uniqueLemmas: number;
+  totalWords: number;
+  estimatedComprehensionPct: number;
+};
+
+/**
+ * Per-text breakdown for the user. `estimatedComprehensionPct` is
+ * the fraction of word-token occurrences whose lemma the user has
+ * marked 'known' — known-lemma occurrences ÷ total word occurrences.
+ *
+ * The query joins text_tokens with the user's known_lemmas and
+ * counts both 'how many tokens overall' and 'how many tokens whose
+ * lemma is known'. We compute over OCCURRENCES (not distinct
+ * lemmas) because comprehension is a function of how often the
+ * known words actually appear in the text — knowing one ultra-
+ * frequent verb is worth dozens of rare ones.
+ */
+export async function listTextStats(
+  userId: string,
+  language: LanguageCode,
+): Promise<TextStats[]> {
+  const list = unwrapRows<{
+    text_id: string;
+    title: string;
+    language: LanguageCode;
+    unique_lemmas: number;
+    total_words: number;
+    known_words: number;
+  }>(
+    await db.execute(sql`
+      SELECT
+        tx.id AS text_id,
+        tx.title AS title,
+        tx.language AS language,
+        COUNT(DISTINCT tt.lemma_id) FILTER (WHERE tt.lemma_id IS NOT NULL)::int AS unique_lemmas,
+        COUNT(*) FILTER (WHERE tt.is_word = true)::int AS total_words,
+        COUNT(*) FILTER (
+          WHERE tt.is_word = true
+            AND tt.lemma_id IS NOT NULL
+            AND ukl.status = 'known'
+        )::int AS known_words
+      FROM texts tx
+      INNER JOIN text_chapters ch ON ch.text_id = tx.id
+      INNER JOIN text_tokens tt ON tt.chapter_id = ch.id
+      LEFT JOIN user_known_lemmas ukl
+        ON ukl.lemma_id = tt.lemma_id AND ukl.user_id = ${userId}
+      WHERE tx.owner_id = ${userId}
+        AND tx.language = ${language}
+      GROUP BY tx.id, tx.title, tx.language
+      ORDER BY tx.created_at DESC
+    `),
+  );
+  return list.map((r) => ({
+    textId: r.text_id,
+    title: r.title,
+    language: r.language,
+    uniqueLemmas: r.unique_lemmas,
+    totalWords: r.total_words,
+    estimatedComprehensionPct:
+      r.total_words === 0
+        ? 0
+        : Math.round((r.known_words / r.total_words) * 100),
+  }));
+}
+
+/**
+ * Single-text comprehension lookup for the library card badge
+ * (T-10.2). Cheap — same shape as one row of listTextStats but
+ * scoped to a single textId so the library grid can fan out one
+ * query per card without a wide join.
+ */
+export async function estimatedComprehensionForText(
+  userId: string,
+  textId: string,
+): Promise<number | null> {
+  const list = unwrapRows<{ total: number; known: number }>(
+    await db.execute(sql`
+      SELECT
+        COUNT(*) FILTER (WHERE tt.is_word = true)::int AS total,
+        COUNT(*) FILTER (
+          WHERE tt.is_word = true
+            AND tt.lemma_id IS NOT NULL
+            AND ukl.status = 'known'
+        )::int AS known
+      FROM text_tokens tt
+      INNER JOIN text_chapters ch ON ch.id = tt.chapter_id
+      LEFT JOIN user_known_lemmas ukl
+        ON ukl.lemma_id = tt.lemma_id AND ukl.user_id = ${userId}
+      WHERE ch.text_id = ${textId}
+    `),
+  );
+  const r = list[0];
+  if (!r || r.total === 0) return null;
+  return Math.round((r.known / r.total) * 100);
+}
+
+export type CollectionStats = {
+  collectionId: string;
+  title: string;
+  textCount: number;
+  estimatedComprehensionPct: number;
+};
+
+/**
+ * Per-collection breakdown for the user. Aggregates over every
+ * text in the collection — same comprehension formula as
+ * listTextStats, just with a wider GROUP BY.
+ */
+export async function listCollectionStats(
+  userId: string,
+  language: LanguageCode,
+): Promise<CollectionStats[]> {
+  const list = unwrapRows<{
+    collection_id: string;
+    title: string;
+    text_count: number;
+    total_words: number;
+    known_words: number;
+  }>(
+    await db.execute(sql`
+      SELECT
+        c.id AS collection_id,
+        c.title AS title,
+        COUNT(DISTINCT ci.text_id)::int AS text_count,
+        COUNT(*) FILTER (WHERE tt.is_word = true)::int AS total_words,
+        COUNT(*) FILTER (
+          WHERE tt.is_word = true
+            AND tt.lemma_id IS NOT NULL
+            AND ukl.status = 'known'
+        )::int AS known_words
+      FROM collections c
+      INNER JOIN collection_items ci ON ci.collection_id = c.id
+      INNER JOIN text_chapters ch ON ch.text_id = ci.text_id
+      INNER JOIN text_tokens tt ON tt.chapter_id = ch.id
+      LEFT JOIN user_known_lemmas ukl
+        ON ukl.lemma_id = tt.lemma_id AND ukl.user_id = ${userId}
+      WHERE c.owner_id = ${userId}
+        AND c.language = ${language}
+      GROUP BY c.id, c.title
+      ORDER BY c.updated_at DESC
+    `),
+  );
+  return list.map((r) => ({
+    collectionId: r.collection_id,
+    title: r.title,
+    textCount: r.text_count,
+    estimatedComprehensionPct:
+      r.total_words === 0
+        ? 0
+        : Math.round((r.known_words / r.total_words) * 100),
+  }));
+}
+

--- a/apps/web/src/routes/stats/[language]/+page.server.ts
+++ b/apps/web/src/routes/stats/[language]/+page.server.ts
@@ -1,0 +1,48 @@
+/**
+ * /stats/:language — per-language learning stats (T-10.1).
+ *
+ * Auth-gated; aggregates the user's known/learning lemma counts +
+ * per-text and per-collection comprehension breakdowns.
+ */
+import { error, redirect } from '@sveltejs/kit';
+
+import {
+  getLanguageStats,
+  listCollectionStats,
+  listTextStats,
+} from '$lib/server/learning-stats.js';
+import {
+  LANGUAGES,
+  isSupportedLanguage,
+  type LanguageCode,
+} from '@ciareader/shared-types';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ params, locals, url }) => {
+  if (!locals.user) {
+    throw redirect(303, `/login?next=${encodeURIComponent(url.pathname)}`);
+  }
+  const lang = params.language;
+  if (!lang || !isSupportedLanguage(lang)) {
+    throw error(400, `Unsupported language '${lang}'`);
+  }
+  const language = lang as LanguageCode;
+
+  const [stats, texts, collections] = await Promise.all([
+    getLanguageStats(locals.user.id, language),
+    listTextStats(locals.user.id, language),
+    listCollectionStats(locals.user.id, language),
+  ]);
+
+  return {
+    language,
+    languageDescriptor: {
+      code: LANGUAGES[language].code,
+      displayName: LANGUAGES[language].displayName,
+      nativeName: LANGUAGES[language].nativeName,
+    },
+    stats,
+    texts,
+    collections,
+  };
+};

--- a/apps/web/src/routes/stats/[language]/+page.svelte
+++ b/apps/web/src/routes/stats/[language]/+page.svelte
@@ -1,0 +1,225 @@
+<script lang="ts">
+  import type { PageData } from './$types';
+
+  let { data }: { data: PageData } = $props();
+</script>
+
+<svelte:head>
+  <title>Stats — {data.languageDescriptor.displayName} — CIA Reader</title>
+</svelte:head>
+
+<div class="ls">
+  <header class="ls-h">
+    <h1>
+      {data.languageDescriptor.displayName}
+      <span class="ls-native">{data.languageDescriptor.nativeName}</span>
+    </h1>
+    <p class="ls-h-sub">Your reading + vocabulary stats for this language.</p>
+  </header>
+
+  <section class="ls-totals">
+    <div class="ls-tile">
+      <div class="ls-tile-n">{data.stats.knownCount.toLocaleString()}</div>
+      <div class="ls-tile-l">Known lemmas</div>
+    </div>
+    <div class="ls-tile">
+      <div class="ls-tile-n">{data.stats.learningCount.toLocaleString()}</div>
+      <div class="ls-tile-l">Learning</div>
+    </div>
+    <div class="ls-tile">
+      <div class="ls-tile-n">{data.stats.encounteredCount.toLocaleString()}</div>
+      <div class="ls-tile-l">Lemmas seen in your texts</div>
+    </div>
+    <div class="ls-tile">
+      <div class="ls-tile-n">{data.stats.ignoredCount.toLocaleString()}</div>
+      <div class="ls-tile-l">Ignored (proper nouns / borrowings)</div>
+    </div>
+  </section>
+
+  <section class="ls-section">
+    <h2>Per-text comprehension</h2>
+    {#if data.texts.length === 0}
+      <p class="ls-empty">No texts in {data.languageDescriptor.displayName} yet.</p>
+    {:else}
+      <table class="ls-table">
+        <thead>
+          <tr>
+            <th>Text</th>
+            <th class="num">Unique lemmas</th>
+            <th class="num">Words</th>
+            <th class="num">Est. comprehension</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each data.texts as t (t.textId)}
+            <tr>
+              <td>
+                <a href={`/reader/${t.textId}`} class="ls-link">{t.title}</a>
+              </td>
+              <td class="num">{t.uniqueLemmas.toLocaleString()}</td>
+              <td class="num">{t.totalWords.toLocaleString()}</td>
+              <td class="num">
+                <span class="ls-pct" data-level={t.estimatedComprehensionPct >= 80 ? 'high' : t.estimatedComprehensionPct >= 50 ? 'mid' : 'low'}>
+                  {t.estimatedComprehensionPct}%
+                </span>
+              </td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    {/if}
+  </section>
+
+  {#if data.collections.length > 0}
+    <section class="ls-section">
+      <h2>Per-collection comprehension</h2>
+      <table class="ls-table">
+        <thead>
+          <tr>
+            <th>Collection</th>
+            <th class="num">Texts</th>
+            <th class="num">Est. comprehension</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each data.collections as c (c.collectionId)}
+            <tr>
+              <td>
+                <a href={`/collections/${c.collectionId}`} class="ls-link">{c.title}</a>
+              </td>
+              <td class="num">{c.textCount}</td>
+              <td class="num">
+                <span class="ls-pct" data-level={c.estimatedComprehensionPct >= 80 ? 'high' : c.estimatedComprehensionPct >= 50 ? 'mid' : 'low'}>
+                  {c.estimatedComprehensionPct}%
+                </span>
+              </td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </section>
+  {/if}
+
+  <section class="ls-section ls-export">
+    <h2>Export</h2>
+    <p>
+      <a class="ls-link" href={`/api/v1/me/vocabulary.csv?language=${data.language}`}>
+        Download vocabulary as CSV
+      </a> · headword, POS, gloss, status — Anki-friendly.
+    </p>
+  </section>
+</div>
+
+<style>
+  .ls {
+    max-width: 56rem;
+    margin: 0 auto;
+    padding: 1.5rem 1.25rem 3rem;
+    color: var(--ink, var(--color-fg));
+  }
+  .ls-h h1 {
+    margin: 0 0 0.2rem;
+    font-family: var(--font-serif, system-ui);
+    font-size: 1.6rem;
+  }
+  .ls-native {
+    font-family: var(--font-serif-dev, var(--font-serif));
+    color: var(--ink-3, var(--color-fg-muted));
+    margin-left: 0.4rem;
+    font-weight: 400;
+  }
+  .ls-h-sub {
+    color: var(--ink-3, var(--color-fg-muted));
+    font-size: 0.85rem;
+    margin: 0 0 1.4rem;
+  }
+  .ls-totals {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+    gap: 0.75rem;
+    margin-bottom: 1.75rem;
+  }
+  .ls-tile {
+    background: var(--card, var(--color-bg));
+    border: 1px solid var(--rule, var(--color-border));
+    border-radius: 10px;
+    padding: 0.85rem 1rem;
+  }
+  .ls-tile-n {
+    font-family: var(--font-mono-display, var(--font-mono));
+    font-feature-settings: 'tnum';
+    font-size: 1.5rem;
+    color: var(--ink, var(--color-fg));
+  }
+  .ls-tile-l {
+    color: var(--ink-3, var(--color-fg-muted));
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-top: 0.2rem;
+  }
+  .ls-section {
+    margin-bottom: 2rem;
+  }
+  .ls-section h2 {
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--ink-3, var(--color-fg-muted));
+    margin: 0 0 0.55rem;
+  }
+  .ls-empty {
+    padding: 1rem;
+    color: var(--ink-3, var(--color-fg-muted));
+    font-style: italic;
+  }
+  .ls-table {
+    width: 100%;
+    border-collapse: collapse;
+    background: var(--card, var(--color-bg));
+    border: 1px solid var(--rule, var(--color-border));
+    border-radius: 8px;
+    overflow: hidden;
+  }
+  .ls-table th,
+  .ls-table td {
+    padding: 0.5rem 0.7rem;
+    border-bottom: 1px solid var(--rule-2, var(--color-border));
+    text-align: left;
+    font-size: 0.85rem;
+  }
+  .ls-table th {
+    background: color-mix(in oklch, var(--ink, var(--color-fg)) 4%, transparent);
+    font-weight: 500;
+    font-size: 0.78rem;
+  }
+  .ls-table th.num,
+  .ls-table td.num {
+    text-align: right;
+    font-feature-settings: 'tnum';
+    font-family: var(--font-mono-display, var(--font-mono));
+  }
+  .ls-link {
+    color: inherit;
+    text-decoration: none;
+  }
+  .ls-link:hover {
+    text-decoration: underline;
+  }
+  .ls-pct {
+    font-feature-settings: 'tnum';
+  }
+  .ls-pct[data-level='high'] {
+    color: #2a9d4a;
+  }
+  .ls-pct[data-level='mid'] {
+    color: #c5851b;
+  }
+  .ls-pct[data-level='low'] {
+    color: var(--ink-3, var(--color-fg-muted));
+  }
+  .ls-export {
+    color: var(--ink-2, var(--color-fg));
+    font-size: 0.9rem;
+  }
+</style>


### PR DESCRIPTION
## Summary

`/stats/:language` page with totals tiles + per-text comprehension table + per-collection rollup.

`learning-stats.ts` exports four queries: getLanguageStats, listTextStats, listCollectionStats, and estimatedComprehensionForText (single-row variant for T-10.2's library card badge).

Estimated comprehension = known_word_OCCURRENCES ÷ total_word_occurrences. Knowing one ultra-frequent verb is worth dozens of rare ones, so we count occurrences rather than distinct lemmas.

Closes #91.

## Test plan
- 917 tests pass; typecheck + lint clean.