### PR TITLE
Preserve reader progress on refresh

### DIFF
--- a/apps/web/src/lib/components/reader/ReaderPage.svelte
+++ b/apps/web/src/lib/components/reader/ReaderPage.svelte
@@ -24,7 +24,7 @@
   import {
     columnIndexForElement,
     computePctRead,
-    findFirstVisibleWordAnchor,
+    findFirstWordInColumn,
     findTokenElementAtOrAfter,
   } from './reader-progress.js';
   import { classifySwipe } from './touch-gestures.js';
@@ -73,8 +73,11 @@
   let contentW = $state(0);
   let pageInChapter = $state(0);
   let initialTokenApplied = $state(false);
+  let restorePaintReady = $state(false);
   let lastReportedKey = '';
-  const isRestoringInitialToken = $derived(initialTokenIdx > 0 && !initialTokenApplied);
+  const isRestoringInitialToken = $derived(
+    initialTokenIdx > 0 && (!initialTokenApplied || !restorePaintReady),
+  );
 
   const pageCount = $derived(pageCountFor(contentW, pageW));
   const offset = $derived(pageOffset(pageInChapter, pageW));
@@ -86,6 +89,7 @@
     void initialTokenIdx;
     pageInChapter = 0;
     initialTokenApplied = false;
+    restorePaintReady = initialTokenIdx <= 0;
     lastReportedKey = '';
   });
 
@@ -247,16 +251,26 @@
       if (tokenEl) {
         pageInChapter = clampPage(columnIndexForElement(tokenEl, contentEl, pageW), pageCount);
       }
+    } else {
+      restorePaintReady = true;
     }
     initialTokenApplied = true;
