### PR TITLE
Fix browser-safe audio helper imports

### DIFF
--- a/apps/web/src/lib/audio/alignments.ts
+++ b/apps/web/src/lib/audio/alignments.ts
@@ -1,0 +1,33 @@
+export type AlignmentListItem = {
+  tokenId: string;
+  startMs: number;
+  endMs: number;
+};
+
+/**
+ * Pure binary search over a startMs-sorted alignment list. Returns the index
+ * of the alignment containing `currentMs`, or null when no alignment covers
+ * that timestamp.
+ */
+export function findAlignmentAt(
+  alignments: AlignmentListItem[],
+  currentMs: number,
+): number | null {
+  let lo = 0;
+  let hi = alignments.length - 1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >>> 1;
+    const a = alignments[mid]!;
+    if (currentMs < a.startMs) hi = mid - 1;
+    else if (currentMs > a.endMs) lo = mid + 1;
+    else return mid;
+  }
+  // Not inside any range, but keep highlighting the most recent word so
+  // small gaps between alignments do not blink the highlight off.
+  let best: number | null = null;
+  for (let i = 0; i < alignments.length; i++) {
+    if (alignments[i]!.startMs <= currentMs) best = i;
+    else break;
+  }
+  return best;
+}

--- a/apps/web/src/lib/audio/sentence-tokens.ts
+++ b/apps/web/src/lib/audio/sentence-tokens.ts
@@ -1,0 +1,37 @@
+export type SentenceTokens = {
+  sentenceIdx: number;
+  tokens: Array<{ id: string; surface: string; isWord: boolean }>;
+};
+
+export type SentenceMark = {
+  sentenceIdx: number;
+  startMs: number;
+  endMs: number;
+};
+
+/**
+ * Linearly interpolate per-token timing across each sentence's
+ * marked (startMs, endMs) range.
+ */
+export function interpolateSentenceMarks(
+  sentences: SentenceTokens[],
+  marks: SentenceMark[],
+): Array<{ tokenId: string; startMs: number; endMs: number }> {
+  const marksBySentence = new Map<number, SentenceMark>();
+  for (const m of marks) marksBySentence.set(m.sentenceIdx, m);
+  const out: Array<{ tokenId: string; startMs: number; endMs: number }> = [];
+  for (const s of sentences) {
+    const mark = marksBySentence.get(s.sentenceIdx);
+    if (!mark) continue;
+    const wordTokens = s.tokens.filter((t) => t.isWord);
+    if (wordTokens.length === 0) continue;
+    const span = Math.max(0, mark.endMs - mark.startMs);
+    const slice = span / wordTokens.length;
+    for (let i = 0; i < wordTokens.length; i++) {
+      const start = Math.round(mark.startMs + slice * i);
+      const end = Math.round(mark.startMs + slice * (i + 1));
+      out.push({ tokenId: wordTokens[i]!.id, startMs: start, endMs: end });
+    }
+  }
+  return out;
+}

--- a/apps/web/src/lib/components/reader/AlignmentHighlighter.svelte
+++ b/apps/web/src/lib/components/reader/AlignmentHighlighter.svelte
@@ -17,7 +17,7 @@
   import {
     findAlignmentAt,
     type AlignmentListItem,
-  } from '$lib/server/audio/alignments.js';
+  } from '$lib/audio/alignments.js';
   import {
     setAlignmentMap,
     subscribeAudio,

--- a/apps/web/src/lib/server/audio/alignments.ts
+++ b/apps/web/src/lib/server/audio/alignments.ts
@@ -6,8 +6,11 @@
  */
 import { asc, eq, inArray } from 'drizzle-orm';
 
+import type { AlignmentListItem } from '../../audio/alignments.js';
 import { db, schema } from '../db/index.js';
 import type { AudioAlignment, User } from '../db/schema.js';
+export { findAlignmentAt } from '../../audio/alignments.js';
+export type { AlignmentListItem } from '../../audio/alignments.js';
 
 export class AlignmentError extends Error {
   constructor(
@@ -18,12 +21,6 @@ export class AlignmentError extends Error {
     this.name = 'AlignmentError';
   }
 }
-
-export type AlignmentListItem = {
-  tokenId: string;
-  startMs: number;
-  endMs: number;
-};
 
 export async function listAlignments(
   audioFileId: string,
@@ -106,38 +103,4 @@ export async function replaceAlignments(
     }
   });
   return input.alignments.length;
-}
-
-/**
- * Pure binary search over a startMs-sorted alignment list — used
- * by the reader's playing-word lookup. Returns the index of the
- * alignment containing `currentMs`, or null when no alignment
- * covers that timestamp.
- *
- * Exported here so unit tests don't need the DOM; callers in the
- * UI re-import from the same module.
- */
-export function findAlignmentAt(
-  alignments: AlignmentListItem[],
-  currentMs: number,
-): number | null {
-  let lo = 0;
-  let hi = alignments.length - 1;
-  while (lo <= hi) {
-    const mid = (lo + hi) >>> 1;
-    const a = alignments[mid]!;
-    if (currentMs < a.startMs) hi = mid - 1;
-    else if (currentMs > a.endMs) lo = mid + 1;
-    else return mid;
-  }
-  // Not inside any range — but the reader still wants to highlight
-  // the *most recent* word so a small gap between alignments
-  // doesn't blink the highlight off. Find the last alignment whose
-  // startMs <= currentMs; null if none.
-  let best: number | null = null;
-  for (let i = 0; i < alignments.length; i++) {
-    if (alignments[i]!.startMs <= currentMs) best = i;
-    else break;
-  }
-  return best;
 }

