### PR TITLE
Ignore English-only reader tokens

### DIFF
--- a/services/nlp/app/pipelines/marathi.py
+++ b/services/nlp/app/pipelines/marathi.py
@@ -27,7 +27,7 @@ from collections.abc import Callable
 from app.schemas import LemmaCandidate, Token
 
 from .base import PipelineResult
-from .stanza_ud import NON_WORD_UPOS, StanzaLike, StanzaUDPipeline
+from .stanza_ud import StanzaLike, StanzaUDPipeline, should_treat_as_word
 
 MarathiTokenizer = Callable[[str], list[str]]
 
@@ -46,21 +46,20 @@ def _is_fallback_punct(surface: str) -> bool:
     return bool(surface) and all(c in _FALLBACK_PUNCT for c in surface)
 
 
-def _fallback_token(idx: int, surface: str) -> Token:
+def _fallback_token(idx: int, surface: str, *, script: str | None) -> Token:
     is_punct = _is_fallback_punct(surface)
     upos = "PUNCT" if is_punct else "X"
+    is_word = should_treat_as_word(surface, upos, script=script)
     return Token(
         idx=idx,
         surface=surface,
-        # NON_WORD_UPOS is imported so the reader's is_word predicate
-        # stays consistent with the Stanza path for the same UPOS.
-        is_word=upos not in NON_WORD_UPOS,
+        is_word=is_word,
         candidates=[LemmaCandidate(lemma=surface, pos=upos, score=1.0, features={})],
         is_ambiguous=False,
         # Fallback tokens are by definition OOV — Stanza produced nothing,
         # so there's no dictionary lemma. Punctuation is exempt by the
         # same rule the Stanza path uses.
-        is_oov=not is_punct,
+        is_oov=is_word and not is_punct,
         romanization=None,
     )
 
@@ -92,7 +91,11 @@ class MarathiPipeline(StanzaUDPipeline):
 
     def _fallback_process(self, text: str) -> PipelineResult:
         surfaces = self._fallback_tokenizer(text)
-        tokens = [_fallback_token(i, s) for i, s in enumerate(surfaces) if s]
+        tokens = [
+            _fallback_token(i, s, script=self._script)
+            for i, s in enumerate(surfaces)
+            if s
+        ]
         return PipelineResult(pipeline_id=self.pipeline_id, tokens=tokens)
 
 

--- a/services/nlp/app/pipelines/odia/__init__.py
+++ b/services/nlp/app/pipelines/odia/__init__.py
@@ -32,7 +32,7 @@ from app.numbers import number_forms as _compute_number_forms
 from app.schemas import LemmaCandidate, Token
 
 from ..base import Pipeline, PipelineResult
-from ..stanza_ud import NON_WORD_UPOS
+from ..stanza_ud import should_treat_as_word
 from .lemmas import OdiaLemmaTable, default_lemma_table
 from .morph import MorphAnalysis, analyze
 
@@ -120,15 +120,20 @@ class OdiaPipeline(Pipeline):
                 LemmaCandidate(lemma=surface, pos="X", score=1.0, features={}),
             ]
 
+        is_word = should_treat_as_word(
+            surface,
+            candidates[0].pos,
+            script="Orya",
+        )
         return Token(
             idx=idx,
             surface=surface,
-            is_word=candidates[0].pos not in NON_WORD_UPOS,
+            is_word=is_word,
             candidates=candidates,
             # Multiple morphological analyses means the reader should
             # surface the "N possible meanings" chevron (M6).
             is_ambiguous=len(analyses) >= 2,
-            is_oov=is_oov,
+            is_oov=is_word and is_oov,
             romanization=None,
             number_forms=_compute_number_forms(surface),
         )

--- a/services/nlp/app/pipelines/stanza_ud.py
+++ b/services/nlp/app/pipelines/stanza_ud.py
@@ -14,6 +14,7 @@ happens in the corresponding ``build_<lang>_pipeline`` factory.
 
 from __future__ import annotations
 
+import unicodedata
 from typing import Any, Protocol
 
 from app.numbers import number_forms as _compute_number_forms
