### PR TITLE
T-10.3: Vocabulary CSV export

### DIFF
--- a/apps/web/src/lib/server/vocabulary.test.ts
+++ b/apps/web/src/lib/server/vocabulary.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const queryRows = vi.fn();
+
+vi.mock('./db/index.js', () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        innerJoin: vi.fn(() => ({
+          where: vi.fn(() => ({
+            orderBy: vi.fn(() => queryRows()),
+          })),
+        })),
+      })),
+    })),
+  },
+  schema: {
+    lemmas: {
+      id: 'lemmas.id',
+      language: 'lemmas.language',
+      headword: 'lemmas.headword',
+      pos: 'lemmas.pos',
+      glossDefault: 'lemmas.gloss_default',
+    },
+    userKnownLemmas: {
+      userId: 'user_known_lemmas.user_id',
+      lemmaId: 'user_known_lemmas.lemma_id',
+      status: 'user_known_lemmas.status',
+    },
+  },
+}));
+
+const { csvEscape, getVocabularyForExport, rowsToCsv } = await import(
+  './vocabulary.js'
+);
+
+beforeEach(() => {
+  queryRows.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('vocabulary export', () => {
+  it('maps touched lemmas to CSV-shaped rows', async () => {
+    queryRows.mockResolvedValueOnce([
+      {
+        headword: 'बोलना',
+        pos: 'VERB',
+        glossDefault: 'to speak',
+        status: 'known',
+      },
+      {
+        headword: 'घर',
+        pos: 'NOUN',
+        glossDefault: null,
+        status: 'learning',
+      },
+    ]);
+
+    await expect(getVocabularyForExport('u1', 'hi')).resolves.toEqual([
+      {
+        headword: 'बोलना',
+        pos: 'VERB',
+        gloss: 'to speak',
+        status: 'known',
+      },
+      {
+        headword: 'घर',
+        pos: 'NOUN',
+        gloss: '',
+        status: 'learning',
+      },
+    ]);
+  });
+
+  it('escapes CSV cells with quotes, commas, and newlines', () => {
+    expect(csvEscape('plain')).toBe('plain');
+    expect(csvEscape('a,b')).toBe('"a,b"');
+    expect(csvEscape('say "hi"')).toBe('"say ""hi"""');
+    expect(csvEscape('line\nbreak')).toBe('"line\nbreak"');
+  });
+
+  it('serializes the required header and status values', () => {
+    const csv = rowsToCsv([
+      {
+        headword: 'a,b',
+        pos: 'NOUN',
+        gloss: 'letter "a"',
+        status: 'ignored',
+      },
+    ]);
+
+    expect(csv).toBe(
+      'headword,pos,gloss,status\n"a,b",NOUN,"letter ""a""",ignored\n',
+    );
+  });
+});

--- a/apps/web/src/lib/server/vocabulary.ts
+++ b/apps/web/src/lib/server/vocabulary.ts
@@ -1,0 +1,73 @@
+/**
+ * Vocabulary export (T-10.3).
+ *
+ * Pulls every lemma the user has touched in one language and projects it to
+ * Anki-friendly CSV rows: headword, POS, gloss, and learning status.
+ */
+import { and, asc, eq } from 'drizzle-orm';
+
+import { db, schema } from './db/index.js';
+import type { LanguageCode } from '@ciareader/shared-types';
+
+export type VocabularyStatus = 'unknown' | 'learning' | 'known' | 'ignored';
+
+export type VocabularyRow = {
+  headword: string;
+  pos: string;
+  gloss: string;
+  status: VocabularyStatus;
+};
+
+export async function getVocabularyForExport(
+  userId: string,
+  language: LanguageCode,
+): Promise<VocabularyRow[]> {
+  const rows = await db
+    .select({
+      headword: schema.lemmas.headword,
+      pos: schema.lemmas.pos,
+      glossDefault: schema.lemmas.glossDefault,
+      status: schema.userKnownLemmas.status,
+    })
+    .from(schema.userKnownLemmas)
+    .innerJoin(
+      schema.lemmas,
+      eq(schema.lemmas.id, schema.userKnownLemmas.lemmaId),
+    )
+    .where(
+      and(
+        eq(schema.userKnownLemmas.userId, userId),
+        eq(schema.lemmas.language, language),
+      ),
+    )
+    .orderBy(asc(schema.lemmas.headword), asc(schema.lemmas.pos));
+
+  return rows.map((r) => ({
+    headword: r.headword,
+    pos: r.pos,
+    gloss: r.glossDefault ?? '',
+    status: r.status,
+  }));
+}
+
+export function csvEscape(value: string): string {
+  if (/[",\n\r]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+export function rowsToCsv(rows: VocabularyRow[]): string {
+  const lines = ['headword,pos,gloss,status'];
+  for (const row of rows) {
+    lines.push(
+      [
+        csvEscape(row.headword),
+        csvEscape(row.pos),
+        csvEscape(row.gloss),
+        csvEscape(row.status),
+      ].join(','),
+    );
+  }
+  return `${lines.join('\n')}\n`;
+}

--- a/apps/web/src/routes/api/v1/me/vocabulary/export/+server.ts
+++ b/apps/web/src/routes/api/v1/me/vocabulary/export/+server.ts
@@ -1,0 +1,39 @@
+/**
+ * GET /api/v1/me/vocabulary/export?language=hi (T-10.3).
+ *
+ * Returns a per-language CSV attachment for the authenticated user's touched
+ * vocabulary: headword, pos, gloss, status.
+ */
+import { error } from '@sveltejs/kit';
+
+import { requireUser } from '$lib/server/auth/require-user.js';
+import {
+  getVocabularyForExport,
+  rowsToCsv,
+} from '$lib/server/vocabulary.js';
+import {
+  isSupportedLanguage,
+  type LanguageCode,
+} from '@ciareader/shared-types';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  const rawLanguage = event.url.searchParams.get('language');
+  if (!rawLanguage) throw error(400, 'language is required');
+  if (!isSupportedLanguage(rawLanguage)) {
+    throw error(400, `Unsupported language '${rawLanguage}'`);
+  }
+
+  const language = rawLanguage as LanguageCode;
+  const rows = await getVocabularyForExport(user.id, language);
+  const csv = rowsToCsv(rows);
+
+  return new Response(csv, {
+    headers: {
+      'content-type': 'text/csv; charset=utf-8',
+      'content-disposition': `attachment; filename="ciareader-vocabulary-${language}.csv"`,
+      'cache-control': 'private, no-store',
+    },
+  });
+};

--- a/apps/web/src/routes/api/v1/me/vocabulary/export/export-server.test.ts
+++ b/apps/web/src/routes/api/v1/me/vocabulary/export/export-server.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const requireUser = vi.fn();
+const getVocabularyForExport = vi.fn();
+
+vi.mock('$lib/server/auth/require-user.js', () => ({
+  requireUser: (...a: unknown[]) => requireUser(...a),
+}));
+
+vi.mock('$lib/server/vocabulary.js', async () => {
+  const actual = await vi.importActual<
+    typeof import('$lib/server/vocabulary.js')
+  >('$lib/server/vocabulary.js');
+  return {
+    ...actual,
+    getVocabularyForExport: (...a: unknown[]) =>
+      getVocabularyForExport(...a),
+  };
+});
+
+type GetFn = (typeof import('./+server.js'))['GET'];
+
+async function callGet(url = 'http://x/api/v1/me/vocabulary/export?language=hi') {
+  const { GET } = await import('./+server.js');
+  const event = {
+    url: new URL(url),
+    request: new Request(url),
+  } as unknown as Parameters<GetFn>[0];
+  try {
+    return (await GET(event)) as Response;
+  } catch (e) {
+    return e as { status: number };
+  }
+}
+
+beforeEach(() => {
+  requireUser.mockReset();
+  requireUser.mockResolvedValue({ id: 'u1' });
+  getVocabularyForExport.mockReset();
+  getVocabularyForExport.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('GET /api/v1/me/vocabulary/export', () => {
+  it('returns a CSV attachment for the requested language', async () => {
+    getVocabularyForExport.mockResolvedValueOnce([
+      {
+        headword: 'बोलना',
+        pos: 'VERB',
+        gloss: 'to speak',
+        status: 'known',
+      },
+    ]);
+
+    const res = (await callGet()) as Response;
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/csv');
+    expect(res.headers.get('content-disposition')).toContain(
+      'ciareader-vocabulary-hi.csv',
+    );
+    expect(await res.text()).toBe(
+      'headword,pos,gloss,status\nबोलना,VERB,to speak,known\n',
+    );
+    expect(getVocabularyForExport).toHaveBeenCalledWith('u1', 'hi');
+  });
+
+  it('rejects a missing language with 400', async () => {
+    const res = (await callGet(
+      'http://x/api/v1/me/vocabulary/export',
+    )) as { status: number };
+
+    expect(res.status).toBe(400);
+    expect(getVocabularyForExport).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unsupported language with 400', async () => {
+    const res = (await callGet(
+      'http://x/api/v1/me/vocabulary/export?language=fr',
+    )) as { status: number };
+
+    expect(res.status).toBe(400);
+    expect(getVocabularyForExport).not.toHaveBeenCalled();
+  });
+
+  it('requires auth', async () => {
+    requireUser.mockImplementationOnce(() => {
+      throw { status: 401 };
+    });
+
+    const res = (await callGet()) as { status: number };
+
+    expect(res.status).toBe(401);
+    expect(getVocabularyForExport).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/routes/words/+page.svelte
+++ b/apps/web/src/routes/words/+page.svelte
@@ -39,6 +39,10 @@
     return qs ? `?${qs}` : '';
   }
 
+  function exportHref(language: string): string {
+    return `/api/v1/me/vocabulary/export?language=${encodeURIComponent(language)}`;
+  }
+
   function relativeFromNow(date: Date | string): string {
     const d = typeof date === 'string' ? new Date(date) : date;
     const seconds = Math.max(0, (Date.now() - d.getTime()) / 1000);
@@ -107,6 +111,30 @@
       </a>
     {/each}
   </nav>
+
+  <div class="language-row" aria-label="Language filter">
+    <a
+      class="language-chip"
+      data-active={data.filters.language === null ? '1' : '0'}
+      href={hrefWith({ language: null })}
+    >
+      All
+    </a>
+    {#each data.languages as language (language.code)}
+      <a
+        class="language-chip"
+        data-active={data.filters.language === language.code ? '1' : '0'}
+        href={hrefWith({ language: language.code })}
+      >
+        {language.nativeName}
+      </a>
+    {/each}
+    {#if data.filters.language}
+      <a class="export-link" href={exportHref(data.filters.language)}>
+        Export CSV
+      </a>
+    {/if}
+  </div>
 
   {#if data.rows.length === 0}
     <p class="empty">
@@ -282,6 +310,54 @@
       transparent
     );
     color: var(--ink, var(--color-fg));
+  }
+
+  .language-row {
+    display: flex;
+    gap: 0.4rem;
+    align-items: center;
+    flex-wrap: wrap;
+    margin: -0.25rem 0 0.9rem;
+  }
+  .language-chip,
+  .export-link {
+    min-height: 32px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 7px;
+    border: 1px solid var(--rule, var(--color-border));
+    padding: 0 0.7rem;
+    font-family: var(--font-sans, var(--font-ui));
+    font-size: 0.76rem;
+    color: var(--ink-2, var(--color-fg-muted));
+    text-decoration: none;
+    background: var(--paper, var(--color-bg));
+  }
+  .language-chip[data-active='1'] {
+    border-color: color-mix(
+      in oklch,
+      var(--ink, var(--color-fg)) 22%,
+      var(--rule, var(--color-border))
+    );
+    color: var(--ink, var(--color-fg));
+    background: color-mix(
+      in oklch,
+      var(--ink, var(--color-fg)) 6%,
+      var(--paper, var(--color-bg))
+    );
+  }
+  .export-link {
+    margin-left: auto;
+    background: var(--ink, var(--color-fg));
+    border-color: var(--ink, var(--color-fg));
+    color: var(--paper, var(--color-bg));
+  }
+  @media (max-width: 560px) {
+    .export-link {
+      width: 100%;
+      margin-left: 0;
+    }
   }
 
   .card {


### PR DESCRIPTION
## Summary
- add an authenticated per-language vocabulary CSV export endpoint
- serialize touched lemmas as headword,pos,gloss,status for Anki-style import
- add language filter chips and an Export CSV action to the Words page
- 
- ## Tests
- pnpm --filter @ciareader/web test -- vocabulary.test.ts export-server.test.ts words/page-server.test.ts
- pnpm --filter @ciareader/web check
- pnpm --filter @ciareader/web lint

Closes #93