### PR TITLE
Show language-specific number forms

### DIFF
--- a/apps/web/src/lib/components/reader/WordPopup.svelte
+++ b/apps/web/src/lib/components/reader/WordPopup.svelte
@@ -54,6 +54,13 @@
     };
   };
 
+  type NumberDisplay = {
+    label: string;
+    nativeDigits: string;
+    spelled: string;
+    romanized: string;
+  };
+
   // anchorRect is accepted but unused — anchor positioning was used
   // before T-5.10 switched to Sheet. Kept on the prop signature for
   // backward compat with callers that still pass it.
@@ -212,6 +219,32 @@
       payload?.translations.personal ?? [],
     ),
   );
+
+  const numberDisplay = $derived((): NumberDisplay | null => {
+    if (!token?.numberForms) return null;
+    if (language === 'or') {
+      return {
+        label: 'Odia',
+        nativeDigits: token.numberForms.digitsOrya,
+        spelled: token.numberForms.odia.spelled,
+        romanized: token.numberForms.odia.romanized,
+      };
+    }
+    if (language === 'mr') {
+      return {
+        label: 'Marathi',
+        nativeDigits: token.numberForms.digitsDeva,
+        spelled: token.numberForms.mr.spelled,
+        romanized: token.numberForms.mr.romanized,
+      };
+    }
+    return {
+      label: 'Hindi',
+      nativeDigits: token.numberForms.digitsDeva,
+      spelled: token.numberForms.hi.spelled,
+      romanized: token.numberForms.hi.romanized,
+    };
+  });
 
   function startCustomize(t: PublicTranslation) {
     customizingId = t.id;
@@ -436,35 +469,26 @@
         >
           ×
         </button>
-        <h2 class="sp-word">{token.surface}</h2>
-      {#if token.numberForms}
-        <!-- T-2.8: digit-only NUM token. Show all three native-script
-             digit renderings, then the spelled-out form + ISO 15919
-             romanization for each MVP language. The lemma / translation
-             / status panes are skipped — numbers aren't lemmas to learn. -->
-        <div class="num-block" data-testid="number-forms">
-          <div class="num-digits">
+        {#if token.numberForms && numberDisplay()}
+          <h2 class="sp-word num-title">
             <span>{token.numberForms.digitsLatin}</span>
-            <span>{token.numberForms.digitsDeva}</span>
-            <span>{token.numberForms.digitsOrya}</span>
+            <span class="num-native">{numberDisplay()?.nativeDigits}</span>
+          </h2>
+        {:else}
+          <h2 class="sp-word">{token.surface}</h2>
+        {/if}
+      {#if token.numberForms}
+        <!-- T-2.8: digit-only NUM token. Show the Latin digits beside
+             the text language's native-script digits, then the
+             language-specific spelled-out form + ISO 15919 romanization.
+             The lemma / translation / status panes are skipped —
+             numbers aren't lemmas to learn. -->
+        <div class="num-block" data-testid="number-forms">
+          <div class="num-entry">
+            <span class="num-lang">{numberDisplay()?.label}</span>
+            <span class="num-spelled">{numberDisplay()?.spelled}</span>
+            <span class="num-roman">{numberDisplay()?.romanized}</span>
           </div>
-          <ul class="num-langs">
-            <li>
-              <span class="num-lang">Hindi</span>
-              <span class="num-spelled">{token.numberForms.hi.spelled}</span>
-              <span class="num-roman">{token.numberForms.hi.romanized}</span>
-            </li>
-            <li>
-              <span class="num-lang">Marathi</span>
-              <span class="num-spelled">{token.numberForms.mr.spelled}</span>
-              <span class="num-roman">{token.numberForms.mr.romanized}</span>
-            </li>
-            <li>
-              <span class="num-lang">Odia</span>
-              <span class="num-spelled">{token.numberForms.odia.spelled}</span>
-              <span class="num-roman">{token.numberForms.odia.romanized}</span>
-            </li>
-          </ul>
         </div>
       {:else}
         {#if token.romanization}
@@ -1106,30 +1130,26 @@
   }
 
   /* T-2.8: number-only token block. */
+  .num-title {
+    display: flex;
+    align-items: baseline;
+    gap: 0.65rem;
+  }
+  .num-native {
+    color: var(--ink-3, var(--color-fg-muted));
+    font-size: 0.62em;
+  }
   .num-block {
     display: flex;
     flex-direction: column;
-    gap: 0.7rem;
-    margin-top: 0.4rem;
-  }
-  .num-digits {
-    display: flex;
-    align-items: baseline;
-    gap: 0.85rem;
-    font-family: var(--font-serif-dev, var(--font-serif));
-    font-size: 1.25rem;
-    color: var(--ink-2, var(--color-fg));
-    padding-bottom: 0.55rem;
+    gap: 0.55rem;
+    margin-top: 0.75rem;
+    padding-top: 0.7rem;
     border-bottom: 1px solid var(--rule-2, var(--color-border));
+    border-top: 1px solid var(--rule-2, var(--color-border));
+    padding-bottom: 0.75rem;
   }
-  .num-langs {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: grid;
-    gap: 0.5rem;
-  }
-  .num-langs li {
+  .num-entry {
     display: grid;
     grid-template-columns: 4.5rem 1fr;
     grid-template-rows: auto auto;

--- a/apps/web/src/lib/components/reader/WordPopup.test.ts
+++ b/apps/web/src/lib/components/reader/WordPopup.test.ts
@@ -65,43 +65,41 @@ function makeToken(overrides: Partial<ServerToken> = {}): ServerToken {
 }
 
 describe('WordPopup — number-only token block (T-2.8)', () => {
-  it('renders all three native-script digit forms', () => {
-    render(WordPopup, {
-      token: makeToken({ numberForms: makeNumberForms() }),
-      language: 'hi',
-      isOwner: true,
-      onClose: vi.fn(),
-    });
-    // Sheet portals to <body>, so query document.body rather than the
-    // testing-library container.
-    const block = document.body.querySelector('[data-testid="number-forms"]');
-    expect(block).not.toBeNull();
-    const digits = block!.querySelector('.num-digits')!.textContent ?? '';
-    expect(digits).toContain('123');
-    expect(digits).toContain('१२३');
-    expect(digits).toContain('୧୨୩');
-  });
+  it.each([
+    ['hi', 'Hindi', '१२३', 'एक सौ तेईस', 'ek sau teīs'],
+    ['mr', 'Marathi', '१२३', 'एकशे तेवीस', 'ēkaśē tēvīsa'],
+    ['or', 'Odia', '୧୨୩', 'ଏକ ଶହ ତେଇଶ', 'ēka śaha tēiśa'],
+  ] as const)(
+    'renders only the %s number forms with Latin + native digits',
+    (language, label, nativeDigits, spelled, romanized) => {
+      render(WordPopup, {
+        token: makeToken({ numberForms: makeNumberForms() }),
+        language,
+        isOwner: true,
+        onClose: vi.fn(),
+      });
+      // Sheet portals to <body>, so query document.body rather than the
+      // testing-library container.
+      const heading = document.body.querySelector('.num-title');
+      expect(heading?.textContent).toContain('123');
+      expect(heading?.textContent).toContain(nativeDigits);
+      expect(heading?.textContent).not.toContain(
+        language === 'or' ? '१२३' : '୧୨୩',
+      );
 
-  it('renders the spelled-out form + romanization for each MVP language', () => {
-    render(WordPopup, {
-      token: makeToken({ numberForms: makeNumberForms() }),
-      language: 'hi',
-      isOwner: true,
-      onClose: vi.fn(),
-    });
-    const langs = Array.from(
-      document.body.querySelectorAll('.num-langs li'),
-    ) as HTMLLIElement[];
-    expect(langs).toHaveLength(3);
-    const text = langs.map((li) => li.textContent ?? '').join('|');
-    expect(text).toContain('Hindi');
-    expect(text).toContain('एक सौ तेईस');
-    expect(text).toContain('ek sau teīs');
-    expect(text).toContain('Marathi');
-    expect(text).toContain('एकशे तेवीस');
-    expect(text).toContain('Odia');
-    expect(text).toContain('ଏକ ଶହ ତେଇଶ');
-  });
+      const block = document.body.querySelector('[data-testid="number-forms"]');
+      expect(block).not.toBeNull();
+      const entries = document.body.querySelectorAll('.num-entry');
+      expect(entries).toHaveLength(1);
+      const text = block!.textContent ?? '';
+      expect(text).toContain(label);
+      expect(text).toContain(spelled);
+      expect(text).toContain(romanized);
+      if (language !== 'hi') expect(text).not.toContain('एक सौ तेईस');
+      if (language !== 'mr') expect(text).not.toContain('एकशे तेवीस');
+      if (language !== 'or') expect(text).not.toContain('ଏକ ଶହ ତେଇଶ');
+    },
+  );
 
   it('hides the status / translations / fix affordances for number tokens', () => {
     // Pass a non-null lemmaId to force the number branch to suppress


### PR DESCRIPTION
## Summary
- show Latin digits beside the current text language's native digits in the number popup
- show only the active language's spelled-out number and romanization
- cover Hindi, Marathi, and Odia number popup rendering in tests

## Verification
- pnpm --filter @ciareader/web exec vitest run src/lib/components/reader/WordPopup.test.ts src/lib/server/texts/in-process-dispatcher.test.ts src/lib/server/texts/tokens.test.ts

Built from fresh worktree: /private/tmp/ciar-number-popup, based on origin/main.