### PR TITLE
Track first visible reader word progress

### DIFF
--- a/apps/web/src/lib/components/reader/ReaderContinuous.svelte
+++ b/apps/web/src/lib/components/reader/ReaderContinuous.svelte
@@ -16,28 +16,40 @@
   readable.
 -->
 <script lang="ts">
-  import { onMount, untrack } from 'svelte';
+  import { onMount, tick, untrack } from 'svelte';
 
   import ChapterBody from './ChapterBody.svelte';
   import { LazyTokenLoader, type ChapterTokenFetcher } from './lazy-tokens.js';
+  import type { ProgressAnchor } from './progress-client.js';
+  import {
+    computePctRead,
+    findFirstVisibleWordAnchor,
+    findTokenElementAtOrAfter,
+    readableRect,
+    readerTopInset,
+  } from './reader-progress.js';
   import type { ChapterView, ServerToken } from './types.js';
 
   let {
     chapters,
     initialChapterIdx = 0,
+    initialTokenIdx = 0,
     showRomanization = false,
     isOwner = false,
     textId,
     language,
+    onProgress,
     /** Override hook for tests — defaults to a real fetch when omitted. */
     fetcher,
   }: {
     chapters: ChapterView[];
     initialChapterIdx?: number;
+    initialTokenIdx?: number;
     showRomanization?: boolean;
     isOwner?: boolean;
     textId: string;
     language: import('@ciareader/shared-types').LanguageCode;
+    onProgress?: (anchor: ProgressAnchor) => void;
     fetcher?: ChapterTokenFetcher;
   } = $props();
 
@@ -47,9 +59,7 @@
   // unnecessary network round-trip for the chapter we already have.
   let lazyTokens = $state(new Map<number, ServerToken[] | null>());
 
-  const loader = $derived(
-    new LazyTokenLoader(textId, fetcher),
-  );
+  const loader = $derived(new LazyTokenLoader(textId, fetcher));
 
   // The chapter views handed to ChapterBody — sibling chapters get
   // their tokens patched in once the lazy loader resolves them.
@@ -84,6 +94,10 @@
   }
 
   let sectionRefs: Map<number, HTMLElement> = new Map();
+  let rootEl: HTMLElement | null = $state(null);
+  let lastReportedKey = '';
+  let reportRaf = 0;
+
   function bindSection(node: HTMLElement, idx: number) {
     sectionRefs.set(idx, node);
     return {
@@ -93,14 +107,67 @@
     };
   }
 