@@ -43,6 +44,46 @@ NON_OOV_UPOS: frozenset[str] = frozenset({"PUNCT", "SYM", "NUM", "PROPN", "X"})
 # UD UPOS tags that aren't lexical words. The reader uses ``is_word`` to
 # skip these when counting known-words and when rendering the pop-up.
 NON_WORD_UPOS: frozenset[str] = frozenset({"PUNCT", "SYM"})
+
+_SCRIPT_RANGES: dict[str, tuple[tuple[int, int], ...]] = {
+    "Deva": ((0x0900, 0x097F),),
+    "Orya": ((0x0B00, 0x0B7F),),
+}
+
+
+def _has_target_script(surface: str, script: str | None) -> bool:
+    if not script:
+        return True
+    ranges = _SCRIPT_RANGES.get(script)
+    if ranges is None:
+        return True
+    return any(
+        start <= ord(ch) <= end
+        for ch in surface
+        for start, end in ranges
+    )
+
+
+def _has_letter(surface: str) -> bool:
+    return any(unicodedata.category(ch).startswith("L") for ch in surface)
+
+
+def should_treat_as_word(surface: str, upos: str, *, script: str | None) -> bool:
+    """Return whether a token should participate in reader word UX.
+
+    Stanza often tags English-only editorial fragments inside Indic
+    articles as ``X`` or ``PROPN``. Those are useful for preserving text,
+    but they should not become known-word entries or clickable dictionary
+    tokens for a Hindi / Marathi / Odia reader. Numeric tokens are kept so
+    the existing number-form popover still works for Latin or native digits.
+    """
+    if upos in NON_WORD_UPOS:
+        return False
+    if upos == "NUM":
+        return True
+    if _has_letter(surface) and not _has_target_script(surface, script):
+        return False
+    return True
 
 
 def parse_feats(feats: str | None) -> dict[str, str]:
@@ -134,8 +175,12 @@ class StanzaUDPipeline(Pipeline):
                 lemma = word.lemma or surface
                 upos = (word.upos or "X").upper()
                 features = parse_feats(word.feats)