+    if (initialTokenIdx > 0) {
+      void tick().then(() => {
+        window.requestAnimationFrame(() => {
+          restorePaintReady = true;
+        });
+      });
+    }
   }
 
   function reportProgress() {
-    if (!onProgress || !viewportEl) return;
-    const anchor = findFirstVisibleWordAnchor(viewportEl, {
-      clip: viewportEl.getBoundingClientRect(),
+    if (!onProgress || !contentEl) return;
+    const anchor = findFirstWordInColumn(contentEl, {
+      contentEl,
+      pageWidth: pageW,
+      pageIdx: pageInChapter,
       fallbackChapterIdx: chapterIdx,
-      minVisiblePx: 4,
     });
     if (!anchor) return;
     const next: ProgressAnchor = {

--- a/apps/web/src/lib/components/reader/ReaderPage.svelte
+++ b/apps/web/src/lib/components/reader/ReaderPage.svelte
@@ -22,6 +22,7 @@
   import { clampPage, pageCountFor, pageOffset } from './paginate.js';
   import type { ProgressAnchor } from './progress-client.js';
   import {
+    WORD_SELECTOR,
     columnIndexForElement,
     computePctRead,
     findFirstWordInColumn,
@@ -246,26 +247,35 @@
 
   function applyInitialTokenPage() {
     if (initialTokenApplied || !contentEl || pageW <= 0 || pageCount <= 0) return;
-    if (initialTokenIdx > 0) {
-      const tokenEl = findTokenElementAtOrAfter(contentEl, initialTokenIdx);
-      if (tokenEl) {
-        pageInChapter = clampPage(columnIndexForElement(tokenEl, contentEl, pageW), pageCount);
-      }
-    } else {
+    if (initialTokenIdx <= 0) {
       restorePaintReady = true;
+      initialTokenApplied = true;
+      return;
+    }
+    const tokenEl = findTokenElementAtOrAfter(contentEl, initialTokenIdx);
+    if (tokenEl) {
+      pageInChapter = clampPage(columnIndexForElement(tokenEl, contentEl, pageW), pageCount);
+    } else if (contentEl.querySelector(WORD_SELECTOR) == null) {
+      // The chapter body hasn't laid down word spans yet — stay
+      // masked and let the effect re-run when contentW/pageW settle
+      // again. Marking applied now would strand the user on page 0.
+      return;
     }
     initialTokenApplied = true;
-    if (initialTokenIdx > 0) {
-      void tick().then(() => {
-        window.requestAnimationFrame(() => {
-          restorePaintReady = true;
-        });
+    void tick().then(() => {
+      window.requestAnimationFrame(() => {
+        restorePaintReady = true;
       });
-    }
+    });
   }
 
   function reportProgress() {
     if (!onProgress || !contentEl) return;
+    // Don't fire while the viewport mask is up — the writer would
+    // see an anchor for whatever pageInChapter happens to be before
+    // applyInitialTokenPage jumps to the saved column, and on a
+    // chapter change we'd briefly mirror tokenIdx=0 to the URL.
+    if (isRestoringInitialToken) return;
     const anchor = findFirstWordInColumn(contentEl, {
       contentEl,
       pageWidth: pageW,

--- a/apps/web/src/lib/components/reader/ReaderScroll.svelte
+++ b/apps/web/src/lib/components/reader/ReaderScroll.svelte
@@ -53,9 +53,12 @@
   let page = $state(0);
   let articleEl: HTMLElement | null = $state(null);
   let initialTokenApplied = $state(false);
+  let restorePaintReady = $state(false);
   let lastReportedKey = '';
   let reportRaf = 0;
-  const isRestoringInitialToken = $derived(initialTokenIdx > 0 && !initialTokenApplied);
+  const isRestoringInitialToken = $derived(
+    initialTokenIdx > 0 && (!initialTokenApplied || !restorePaintReady),
+  );
 
   const current = $derived(chapters[Math.max(0, Math.min(chapterIdx, chapters.length - 1))]);
 
@@ -161,6 +164,7 @@
     void initialTokenIdx;
     page = 0;
     initialTokenApplied = false;
+    restorePaintReady = initialTokenIdx <= 0;
     lastReportedKey = '';
   });
 
@@ -171,11 +175,22 @@
     if (initialTokenApplied) return;
     initialTokenApplied = true;
     page = firstTokenPage(activePages, initialTokenIdx);
+    if (initialTokenIdx > 0) {
+      void tick().then(() => {
+        window.requestAnimationFrame(() => {
+          restorePaintReady = true;
+        });
+      });
+    }
   });
 
   function reportProgress() {
     reportRaf = 0;
     if (!onProgress || !articleEl) return;
+    // Same guard as ReaderPage — don't mirror an anchor while the
+    // viewport mask is up; the page might still be 0 before the
+    // restore-jump effect runs.
+    if (isRestoringInitialToken) return;
     const anchor = findFirstVisibleWordAnchor(articleEl, {
       clip: readableRect(articleEl),
       fallbackChapterIdx: chapterIdx,

--- a/apps/web/src/lib/components/reader/progress-client.test.ts
+++ b/apps/web/src/lib/components/reader/progress-client.test.ts
@@ -66,6 +66,30 @@ describe('ProgressWriter', () => {
     expect(call[1].keepalive).toBe(true);
   });
 
+  it('does not set keepalive on a default flush() (steady-state writes)', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(new Response('{}', { status: 200 })));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const w = new ProgressWriter('text-1');
+    w.schedule({ chapterIdx: 4, tokenIdx: 7, pctRead: 12 });
+    await w.flush();
+
+    const call = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(call[1].keepalive).toBe(false);
+  });
+
+  it('does not set keepalive on the debounced background flush', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(new Response('{}', { status: 200 })));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const w = new ProgressWriter('text-1');
+    w.schedule({ chapterIdx: 4, tokenIdx: 7, pctRead: 12 });
+    await vi.advanceTimersByTimeAsync(2000);
+
+    const call = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(call[1].keepalive).toBe(false);
+  });
+
   it('swallows network errors so the reader keeps working', async () => {
     const fetchMock = vi.fn(() => Promise.reject(new Error('network down')));
     vi.stubGlobal('fetch', fetchMock);

--- a/apps/web/src/lib/components/reader/progress-client.test.ts
+++ b/apps/web/src/lib/components/reader/progress-client.test.ts
@@ -12,9 +12,7 @@ afterEach(() => {
 
 describe('ProgressWriter', () => {
   it('debounces repeated schedule() calls into a single PATCH', async () => {
-    const fetchMock = vi.fn(() =>
-      Promise.resolve(new Response('{}', { status: 200 })),
-    );
+    const fetchMock = vi.fn(() => Promise.resolve(new Response('{}', { status: 200 })));
     vi.stubGlobal('fetch', fetchMock);
 
     const w = new ProgressWriter('text-1');
@@ -33,9 +31,7 @@ describe('ProgressWriter', () => {
   });
 
   it('suppresses a flush when nothing has changed since the previous send', async () => {
-    const fetchMock = vi.fn(() =>
-      Promise.resolve(new Response('{}', { status: 200 })),
-    );
+    const fetchMock = vi.fn(() => Promise.resolve(new Response('{}', { status: 200 })));
     vi.stubGlobal('fetch', fetchMock);
 
     const w = new ProgressWriter('text-1');
@@ -49,15 +45,25 @@ describe('ProgressWriter', () => {
   });
 
   it('flush() bypasses the debounce timer', async () => {
-    const fetchMock = vi.fn(() =>
-      Promise.resolve(new Response('{}', { status: 200 })),
-    );
+    const fetchMock = vi.fn(() => Promise.resolve(new Response('{}', { status: 200 })));
     vi.stubGlobal('fetch', fetchMock);
 
     const w = new ProgressWriter('text-1');
     w.schedule({ chapterIdx: 1, tokenIdx: 5, pctRead: 5 });
     await w.flush();
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('can flush through the browser keepalive path for refresh/pagehide', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(new Response('{}', { status: 200 })));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const w = new ProgressWriter('text-1');
+    w.schedule({ chapterIdx: 2, tokenIdx: 25, pctRead: 50 });
+    await w.flush({ keepalive: true });
+
+    const call = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(call[1].keepalive).toBe(true);
   });
 
   it('swallows network errors so the reader keeps working', async () => {

--- a/apps/web/src/lib/components/reader/progress-client.ts
+++ b/apps/web/src/lib/components/reader/progress-client.ts
@@ -7,8 +7,8 @@
  * has actually changed since the last one.
  *
  * Anonymous viewers of an official text don't have a user_id row to
- * write against; the reader gates calls behind `isOwner` (the only
- * case we currently track progress for) before invoking this.
+ * write against; the reader gates calls behind `canPersistSettings`
+ * before invoking this.
  */
 
 const DEBOUNCE_MS = 1500;
@@ -17,6 +17,15 @@ export type ProgressAnchor = {
   chapterIdx: number;
   tokenIdx: number;
   pctRead: number;
+};
+
+export type ProgressFlushOptions = {
+  /**
+   * Use the browser's keepalive request path. This is important for
+   * pagehide / refresh, where a normal async fetch is commonly
+   * cancelled before the PATCH reaches the server.
+   */
+  keepalive?: boolean;
 };
 
 export class ProgressWriter {
@@ -40,7 +49,7 @@ export class ProgressWriter {
   }
 
   /** Force-flush any pending anchor immediately (e.g. on page hide). */
-  async flush(): Promise<void> {
+  async flush(opts: ProgressFlushOptions = {}): Promise<void> {
     if (this.timer) {
       clearTimeout(this.timer);
       this.timer = null;
@@ -63,6 +72,7 @@ export class ProgressWriter {
         method: 'PATCH',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify(next),
+        keepalive: opts.keepalive === true,
       });
     } catch {
       // Network blips: drop silently. The next debounced flush

--- a/apps/web/src/lib/components/reader/reader-progress.test.ts
+++ b/apps/web/src/lib/components/reader/reader-progress.test.ts
@@ -4,6 +4,7 @@ import {
   columnIndexForElement,
   computePctRead,
   findFirstVisibleWordAnchor,
+  findFirstWordInColumn,
   findTokenElementAtOrAfter,
   firstTokenPage,
 } from './reader-progress.js';
@@ -100,6 +101,51 @@ describe('reader progress helpers', () => {
       }) as DOMRectList;
 
     expect(columnIndexForElement(el, content, 300)).toBe(2);
+  });
+
+  it('finds the first word in a paginated column without relying on transform visibility', () => {
+    const content = document.createElement('div');
+    content.getBoundingClientRect = () => rect(0, 20, 400, 420);
+    const first = word(8, rect(40, 330, 60, 380), { tokenId: 'a' });
+    const second = word(12, rect(20, 625, 40, 700), { tokenId: 'b' });
+    const third = word(13, rect(80, 625, 100, 700), { tokenId: 'c' });
+    first.getClientRects = () =>
+      ({
+        0: rect(40, 330, 60, 380),
+        length: 1,
+        item: (idx: number) => (idx === 0 ? rect(40, 330, 60, 380) : null),
+        [Symbol.iterator]: function* () {
+          yield rect(40, 330, 60, 380);
+        },
+      }) as DOMRectList;
+    second.getClientRects = () =>
+      ({
+        0: rect(20, 625, 40, 700),
+        length: 1,
+        item: (idx: number) => (idx === 0 ? rect(20, 625, 40, 700) : null),
+        [Symbol.iterator]: function* () {
+          yield rect(20, 625, 40, 700);
+        },
+      }) as DOMRectList;
+    third.getClientRects = () =>
+      ({
+        0: rect(80, 625, 100, 700),
+        length: 1,
+        item: (idx: number) => (idx === 0 ? rect(80, 625, 100, 700) : null),
+        [Symbol.iterator]: function* () {
+          yield rect(80, 625, 100, 700);
+        },
+      }) as DOMRectList;
+    content.append(first, third, second);
+
+    expect(
+      findFirstWordInColumn(content, {
+        contentEl: content,
+        pageWidth: 300,
+        pageIdx: 2,
+        fallbackChapterIdx: 3,
+      }),
+    ).toEqual({ chapterIdx: 3, tokenIdx: 12 });
   });
 
   it('maps a saved token to the first paged-scroll page that contains it', () => {

--- a/apps/web/src/lib/components/reader/reader-progress.test.ts
+++ b/apps/web/src/lib/components/reader/reader-progress.test.ts
@@ -168,4 +168,58 @@ describe('reader progress helpers', () => {
     expect(computePctRead(chapters, 1, 10)).toBe(50);
     expect(computePctRead(chapters, 1, 10, { completedText: true })).toBe(100);
   });
+
+  it('returns null when the target column has no words (still-laying-out case)', () => {
+    const content = document.createElement('div');
+    content.getBoundingClientRect = () => rect(0, 20, 400, 420);
+    // Both words sit in column 0 — the saved page is column 5.
+    const a = word(1, rect(20, 20, 40, 60), { tokenId: 'a' });
+    const b = word(2, rect(40, 20, 60, 80), { tokenId: 'b' });
+    a.getClientRects = () =>
+      ({
+        0: rect(20, 20, 40, 60),
+        length: 1,
+        item: (i: number) => (i === 0 ? rect(20, 20, 40, 60) : null),
+        [Symbol.iterator]: function* () {
+          yield rect(20, 20, 40, 60);
+        },
+      }) as DOMRectList;
+    b.getClientRects = () =>
+      ({
+        0: rect(40, 20, 60, 80),
+        length: 1,
+        item: (i: number) => (i === 0 ? rect(40, 20, 60, 80) : null),
+        [Symbol.iterator]: function* () {
+          yield rect(40, 20, 60, 80);
+        },
+      }) as DOMRectList;
+    content.append(a, b);
+
+    expect(
+      findFirstWordInColumn(content, {
+        contentEl: content,
+        pageWidth: 300,
+        pageIdx: 5,
+        fallbackChapterIdx: 0,
+      }),
+    ).toBeNull();
+  });
+
+  it('returns null when called with a zero pageWidth (pre-measure)', () => {
+    const content = document.createElement('div');
+    expect(
+      findFirstWordInColumn(content, {
+        contentEl: content,
+        pageWidth: 0,
+        pageIdx: 0,
+        fallbackChapterIdx: 0,
+      }),
+    ).toBeNull();
+  });
+
+  it('findTokenElementAtOrAfter returns null when no token is at or past the saved index', () => {
+    const root = document.createElement('article');
+    root.append(word(3, rect(0, 0, 1, 1)), word(7, rect(0, 0, 1, 1)));
+    expect(findTokenElementAtOrAfter(root, 99)).toBeNull();
+  });
 });

--- a/apps/web/src/lib/components/reader/reader-progress.ts
+++ b/apps/web/src/lib/components/reader/reader-progress.ts
@@ -110,6 +110,48 @@ export function columnIndexForElement(el: Element, contentEl: Element, pageWidth
   return Math.max(0, Math.floor((x + 1) / pageWidth));
 }
 
+export function findFirstWordInColumn(
+  root: ParentNode,
+  args: {
+    contentEl: Element;
+    pageWidth: number;
+    pageIdx: number;
+    fallbackChapterIdx: number;
+  },
+): Pick<ProgressAnchor, 'chapterIdx' | 'tokenIdx'> | null {
+  if (args.pageWidth <= 0) return null;
+  let best: {
+    chapterIdx: number;
+    tokenIdx: number;
+    top: number;
+    left: number;
+  } | null = null;
+
+  for (const el of Array.from(root.querySelectorAll<HTMLElement>(WORD_SELECTOR))) {
+    const rawTokenIdx = el.dataset.tokenIdx;
+    if (rawTokenIdx == null) continue;
+    const tokenIdx = Number.parseInt(rawTokenIdx, 10);
+    if (!Number.isFinite(tokenIdx)) continue;
+    if (columnIndexForElement(el, args.contentEl, args.pageWidth) !== args.pageIdx) {
+      continue;
+    }
+
+    const rawChapterIdx = el.closest<HTMLElement>('[data-chapter-idx]')?.dataset.chapterIdx;
+    const chapterIdx =
+      rawChapterIdx == null ? args.fallbackChapterIdx : Number.parseInt(rawChapterIdx, 10);
+    if (!Number.isFinite(chapterIdx)) continue;
+
+    const rect = el.getClientRects()[0] ?? el.getBoundingClientRect();
+    const top = rect.top;
+    const left = rect.left;
+    if (!best || top < best.top || (top === best.top && left < best.left)) {
+      best = { chapterIdx, tokenIdx, top, left };
+    }
+  }
+
+  return best ? { chapterIdx: best.chapterIdx, tokenIdx: best.tokenIdx } : null;
+}
+
 export function computePctRead(
   chapters: ChapterView[],
   chapterIdx: number,

--- a/apps/web/src/lib/components/reader/reader-progress.ts
+++ b/apps/web/src/lib/components/reader/reader-progress.ts
@@ -8,7 +8,7 @@ export type VisibleRect = {
   bottom: number;
 };
 
-const WORD_SELECTOR = '[data-token-id][data-token-idx], .word[data-token-idx]';
+export const WORD_SELECTOR = '[data-token-id][data-token-idx], .word[data-token-idx]';
 
 function visibleSize(a: DOMRect, b: VisibleRect): { width: number; height: number } {
   return {

--- a/apps/web/src/routes/reader/[textId]/+page.svelte
+++ b/apps/web/src/routes/reader/[textId]/+page.svelte
@@ -113,9 +113,25 @@
   }
 
   let currentProgressAnchor = $state<ProgressAnchor>(untrack(anchorFromData));
+  let lastUrlAnchorKey = '';
+
+  function mirrorAnchorToUrl(anchor: ProgressAnchor) {
+    if (typeof window === 'undefined') return;
+    const key = `${data.mode}:${anchor.chapterIdx}:${anchor.tokenIdx}:${showRomanization ? 1 : 0}`;
+    if (key === lastUrlAnchorKey) return;
+    lastUrlAnchorKey = key;
+    const url = new URL(window.location.href);
+    url.searchParams.set('mode', data.mode);
+    url.searchParams.set('chapter', String(anchor.chapterIdx));
+    url.searchParams.set('token', String(anchor.tokenIdx));
+    if (showRomanization) url.searchParams.set('roman', '1');
+    else url.searchParams.delete('roman');
+    window.history.replaceState(window.history.state, '', url.toString());
+  }
 
   function onReaderProgress(anchor: ProgressAnchor) {
     currentProgressAnchor = anchor;
+    mirrorAnchorToUrl(anchor);
     progressWriter?.schedule(anchor);
   }
 
@@ -150,7 +166,7 @@
   // T-5.6 progress writer. Signed-in readers get one; anonymous
   // viewers of an official text don't have a row to write against.
   let progressWriter: ProgressWriter | null = null;
-  let beforeUnloadHandler: (() => void) | null = null;
+  let pageHideHandler: (() => void) | null = null;
 
   // The reader's top bar is a full-width fixed element. We measure
   // its height into a `--reader-top-h` CSS variable so the AppShell
@@ -207,17 +223,13 @@
     // viewers (the only false branch of canPersistSettings) skip.
     if (data.canPersistSettings) {
       progressWriter = new ProgressWriter(data.text.id);
-      // Schedule an initial write so reopening immediately at the
-      // current chapter persists even without scrolling.
       currentProgressAnchor = anchorFromData();
-      progressWriter.schedule(currentProgressAnchor);
-      // Flush on tab close so the user resumes near where they were
-      // even if their last action was scrolling and they didn't trip
-      // the debounce timer.
-      beforeUnloadHandler = () => {
-        void progressWriter?.flush();
+      // Flush on refresh / tab close through the keepalive path so
+      // the latest debounced anchor survives the navigation.
+      pageHideHandler = () => {
+        void progressWriter?.flush({ keepalive: true });
       };
-      window.addEventListener('beforeunload', beforeUnloadHandler);
+      window.addEventListener('pagehide', pageHideHandler);
     }
 
     // Track the .reader-top height so the rail can sit below it.
@@ -236,23 +248,21 @@
     return () => {
       cleanupPoll?.();
       window.removeEventListener('keydown', onKey);
-      if (beforeUnloadHandler) window.removeEventListener('beforeunload', beforeUnloadHandler);
+      if (pageHideHandler) window.removeEventListener('pagehide', pageHideHandler);
       void progressWriter?.flush();
       topRO?.disconnect();
       document.documentElement.style.removeProperty('--reader-top-h');
     };
   });
 
-  // Watch URL anchor changes and write them to the progress writer.
-  // The mode-toggle / chapter-nav buttons all funnel through goto(),
-  // which re-runs the loader and hands us a new `data.anchor` —
-  // sending here keeps a fresh row even if the user navigates by
-  // URL without scrolling.
+  // Watch URL anchor changes so mode switches and fresh loads start
+  // from the loader's anchor locally. We deliberately don't write it
+  // back immediately; the active reader mode reports the actual
+  // first visible word once it has restored layout.
   $effect(() => {
     const anchor = anchorFromData();
     currentProgressAnchor = anchor;
-    if (!progressWriter) return;
-    progressWriter.schedule(anchor);
+    lastUrlAnchorKey = `${data.mode}:${anchor.chapterIdx}:${anchor.tokenIdx}:${showRomanization ? 1 : 0}`;
   });
 </script>
 

--- a/apps/web/src/routes/reader/[textId]/+page.svelte
+++ b/apps/web/src/routes/reader/[textId]/+page.svelte
@@ -135,15 +135,19 @@
     progressWriter?.schedule(anchor);
   }
 
-  async function setMode(mode: 'page' | 'paged_scroll' | 'continuous') {
+  function setMode(mode: 'page' | 'paged_scroll' | 'continuous') {
+    // Snapshot the anchor synchronously so a late `reportProgress`
+    // can't change it between flush and goto. Use the keepalive
+    // path so the navigation that follows can't cancel the PATCH.
+    const anchor = currentProgressAnchor;
     if (progressWriter) {
-      progressWriter.schedule(currentProgressAnchor);
-      await progressWriter.flush();
+      progressWriter.schedule(anchor);
+      void progressWriter.flush({ keepalive: true });
     }
     const params = new URLSearchParams();
     params.set('mode', mode);
-    params.set('chapter', String(currentProgressAnchor.chapterIdx));
-    params.set('token', String(currentProgressAnchor.tokenIdx));
+    params.set('chapter', String(anchor.chapterIdx));
+    params.set('token', String(anchor.tokenIdx));
     if (showRomanization) params.set('roman', '1');
     void goto(`/reader/${data.text.id}?${params.toString()}`, {
       keepFocus: true,
@@ -167,6 +171,7 @@
   // viewers of an official text don't have a row to write against.
   let progressWriter: ProgressWriter | null = null;
   let pageHideHandler: (() => void) | null = null;
+  let visibilityHandler: (() => void) | null = null;
 
   // The reader's top bar is a full-width fixed element. We measure
   // its height into a `--reader-top-h` CSS variable so the AppShell
@@ -225,11 +230,19 @@
       progressWriter = new ProgressWriter(data.text.id);
       currentProgressAnchor = anchorFromData();
       // Flush on refresh / tab close through the keepalive path so
-      // the latest debounced anchor survives the navigation.
-      pageHideHandler = () => {
+      // the latest debounced anchor survives the navigation. iOS
+      // Safari doesn't reliably fire `pagehide` when the tab is
+      // backgrounded — `visibilitychange → hidden` is the more
+      // dependable hook there, so we wire both.
+      const flushKeepalive = () => {
         void progressWriter?.flush({ keepalive: true });
       };
+      pageHideHandler = flushKeepalive;
+      visibilityHandler = () => {
+        if (document.visibilityState === 'hidden') flushKeepalive();
+      };
       window.addEventListener('pagehide', pageHideHandler);
+      document.addEventListener('visibilitychange', visibilityHandler);
     }
 
     // Track the .reader-top height so the rail can sit below it.
@@ -249,6 +262,7 @@
       cleanupPoll?.();
       window.removeEventListener('keydown', onKey);
       if (pageHideHandler) window.removeEventListener('pagehide', pageHideHandler);
+      if (visibilityHandler) document.removeEventListener('visibilitychange', visibilityHandler);
       void progressWriter?.flush();
       topRO?.disconnect();
       document.documentElement.style.removeProperty('--reader-top-h');


### PR DESCRIPTION
## Summary
- Mirrors the latest visible-word anchor into the reader URL with replaceState, so browser refresh uses the explicit chapter/token anchor even if the server write is delayed.
- Makes page mode report progress from the active pagination column instead of a transform/visibility scan, avoiding transition timing and edge-page errors.
- Keeps the restored page hidden and page transitions disabled until the target page has painted, so refresh opens directly at the saved page instead of sliding over from page one.
- Keeps the pagehide keepalive flush and removes the eager initial progress write from the previous patch.
- Adds coverage for keepalive flushes and page-column anchor selection.

Follow-up to #337 and #338.

## Verification
- pnpm --filter @ciareader/web check
- pnpm --filter @ciareader/web lint
- pnpm --filter @ciareader/web test -- src/lib/components/reader/reader-progress.test.ts src/lib/components/reader/progress-client.test.ts "src/routes/reader/[textId]/page-server.test.ts"
- pnpm --filter @ciareader/web test
- git diff --check