+  function scrollToInitialAnchor() {
+    const section = sectionRefs.get(initialChapterIdx);
+    if (!section) return;
+    const tokenEl =
+      initialTokenIdx > 0 ? findTokenElementAtOrAfter(section, initialTokenIdx) : null;
+    const target = tokenEl ?? section;
+    const rect = target.getBoundingClientRect();
+    window.scrollTo({
+      top: Math.max(0, window.scrollY + rect.top - readerTopInset()),
+      behavior: 'auto',
+    });
+  }
+
+  function isAtDocumentEnd(): boolean {
+    const doc = document.documentElement;
+    return window.scrollY + window.innerHeight >= doc.scrollHeight - 2;
+  }
+
+  function reportProgress() {
+    reportRaf = 0;
+    if (!onProgress || !rootEl) return;
+    const anchor = findFirstVisibleWordAnchor(rootEl, {
+      clip: readableRect(rootEl),
+    });
+    if (!anchor) return;
+    const next: ProgressAnchor = {
+      ...anchor,
+      pctRead: computePctRead(chapters, anchor.chapterIdx, anchor.tokenIdx, {
+        completedText: isAtDocumentEnd(),
+      }),
+    };
+    const key = `${next.chapterIdx}:${next.tokenIdx}:${next.pctRead}`;
+    if (key === lastReportedKey) return;
+    lastReportedKey = key;
+    onProgress(next);
+  }
+
+  function queueProgressReport() {
+    if (reportRaf) return;
+    reportRaf = window.requestAnimationFrame(reportProgress);
+  }
+
   onMount(() => {
+    void tick().then(() => {
+      scrollToInitialAnchor();
+      queueProgressReport();
+    });
+    window.addEventListener('scroll', queueProgressReport, { passive: true });
+    window.addEventListener('resize', queueProgressReport);
+
     if (typeof IntersectionObserver === 'undefined') {
       // jsdom / SSR fallback: prefetch every chapter eagerly so the
       // experience degrades gracefully (still better than the old
       // load-everything-server-side behavior because each chapter
       // ships in its own JSON response and Postgres roundtrip).
       for (const c of chapters) ensureChapter(c.idx);
-      return;
+      return () => {
+        window.removeEventListener('scroll', queueProgressReport);
+        window.removeEventListener('resize', queueProgressReport);
+        if (reportRaf) window.cancelAnimationFrame(reportRaf);
+      };
     }
     const io = new IntersectionObserver(
       (entries) => {
@@ -115,18 +182,33 @@
       { rootMargin: '600px 0px' },
     );
     for (const node of sectionRefs.values()) io.observe(node);
-    return () => io.disconnect();
+    return () => {
+      io.disconnect();
+      window.removeEventListener('scroll', queueProgressReport);
+      window.removeEventListener('resize', queueProgressReport);
+      if (reportRaf) window.cancelAnimationFrame(reportRaf);
+    };
+  });
+
+  $effect(() => {
+    void renderedChapters;
+    void showRomanization;
+    void tick().then(queueProgressReport);
   });
 </script>
 
-<div class="reader-continuous" data-mode="continuous" data-initial-chapter={initialChapterIdx}>
+<div
+  class="reader-continuous"
+  data-mode="continuous"
+  data-initial-chapter={initialChapterIdx}
+  bind:this={rootEl}
+>
   {#each renderedChapters as chapter (chapter.id)}
     <section
       id={`chapter-${chapter.idx}`}
       data-chapter-idx={chapter.idx}
       class:active={chapter.idx === initialChapterIdx}
       use:bindSection={chapter.idx}
-
     >
       {#if chapter.title || renderedChapters.length > 1}
         <h2>

--- a/apps/web/src/lib/components/reader/ReaderPage.svelte
+++ b/apps/web/src/lib/components/reader/ReaderPage.svelte
@@ -16,20 +16,28 @@
 -->
 <script lang="ts">
   import { goto } from '$app/navigation';
-  import { onMount } from 'svelte';
+  import { onMount, tick } from 'svelte';
 
   import ChapterBody from './ChapterBody.svelte';
   import { clampPage, pageCountFor, pageOffset } from './paginate.js';
+  import type { ProgressAnchor } from './progress-client.js';
+  import {
+    computePctRead,
+    findFirstVisibleWordAnchor,
+    findTokenElementAtOrAfter,
+  } from './reader-progress.js';
   import { classifySwipe } from './touch-gestures.js';
   import type { ChapterView } from './types.js';
 
   let {
     chapters,
     chapterIdx,
+    initialTokenIdx = 0,
     textId,
     language,
     showRomanization = false,
     isOwner = false,
+    onProgress,
     fontSize,
     lineSpacing,
     fontFamily,
@@ -37,19 +45,19 @@
   }: {
     chapters: ChapterView[];
     chapterIdx: number;
+    initialTokenIdx?: number;
     textId: string;
     language: import('@ciareader/shared-types').LanguageCode;
     showRomanization?: boolean;
     isOwner?: boolean;
+    onProgress?: (anchor: ProgressAnchor) => void;
     fontSize?: number;
     lineSpacing?: number;
     fontFamily?: string | null;
     readingWidth?: string;
   } = $props();
 
-  const current = $derived(
-    chapters[Math.max(0, Math.min(chapterIdx, chapters.length - 1))],
-  );
+  const current = $derived(chapters[Math.max(0, Math.min(chapterIdx, chapters.length - 1))]);
   const hasPrevChapter = $derived(chapterIdx > 0);
   const hasNextChapter = $derived(chapterIdx < chapters.length - 1);
 
@@ -63,6 +71,8 @@
   let pageW = $state(0);
   let contentW = $state(0);
   let pageInChapter = $state(0);
+  let initialTokenApplied = $state(false);
+  let lastReportedKey = '';
 
   const pageCount = $derived(pageCountFor(contentW, pageW));
   const offset = $derived(pageOffset(pageInChapter, pageW));
@@ -71,7 +81,10 @@
   // shouldn't see "stuck" mid-page state when they navigate.
   $effect(() => {
     void chapterIdx;
+    void initialTokenIdx;
     pageInChapter = 0;
+    initialTokenApplied = false;
+    lastReportedKey = '';
   });
 
   // Keep pageInChapter in range when pageCount shrinks (e.g. window
@@ -91,8 +104,7 @@
   const progressPct = $derived(
     chapters.length > 0
       ? Math.round(
-          ((chapterIdx + (pageCount > 0 ? (pageInChapter + 1) / pageCount : 0)) /
-            chapters.length) *
+          ((chapterIdx + (pageCount > 0 ? (pageInChapter + 1) / pageCount : 0)) / chapters.length) *
             100,
         )
       : 0,
@@ -224,6 +236,59 @@
     void fontFamily;
     void readingWidth;
     measure();
+  });
+
+  function applyInitialTokenPage() {
+    if (initialTokenApplied || !contentEl || pageW <= 0 || pageCount <= 0) return;
+    initialTokenApplied = true;
+    if (initialTokenIdx <= 0) return;
+    const tokenEl = findTokenElementAtOrAfter(contentEl, initialTokenIdx);
+    if (!tokenEl) return;
+    const tokenRect = tokenEl.getBoundingClientRect();
+    const contentRect = contentEl.getBoundingClientRect();
+    const page = Math.floor(Math.max(0, tokenRect.left - contentRect.left) / pageW);
+    pageInChapter = clampPage(page, pageCount);
+  }
+
+  function reportProgress() {
+    if (!onProgress || !viewportEl) return;
+    const anchor = findFirstVisibleWordAnchor(viewportEl, {
+      clip: viewportEl.getBoundingClientRect(),
+      fallbackChapterIdx: chapterIdx,
+    });
+    if (!anchor) return;
+    const next: ProgressAnchor = {
+      ...anchor,
+      pctRead: computePctRead(chapters, anchor.chapterIdx, anchor.tokenIdx, {
+        completedText: anchor.chapterIdx >= chapters.length - 1 && pageInChapter >= pageCount - 1,
+      }),
+    };
+    const key = `${next.chapterIdx}:${next.tokenIdx}:${next.pctRead}`;
+    if (key === lastReportedKey) return;
+    lastReportedKey = key;
+    onProgress(next);
+  }
+
+  $effect(() => {
+    void initialTokenIdx;
+    void pageCount;
+    void pageW;
+    void contentW;
+    applyInitialTokenPage();
+  });
+
+  $effect(() => {
+    void chapterIdx;
+    void pageInChapter;
+    void pageCount;
+    void contentW;
+    void pageW;
+    void showRomanization;
+    void fontSize;
+    void lineSpacing;
+    void fontFamily;
+    void readingWidth;
+    void tick().then(reportProgress);
   });
 </script>
 
@@ -450,11 +515,7 @@
 
   .reader-foot {
     border-top: 1px solid var(--rule, var(--color-border));
-    background: color-mix(
-      in oklch,
-      var(--paper, var(--color-bg)) 88%,
-      var(--paper-2, transparent)
-    );
+    background: color-mix(in oklch, var(--paper, var(--color-bg)) 88%, var(--paper-2, transparent));
     padding: 0.6rem 1.25rem 0.75rem;
     position: sticky;
     bottom: 0;

--- a/apps/web/src/lib/components/reader/ReaderScroll.svelte
+++ b/apps/web/src/lib/components/reader/ReaderScroll.svelte
@@ -8,7 +8,16 @@
   per-paragraph TokenSpan render so all three modes share styles.
 -->
 <script lang="ts">
+  import { onMount, tick } from 'svelte';
+
   import TokenSpan from './TokenSpan.svelte';
+  import type { ProgressAnchor } from './progress-client.js';
+  import {
+    computePctRead,
+    findFirstVisibleWordAnchor,
+    firstTokenPage,
+    readableRect,
+  } from './reader-progress.js';
   import {
     paragraphsOfServerTokens,
     paragraphsOfTokens,
@@ -24,24 +33,30 @@
   let {
     chapters,
     chapterIdx,
+    initialTokenIdx = 0,
     wordsPerPage = 250,
     showRomanization = false,
     isOwner = false,
     language,
+    onProgress,
   }: {
     chapters: ChapterView[];
     chapterIdx: number;
+    initialTokenIdx?: number;
     wordsPerPage?: number;
     showRomanization?: boolean;
     isOwner?: boolean;
     language: import('@ciareader/shared-types').LanguageCode;
+    onProgress?: (anchor: ProgressAnchor) => void;
   } = $props();
 
   let page = $state(0);
+  let articleEl: HTMLElement | null = $state(null);
+  let initialTokenApplied = $state(false);
+  let lastReportedKey = '';
+  let reportRaf = 0;
 
-  const current = $derived(
-    chapters[Math.max(0, Math.min(chapterIdx, chapters.length - 1))],
-  );
+  const current = $derived(chapters[Math.max(0, Math.min(chapterIdx, chapters.length - 1))]);
 
   // Source-of-tokens decision happens once per chapter — server
   // tokens beat the client fallback.
@@ -61,9 +76,7 @@
       if (correctedLemmaId && correctedLemmaId !== t.lemmaId) {
         const chosen = t.candidates.find((c) => c.lemmaId === correctedLemmaId);
         if (chosen) {
-          const remaining = t.candidates.filter(
-            (c) => c.lemmaId !== correctedLemmaId,
-          );
+          const remaining = t.candidates.filter((c) => c.lemmaId !== correctedLemmaId);
           next = {
             ...t,
             lemmaId: chosen.lemmaId,
@@ -125,16 +138,13 @@
   }
 
   const serverPages = $derived(serverParagraphs ? packServer(serverParagraphs) : null);
-  const fallbackPages = $derived(
-    fallbackParagraphs ? packFallback(fallbackParagraphs) : null,
-  );
+  const fallbackPages = $derived(fallbackParagraphs ? packFallback(fallbackParagraphs) : null);
+  const activePages = $derived(serverPages ?? fallbackPages);
   const pageCount = $derived(serverPages?.length ?? fallbackPages?.length ?? 1);
 
   const clampedPage = $derived(Math.max(0, Math.min(page, pageCount - 1)));
-  const visibleServer = $derived(serverPages ? serverPages[clampedPage] ?? [] : null);
-  const visibleFallback = $derived(
-    fallbackPages ? fallbackPages[clampedPage] ?? [] : null,
-  );
+  const visibleServer = $derived(serverPages ? (serverPages[clampedPage] ?? []) : null);
+  const visibleFallback = $derived(fallbackPages ? (fallbackPages[clampedPage] ?? []) : null);
   const hasPrev = $derived(clampedPage > 0);
   const hasNext = $derived(clampedPage < pageCount - 1);
 
@@ -144,6 +154,68 @@
   function next() {
     if (hasNext) page = clampedPage + 1;
   }
+
+  $effect(() => {
+    void chapterIdx;
+    void initialTokenIdx;
+    page = 0;
+    initialTokenApplied = false;
+    lastReportedKey = '';
+  });
+
+  $effect(() => {
+    void initialTokenIdx;
+    void pageCount;
+    void activePages;
+    if (initialTokenApplied) return;
+    initialTokenApplied = true;
+    page = firstTokenPage(activePages, initialTokenIdx);
+  });
+
+  function reportProgress() {
+    reportRaf = 0;
+    if (!onProgress || !articleEl) return;
+    const anchor = findFirstVisibleWordAnchor(articleEl, {
+      clip: readableRect(articleEl),
+      fallbackChapterIdx: chapterIdx,
+    });
+    if (!anchor) return;
+    const next: ProgressAnchor = {
+      ...anchor,
+      pctRead: computePctRead(chapters, anchor.chapterIdx, anchor.tokenIdx, {
+        completedText: anchor.chapterIdx >= chapters.length - 1 && clampedPage >= pageCount - 1,
+      }),
+    };
+    const key = `${next.chapterIdx}:${next.tokenIdx}:${next.pctRead}`;
+    if (key === lastReportedKey) return;
+    lastReportedKey = key;
+    onProgress(next);
+  }
+
+  function queueProgressReport() {
+    if (reportRaf) return;
+    reportRaf = window.requestAnimationFrame(reportProgress);
+  }
+
+  onMount(() => {
+    window.addEventListener('scroll', queueProgressReport, { passive: true });
+    window.addEventListener('resize', queueProgressReport);
+    void tick().then(queueProgressReport);
+    return () => {
+      window.removeEventListener('scroll', queueProgressReport);
+      window.removeEventListener('resize', queueProgressReport);
+      if (reportRaf) window.cancelAnimationFrame(reportRaf);
+    };
+  });
+
+  $effect(() => {
+    void clampedPage;
+    void pageCount;
+    void visibleServer;
+    void visibleFallback;
+    void showRomanization;
+    void tick().then(queueProgressReport);
+  });
 
   // Same click → popup pattern as ChapterBody — duplicated rather
   // than refactored because ReaderScroll also slices by paragraph
@@ -204,9 +276,7 @@
     // T-9.4: tap-to-seek. Same flow as ChapterBody — audio
     // alignment + player handle, no-op when neither is present.
     void (async () => {
-      const { getAlignmentStartMs, getAudioController } = await import(
-        './audio-bus.js'
-      );
+      const { getAlignmentStartMs, getAudioController } = await import('./audio-bus.js');
       const startMs = getAlignmentStartMs(found.token.id);
       if (startMs == null) return;
       const ctrl = getAudioController();
@@ -241,8 +311,7 @@
   }
 
   function hideHoverTooltip(event: Event) {
-    const related =
-      'relatedTarget' in event ? (event.relatedTarget as HTMLElement | null) : null;
+    const related = 'relatedTarget' in event ? (event.relatedTarget as HTMLElement | null) : null;
     if (related && (event.currentTarget as HTMLElement).contains(related)) {
       return;
     }
@@ -329,6 +398,7 @@
     <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
     <!-- svelte-ignore a11y_mouse_events_have_key_events -->
     <article
+      bind:this={articleEl}
       onclick={onArticleClick}
       onmouseover={showHoverTooltip}
       onmouseout={hideHoverTooltip}
@@ -338,10 +408,7 @@
       {#if visibleServer}
         {#each visibleServer as paragraph, pIdx (pIdx)}
           <p class="body">
-            {#each paragraph as token (token.id)}<TokenSpan
-                {token}
-                {showRomanization}
-              />{/each}
+            {#each paragraph as token (token.id)}<TokenSpan {token} {showRomanization} />{/each}
           </p>
         {/each}
       {:else if visibleFallback}
@@ -349,7 +416,8 @@
           <p class="body">
             {#each paragraph as token (token.idx)}<span
                 class:word={token.isWord}
-                data-token-idx={token.idx}>{token.surface}</span>{/each}
+                data-token-idx={token.idx}>{token.surface}</span
+              >{/each}
           </p>
         {/each}
       {/if}

--- a/apps/web/src/lib/components/reader/reader-progress.test.ts
+++ b/apps/web/src/lib/components/reader/reader-progress.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  computePctRead,
+  findFirstVisibleWordAnchor,
+  findTokenElementAtOrAfter,
+  firstTokenPage,
+} from './reader-progress.js';
+import type { ChapterView } from './types.js';
+
+function rect(top: number, left: number, bottom: number, right: number): DOMRect {
+  return {
+    top,
+    left,
+    bottom,
+    right,
+    x: left,
+    y: top,
+    width: right - left,
+    height: bottom - top,
+    toJSON: () => ({}),
+  } as DOMRect;
+}
+
+function word(idx: number, bounds: DOMRect, attrs: { tokenId?: string } = {}): HTMLElement {
+  const el = document.createElement('span');
+  el.className = 'word';
+  el.dataset.tokenIdx = String(idx);
+  if (attrs.tokenId) el.dataset.tokenId = attrs.tokenId;
+  el.getBoundingClientRect = () => bounds;
+  return el;
+}
+
+describe('reader progress helpers', () => {
+  it('finds the first visible word inside the clipped reading area', () => {
+    const root = document.createElement('section');
+    root.dataset.chapterIdx = '2';
+    root.append(
+      word(1, rect(20, -200, 40, -160)),
+      word(2, rect(-20, 10, 10, 60)),
+      word(3, rect(12, 10, 34, 60)),
+    );
+
+    expect(
+      findFirstVisibleWordAnchor(root, {
+        clip: { top: 0, left: 0, right: 300, bottom: 500 },
+      }),
+    ).toEqual({ chapterIdx: 2, tokenIdx: 2 });
+  });
+
+  it('uses the fallback chapter when tokens are rendered outside chapter sections', () => {
+    const root = document.createElement('article');
+    root.append(word(7, rect(10, 10, 20, 80)));
+
+    expect(
+      findFirstVisibleWordAnchor(root, {
+        clip: { top: 0, left: 0, right: 300, bottom: 500 },
+        fallbackChapterIdx: 4,
+      }),
+    ).toEqual({ chapterIdx: 4, tokenIdx: 7 });
+  });
+
+  it('finds the nearest rendered word at or after a saved token index', () => {
+    const root = document.createElement('article');
+    const before = word(3, rect(0, 0, 1, 1));
+    const exact = word(8, rect(0, 0, 1, 1));
+    const after = word(12, rect(0, 0, 1, 1));
+    root.append(before, after, exact);
+
+    expect(findTokenElementAtOrAfter(root, 8)).toBe(exact);
+    expect(findTokenElementAtOrAfter(root, 9)).toBe(after);
+  });
+
+  it('maps a saved token to the first paged-scroll page that contains it', () => {
+    const pages = [
+      [[{ idx: 2, isWord: true }], [{ idx: 5, isWord: true }]],
+      [[{ idx: 9, isWord: true }], [{ idx: 13, isWord: true }]],
+    ];
+
+    expect(firstTokenPage(pages, 0)).toBe(0);
+    expect(firstTokenPage(pages, 6)).toBe(1);
+    expect(firstTokenPage(pages, 99)).toBe(1);
+  });
+
+  it('computes pctRead from token position and preserves explicit completion', () => {
+    const chapters = [
+      { idx: 0, tokenCount: 10 },
+      { idx: 1, tokenCount: 30 },
+    ] as ChapterView[];
+
+    expect(computePctRead(chapters, 1, 10)).toBe(50);
+    expect(computePctRead(chapters, 1, 10, { completedText: true })).toBe(100);
+  });
+});

--- a/apps/web/src/lib/components/reader/reader-progress.ts
+++ b/apps/web/src/lib/components/reader/reader-progress.ts
@@ -1,0 +1,142 @@
+import type { ProgressAnchor } from './progress-client.js';
+import type { ChapterView } from './types.js';
+
+export type VisibleRect = {
+  top: number;
+  left: number;
+  right: number;
+  bottom: number;
+};
+
+const WORD_SELECTOR = '[data-token-id][data-token-idx], .word[data-token-idx]';
+
+function intersects(a: DOMRect, b: VisibleRect): boolean {
+  return a.bottom > b.top && a.top < b.bottom && a.right > b.left && a.left < b.right;
+}
+
+export function viewportRect(topInset = 0): VisibleRect {
+  const vv = window.visualViewport;
+  const top = (vv?.offsetTop ?? 0) + topInset;
+  const left = vv?.offsetLeft ?? 0;
+  const width = vv?.width ?? window.innerWidth;
+  const height = vv?.height ?? window.innerHeight;
+  return {
+    top,
+    left,
+    right: left + width,
+    bottom: top + Math.max(0, height - topInset),
+  };
+}
+
+export function readerTopInset(): number {
+  if (typeof document === 'undefined') return 0;
+  const raw = getComputedStyle(document.documentElement).getPropertyValue('--reader-top-h').trim();
+  const n = Number.parseFloat(raw);
+  return Number.isFinite(n) ? n : 0;
+}
+
+export function intersectRects(a: VisibleRect, b: VisibleRect): VisibleRect {
+  return {
+    top: Math.max(a.top, b.top),
+    left: Math.max(a.left, b.left),
+    right: Math.min(a.right, b.right),
+    bottom: Math.min(a.bottom, b.bottom),
+  };
+}
+
+export function rectFromElement(el: Element): VisibleRect {
+  const rect = el.getBoundingClientRect();
+  return {
+    top: rect.top,
+    left: rect.left,
+    right: rect.right,
+    bottom: rect.bottom,
+  };
+}
+
+export function readableRect(root: HTMLElement, topInset = readerTopInset()): VisibleRect {
+  return intersectRects(viewportRect(topInset), rectFromElement(root));
+}
+
+export function findFirstVisibleWordAnchor(
+  root: ParentNode,
+  args: {
+    clip: VisibleRect;
+    fallbackChapterIdx?: number;
+  },
+): Pick<ProgressAnchor, 'chapterIdx' | 'tokenIdx'> | null {
+  let best: {
+    chapterIdx: number;
+    tokenIdx: number;
+    top: number;
+    left: number;
+  } | null = null;
+
+  for (const el of Array.from(root.querySelectorAll<HTMLElement>(WORD_SELECTOR))) {
+    const rawTokenIdx = el.dataset.tokenIdx;
+    if (rawTokenIdx == null) continue;
+    const tokenIdx = Number.parseInt(rawTokenIdx, 10);
+    if (!Number.isFinite(tokenIdx)) continue;
+
+    const rect = el.getBoundingClientRect();
+    if (!intersects(rect, args.clip)) continue;
+
+    const rawChapterIdx = el.closest<HTMLElement>('[data-chapter-idx]')?.dataset.chapterIdx;
+    const chapterIdx =
+      rawChapterIdx == null ? args.fallbackChapterIdx : Number.parseInt(rawChapterIdx, 10);
+    if (chapterIdx == null || !Number.isFinite(chapterIdx)) continue;
+
+    const top = Math.max(rect.top, args.clip.top);
+    const left = Math.max(rect.left, args.clip.left);
+    if (!best || top < best.top || (top === best.top && left < best.left)) {
+      best = { chapterIdx, tokenIdx, top, left };
+    }
+  }
+
+  return best ? { chapterIdx: best.chapterIdx, tokenIdx: best.tokenIdx } : null;
+}
+
+export function computePctRead(
+  chapters: ChapterView[],
+  chapterIdx: number,
+  tokenIdx: number,
+  opts: { completedText?: boolean } = {},
+): number {
+  if (opts.completedText) return 100;
+  const total = chapters.reduce((sum, c) => sum + Math.max(0, c.tokenCount), 0);
+  if (total <= 0) return 0;
+  const before = chapters
+    .slice(0, Math.max(0, chapterIdx))
+    .reduce((sum, c) => sum + Math.max(0, c.tokenCount), 0);
+  const currentCount = Math.max(0, chapters[chapterIdx]?.tokenCount ?? 0);
+  const inChapter = Math.max(0, Math.min(tokenIdx, Math.max(0, currentCount - 1)));
+  return Math.max(0, Math.min(100, Math.round(((before + inChapter) / total) * 100)));
+}
+
+export function firstTokenPage<T extends { idx: number; isWord: boolean }>(
+  pages: T[][][] | null,
+  tokenIdx: number,
+): number {
+  if (!pages || pages.length === 0) return 0;
+  const target = Math.max(0, tokenIdx);
+  for (let i = 0; i < pages.length; i += 1) {
+    const words = pages[i]!.flat().filter((t) => t.isWord);
+    if (words.length === 0) continue;
+    const last = words[words.length - 1]!.idx;
+    if (target <= last) return i;
+  }
+  return pages.length - 1;
+}
+
+export function findTokenElementAtOrAfter(root: ParentNode, tokenIdx: number): HTMLElement | null {
+  const target = Math.max(0, tokenIdx);
+  let best: { el: HTMLElement; idx: number } | null = null;
+  for (const el of Array.from(root.querySelectorAll<HTMLElement>(WORD_SELECTOR))) {
+    const raw = el.dataset.tokenIdx;
+    if (raw == null) continue;
+    const idx = Number.parseInt(raw, 10);
+    if (!Number.isFinite(idx) || idx < target) continue;
+    if (!best || idx < best.idx) best = { el, idx };
+  }
+  return best?.el ?? null;
+}

--- a/apps/web/src/routes/reader/[textId]/+page.svelte
+++ b/apps/web/src/routes/reader/[textId]/+page.svelte
@@ -8,7 +8,8 @@
   import ReaderPage from '$lib/components/reader/ReaderPage.svelte';
   import ReaderScroll from '$lib/components/reader/ReaderScroll.svelte';
   import ReaderSettings from '$lib/components/reader/ReaderSettings.svelte';
-  import { ProgressWriter } from '$lib/components/reader/progress-client.js';
+  import { ProgressWriter, type ProgressAnchor } from '$lib/components/reader/progress-client.js';
+  import { computePctRead } from '$lib/components/reader/reader-progress.js';
   import {
     isImmersiveAttributeSet,
     setImmersiveAttribute,
@@ -50,9 +51,7 @@
   // T-5.1b: live reader settings. Seeded from the server-loaded
   // user_languages row; the popover updates this state on every
   // interaction (live preview) and PATCHes the row in the background.
-  let readerSettings = $state<ReaderSettingsT>(
-    untrack(() => data.readerSettings),
-  );
+  let readerSettings = $state<ReaderSettingsT>(untrack(() => data.readerSettings));
   $effect(() => {
     readerSettings = data.readerSettings;
   });
@@ -105,10 +104,30 @@
     }[liveStatus] ?? liveStatus,
   );
 
-  function setMode(mode: 'page' | 'paged_scroll' | 'continuous') {
+  function anchorFromData(): ProgressAnchor {
+    return {
+      chapterIdx: data.anchor.chapterIdx,
+      tokenIdx: data.anchor.tokenIdx,
+      pctRead: computePctRead(data.chapters, data.anchor.chapterIdx, data.anchor.tokenIdx),
+    };
+  }
+
+  let currentProgressAnchor = $state<ProgressAnchor>(untrack(anchorFromData));
+
+  function onReaderProgress(anchor: ProgressAnchor) {
+    currentProgressAnchor = anchor;
+    progressWriter?.schedule(anchor);
+  }
+
+  async function setMode(mode: 'page' | 'paged_scroll' | 'continuous') {
+    if (progressWriter) {
+      progressWriter.schedule(currentProgressAnchor);
+      await progressWriter.flush();
+    }
     const params = new URLSearchParams();
     params.set('mode', mode);
-    if (data.anchor.chapterIdx) params.set('chapter', String(data.anchor.chapterIdx));
+    params.set('chapter', String(currentProgressAnchor.chapterIdx));
+    params.set('token', String(currentProgressAnchor.tokenIdx));
     if (showRomanization) params.set('roman', '1');
     void goto(`/reader/${data.text.id}?${params.toString()}`, {
       keepFocus: true,
@@ -128,8 +147,8 @@
     window.history.replaceState(window.history.state, '', url.toString());
   }
 
-  // T-5.6 progress writer. Only owners get one — anonymous viewers
-  // of an official text don't have a row to write against.
+  // T-5.6 progress writer. Signed-in readers get one; anonymous
+  // viewers of an official text don't have a row to write against.
   let progressWriter: ProgressWriter | null = null;
   let beforeUnloadHandler: (() => void) | null = null;
 
@@ -190,16 +209,8 @@
       progressWriter = new ProgressWriter(data.text.id);
       // Schedule an initial write so reopening immediately at the
       // current chapter persists even without scrolling.
-      const totalChapters = data.chapters.length;
-      const pctRead =
-        totalChapters > 0
-          ? Math.round(((data.anchor.chapterIdx + 1) / totalChapters) * 100)
-          : 0;
-      progressWriter.schedule({
-        chapterIdx: data.anchor.chapterIdx,
-        tokenIdx: data.anchor.tokenIdx,
-        pctRead,
-      });
+      currentProgressAnchor = anchorFromData();
+      progressWriter.schedule(currentProgressAnchor);
       // Flush on tab close so the user resumes near where they were
       // even if their last action was scrolling and they didn't trip
       // the debounce timer.
@@ -225,8 +236,7 @@
     return () => {
       cleanupPoll?.();
       window.removeEventListener('keydown', onKey);
-      if (beforeUnloadHandler)
-        window.removeEventListener('beforeunload', beforeUnloadHandler);
+      if (beforeUnloadHandler) window.removeEventListener('beforeunload', beforeUnloadHandler);
       void progressWriter?.flush();
       topRO?.disconnect();
       document.documentElement.style.removeProperty('--reader-top-h');
@@ -239,17 +249,10 @@
   // sending here keeps a fresh row even if the user navigates by
   // URL without scrolling.
   $effect(() => {
+    const anchor = anchorFromData();
+    currentProgressAnchor = anchor;
     if (!progressWriter) return;
-    const totalChapters = data.chapters.length;
-    const pctRead =
-      totalChapters > 0
-        ? Math.round(((data.anchor.chapterIdx + 1) / totalChapters) * 100)
-        : 0;
-    progressWriter.schedule({
-      chapterIdx: data.anchor.chapterIdx,
-      tokenIdx: data.anchor.tokenIdx,
-      pctRead,
-    });
+    progressWriter.schedule(anchor);
   });
 </script>
 
@@ -257,14 +260,19 @@
   <title>{data.text.title} — CIA Reader</title>
 </svelte:head>
 
-<div
-  class="reader"
-  data-mode={data.mode}
-  style={readerStyle}
->
+<div class="reader" data-mode={data.mode} style={readerStyle}>
   <header class="reader-top" bind:this={readerTopEl}>
     <a class="reader-close" href="/library" aria-label="Close reader" title="Close reader">
-      <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true">
+      <svg
+        viewBox="0 0 24 24"
+        width="14"
+        height="14"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.8"
+        stroke-linecap="round"
+        aria-hidden="true"
+      >
         <path d="M6 6l12 12" />
         <path d="M18 6L6 18" />
       </svg>
@@ -284,8 +292,8 @@
                 href={`/reader/${data.collectionContext.prevTextId}`}
                 class="reader-coll-arrow"
                 title="Previous text"
-                aria-label="Previous text in collection"
-              >‹ prev</a>
+                aria-label="Previous text in collection">‹ prev</a
+              >
             {/if}
             {#if data.collectionContext.nextTextId}
               {#if data.collectionContext.nextLocked}
@@ -293,15 +301,15 @@
                   href={`/reader/${data.collectionContext.nextTextId}?skipLock=1`}
                   class="reader-coll-arrow reader-coll-locked"
                   title="Course gate — finish this text or click to skip"
-                  aria-label="Next text (locked — finish to advance, or click to skip)"
-                >next 🔒</a>
+                  aria-label="Next text (locked — finish to advance, or click to skip)">next 🔒</a
+                >
               {:else}
                 <a
                   href={`/reader/${data.collectionContext.nextTextId}`}
                   class="reader-coll-arrow"
                   title="Next text"
-                  aria-label="Next text in collection"
-                >next ›</a>
+                  aria-label="Next text in collection">next ›</a
+                >
               {/if}
             {/if}
           </span>
@@ -359,16 +367,27 @@
         aria-expanded={settingsOpen}
         title="Reader settings"
       >
-        <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <svg
+          viewBox="0 0 24 24"
+          width="16"
+          height="16"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.6"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
           <circle cx="12" cy="12" r="3" />
-          <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33 1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82 1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+          <path
+            d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33 1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82 1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"
+          />
         </svg>
       </button>
 
       <!-- T-5.26 moved the immersive / hide-chrome toggle to the
            AppShell rail (a hamburger glyph) — it's globally available
            now, not just from the reader top bar. -->
-
     </div>
   </header>
 
@@ -380,10 +399,12 @@
     <ReaderPage
       chapters={data.chapters}
       chapterIdx={data.anchor.chapterIdx}
+      initialTokenIdx={data.anchor.tokenIdx}
       textId={data.text.id}
       language={data.text.language as LanguageCode}
       {showRomanization}
       isOwner={data.isOwner}
+      onProgress={onReaderProgress}
       fontSize={readerSettings.fontSize}
       lineSpacing={readerSettings.lineSpacing}
       fontFamily={readerSettings.fontFamily}
@@ -393,19 +414,23 @@
     <ReaderScroll
       chapters={data.chapters}
       chapterIdx={data.anchor.chapterIdx}
+      initialTokenIdx={data.anchor.tokenIdx}
       wordsPerPage={readerSettings.wordsPerPage}
       language={data.text.language as LanguageCode}
       {showRomanization}
       isOwner={data.isOwner}
+      onProgress={onReaderProgress}
     />
   {:else}
     <ReaderContinuous
       chapters={data.chapters}
       initialChapterIdx={data.anchor.chapterIdx}
+      initialTokenIdx={data.anchor.tokenIdx}
       textId={data.text.id}
       language={data.text.language as LanguageCode}
       {showRomanization}
       isOwner={data.isOwner}
+      onProgress={onReaderProgress}
     />
   {/if}
 
@@ -492,11 +517,7 @@
   }
   .reader-close:hover {
     color: var(--ink, var(--color-fg));
-    background: color-mix(
-      in oklch,
-      var(--ink, var(--color-fg)) 6%,
-      transparent
-    );
+    background: color-mix(in oklch, var(--ink, var(--color-fg)) 6%, transparent);
     border-color: var(--rule, var(--color-border));
   }
   .reader-meta {

--- a/scripts/bootstrap-issues.py
+++ b/scripts/bootstrap-issues.py
@@ -301,6 +301,11 @@ MILESTONES = [
              "known-count cache."),
             ("T-5.6", "Reading progress",
              "Debounced `PATCH /api/text-progress` as user scrolls/paginates."),
+            ("T-5.6a", "First-visible-word progress anchors",
+             "Persist progress as the first visible word in `page`, "
+             "`paged-scroll`, and `continuous` modes. Switching modes "
+             "flushes and carries the current `chapter` + `token` anchor "
+             "so readers resume at the same visible word."),
             ("T-5.7", "Keyboard shortcuts",
              "`k`=known, `l`=learning, `i`=ignore, `→/←`=next/prev word."),
         ],


### PR DESCRIPTION
## Summary
- Adds T-5.6a for first-visible-word reader progress anchors.
- Tracks the first visible rendered word in page, paged-scroll, and continuous modes.
- Flushes and carries the current chapter/token anchor when switching reading modes.
- Resumes page/scroll/continuous layouts from saved token anchors.

Fixes #336

## Verification
- pnpm --filter @ciareader/web check
- pnpm --filter @ciareader/web lint
- pnpm --filter @ciareader/web test
- pnpm exec prettier --check 'apps/web/src/routes/reader/[textId]/+page.svelte' apps/web/src/lib/components/reader/ReaderPage.svelte apps/web/src/lib/components/reader/ReaderScroll.svelte apps/web/src/lib/components/reader/ReaderContinuous.svelte apps/web/src/lib/components/reader/reader-progress.ts apps/web/src/lib/components/reader/reader-progress.test.ts
- python3 -m py_compile scripts/bootstrap-issues.py
- git diff --check