### PR TITLE
Fix reader progress restore alignment

### DIFF
--- a/apps/web/src/lib/components/reader/ReaderContinuous.svelte
+++ b/apps/web/src/lib/components/reader/ReaderContinuous.svelte
@@ -97,6 +97,10 @@
   let rootEl: HTMLElement | null = $state(null);
   let lastReportedKey = '';
   let reportRaf = 0;
+  let initialAnchorApplied = $state(false);
+  const isRestoringInitialAnchor = $derived(
+    (initialChapterIdx > 0 || initialTokenIdx > 0) && !initialAnchorApplied,
+  );
 
   function bindSection(node: HTMLElement, idx: number) {
     sectionRefs.set(idx, node);
@@ -109,7 +113,10 @@
 
   function scrollToInitialAnchor() {
     const section = sectionRefs.get(initialChapterIdx);
-    if (!section) return;
+    if (!section) {
+      initialAnchorApplied = true;
+      return;
+    }
     const tokenEl =
       initialTokenIdx > 0 ? findTokenElementAtOrAfter(section, initialTokenIdx) : null;
     const target = tokenEl ?? section;
@@ -118,6 +125,7 @@
       top: Math.max(0, window.scrollY + rect.top - readerTopInset()),
       behavior: 'auto',
     });
+    initialAnchorApplied = true;
   }
 
   function isAtDocumentEnd(): boolean {
@@ -130,6 +138,7 @@
     if (!onProgress || !rootEl) return;
     const anchor = findFirstVisibleWordAnchor(rootEl, {
       clip: readableRect(rootEl),
+      minVisiblePx: 4,
     });
     if (!anchor) return;
     const next: ProgressAnchor = {
@@ -201,6 +210,7 @@
   class="reader-continuous"
   data-mode="continuous"
   data-initial-chapter={initialChapterIdx}
+  data-restoring={isRestoringInitialAnchor ? '1' : undefined}
   bind:this={rootEl}
 >
   {#each renderedChapters as chapter (chapter.id)}
@@ -230,6 +240,9 @@
     font-size: var(--reader-font-size, 1.1rem);
     line-height: var(--reader-line-height, 2);
     color: var(--ink, var(--color-fg));
+  }
+  .reader-continuous[data-restoring='1'] {
+    opacity: 0;
   }
   section {
     margin: 1.5rem 0;

--- a/apps/web/src/lib/components/reader/ReaderPage.svelte
+++ b/apps/web/src/lib/components/reader/ReaderPage.svelte
@@ -22,6 +22,7 @@
   import { clampPage, pageCountFor, pageOffset } from './paginate.js';
   import type { ProgressAnchor } from './progress-client.js';
   import {
+    columnIndexForElement,
     computePctRead,
     findFirstVisibleWordAnchor,
     findTokenElementAtOrAfter,
@@ -73,6 +74,7 @@
   let pageInChapter = $state(0);
   let initialTokenApplied = $state(false);
   let lastReportedKey = '';
+  const isRestoringInitialToken = $derived(initialTokenIdx > 0 && !initialTokenApplied);
 
   const pageCount = $derived(pageCountFor(contentW, pageW));
   const offset = $derived(pageOffset(pageInChapter, pageW));
@@ -240,14 +242,13 @@
 
   function applyInitialTokenPage() {
     if (initialTokenApplied || !contentEl || pageW <= 0 || pageCount <= 0) return;
+    if (initialTokenIdx > 0) {
+      const tokenEl = findTokenElementAtOrAfter(contentEl, initialTokenIdx);
+      if (tokenEl) {
+        pageInChapter = clampPage(columnIndexForElement(tokenEl, contentEl, pageW), pageCount);
+      }
+    }
     initialTokenApplied = true;
-    if (initialTokenIdx <= 0) return;
-    const tokenEl = findTokenElementAtOrAfter(contentEl, initialTokenIdx);
-    if (!tokenEl) return;
-    const tokenRect = tokenEl.getBoundingClientRect();
-    const contentRect = contentEl.getBoundingClientRect();
-    const page = Math.floor(Math.max(0, tokenRect.left - contentRect.left) / pageW);
-    pageInChapter = clampPage(page, pageCount);
   }
 
   function reportProgress() {
@@ -255,6 +256,7 @@
     const anchor = findFirstVisibleWordAnchor(viewportEl, {
       clip: viewportEl.getBoundingClientRect(),
       fallbackChapterIdx: chapterIdx,
+      minVisiblePx: 4,
     });
     if (!anchor) return;
     const next: ProgressAnchor = {
@@ -316,8 +318,16 @@
   </button>
 
   <div class="reader-page-viewport">
-    <div class="reader-page-window" bind:this={viewportEl}>
-      <div class="reader-page-track" style:transform="translateX(-{offset}px)">
+    <div
+      class="reader-page-window"
+      bind:this={viewportEl}
+      data-restoring={isRestoringInitialToken ? '1' : undefined}
+    >
+      <div
+        class="reader-page-track"
+        style:transform="translateX(-{offset}px)"
+        data-restoring={isRestoringInitialToken ? '1' : undefined}
+      >
         <div class="reader-page-content" bind:this={contentEl}>
           {#if current}
             <header class="chapter-h">
@@ -403,6 +413,9 @@
     overflow: hidden;
     position: relative;
   }
+  .reader-page-window[data-restoring='1'] {
+    opacity: 0;
+  }
 
   /* The track is the transform target. We can't translateX a CSS
      multicolumn container directly — Blink renders fragmented column
@@ -413,6 +426,9 @@
     height: 100%;
     transition: transform 200ms ease;
     will-change: transform;
+  }
+  .reader-page-track[data-restoring='1'] {
+    transition: none;
   }
 
   /* Horizontal pagination via CSS multi-column. The content element

--- a/apps/web/src/lib/components/reader/ReaderScroll.svelte
+++ b/apps/web/src/lib/components/reader/ReaderScroll.svelte
@@ -55,6 +55,7 @@
   let initialTokenApplied = $state(false);
   let lastReportedKey = '';
   let reportRaf = 0;
+  const isRestoringInitialToken = $derived(initialTokenIdx > 0 && !initialTokenApplied);
 
   const current = $derived(chapters[Math.max(0, Math.min(chapterIdx, chapters.length - 1))]);
 
@@ -178,6 +179,7 @@
     const anchor = findFirstVisibleWordAnchor(articleEl, {
       clip: readableRect(articleEl),
       fallbackChapterIdx: chapterIdx,
+      minVisiblePx: 4,
     });
     if (!anchor) return;
     const next: ProgressAnchor = {
@@ -381,7 +383,7 @@
     ‹
   </button>
 
-  <div class="reader-scroll-inner">
+  <div class="reader-scroll-inner" data-restoring={isRestoringInitialToken ? '1' : undefined}>
     <header class="page-header">
       {#if current}
         <h2>
@@ -466,6 +468,9 @@
     max-width: var(--reader-col-width, 40rem);
     margin: 0 auto;
     padding: 1.25rem 3rem 2rem;
+  }
+  .reader-scroll-inner[data-restoring='1'] {
+    opacity: 0;
   }
   @media (min-width: 1024px) {
     .reader-scroll-inner {

--- a/apps/web/src/lib/components/reader/reader-progress.test.ts
+++ b/apps/web/src/lib/components/reader/reader-progress.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  columnIndexForElement,
   computePctRead,
   findFirstVisibleWordAnchor,
   findTokenElementAtOrAfter,
@@ -60,6 +61,19 @@ describe('reader progress helpers', () => {
     ).toEqual({ chapterIdx: 4, tokenIdx: 7 });
   });
 
+  it('ignores tiny clipped edge slivers when finding the first visible word', () => {
+    const root = document.createElement('section');
+    root.dataset.chapterIdx = '1';
+    root.append(word(4, rect(0, 0, 100, 1)), word(5, rect(20, 10, 40, 80)));
+
+    expect(
+      findFirstVisibleWordAnchor(root, {
+        clip: { top: 0, left: 0, right: 300, bottom: 500 },
+        minVisiblePx: 4,
+      }),
+    ).toEqual({ chapterIdx: 1, tokenIdx: 5 });
+  });
+
   it('finds the nearest rendered word at or after a saved token index', () => {
     const root = document.createElement('article');
     const before = word(3, rect(0, 0, 1, 1));
@@ -69,6 +83,23 @@ describe('reader progress helpers', () => {
 
     expect(findTokenElementAtOrAfter(root, 8)).toBe(exact);
     expect(findTokenElementAtOrAfter(root, 9)).toBe(after);
+  });
+
+  it('computes a token element column from its first rendered rect', () => {
+    const content = document.createElement('div');
+    const el = document.createElement('span');
+    content.getBoundingClientRect = () => rect(0, 20, 400, 420);
+    el.getClientRects = () =>
+      ({
+        0: rect(20, 625, 40, 700),
+        length: 1,
+        item: (idx: number) => (idx === 0 ? rect(20, 625, 40, 700) : null),
+        [Symbol.iterator]: function* () {
+          yield rect(20, 625, 40, 700);
+        },
+      }) as DOMRectList;
+
+    expect(columnIndexForElement(el, content, 300)).toBe(2);
   });
 
   it('maps a saved token to the first paged-scroll page that contains it', () => {

--- a/apps/web/src/lib/components/reader/reader-progress.ts
+++ b/apps/web/src/lib/components/reader/reader-progress.ts
@@ -10,8 +10,11 @@ export type VisibleRect = {
 
 const WORD_SELECTOR = '[data-token-id][data-token-idx], .word[data-token-idx]';
 
-function intersects(a: DOMRect, b: VisibleRect): boolean {
-  return a.bottom > b.top && a.top < b.bottom && a.right > b.left && a.left < b.right;
+function visibleSize(a: DOMRect, b: VisibleRect): { width: number; height: number } {
+  return {
+    width: Math.max(0, Math.min(a.right, b.right) - Math.max(a.left, b.left)),
+    height: Math.max(0, Math.min(a.bottom, b.bottom) - Math.max(a.top, b.top)),
+  };
 }
 
 export function viewportRect(topInset = 0): VisibleRect {
@@ -63,8 +66,10 @@ export function findFirstVisibleWordAnchor(
   args: {
     clip: VisibleRect;
     fallbackChapterIdx?: number;
+    minVisiblePx?: number;
   },
 ): Pick<ProgressAnchor, 'chapterIdx' | 'tokenIdx'> | null {
+  const minVisiblePx = args.minVisiblePx ?? 2;
   let best: {
     chapterIdx: number;
     tokenIdx: number;
@@ -79,7 +84,8 @@ export function findFirstVisibleWordAnchor(
     if (!Number.isFinite(tokenIdx)) continue;
 
     const rect = el.getBoundingClientRect();
-    if (!intersects(rect, args.clip)) continue;
+    const visible = visibleSize(rect, args.clip);
+    if (visible.width < minVisiblePx || visible.height < minVisiblePx) continue;
 
     const rawChapterIdx = el.closest<HTMLElement>('[data-chapter-idx]')?.dataset.chapterIdx;
     const chapterIdx =
@@ -94,6 +100,14 @@ export function findFirstVisibleWordAnchor(
   }
 
   return best ? { chapterIdx: best.chapterIdx, tokenIdx: best.tokenIdx } : null;
+}
+
+export function columnIndexForElement(el: Element, contentEl: Element, pageWidth: number): number {
+  if (pageWidth <= 0) return 0;
+  const firstRect = el.getClientRects()[0] ?? el.getBoundingClientRect();
+  const contentRect = contentEl.getBoundingClientRect();
+  const x = Math.max(0, firstRect.left - contentRect.left);
+  return Math.max(0, Math.floor((x + 1) / pageWidth));
 }
 
 export function computePctRead(


### PR DESCRIPTION
## Summary
- Hides page, paged-scroll, and continuous reader surfaces until their saved token anchor is applied, avoiding the brief first-page flash.
- Tightens first-visible-word detection so tiny clipped edge slivers do not save/restore the adjacent page.
- Uses a first rendered rect helper for page-mode column restore math.

Follow-up to #337.

## Verification
- pnpm --filter @ciareader/web check
- pnpm --filter @ciareader/web lint
- pnpm --filter @ciareader/web test -- src/lib/components/reader/reader-progress.test.ts src/lib/components/reader/progress-client.test.ts 'src/routes/reader/[textId]/page-server.test.ts'
- pnpm --filter @ciareader/web test
- git diff --check