### PR TITLE
Fix number forms during text reprocessing

### DIFF
--- a/apps/web/scripts/reprocess-text.mjs
+++ b/apps/web/scripts/reprocess-text.mjs
@@ -118,7 +118,6 @@ async function main() {
     const inserted = await sql.unsafe(
       `INSERT INTO lemmas (language, headword, pos, script, source, source_attribution, curator_locked, created_at, updated_at)
        VALUES ($1, $2, $3, $4, 'official_dictionary', 'Stanza UD', false, NOW(), NOW())
-       ON CONFLICT (language, headword, pos) DO NOTHING
        RETURNING id`,
       [language, headword, pos, SCRIPT_FOR[language]],
     );
@@ -209,6 +208,7 @@ async function main() {
         isWord: t.is_word,
         sentenceIdx: 0,
         romanization: t.romanization,
+        numberForms: t.number_forms ?? null,
         };
       });
 

--- a/apps/web/src/lib/server/texts/in-process-dispatcher.test.ts
+++ b/apps/web/src/lib/server/texts/in-process-dispatcher.test.ts
@@ -145,6 +145,15 @@ describe('processTextNow', () => {
           is_ambiguous: false,
           is_oov: false,
           romanization: 'bolnā',
+          number_forms: {
+            value: 123,
+            digits_latin: '123',
+            digits_deva: '१२३',
+            digits_orya: '୧୨୩',
+            hi: { spelled: 'एक सौ तेईस', romanized: 'ek sau teīs' },
+            mr: { spelled: 'एकशे तेवीस', romanized: 'ēkaśē tēvīsa' },
+            odia: { spelled: 'ଏକ ଶହ ତେଇଶ', romanized: 'ēka śaha tēiśa' },
+          },
           candidates: [
             { lemma: 'बोलना', pos: 'verb', score: 0.9, features: { Tense: 'Pres' } },
           ],
@@ -178,16 +187,20 @@ describe('processTextNow', () => {
       lemmaId: string | null;
       surface: string;
       romanization: string | null;
+      numberForms: { value: number } | null;
     }>;
     expect(firstInsert[0]!.lemmaId).toBe('lemma-bolnaa');
     expect(firstInsert[0]!.romanization).toBe('bolnā');
+    expect(firstInsert[0]!.numberForms?.value).toBe(123);
 
     const secondInsert = (inserts[1] as Extract<Call, { kind: 'insert' }>).values as Array<{
       lemmaId: string | null;
       isOov: boolean;
+      numberForms: unknown;
     }>;
     expect(secondInsert[0]!.lemmaId).toBeNull();
     expect(secondInsert[0]!.isOov).toBe(true);
+    expect(secondInsert[0]!.numberForms).toBeNull();
 
     // Two delete calls (one per chapter, idempotency clear before insert).
     expect(calls.filter((c) => c.kind === 'delete')).toHaveLength(2);

--- a/apps/web/src/lib/server/texts/in-process-dispatcher.ts
+++ b/apps/web/src/lib/server/texts/in-process-dispatcher.ts
@@ -160,9 +160,6 @@ async function ensureLemma(
       source: 'official_dictionary',
       sourceAttribution: 'Stanza UD',
     })
-    .onConflictDoNothing({
-      target: [schema.lemmas.language, schema.lemmas.headword, schema.lemmas.pos],
-    })
     .returning()) as Lemma[];
 
   if (row) {
@@ -270,7 +267,7 @@ async function processChapter(
       isWord: t.is_word,
       sentenceIdx: 0,
       romanization: t.romanization,
-      numberForms: t.number_forms,
+      numberForms: t.number_forms ?? null,
     };
   }) satisfies Array<Omit<TextToken, 'id'>>;
   if (rows.length === 0) return 0;

--- a/apps/web/src/lib/server/texts/tokens.test.ts
+++ b/apps/web/src/lib/server/texts/tokens.test.ts
@@ -85,6 +85,36 @@ describe('loadChapterTokens', () => {
     expect(result).toBeNull();
   });
 
+  it('maps stored number_forms onto the reader numberForms payload (T-2.8)', async () => {
+    stage([
+      tokenRow({
+        id: 'num-1',
+        surface: '123',
+        lemmaId: null,
+        numberForms: {
+          value: 123,
+          digits_latin: '123',
+          digits_deva: '१२३',
+          digits_orya: '୧୨୩',
+          hi: { spelled: 'एक सौ तेईस', romanized: 'ek sau teīs' },
+          mr: { spelled: 'एकशे तेवीस', romanized: 'ēkaśē tēvīsa' },
+          odia: { spelled: 'ଏକ ଶହ ତେଇଶ', romanized: 'ēka śaha tēiśa' },
+        },
+      }),
+    ]);
+    const result = await loadChapterTokens('chap-1', null);
+    expect(result![0]).toMatchObject({
+      id: 'num-1',
+      numberForms: {
+        value: 123,
+        digitsLatin: '123',
+        digitsDeva: '१२३',
+        digitsOrya: '୧୨୩',
+        hi: { spelled: 'एक सौ तेईस', romanized: 'ek sau teīs' },
+      },
+    });
+  });
+
   it('returns tokens with status=unknown when the viewer has no known-lemma rows', async () => {
     stage([tokenRow({ id: 't1', idx: 0 }), tokenRow({ id: 't2', idx: 1 })]);
     stage([]); // token_corrections (T-6.4) — none


### PR DESCRIPTION
## Summary
- persist NLP number_forms payloads during in-process and standalone text reprocessing
- remove stale lemma ON CONFLICT target now that lemma headword/POS is non-unique
- add regression coverage for persisted number forms and reader mapping

## Verification
- pnpm --filter @ciareader/web exec vitest run src/lib/server/texts/in-process-dispatcher.test.ts src/lib/server/texts/tokens.test.ts src/lib/components/reader/WordPopup.test.ts
- node apps/web/scripts/reprocess-text.mjs 72e201f8-bcb7-46cd-b691-e5a43c548b34
- verified 155 text_tokens rows have number_forms after reprocess