-                is_word = upos not in NON_WORD_UPOS
-                is_oov = lemma == surface and upos not in NON_OOV_UPOS
+                is_word = should_treat_as_word(
+                    surface,
+                    upos,
+                    script=self._script,
+                )
+                is_oov = is_word and lemma == surface and upos not in NON_OOV_UPOS
                 tokens.append(
                     Token(
                         idx=idx,
@@ -209,4 +254,5 @@ __all__ = [
     "StanzaLike",
     "StanzaUDPipeline",
     "parse_feats",
+    "should_treat_as_word",
 ]

--- a/services/nlp/app/pipelines/stub.py
+++ b/services/nlp/app/pipelines/stub.py
@@ -24,6 +24,7 @@ from app.romanize import UnsupportedScriptError, to_roman
 from app.schemas import LemmaCandidate, Token
 
 from .base import Pipeline, PipelineResult
+from .stanza_ud import should_treat_as_word
 
 
 def _is_word_char(ch: str) -> bool:
@@ -106,7 +107,12 @@ class StubPipeline(Pipeline):
             return None
 
     def _make_token(self, idx: int, surface: str, is_word: bool) -> Token:
-        if is_word:
+        token_is_word = is_word and should_treat_as_word(
+            surface,
+            "X",
+            script=self._script,
+        )
+        if token_is_word:
             return Token(
                 idx=idx,
                 surface=surface,

--- a/services/nlp/tests/test_hindi_pipeline.py
+++ b/services/nlp/tests/test_hindi_pipeline.py
@@ -180,6 +180,34 @@ def test_process_does_not_flag_oov_for_numbers_punctuation_symbols():
     assert [t.is_oov for t in tokens] == [False, False, False, False]
 
 
+def test_process_ignores_latin_only_words_when_script_known():
+    doc = FakeDoc(
+        sentences=[
+            FakeSentence(
+                words=[
+                    FakeWord(text="Edit", lemma="Edit", upos="X"),
+                    FakeWord(text="this", lemma="this", upos="X"),
+                    FakeWord(text="बोलता", lemma="बोलना", upos="VERB"),
+                ]
+            )
+        ]
+    )
+    pipe = HindiPipeline(nlp=FakeStanza(doc), script="Deva")
+    tokens = pipe.process("Edit this बोलता").tokens
+    assert [t.is_word for t in tokens] == [False, False, True]
+    assert [t.is_oov for t in tokens] == [False, False, False]
+
+
+def test_process_keeps_numeric_tokens_even_when_script_known():
+    doc = FakeDoc(
+        sentences=[FakeSentence(words=[FakeWord(text="1910", lemma="1910", upos="NUM")])]
+    )
+    pipe = HindiPipeline(nlp=FakeStanza(doc), script="Deva")
+    tok = pipe.process("1910").tokens[0]
+    assert tok.is_word is True
+    assert tok.is_oov is False
+
+
 def test_process_marks_punctuation_as_non_word():
     doc = FakeDoc(
         sentences=[

--- a/services/nlp/tests/test_marathi_pipeline.py
+++ b/services/nlp/tests/test_marathi_pipeline.py
@@ -131,6 +131,20 @@ def test_fallback_marks_punctuation_correctly():
     assert result.tokens[2].is_oov is False
 
 
+def test_fallback_ignores_latin_only_words_when_script_known():
+    def fb(_text: str) -> list[str]:
+        return ["Edit", "नमस्कार"]
+
+    pipe = MarathiPipeline(
+        nlp=FakeStanza(FakeDoc(sentences=[])),
+        fallback_tokenizer=fb,
+        script="Deva",
+    )
+    result = pipe.process("Edit नमस्कार")
+    assert [t.is_word for t in result.tokens] == [False, True]
+    assert [t.is_oov for t in result.tokens] == [False, True]
+
+
 def test_fallback_drops_empty_surfaces():
     # A fallback tokenizer that returns stray empty strings (e.g. because
     # IndicNLP split on a trailing newline) shouldn't emit empty tokens —

--- a/services/nlp/tests/test_odia_pipeline.py
+++ b/services/nlp/tests/test_odia_pipeline.py
@@ -80,6 +80,18 @@ def test_unknown_surface_is_oov_with_fallback_candidate():
     assert tok.is_word is True
 
 
+def test_latin_only_surface_is_plain_text_not_oov_word():
+    lemmas = _table(ଘର=OdiaLemma(headword="ଘର", pos="NOUN", gloss="house"))
+    result = _pipe(lemmas).process("Edit ଘର")
+    english, odia = result.tokens
+    assert english.surface == "Edit"
+    assert english.is_word is False
+    assert english.is_oov is False
+    assert english.candidates[0].pos == "X"
+    assert odia.is_word is True
+    assert odia.is_oov is False
+
+
 def test_inflected_noun_strips_to_known_stem():
     # Locative suffix "ରେ" on ଘର → lemma ଘର with Case=Loc.
     lemmas = _table(ଘର=OdiaLemma(headword="ଘର", pos="NOUN"))

--- a/services/nlp/tests/test_pipelines.py
+++ b/services/nlp/tests/test_pipelines.py
@@ -90,6 +90,13 @@ def test_stub_pipeline_emits_romanization_when_script_known():
     assert space_tokens[0].romanization is None
 
 
+def test_stub_pipeline_ignores_latin_only_words_when_script_known():
+    out = StubPipeline(script="Deva", roman_scheme="iso15919").process("Edit this नमस्ते")
+    assert [t.surface for t in out.tokens] == ["Edit", " ", "this", " ", "नमस्ते"]
+    assert [t.is_word for t in out.tokens] == [False, False, False, False, True]
+    assert [t.is_oov for t in out.tokens] == [False, False, False, False, True]
+
+
 def test_stub_pipeline_returns_valid_token_shape():
     out = StubPipeline().process("one two")
     tok: Token = out.tokens[0]


### PR DESCRIPTION
## Summary
- add a shared script-aware token eligibility helper for reader word UX
- preserve English-only editorial/code-switch fragments as plain text instead of clickable/OOV words
- apply the rule across Stanza, Marathi fallback, Odia, and stub pipelines with regression coverage

## Tests
- PYTHONPATH=../../packages/shared-types/python:. .venv/bin/pytest --no-cov
- .venv/bin/ruff check app/pipelines/stanza_ud.py app/pipelines/marathi.py app/pipelines/odia/__init__.py app/pipelines/stub.py tests/test_hindi_pipeline.py tests/test_marathi_pipeline.py tests/test_odia_pipeline.py tests/test_pipelines.py