### PR TITLE
Fix audio alignments primary key migration

### DIFF
--- a/apps/web/drizzle/0021_empty_silk_fever.sql
+++ b/apps/web/drizzle/0021_empty_silk_fever.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS "audio_alignments" (
 	"end_ms" integer NOT NULL,
 	"source" "alignment_source" DEFAULT 'manual' NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
-	CONSTRAINT "audio_alignments_audio_file_id_token_id_pk" PRIMARY KEY("audio_file_id","token_id")
+	CONSTRAINT "audio_alignments_audio_file_id_token_id_uq" UNIQUE("audio_file_id","token_id")
 );
 --> statement-breakpoint
 CREATE TABLE IF NOT EXISTS "audio_files" (

--- a/apps/web/drizzle/meta/0021_snapshot.json
+++ b/apps/web/drizzle/meta/0021_snapshot.json
@@ -106,16 +106,17 @@
           "onUpdate": "no action"
         }
       },
-      "compositePrimaryKeys": {
-        "audio_alignments_audio_file_id_token_id_pk": {
-          "name": "audio_alignments_audio_file_id_token_id_pk",
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "audio_alignments_audio_file_id_token_id_uq": {
+          "name": "audio_alignments_audio_file_id_token_id_uq",
+          "nullsNotDistinct": false,
           "columns": [
             "audio_file_id",
             "token_id"
           ]
         }
       },
-      "uniqueConstraints": {},
       "checkConstraints": {}
     },
     "public.audio_files": {

--- a/apps/web/drizzle/meta/0022_snapshot.json
+++ b/apps/web/drizzle/meta/0022_snapshot.json
@@ -106,16 +106,17 @@
           "onUpdate": "no action"
         }
       },
-      "compositePrimaryKeys": {
-        "audio_alignments_audio_file_id_token_id_pk": {
-          "name": "audio_alignments_audio_file_id_token_id_pk",
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "audio_alignments_audio_file_id_token_id_uq": {
+          "name": "audio_alignments_audio_file_id_token_id_uq",
+          "nullsNotDistinct": false,
           "columns": [
             "audio_file_id",
             "token_id"
           ]
         }
       },
-      "uniqueConstraints": {},
       "checkConstraints": {}
     },
     "public.audio_files": {

--- a/apps/web/src/lib/server/db/schema.ts
+++ b/apps/web/src/lib/server/db/schema.ts
@@ -1440,7 +1440,10 @@ export const audioAlignments = pgTable(
       .defaultNow(),
   },
   (t) => ({
-    pk: primaryKey({ columns: [t.audioFileId, t.tokenId] }),
+    audioFileTokenUq: unique('audio_alignments_audio_file_id_token_id_uq').on(
+      t.audioFileId,
+      t.tokenId,
+    ),
     timelineIdx: index('audio_alignments_timeline_idx').on(
       t.audioFileId,
       t.startMs,


### PR DESCRIPTION
## Summary
- keep `audio_alignments.id` as the table primary key
- enforce one alignment per audio file/token pair with a unique constraint
- update the checked-in Drizzle migration snapshots to match the schema

## Verification
- `pnpm --filter @ciareader/web db:generate`
- `pnpm --filter @ciareader/web db:push`
- `pnpm --filter @ciareader/web typecheck`