--- a/apps/web/src/lib/server/audio/sentence-tokens.ts
+++ b/apps/web/src/lib/server/audio/sentence-tokens.ts
@@ -8,13 +8,11 @@
  */
 import { asc, eq } from 'drizzle-orm';
 
+import type { SentenceTokens } from '../../audio/sentence-tokens.js';
 import { db, schema } from '../db/index.js';
 import type { TextToken } from '../db/schema.js';
-
-export type SentenceTokens = {
-  sentenceIdx: number;
-  tokens: Array<{ id: string; surface: string; isWord: boolean }>;
-};
+export { interpolateSentenceMarks } from '../../audio/sentence-tokens.js';
+export type { SentenceMark, SentenceTokens } from '../../audio/sentence-tokens.js';
 
 export async function loadSentenceTokensForAudio(
   audioFileId: string,
@@ -50,45 +48,6 @@ export async function loadSentenceTokensForAudio(
       out.push(cur);
     }
     cur.tokens.push({ id: t.id, surface: t.surface, isWord: t.isWord });
-  }
-  return out;
-}
-
-export type SentenceMark = {
-  sentenceIdx: number;
-  startMs: number;
-  endMs: number;
-};
-
-/**
- * Linearly interpolate per-token timing across each sentence's
- * marked (startMs, endMs) range. Each word in a sentence gets an
- * equal slice; non-word tokens (punctuation / whitespace) are
- * skipped — the alignment table is per-token but the highlighter
- * only paints `isWord` spans anyway, so emitting rows for
- * punctuation just bloats the table.
- *
- * Pure function — unit-tested without the DB.
- */
-export function interpolateSentenceMarks(
-  sentences: SentenceTokens[],
-  marks: SentenceMark[],
-): Array<{ tokenId: string; startMs: number; endMs: number }> {
-  const marksBySentence = new Map<number, SentenceMark>();
-  for (const m of marks) marksBySentence.set(m.sentenceIdx, m);
-  const out: Array<{ tokenId: string; startMs: number; endMs: number }> = [];
-  for (const s of sentences) {
-    const mark = marksBySentence.get(s.sentenceIdx);
-    if (!mark) continue;
-    const wordTokens = s.tokens.filter((t) => t.isWord);
-    if (wordTokens.length === 0) continue;
-    const span = Math.max(0, mark.endMs - mark.startMs);
-    const slice = span / wordTokens.length;
-    for (let i = 0; i < wordTokens.length; i++) {
-      const start = Math.round(mark.startMs + slice * i);
-      const end = Math.round(mark.startMs + slice * (i + 1));
-      out.push({ tokenId: wordTokens[i]!.id, startMs: start, endMs: end });
-    }
   }
   return out;
 }

--- a/apps/web/src/routes/audio/[id]/align/+page.svelte
+++ b/apps/web/src/routes/audio/[id]/align/+page.svelte
@@ -66,11 +66,8 @@
     saveOk = false;
     try {
       const { interpolateSentenceMarks } = await import(
-        '$lib/server/audio/sentence-tokens.js'
+        '$lib/audio/sentence-tokens.js'
       );
-      // Browser-side import works because the helper is pure (no
-      // server-only deps). We pass the loader-provided sentences +
-      // the user's marks straight through.
       const flat = Array.from(marks.entries()).map(([sentenceIdx, m]) => ({
         sentenceIdx,
         startMs: m.startMs,


### PR DESCRIPTION
## Summary
- move pure audio alignment helpers into browser-safe `/audio` modules
- update reader and audio alignment pages to avoid importing `/server` code in the browser
- keep server modules re-exporting the helpers for existing server-side tests/imports

## Verification
- `pnpm --filter @ciareader/web check`
- `pnpm --filter @ciareader/web test -- src/lib/server/audio/alignments.test.ts src/lib/server/audio/sentence-tokens.test.ts`
- `pnpm --filter @ciareader/web build`
- `pnpm --filter @ciareader/web lint`