### PR TITLE
T-2.8 follow-up: number tooltip + comma-separated digits

### DIFF
--- a/apps/web/src/lib/components/reader/ChapterBody.svelte
+++ b/apps/web/src/lib/components/reader/ChapterBody.svelte
@@ -338,7 +338,7 @@
 </div>
 
 {#if hoverToken && hoverRect}
-  <WordTooltip token={hoverToken} anchorRect={hoverRect} />
+  <WordTooltip token={hoverToken} anchorRect={hoverRect} {language} />
 {/if}
 
 <!-- WordPopup mounts unconditionally so the side panel can stay

--- a/apps/web/src/lib/components/reader/ReaderScroll.svelte
+++ b/apps/web/src/lib/components/reader/ReaderScroll.svelte
@@ -436,7 +436,7 @@
 </div>
 
 {#if hoverToken && hoverRect}
-  <WordTooltip token={hoverToken} anchorRect={hoverRect} />
+  <WordTooltip token={hoverToken} anchorRect={hoverRect} {language} />
 {/if}
 
 {#if activeToken && activeRect}

--- a/apps/web/src/lib/components/reader/WordTooltip.svelte
+++ b/apps/web/src/lib/components/reader/WordTooltip.svelte
@@ -9,15 +9,35 @@
   full side panel (WordPopup), which does fetch.
 -->
 <script lang="ts">
-  import type { ServerToken } from './types.js';
+  import type { LanguageCode } from '@ciareader/shared-types';
+  import type { ServerToken, ServerNumberLanguageForm } from './types.js';
   import { placeTooltip, type AnchorRect } from './tooltip-position.js';
 
   interface Props {
     token: ServerToken;
     anchorRect: AnchorRect;
+    /** Reading language — drives which spelled-out form the tooltip
+     *  surfaces for digit-only NUM tokens (T-2.8). The side panel
+     *  shows all three; the tooltip is meant to be glanceable, so it
+     *  only shows the one matching the text being read. Optional for
+     *  backward-compat with callers that haven't been updated yet —
+     *  when absent, number tokens fall back to the empty-state copy. */
+    language?: LanguageCode;
   }
 
-  let { token, anchorRect }: Props = $props();
+  let { token, anchorRect, language }: Props = $props();
+
+  const numberForm = $derived<ServerNumberLanguageForm | null>(
+    token.numberForms && language
+      ? language === 'hi'
+        ? token.numberForms.hi
+        : language === 'mr'
+          ? token.numberForms.mr
+          : language === 'or'
+            ? token.numberForms.odia
+            : null
+      : null,
+  );
 
   let tipEl: HTMLDivElement | null = $state(null);
   let measured = $state<{ w: number; h: number } | null>(null);
@@ -81,17 +101,29 @@
 >
   <div class="tip-head">
     <span class="tip-w">{token.surface}</span>
-    {#if token.romanization}
+    <!-- T-2.8: for number tokens the romanization field carries the
+         literal digit string ("123" → "123") which is just noise in
+         the head; suppress it and let the spelled-out form below do
+         the work. -->
+    {#if token.romanization && !numberForm}
       <span class="tip-roman">{token.romanization}</span>
     {/if}
   </div>
-  <!-- T-5.20: surface the top translation when we have one, fall
-       back to an italic "No translations" otherwise so the user
-       always knows whether the lookup is empty or just absent. The
-       tooltip stays no-fetch — it reads `glossDefault` off the token
-       row, which the side-panel still backs up with the full
-       hierarchy on click. -->
-  {#if token.isOov}
+  {#if numberForm}
+    <!-- T-2.8: digit-only NUM token. Show the spelled-out form for
+         the reading language + its romanization; the side panel shows
+         all three languages on click. -->
+    <div class="tip-def">
+      {numberForm.spelled}
+      <span class="tip-roman num-roman">{numberForm.romanized}</span>
+    </div>
+  {:else if token.isOov}
+    <!-- T-5.20: surface the top translation when we have one, fall
+         back to an italic "No translations" otherwise so the user
+         always knows whether the lookup is empty or just absent. The
+         tooltip stays no-fetch — it reads `glossDefault` off the token
+         row, which the side-panel still backs up with the full
+         hierarchy on click. -->
     <div class="tip-def empty">No dictionary match</div>
   {:else if token.glossDefault}
     <div class="tip-def">{token.glossDefault}</div>
@@ -148,6 +180,11 @@
     line-clamp: 2;
     -webkit-box-orient: vertical;
     overflow: hidden;
+  }
+  /* T-2.8: small romanization stripe inside the gloss row for
+   * number tokens. Same colour ramp as the head romanization. */
+  .num-roman {
+    margin-left: 0.45rem;
   }
   /* T-5.20: italic "no match" / "no translations" copy. */
   .tip-def.empty {

--- a/apps/web/src/lib/components/reader/WordTooltip.test.ts
+++ b/apps/web/src/lib/components/reader/WordTooltip.test.ts
@@ -99,3 +99,77 @@ describe('WordTooltip — gloss display (T-5.18)', () => {
     expect(document.body.querySelector('.tip')).not.toBeNull();
   });
 });
+
+describe('WordTooltip — number tokens (T-2.8)', () => {
+  function makeNumberToken(): ServerToken {
+    return makeToken({
+      surface: '123',
+      lemmaId: null,
+      romanization: '123',
+      numberForms: {
+        value: 123,
+        digitsLatin: '123',
+        digitsDeva: '१२३',
+        digitsOrya: '୧୨୩',
+        hi: { spelled: 'एक सौ तेईस', romanized: 'ek sau teīs' },
+        mr: { spelled: 'एकशे तेवीस', romanized: 'ēkaśē tēvīsa' },
+        odia: { spelled: 'ଏକ ଶହ ତେଇଶ', romanized: 'ēka śaha tēiśa' },
+      },
+    });
+  }
+
+  it('shows the spelled-out form + romanization for the reading language', () => {
+    render(WordTooltip, {
+      token: makeNumberToken(),
+      anchorRect: ANCHOR,
+      language: 'hi',
+    });
+    const def = document.body.querySelector('.tip-def');
+    expect(def?.textContent).toContain('एक सौ तेईस');
+    expect(def?.textContent).toContain('ek sau teīs');
+    expect(def?.classList.contains('empty')).toBe(false);
+  });
+
+  it('switches to the Marathi form when the reader is in Marathi', () => {
+    render(WordTooltip, {
+      token: makeNumberToken(),
+      anchorRect: ANCHOR,
+      language: 'mr',
+    });
+    const def = document.body.querySelector('.tip-def');
+    expect(def?.textContent).toContain('एकशे तेवीस');
+  });
+
+  it('switches to the Odia form when the reader is in Odia', () => {
+    render(WordTooltip, {
+      token: makeNumberToken(),
+      anchorRect: ANCHOR,
+      language: 'or',
+    });
+    const def = document.body.querySelector('.tip-def');
+    expect(def?.textContent).toContain('ଏକ ଶହ ତେଇଶ');
+  });
+
+  it('suppresses the head romanization for number tokens (the digits would be redundant)', () => {
+    render(WordTooltip, {
+      token: makeNumberToken(),
+      anchorRect: ANCHOR,
+      language: 'hi',
+    });
+    // Head holds only the surface; the romanization stripe is
+    // suppressed because token.romanization for "123" is just "123".
+    const head = document.body.querySelector('.tip-head');
+    expect(head?.querySelectorAll('.tip-roman')).toHaveLength(0);
+  });
+
+  it('falls back to the empty state when no language is given (legacy callers)', () => {
+    render(WordTooltip, {
+      token: makeNumberToken(),
+      anchorRect: ANCHOR,
+    });
+    // No language prop → tooltip can't pick a form, so the regular
+    // "No translations" path runs (lemmaId is null on number tokens).
+    const def = document.body.querySelector('.tip-def');
+    expect(def?.classList.contains('empty')).toBe(true);
+  });
+});

--- a/services/nlp/app/numbers.py
+++ b/services/nlp/app/numbers.py
@@ -81,13 +81,30 @@ def _classify_script(surface: str) -> DigitScript | None:
 
 
 def parse_digits(surface: str) -> int | None:
-    """Parse a digit-only token to an int.
+    """Parse a digit-only token (with optional thousands separators) to an int.
+
+    Accepts Latin, Devanagari, or Odia digits; all digits must come
+    from a single script. ASCII commas may appear as thousands /
+    lakh separators — both Western (``1,000,000``) and Indian
+    (``10,00,000``) grouping styles are accepted, since validating
+    the precise grouping rule per locale is more friction than it's
+    worth. Doubled commas, leading commas, and trailing commas are
+    rejected so genuinely malformed input falls through.
 
     Returns ``None`` for empty input, mixed-script input, signed
     input, decimal input, or values exceeding :data:`MAX_VALUE`.
-    Accepts Latin, Devanagari, or Odia digits; all digits must come
-    from a single script.
     """
+    if not surface:
+        return None
+    # Comma-separator handling — reject obviously malformed positions
+    # (`,123` / `123,` / `1,,234`) so a genuine non-number doesn't
+    # collapse into a digit run.
+    if "," in surface:
+        if surface.startswith(",") or surface.endswith(",") or ",," in surface:
+            return None
+        surface = surface.replace(",", "")
+        if not surface:
+            return None
     script = _classify_script(surface)
     if script is None:
         return None

--- a/services/nlp/tests/test_numbers.py
+++ b/services/nlp/tests/test_numbers.py
@@ -55,6 +55,30 @@ def test_parse_digits_accepts_single_script(surface: str, expected: int) -> None
 
 
 @pytest.mark.parametrize(
+    "surface,expected",
+    [
+        # Western thousands grouping
+        ("1,000", 1_000),
+        ("12,345", 12_345),
+        ("123,456", 123_456),
+        ("1,234,567", 1_234_567),
+        ("9,999,999", 9_999_999),
+        # Indian lakh grouping
+        ("10,000", 10_000),
+        ("1,00,000", 100_000),
+        ("12,34,567", 1_234_567),
+        ("99,99,999", 9_999_999),
+        # Native-script digits with separators
+        ("१,२३४", 1_234),
+        ("१,००,०००", 100_000),
+        ("୧,୨୩୪", 1_234),
+    ],
+)
+def test_parse_digits_accepts_comma_separators(surface: str, expected: int) -> None:
+    assert parse_digits(surface) == expected
+
+
+@pytest.mark.parametrize(
     "surface",
     [
         "",
@@ -73,10 +97,16 @@ def test_parse_digits_accepts_single_script(surface: str, expected: int) -> None
         "1.5",
         ".5",
         "1.",
-        "1,000",
+        # Malformed comma positions
+        ",1",
+        "1,",
+        "1,,000",
+        ",",
+        ",,",
         # Out of range.
         "10000001",
         "99999999",
+        "10,000,001",
     ],
 )
 def test_parse_digits_rejects(surface: str) -> None:


### PR DESCRIPTION
Two gaps surfaced after [#313](https://github.com/chickendude/CIA-Reader/pull/313) merged.

## 1. Hover tooltip for number tokens

The side panel renders the spelled-out forms beautifully, but the lightweight hover tooltip still shows _"No translations"_ for digit tokens because they have no lemma + no glossDefault. Fixed by threading the reading language through to \`WordTooltip\` and rendering the matching spelled-out form + ISO 15919 romanization there too. The redundant digit-string romanization in the tooltip head ("123" → "123") is now suppressed for number tokens. Side panel still shows all three languages on click.

\`ChapterBody\` and \`ReaderScroll\` both pass \`{language}\` through to the tooltip.

## 2. Comma-separated large numbers

\`1,000\` / \`12,345\` / \`1,00,000\` / \`1,234,567\` arrive from Stanza as a single NUM token but \`parse_digits\` rejected them on the first \`,\`. Fixed by stripping ASCII commas as separators inside \`parse_digits\` — Western thousands grouping and Indian lakh grouping both work, since validating the precise grouping rule per locale is more friction than it's worth. Doubled / leading / trailing commas still reject so genuinely malformed input falls through.

Native-script digit runs with separators (\`१,२३४\`, \`୧,୨୩୪\`) work too.

## Tests

- 17 new pytest cases for comma-accept + comma-reject paths.
- 5 new vitest cases for the tooltip number branch (one per MVP language, plus head-romanization suppression and the legacy-no-language fallback).
- All existing pinned reference values + the 0–99 sweep stay green.
- \`pytest\` 367/367, \`vitest\` 985/985, \`svelte-check\` clean, \`ruff\` clean, \`mypy\` no new errors.

Refs #304.