### PR TITLE
Treat coordinate fragments as non-word tokens

### DIFF
--- a/services/nlp/app/pipelines/stanza_ud.py
+++ b/services/nlp/app/pipelines/stanza_ud.py
@@ -50,6 +50,8 @@ _SCRIPT_RANGES: dict[str, tuple[tuple[int, int], ...]] = {
     "Orya": ((0x0B00, 0x0B7F),),
 }
 
+_COORDINATE_MARKS: frozenset[str] = frozenset({"°", "′", "″"})
+
 
 def _has_target_script(surface: str, script: str | None) -> bool:
     if not script:
@@ -68,6 +70,18 @@ def _has_letter(surface: str) -> bool:
     return any(unicodedata.category(ch).startswith("L") for ch in surface)
 
 
+def _looks_like_coordinate_part(surface: str) -> bool:
+    """Return True for coordinate / measurement fragments such as
+    ``113°43`` or ``′6″W``.
+
+    Stanza can split DMS coordinates in the middle and tag the numeric
+    chunk as ``PROPN``. Those surfaces are not dictionary words and
+    should not become clickable reader tokens; digit-only numbers still
+    pass through so the number popup can handle them.
+    """
+    return any(mark in surface for mark in _COORDINATE_MARKS)
+
+
 def should_treat_as_word(surface: str, upos: str, *, script: str | None) -> bool:
     """Return whether a token should participate in reader word UX.
 
@@ -78,6 +92,8 @@ def should_treat_as_word(surface: str, upos: str, *, script: str | None) -> bool
     the existing number-form popover still works for Latin or native digits.
     """
     if upos in NON_WORD_UPOS:
+        return False
+    if _looks_like_coordinate_part(surface):
         return False
     if upos == "NUM":
         return True

--- a/services/nlp/tests/test_hindi_pipeline.py
+++ b/services/nlp/tests/test_hindi_pipeline.py
@@ -225,6 +225,32 @@ def test_process_marks_punctuation_as_non_word():
     assert tokens[1].is_word is False
 
 
+def test_process_marks_coordinate_fragments_as_non_words():
+    # Stanza may split a DMS coordinate like "113°43′6″W" into
+    # "113°43" + "′6″W" and tag the first chunk as PROPN. The reader
+    # must still render both as plain text, not as underlined/clickable
+    # dictionary words. Plain digit-only numbers remain handled by the
+    # number popup; coordinate fragments do not get number_forms.
+    doc = FakeDoc(
+        sentences=[
+            FakeSentence(
+                words=[
+                    FakeWord(text="48°41′48″N", lemma="48°41′48″N", upos="PROPN"),
+                    FakeWord(text="113°43", lemma="113°43", upos="PROPN"),
+                    FakeWord(text="′6″W", lemma="′6″W", upos="PROPN"),
+                    FakeWord(text="2024", lemma="2024", upos="NUM"),
+                ]
+            )
+        ]
+    )
+    pipe, _ = _pipe(doc)
+    tokens = pipe.process("x").tokens
+    assert [t.is_word for t in tokens] == [False, False, False, True]
+    assert [t.romanization for t in tokens[:3]] == [None, None, None]
+    assert [t.number_forms for t in tokens[:3]] == [None, None, None]
+    assert tokens[3].number_forms is not None
+
+
 def test_process_indexes_tokens_contiguously_across_sentences():
     doc = FakeDoc(
         sentences=[


### PR DESCRIPTION
## Summary
- classify DMS coordinate fragments like 113°43 and ′6″W as non-word tokens
- keep digit-only numbers eligible for number forms
- add Hindi pipeline regression coverage for latitude/longitude fragments

## Verification
- /Users/basati/Documents/New\ project/ciareader/services/nlp/.venv/bin/python -m pytest services/nlp/tests/test_hindi_pipeline.py services/nlp/tests/test_pipelines.py -q --no-cov

Built from fresh worktree: /private/tmp/ciar-coordinate-token, based on origin/main.