### PR TITLE
Dictionary search: nukta-agnostic fallback for Hindi headword queries

### DIFF
--- a/apps/web/drizzle/0025_nukta_stripped_headword.sql
+++ b/apps/web/drizzle/0025_nukta_stripped_headword.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "lemmas" ADD COLUMN "headword_nukta_stripped" text GENERATED ALWAYS AS (translate(normalize("headword", NFD), '़', '')) STORED NOT NULL;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "lemmas_language_headword_stripped_idx" ON "lemmas" USING btree ("language","headword_nukta_stripped");

--- a/apps/web/drizzle/meta/0025_snapshot.json
+++ b/apps/web/drizzle/meta/0025_snapshot.json
@@ -1,0 +1,4212 @@
+{
+  "id": "913e1df8-db10-439b-9a78-ce7c3ab0e15d",
+  "prevId": "d98c52f0-141f-43dc-8373-55a09f365fa7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audio_alignments": {
+      "name": "audio_alignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "audio_file_id": {
+          "name": "audio_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_ms": {
+          "name": "start_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_ms": {
+          "name": "end_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "alignment_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audio_alignments_timeline_idx": {
+          "name": "audio_alignments_timeline_idx",
+          "columns": [
+            {
+              "expression": "audio_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audio_alignments_audio_file_id_audio_files_id_fk": {
+          "name": "audio_alignments_audio_file_id_audio_files_id_fk",
+          "tableFrom": "audio_alignments",
+          "tableTo": "audio_files",
+          "columnsFrom": [
+            "audio_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audio_alignments_token_id_text_tokens_id_fk": {
+          "name": "audio_alignments_token_id_text_tokens_id_fk",
+          "tableFrom": "audio_alignments",
+          "tableTo": "text_tokens",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "audio_alignments_audio_file_id_token_id_uq": {
+          "name": "audio_alignments_audio_file_id_token_id_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "audio_file_id",
+            "token_id"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.audio_files": {
+      "name": "audio_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime": {
+          "name": "mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license": {
+          "name": "license",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by_id": {
+          "name": "uploaded_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audio_files_text_idx": {
+          "name": "audio_files_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audio_files_chapter_idx": {
+          "name": "audio_files_chapter_idx",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audio_files_text_id_texts_id_fk": {
+          "name": "audio_files_text_id_texts_id_fk",
+          "tableFrom": "audio_files",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audio_files_chapter_id_text_chapters_id_fk": {
+          "name": "audio_files_chapter_id_text_chapters_id_fk",
+          "tableFrom": "audio_files",
+          "tableTo": "text_chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audio_files_uploaded_by_id_users_id_fk": {
+          "name": "audio_files_uploaded_by_id_users_id_fk",
+          "tableFrom": "audio_files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.collection_items": {
+      "name": "collection_items",
+      "schema": "",
+      "columns": {
+        "collection_id": {
+          "name": "collection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collection_items_order_idx": {
+          "name": "collection_items_order_idx",
+          "columns": [
+            {
+              "expression": "collection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collection_items_collection_id_collections_id_fk": {
+          "name": "collection_items_collection_id_collections_id_fk",
+          "tableFrom": "collection_items",
+          "tableTo": "collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collection_items_text_id_texts_id_fk": {
+          "name": "collection_items_text_id_texts_id_fk",
+          "tableFrom": "collection_items",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "collection_items_collection_id_text_id_pk": {
+          "name": "collection_items_collection_id_text_id_pk",
+          "columns": [
+            "collection_id",
+            "text_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.collection_shares": {
+      "name": "collection_shares",
+      "schema": "",
+      "columns": {
+        "collection_id": {
+          "name": "collection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shared_with_user_id": {
+          "name": "shared_with_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by_id": {
+          "name": "granted_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collection_shares_recipient_idx": {
+          "name": "collection_shares_recipient_idx",
+          "columns": [
+            {
+              "expression": "shared_with_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collection_shares_collection_id_collections_id_fk": {
+          "name": "collection_shares_collection_id_collections_id_fk",
+          "tableFrom": "collection_shares",
+          "tableTo": "collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collection_shares_shared_with_user_id_users_id_fk": {
+          "name": "collection_shares_shared_with_user_id_users_id_fk",
+          "tableFrom": "collection_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "shared_with_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collection_shares_granted_by_id_users_id_fk": {
+          "name": "collection_shares_granted_by_id_users_id_fk",
+          "tableFrom": "collection_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "collection_shares_collection_id_shared_with_user_id_pk": {
+          "name": "collection_shares_collection_id_shared_with_user_id_pk",
+          "columns": [
+            "collection_id",
+            "shared_with_user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.collections": {
+      "name": "collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "collection_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'chapter_book'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "collection_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collections_owner_idx": {
+          "name": "collections_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collections_visibility_idx": {
+          "name": "collections_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collections_owner_id_users_id_fk": {
+          "name": "collections_owner_id_users_id_fk",
+          "tableFrom": "collections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.curator_languages": {
+      "name": "curator_languages",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "curator_languages_user_idx": {
+          "name": "curator_languages_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "curator_languages_user_id_users_id_fk": {
+          "name": "curator_languages_user_id_users_id_fk",
+          "tableFrom": "curator_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "curator_languages_granted_by_users_id_fk": {
+          "name": "curator_languages_granted_by_users_id_fk",
+          "tableFrom": "curator_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "curator_languages_user_id_language_pk": {
+          "name": "curator_languages_user_id_language_pk",
+          "columns": [
+            "user_id",
+            "language"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.dictionary_imports": {
+      "name": "dictionary_imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_name": {
+          "name": "source_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_at": {
+          "name": "run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lemmas_created": {
+          "name": "lemmas_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lemmas_updated": {
+          "name": "lemmas_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lemmas_skipped_curator_locked": {
+          "name": "lemmas_skipped_curator_locked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "translations_created": {
+          "name": "translations_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "translations_updated": {
+          "name": "translations_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "dictionary_imports_language_idx": {
+          "name": "dictionary_imports_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.form_lemma_overrides": {
+      "name": "form_lemma_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_nfc": {
+          "name": "surface_nfc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_signature": {
+          "name": "context_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "chosen_lemma_id": {
+          "name": "chosen_lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "promoted_at": {
+          "name": "promoted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "promoted_by": {
+          "name": "promoted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "form_lemma_overrides_lookup_idx": {
+          "name": "form_lemma_overrides_lookup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface_nfc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "form_lemma_overrides_chosen_lemma_id_lemmas_id_fk": {
+          "name": "form_lemma_overrides_chosen_lemma_id_lemmas_id_fk",
+          "tableFrom": "form_lemma_overrides",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "chosen_lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_lemma_overrides_promoted_by_users_id_fk": {
+          "name": "form_lemma_overrides_promoted_by_users_id_fk",
+          "tableFrom": "form_lemma_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "promoted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "form_lemma_overrides_lang_surface_ctx_uq": {
+          "name": "form_lemma_overrides_lang_surface_ctx_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "language",
+            "surface_nfc",
+            "context_signature"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.group_memberships": {
+      "name": "group_memberships",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by_id": {
+          "name": "added_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_memberships_user_idx": {
+          "name": "group_memberships_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_memberships_group_id_groups_id_fk": {
+          "name": "group_memberships_group_id_groups_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_memberships_user_id_users_id_fk": {
+          "name": "group_memberships_user_id_users_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_memberships_added_by_id_users_id_fk": {
+          "name": "group_memberships_added_by_id_users_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "added_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "group_memberships_group_id_user_id_pk": {
+          "name": "group_memberships_group_id_user_id_pk",
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "groups_owner_idx": {
+          "name": "groups_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_owner_id_users_id_fk": {
+          "name": "groups_owner_id_users_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemma_edit_history": {
+      "name": "lemma_edit_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "editor_id": {
+          "name": "editor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "lemma_edit_change_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change": {
+          "name": "change",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_edit_history_lemma_idx": {
+          "name": "lemma_edit_history_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_edit_history_editor_idx": {
+          "name": "lemma_edit_history_editor_idx",
+          "columns": [
+            {
+              "expression": "editor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_edit_history_lemma_id_lemmas_id_fk": {
+          "name": "lemma_edit_history_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_edit_history",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lemma_edit_history_editor_id_users_id_fk": {
+          "name": "lemma_edit_history_editor_id_users_id_fk",
+          "tableFrom": "lemma_edit_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "editor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemma_forms": {
+      "name": "lemma_forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "romanization": {
+          "name": "romanization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_forms_lemma_idx": {
+          "name": "lemma_forms_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_forms_surface_idx": {
+          "name": "lemma_forms_surface_idx",
+          "columns": [
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_forms_lemma_id_lemmas_id_fk": {
+          "name": "lemma_forms_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_forms",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemma_proposals": {
+      "name": "lemma_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "proposer_id": {
+          "name": "proposer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headword": {
+          "name": "headword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos": {
+          "name": "pos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gloss_default": {
+          "name": "gloss_default",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "lemma_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "promoted_lemma_id": {
+          "name": "promoted_lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_id": {
+          "name": "reviewer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_note": {
+          "name": "reviewer_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_proposals_lang_status_idx": {
+          "name": "lemma_proposals_lang_status_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_proposals_headword_idx": {
+          "name": "lemma_proposals_headword_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "headword",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pos",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_proposals_proposer_id_users_id_fk": {
+          "name": "lemma_proposals_proposer_id_users_id_fk",
+          "tableFrom": "lemma_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "proposer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "lemma_proposals_promoted_lemma_id_lemmas_id_fk": {
+          "name": "lemma_proposals_promoted_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_proposals",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "promoted_lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "lemma_proposals_reviewer_id_users_id_fk": {
+          "name": "lemma_proposals_reviewer_id_users_id_fk",
+          "tableFrom": "lemma_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemmas": {
+      "name": "lemmas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headword": {
+          "name": "headword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos": {
+          "name": "pos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script": {
+          "name": "script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gloss_default": {
+          "name": "gloss_default",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_rank": {
+          "name": "frequency_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "translation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "curator_locked": {
+          "name": "curator_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "headword_nukta_stripped": {
+          "name": "headword_nukta_stripped",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "translate(normalize(\"headword\", NFD), '़', '')",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "lemmas_language_headword_pos_idx": {
+          "name": "lemmas_language_headword_pos_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "headword",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pos",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_language_idx": {
+          "name": "lemmas_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_language_frequency_idx": {
+          "name": "lemmas_language_frequency_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "frequency_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_source_lookup_idx": {
+          "name": "lemmas_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_language_headword_stripped_idx": {
+          "name": "lemmas_language_headword_stripped_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "headword_nukta_stripped",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.magic_links": {
+      "name": "magic_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "magic_links_user_idx": {
+          "name": "magic_links_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "magic_links_expires_idx": {
+          "name": "magic_links_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "magic_links_user_id_users_id_fk": {
+          "name": "magic_links_user_id_users_id_fk",
+          "tableFrom": "magic_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.nlp_jobs": {
+      "name": "nlp_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "nlp_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nlp_jobs_text_idx": {
+          "name": "nlp_jobs_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nlp_jobs_status_idx": {
+          "name": "nlp_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nlp_jobs_text_id_texts_id_fk": {
+          "name": "nlp_jobs_text_id_texts_id_fk",
+          "tableFrom": "nlp_jobs",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.parse_reports": {
+      "name": "parse_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_nfc": {
+          "name": "surface_nfc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_signature": {
+          "name": "context_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "original_candidates": {
+          "name": "original_candidates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "corrected_lemma_id": {
+          "name": "corrected_lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "correction_type": {
+          "name": "correction_type",
+          "type": "token_correction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "parse_report_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "assigned_reviewer_id": {
+          "name": "assigned_reviewer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_note": {
+          "name": "resolution_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duplicate_count": {
+          "name": "duplicate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parse_reports_lang_status_idx": {
+          "name": "parse_reports_lang_status_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parse_reports_dedup_idx": {
+          "name": "parse_reports_dedup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface_nfc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_signature",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "corrected_lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parse_reports_token_id_text_tokens_id_fk": {
+          "name": "parse_reports_token_id_text_tokens_id_fk",
+          "tableFrom": "parse_reports",
+          "tableTo": "text_tokens",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "parse_reports_corrected_lemma_id_lemmas_id_fk": {
+          "name": "parse_reports_corrected_lemma_id_lemmas_id_fk",
+          "tableFrom": "parse_reports",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "corrected_lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "parse_reports_reporter_id_users_id_fk": {
+          "name": "parse_reports_reporter_id_users_id_fk",
+          "tableFrom": "parse_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "parse_reports_assigned_reviewer_id_users_id_fk": {
+          "name": "parse_reports_assigned_reviewer_id_users_id_fk",
+          "tableFrom": "parse_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_reviewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by": {
+          "name": "replaced_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "refresh_tokens_user_idx": {
+          "name": "refresh_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_expires_idx": {
+          "name": "refresh_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.text_chapters": {
+      "name": "text_chapters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idx": {
+          "name": "idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "text_chapters_text_idx": {
+          "name": "text_chapters_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_chapters_text_id_texts_id_fk": {
+          "name": "text_chapters_text_id_texts_id_fk",
+          "tableFrom": "text_chapters",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "text_chapters_text_idx_uq": {
+          "name": "text_chapters_text_idx_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "text_id",
+            "idx"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.text_group_shares": {
+      "name": "text_group_shares",
+      "schema": "",
+      "columns": {
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by_id": {
+          "name": "granted_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "text_group_shares_group_idx": {
+          "name": "text_group_shares_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_group_shares_text_id_texts_id_fk": {
+          "name": "text_group_shares_text_id_texts_id_fk",
+          "tableFrom": "text_group_shares",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_group_shares_group_id_groups_id_fk": {
+          "name": "text_group_shares_group_id_groups_id_fk",
+          "tableFrom": "text_group_shares",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_group_shares_granted_by_id_users_id_fk": {
+          "name": "text_group_shares_granted_by_id_users_id_fk",
+          "tableFrom": "text_group_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "text_group_shares_text_id_group_id_pk": {
+          "name": "text_group_shares_text_id_group_id_pk",
+          "columns": [
+            "text_id",
+            "group_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.text_shares": {
+      "name": "text_shares",
+      "schema": "",
+      "columns": {
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shared_with_user_id": {
+          "name": "shared_with_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "text_share_permission",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'read'"
+        },
+        "granted_by_id": {
+          "name": "granted_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "text_shares_recipient_idx": {
+          "name": "text_shares_recipient_idx",
+          "columns": [
+            {
+              "expression": "shared_with_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_shares_text_id_texts_id_fk": {
+          "name": "text_shares_text_id_texts_id_fk",
+          "tableFrom": "text_shares",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_shares_shared_with_user_id_users_id_fk": {
+          "name": "text_shares_shared_with_user_id_users_id_fk",
+          "tableFrom": "text_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "shared_with_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_shares_granted_by_id_users_id_fk": {
+          "name": "text_shares_granted_by_id_users_id_fk",
+          "tableFrom": "text_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "text_shares_text_id_shared_with_user_id_pk": {
+          "name": "text_shares_text_id_shared_with_user_id_pk",
+          "columns": [
+            "text_id",
+            "shared_with_user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.text_tokens": {
+      "name": "text_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idx": {
+          "name": "idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lemma_candidates": {
+          "name": "lemma_candidates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_ambiguous": {
+          "name": "is_ambiguous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_oov": {
+          "name": "is_oov",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_word": {
+          "name": "is_word",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sentence_idx": {
+          "name": "sentence_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "romanization": {
+          "name": "romanization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_forms": {
+          "name": "number_forms",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "text_tokens_chapter_scan_idx": {
+          "name": "text_tokens_chapter_scan_idx",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "text_tokens_lemma_idx": {
+          "name": "text_tokens_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_tokens_chapter_id_text_chapters_id_fk": {
+          "name": "text_tokens_chapter_id_text_chapters_id_fk",
+          "tableFrom": "text_tokens",
+          "tableTo": "text_chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_tokens_lemma_id_lemmas_id_fk": {
+          "name": "text_tokens_lemma_id_lemmas_id_fk",
+          "tableFrom": "text_tokens",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "text_tokens_chapter_idx_uq": {
+          "name": "text_tokens_chapter_idx_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chapter_id",
+            "idx"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.texts": {
+      "name": "texts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "status_error": {
+          "name": "status_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "texts_owner_idx": {
+          "name": "texts_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "texts_visibility_idx": {
+          "name": "texts_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "texts_owner_id_users_id_fk": {
+          "name": "texts_owner_id_users_id_fk",
+          "tableFrom": "texts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.token_corrections": {
+      "name": "token_corrections",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "token_correction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chosen_lemma_id": {
+          "name": "chosen_lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "token_corrections_token_idx": {
+          "name": "token_corrections_token_idx",
+          "columns": [
+            {
+              "expression": "token_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "token_corrections_chosen_lemma_idx": {
+          "name": "token_corrections_chosen_lemma_idx",
+          "columns": [
+            {
+              "expression": "chosen_lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "token_corrections_user_id_users_id_fk": {
+          "name": "token_corrections_user_id_users_id_fk",
+          "tableFrom": "token_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "token_corrections_token_id_text_tokens_id_fk": {
+          "name": "token_corrections_token_id_text_tokens_id_fk",
+          "tableFrom": "token_corrections",
+          "tableTo": "text_tokens",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "token_corrections_chosen_lemma_id_lemmas_id_fk": {
+          "name": "token_corrections_chosen_lemma_id_lemmas_id_fk",
+          "tableFrom": "token_corrections",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "chosen_lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "token_corrections_user_id_token_id_pk": {
+          "name": "token_corrections_user_id_token_id_pk",
+          "columns": [
+            "user_id",
+            "token_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.translation_votes": {
+      "name": "translation_votes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "translation_id": {
+          "name": "translation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "translation_vote_value",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "translation_votes_translation_idx": {
+          "name": "translation_votes_translation_idx",
+          "columns": [
+            {
+              "expression": "translation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translation_votes_user_idx": {
+          "name": "translation_votes_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "translation_votes_user_id_users_id_fk": {
+          "name": "translation_votes_user_id_users_id_fk",
+          "tableFrom": "translation_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "translation_votes_translation_id_translations_id_fk": {
+          "name": "translation_votes_translation_id_translations_id_fk",
+          "tableFrom": "translation_votes",
+          "tableTo": "translations",
+          "columnsFrom": [
+            "translation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "translation_votes_user_id_translation_id_pk": {
+          "name": "translation_votes_user_id_translation_id_pk",
+          "columns": [
+            "user_id",
+            "translation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.translations": {
+      "name": "translations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "translation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_translation_id": {
+          "name": "parent_translation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_language": {
+          "name": "target_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_rank": {
+          "name": "display_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "translations_lemma_idx": {
+          "name": "translations_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translations_submitted_by_idx": {
+          "name": "translations_submitted_by_idx",
+          "columns": [
+            {
+              "expression": "submitted_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translations_source_lookup_idx": {
+          "name": "translations_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "translations_lemma_id_lemmas_id_fk": {
+          "name": "translations_lemma_id_lemmas_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "translations_submitted_by_users_id_fk": {
+          "name": "translations_submitted_by_users_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "translations_parent_translation_id_translations_id_fk": {
+          "name": "translations_parent_translation_id_translations_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "translations",
+          "columnsFrom": [
+            "parent_translation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_audio_listening": {
+      "name": "user_audio_listening",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audio_file_id": {
+          "name": "audio_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "listened_ms": {
+          "name": "listened_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_listened_at": {
+          "name": "last_listened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_audio_listening_user_text_idx": {
+          "name": "user_audio_listening_user_text_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_audio_listening_text_idx": {
+          "name": "user_audio_listening_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_audio_listening_user_id_users_id_fk": {
+          "name": "user_audio_listening_user_id_users_id_fk",
+          "tableFrom": "user_audio_listening",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_audio_listening_audio_file_id_audio_files_id_fk": {
+          "name": "user_audio_listening_audio_file_id_audio_files_id_fk",
+          "tableFrom": "user_audio_listening",
+          "tableTo": "audio_files",
+          "columnsFrom": [
+            "audio_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_audio_listening_text_id_texts_id_fk": {
+          "name": "user_audio_listening_text_id_texts_id_fk",
+          "tableFrom": "user_audio_listening",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_audio_listening_user_id_audio_file_id_pk": {
+          "name": "user_audio_listening_user_id_audio_file_id_pk",
+          "columns": [
+            "user_id",
+            "audio_file_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_known_lemmas": {
+      "name": "user_known_lemmas",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "known_lemma_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'learning'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_known_lemmas_user_idx": {
+          "name": "user_known_lemmas_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_known_lemmas_user_id_users_id_fk": {
+          "name": "user_known_lemmas_user_id_users_id_fk",
+          "tableFrom": "user_known_lemmas",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_known_lemmas_lemma_id_lemmas_id_fk": {
+          "name": "user_known_lemmas_lemma_id_lemmas_id_fk",
+          "tableFrom": "user_known_lemmas",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_known_lemmas_user_id_lemma_id_pk": {
+          "name": "user_known_lemmas_user_id_lemma_id_pk",
+          "columns": [
+            "user_id",
+            "lemma_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_languages": {
+      "name": "user_languages",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script_preference": {
+          "name": "script_preference",
+          "type": "script_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "romanization_scheme": {
+          "name": "romanization_scheme",
+          "type": "romanization_scheme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'iso15919'"
+        },
+        "known_words_count_cache": {
+          "name": "known_words_count_cache",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reader_layout_mode": {
+          "name": "reader_layout_mode",
+          "type": "reader_layout_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'page'"
+        },
+        "words_per_page": {
+          "name": "words_per_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 250
+        },
+        "font_family": {
+          "name": "font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_size": {
+          "name": "font_size",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 18
+        },
+        "line_spacing": {
+          "name": "line_spacing",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1.6
+        },
+        "highlight_style": {
+          "name": "highlight_style",
+          "type": "highlight_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'background'"
+        },
+        "reading_width": {
+          "name": "reading_width",
+          "type": "reading_width",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "baseline": {
+          "name": "baseline",
+          "type": "language_baseline",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_languages_user_id_users_id_fk": {
+          "name": "user_languages_user_id_users_id_fk",
+          "tableFrom": "user_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_languages_user_id_language_pk": {
+          "name": "user_languages_user_id_language_pk",
+          "columns": [
+            "user_id",
+            "language"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_text_progress": {
+      "name": "user_text_progress",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_chapter_idx": {
+          "name": "last_chapter_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_token_idx": {
+          "name": "last_token_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pct_read": {
+          "name": "pct_read",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_text_progress_user_idx": {
+          "name": "user_text_progress_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_text_progress_user_id_users_id_fk": {
+          "name": "user_text_progress_user_id_users_id_fk",
+          "tableFrom": "user_text_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_text_progress_text_id_texts_id_fk": {
+          "name": "user_text_progress_text_id_texts_id_fk",
+          "tableFrom": "user_text_progress",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_text_progress_user_id_text_id_pk": {
+          "name": "user_text_progress_user_id_text_id_pk",
+          "columns": [
+            "user_id",
+            "text_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_preference": {
+          "name": "theme_preference",
+          "type": "theme_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarded_at": {
+          "name": "onboarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    }
+  },
+  "enums": {
+    "public.alignment_source": {
+      "name": "alignment_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "imported",
+        "whisper"
+      ]
+    },
+    "public.collection_kind": {
+      "name": "collection_kind",
+      "schema": "public",
+      "values": [
+        "chapter_book",
+        "course",
+        "anthology"
+      ]
+    },
+    "public.collection_visibility": {
+      "name": "collection_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "shared",
+        "official"
+      ]
+    },
+    "public.highlight_style": {
+      "name": "highlight_style",
+      "schema": "public",
+      "values": [
+        "underline",
+        "background",
+        "colored_text"
+      ]
+    },
+    "public.known_lemma_status": {
+      "name": "known_lemma_status",
+      "schema": "public",
+      "values": [
+        "unknown",
+        "learning",
+        "known",
+        "ignored"
+      ]
+    },
+    "public.language": {
+      "name": "language",
+      "schema": "public",
+      "values": [
+        "hi",
+        "mr",
+        "or"
+      ]
+    },
+    "public.language_baseline": {
+      "name": "language_baseline",
+      "schema": "public",
+      "values": [
+        "none",
+        "beginner",
+        "intermediate"
+      ]
+    },
+    "public.lemma_edit_change_type": {
+      "name": "lemma_edit_change_type",
+      "schema": "public",
+      "values": [
+        "lemma_update",
+        "lemma_unlock",
+        "lemma_lock",
+        "translation_insert",
+        "translation_update",
+        "translation_hide",
+        "translation_unhide",
+        "form_insert",
+        "form_delete",
+        "lemma_merge",
+        "lemma_split",
+        "translation_reorder"
+      ]
+    },
+    "public.lemma_proposal_status": {
+      "name": "lemma_proposal_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.nlp_job_status": {
+      "name": "nlp_job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.parse_report_status": {
+      "name": "parse_report_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "triaged",
+        "resolved",
+        "rejected",
+        "duplicate",
+        "deferred"
+      ]
+    },
+    "public.reader_layout_mode": {
+      "name": "reader_layout_mode",
+      "schema": "public",
+      "values": [
+        "page",
+        "paged_scroll",
+        "continuous"
+      ]
+    },
+    "public.reading_width": {
+      "name": "reading_width",
+      "schema": "public",
+      "values": [
+        "narrow",
+        "medium",
+        "wide"
+      ]
+    },
+    "public.romanization_scheme": {
+      "name": "romanization_scheme",
+      "schema": "public",
+      "values": [
+        "iso15919",
+        "iast",
+        "hunterian",
+        "itrans"
+      ]
+    },
+    "public.script_preference": {
+      "name": "script_preference",
+      "schema": "public",
+      "values": [
+        "native",
+        "native_with_romanization",
+        "romanization_only"
+      ]
+    },
+    "public.text_share_permission": {
+      "name": "text_share_permission",
+      "schema": "public",
+      "values": [
+        "read"
+      ]
+    },
+    "public.text_source_type": {
+      "name": "text_source_type",
+      "schema": "public",
+      "values": [
+        "paste",
+        "txt",
+        "epub"
+      ]
+    },
+    "public.text_status": {
+      "name": "text_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.text_visibility": {
+      "name": "text_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "shared",
+        "official"
+      ]
+    },
+    "public.theme_preference": {
+      "name": "theme_preference",
+      "schema": "public",
+      "values": [
+        "system",
+        "light",
+        "dark"
+      ]
+    },
+    "public.token_correction_type": {
+      "name": "token_correction_type",
+      "schema": "public",
+      "values": [
+        "pick_candidate",
+        "manual_lemma",
+        "new_lemma",
+        "mark_proper_noun",
+        "mark_foreign",
+        "mark_not_a_word"
+      ]
+    },
+    "public.translation_source": {
+      "name": "translation_source",
+      "schema": "public",
+      "values": [
+        "official_dictionary",
+        "curator",
+        "user"
+      ]
+    },
+    "public.translation_vote_value": {
+      "name": "translation_vote_value",
+      "schema": "public",
+      "values": [
+        "up",
+        "down"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "curator",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1777513538222,
       "tag": "0024_uneven_oracle",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1777514311003,
+      "tag": "0025_nukta_stripped_headword",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/src/lib/server/db/schema.ts
+++ b/apps/web/src/lib/server/db/schema.ts
@@ -13,7 +13,7 @@ import {
   unique,
   uuid,
 } from 'drizzle-orm/pg-core';
-import type { InferSelectModel } from 'drizzle-orm';
+import { sql, type InferSelectModel } from 'drizzle-orm';
 
 export const userRole = pgEnum('user_role', ['user', 'curator', 'admin']);
 export const themePreference = pgEnum('theme_preference', ['system', 'light', 'dark']);
@@ -248,6 +248,21 @@ export const lemmas = pgTable(
     curatorLocked: boolean('curator_locked').notNull().default(false),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+    // #318: nukta-agnostic search column. Postgres-side mirror of
+    // the JS `stripNukta` helper in `@ciareader/shared-types/nukta`:
+    // NFD-normalize so atomic precomposed nukta consonants
+    // (U+0958..U+095F + U+0929) decompose to base + U+093C, then
+    // delete every U+093C. The resulting string contains only
+    // non-nukta base consonants, which is what the search query also
+    // gets reduced to before the fallback compares them. STORED
+    // because we read it on every fallback search; the index below
+    // must be on the materialized column. Generated columns require
+    // an IMMUTABLE expression — `normalize` and `translate` both are.
+    headwordNuktaStripped: text('headword_nukta_stripped')
+      .notNull()
+      .generatedAlwaysAs(
+        sql`translate(normalize("headword", NFD), '़', '')`,
+      ),
   },
   (t) => ({
     // T-3.10: per-source duplication is allowed by design — Kaikki and
@@ -267,6 +282,13 @@ export const lemmas = pgTable(
     // Lookup by (language, source, source_id) is the idempotent-upsert key
     // for re-running an importer — indexed so re-imports don't full-scan.
     sourceIdx: index('lemmas_source_lookup_idx').on(t.language, t.source, t.sourceId),
+    // #318: index for the nukta-agnostic ILIKE prefix fallback. Same
+    // shape as the canonical headword index so the planner can pick
+    // it without a re-collation.
+    headwordStrippedIdx: index('lemmas_language_headword_stripped_idx').on(
+      t.language,
+      t.headwordNuktaStripped,
+    ),
   }),
 );
 

--- a/apps/web/src/lib/server/dictionary/browse.test.ts
+++ b/apps/web/src/lib/server/dictionary/browse.test.ts
@@ -47,6 +47,7 @@ vi.mock('../db/index.js', () => ({
       id: 'lemmas.id',
       language: 'lemmas.language',
       headword: 'lemmas.headword',
+      headwordNuktaStripped: 'lemmas.headword_nukta_stripped',
       pos: 'lemmas.pos',
       frequencyRank: 'lemmas.frequency_rank',
     },
@@ -100,6 +101,7 @@ describe('listDictionaryLemmas', () => {
     expect(result.totalCount).toBe(57);
     expect(result.limit).toBe(DEFAULT_PAGE_SIZE);
     expect(result.offset).toBe(0);
+    expect(result.usedNuktaFallback).toBe(false);
   });
 
   it('clamps limit to MAX_PAGE_SIZE when caller asks for too many', async () => {
@@ -174,6 +176,74 @@ describe('listDictionaryLemmas', () => {
     await expect(
       listDictionaryLemmas('hi', { pos: [] }),
     ).resolves.toMatchObject({ totalCount: 1 });
+  });
+
+  // ---- nukta-agnostic fallback (#318) ----------------------------------
+
+  it('falls back to a nukta-agnostic search when the user typed without nukta but DB has it', async () => {
+    // The bug-driving direction: user types `पढना` (no nukta), the
+    // canonical entry is `पढ़ना`. Strict misses; fallback should
+    // surface the entry. Mock convention: each tier issues
+    // rows-then-count, two `db` calls = two `stage()` entries.
+    stage([]);
+    stage([{ n: 0 }]);
+    stage([lemmaRow({ headword: 'पढ़ना' })]);
+    stage([{ n: 1 }]);
+
+    const result = await listDictionaryLemmas('hi', { q: 'पढना' });
+    expect(result.usedNuktaFallback).toBe(true);
+    expect(result.lemmas).toHaveLength(1);
+    expect(result.totalCount).toBe(1);
+  });
+
+  it('falls back to a nukta-agnostic search when the user typed with nukta but DB strips it', async () => {
+    // Inverse direction: user types `पढ़ना`, DB has `पढना` (e.g.
+    // pre-#316 lemma rows). Same fallback path because both sides
+    // reduce to the same nukta-free key.
+    stage([]);
+    stage([{ n: 0 }]);
+    stage([lemmaRow({ headword: 'पढना' })]);
+    stage([{ n: 1 }]);
+
+    const result = await listDictionaryLemmas('hi', { q: 'पढ़ना' });
+    expect(result.usedNuktaFallback).toBe(true);
+    expect(result.totalCount).toBe(1);
+  });
+
+  it('does not run the fallback when the strict tier already has hits', async () => {
+    stage([lemmaRow({ headword: 'पढ़ना' })]);
+    stage([{ n: 1 }]);
+    // No fallback stages — if the function were to run the fallback
+    // the test would explode in nextStaged().
+
+    const result = await listDictionaryLemmas('hi', { q: 'पढ़ना' });
+    expect(result.usedNuktaFallback).toBe(false);
+    expect(result.lemmas).toHaveLength(1);
+  });
+
+  it('does not advertise the fallback when both tiers are empty', async () => {
+    // Strict empty.
+    stage([]);
+    stage([{ n: 0 }]);
+    // Fallback also empty — a "showing nukta-agnostic results"
+    // banner over zero rows would read worse than a plain "no
+    // matches".
+    stage([]);
+    stage([{ n: 0 }]);
+
+    const result = await listDictionaryLemmas('hi', { q: 'पढ़ना' });
+    expect(result.usedNuktaFallback).toBe(false);
+    expect(result.totalCount).toBe(0);
+  });
+
+  it('does not run the fallback when no query is provided', async () => {
+    // Empty-query browse must skip the fallback entirely so an
+    // unfiltered list isn't double-counted (and no extra DB call is
+    // wasted on every page-load of the dictionary index).
+    stage([lemmaRow()]);
+    stage([{ n: 1 }]);
+    const result = await listDictionaryLemmas('hi');
+    expect(result.usedNuktaFallback).toBe(false);
   });
 });
 

--- a/apps/web/src/lib/server/dictionary/browse.ts
+++ b/apps/web/src/lib/server/dictionary/browse.ts
@@ -11,12 +11,21 @@
  * headword. The client-side `<ScriptAwareInput>` (T-6.2a) is responsible
  * for turning a user's romanized input into the native script before it
  * arrives here — this service does not transliterate.
+ *
+ * Nukta-agnostic fallback (#318): when the user's query has zero
+ * exact-prefix hits AND the query strips down to something different
+ * (i.e. it itself contained a nukta marker, OR an entry in the table
+ * has nuktas the query lacks), we re-run the search against the
+ * `headword_nukta_stripped` generated column with the query also
+ * nukta-stripped. This is **lossy by design** (`ज़रा` and `जरा` collapse
+ * to the same key), so the result advertises `usedNuktaFallback` and
+ * the UI surfaces a "showing nukta-agnostic results" hint.
  */
 import { and, asc, count, eq, gte, ilike, inArray, lte, sql } from 'drizzle-orm';
 
 import { db, schema } from '../db/index.js';
 import type { Lemma } from '../db/schema.js';
-import type { LanguageCode } from '@ciareader/shared-types';
+import { stripNukta, type LanguageCode } from '@ciareader/shared-types';
 
 /**
  * Default + cap. Browse pages are paginated; the cap keeps a rogue
@@ -45,6 +54,16 @@ export type BrowseResult = {
   totalCount: number;
   limit: number;
   offset: number;
+  /**
+   * #318: True when these results came from the nukta-agnostic
+   * fallback tier — i.e. the strict ILIKE on `headword` returned zero
+   * hits AND we re-queried against `headword_nukta_stripped`. The UI
+   * uses this to render a "showing nukta-agnostic results" hint so
+   * the lossy step is visible to the user. False whenever the result
+   * came from the strict tier (including when both tiers would have
+   * been empty — there's no fallback to advertise).
+   */
+  usedNuktaFallback: boolean;
 };
 
 /** `%` and `_` are the two wildcards Postgres recognises in LIKE/ILIKE. */
@@ -69,24 +88,16 @@ function normalizeQuery(q: string | null | undefined): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
-/**
- * List lemmas for a language, filtered and paginated.
- *
- * Returns both the rows and a total-count so the UI can render a page
- * indicator without a second round trip.
- */
-export async function listDictionaryLemmas(
-  language: LanguageCode,
-  query: BrowseQuery = {},
-): Promise<BrowseResult> {
-  const limit = clampLimit(query.limit);
-  const offset = clampOffset(query.offset);
-  const q = normalizeQuery(query.q);
+type SearchClause = ReturnType<typeof ilike> | null;
 
+/**
+ * Build the non-search filter conditions (language, POS, rank range,
+ * has-official). Shared between the strict tier and the
+ * nukta-agnostic fallback so the two tiers can't drift on what
+ * "matches the rest of the query" means.
+ */
+function baseConditions(language: LanguageCode, query: BrowseQuery) {
   const conditions = [eq(schema.lemmas.language, language)];
-  if (q) {
-    conditions.push(ilike(schema.lemmas.headword, `${escapeLikePrefix(q)}%`));
-  }
   if (query.pos && query.pos.length > 0) {
     conditions.push(inArray(schema.lemmas.pos, [...query.pos]));
   }
@@ -106,6 +117,18 @@ export async function listDictionaryLemmas(
       )`,
     );
   }
+  return conditions;
+}
+
+async function runSearchTier(
+  language: LanguageCode,
+  query: BrowseQuery,
+  searchClause: SearchClause,
+  limit: number,
+  offset: number,
+): Promise<{ rows: Lemma[]; totalCount: number }> {
+  const conditions = baseConditions(language, query);
+  if (searchClause) conditions.push(searchClause);
   const where = conditions.length === 1 ? conditions[0] : and(...conditions);
 
   const rows = await db
@@ -127,11 +150,91 @@ export async function listDictionaryLemmas(
     .from(schema.lemmas)
     .where(where);
 
-  return {
-    lemmas: rows as Lemma[],
-    totalCount: Number(n),
+  return { rows: rows as Lemma[], totalCount: Number(n) };
+}
+
+/**
+ * List lemmas for a language, filtered and paginated.
+ *
+ * Returns both the rows and a total-count so the UI can render a page
+ * indicator without a second round trip.
+ *
+ * Search tiers (#318):
+ *  1. Strict: case-insensitive ILIKE prefix on `headword` (NFC).
+ *  2. Nukta-agnostic fallback: ILIKE prefix on
+ *     `headword_nukta_stripped` with the query also stripped. Fires
+ *     whenever the strict tier returned zero rows for a non-empty
+ *     query. The fallback handles BOTH directions of the user/DB
+ *     mismatch — user typed `पढना` and DB has `पढ़ना`, OR user typed
+ *     `पढ़ना` and DB has `पढना` — because both sides reduce to the
+ *     same nukta-free key.
+ *
+ * Cost shape: the second tier costs at most one extra index seek
+ * when the strict tier missed AND the query was non-empty. On the
+ * happy path (strict hit) we issue exactly the same two queries as
+ * before.
+ */
+export async function listDictionaryLemmas(
+  language: LanguageCode,
+  query: BrowseQuery = {},
+): Promise<BrowseResult> {
+  const limit = clampLimit(query.limit);
+  const offset = clampOffset(query.offset);
+  const q = normalizeQuery(query.q);
+
+  const strictClause: SearchClause = q
+    ? ilike(schema.lemmas.headword, `${escapeLikePrefix(q)}%`)
+    : null;
+  const strict = await runSearchTier(language, query, strictClause, limit, offset);
+
+  if (!q || strict.rows.length > 0) {
+    return {
+      lemmas: strict.rows,
+      totalCount: strict.totalCount,
+      limit,
+      offset,
+      usedNuktaFallback: false,
+    };
+  }
+
+  // Strict tier was empty for a non-empty query — try the
+  // nukta-agnostic tier. We `stripNukta` on the query side too: even
+  // when the query has no nukta of its own, the stripped column on
+  // the DB side has had nuktas removed, and a nukta-free query
+  // matches a stored stripped value directly. When the query DID
+  // have nuktas, stripping equalizes both sides.
+  const stripped = stripNukta(q);
+  const fallbackClause: SearchClause = ilike(
+    schema.lemmas.headwordNuktaStripped,
+    `${escapeLikePrefix(stripped)}%`,
+  );
+  const fallback = await runSearchTier(
+    language,
+    query,
+    fallbackClause,
     limit,
     offset,
+  );
+
+  // If the fallback also misses, advertise the strict (empty) result
+  // — no point telling the user we ran a fallback that found
+  // nothing.
+  if (fallback.rows.length === 0) {
+    return {
+      lemmas: strict.rows,
+      totalCount: strict.totalCount,
+      limit,
+      offset,
+      usedNuktaFallback: false,
+    };
+  }
+
+  return {
+    lemmas: fallback.rows,
+    totalCount: fallback.totalCount,
+    limit,
+    offset,
+    usedNuktaFallback: true,
   };
 }
 

--- a/apps/web/src/lib/server/dictionary/get-lemma-translations.test.ts
+++ b/apps/web/src/lib/server/dictionary/get-lemma-translations.test.ts
@@ -46,6 +46,7 @@ vi.mock('../db/index.js', () => ({
       id: 'lemmas.id',
       language: 'lemmas.language',
       headword: 'lemmas.headword',
+      headwordNuktaStripped: 'lemmas.headword_nukta_stripped',
     },
     translations: {
       id: 'translations.id',
@@ -152,14 +153,42 @@ describe('getLemmaTranslations (T-3.14 sibling fallback)', () => {
     expect(selectFn).toHaveBeenCalledTimes(3);
   });
 
-  it('still returns empty when neither the primary nor any sibling has translations', async () => {
+  it('still returns empty when neither the primary nor any sibling tier has translations', async () => {
     stage([lemmaRow()]);
     stage([]); // primary empty
-    stage([]); // sibling join empty
+    stage([]); // exact-headword sibling join empty
+    stage([]); // #318: nukta-stripped sibling join empty
     const out = await getLemmaTranslations('lemma-1', null);
     expect(out.translations.personal).toEqual([]);
     expect(out.translations.official).toEqual([]);
     expect(out.translations.community).toEqual([]);
+  });
+
+  it('falls back to nukta-stripped siblings when exact-headword siblings are empty (#318)', async () => {
+    // Linked lemma is `पढना` (pre-#316, no nukta). Exact-headword
+    // sibling fetch finds nothing (no other `पढना` rows). The
+    // canonical entry sits under `पढ़ना` (with nukta) and ships the
+    // gloss — caught by the nukta-stripped tier because both reduce
+    // to the same key.
+    stage([lemmaRow({ id: 'lemma-1', headword: 'पढना', pos: 'VERB' })]);
+    stage([]); // primary translations empty
+    stage([]); // exact-headword sibling fetch empty
+    stage([
+      // nukta-stripped sibling fetch finds the canonical `पढ़ना` row
+      {
+        translation: translationRow({
+          lemmaId: 'lemma-canonical',
+          body: 'to read',
+        }),
+      },
+    ]);
+    const out = await getLemmaTranslations('lemma-1', null);
+    // We honor the user-clicked lemma's metadata; only the
+    // translation text comes from the canonical sibling.
+    expect(out.lemma.id).toBe('lemma-1');
+    expect(out.lemma.headword).toBe('पढना');
+    expect(out.translations.official.map((t) => t.body)).toEqual(['to read']);
+    expect(selectFn).toHaveBeenCalledTimes(4);
   });
 
   it('honors the viewer when bucketing sibling translations into personal vs community', async () => {

--- a/apps/web/src/lib/server/dictionary/lookups.ts
+++ b/apps/web/src/lib/server/dictionary/lookups.ts
@@ -24,6 +24,8 @@
  */
 import { and, eq, ne, sql } from 'drizzle-orm';
 
+import { stripNukta } from '@ciareader/shared-types';
+
 import { db, schema } from '../db/index.js';
 import type { Lemma, Translation, User } from '../db/schema.js';
 import type { TranslationVoteValue } from './votes.js';
@@ -326,6 +328,15 @@ export async function getLemmaTranslations(
   // its meaning, not a metadata lecture about how the parser tagged
   // it. Only triggered on empty primaries so the cost is paid exactly
   // when it would otherwise be a dead-end click.
+  //
+  // #318: Two-stage fallback. First try exact-headword siblings
+  // (T-3.14's original behavior). If that's also empty, try
+  // nukta-stripped siblings — the directly-linked lemma might be a
+  // nukta-stripped form (e.g. pre-#316 `पढना`) while the dictionary
+  // entry that ships the gloss is under the canonical with-nukta
+  // form (`पढ़ना`), or vice-versa. Both sides reduce to the same
+  // stripped key, so the second tier finds the entry the first
+  // tier's strict-equality `headword =` clause missed.
   const lemmaTyped = lemma as Lemma;
   let rows: Translation[] = primaryRows as Translation[];
   if (rows.length === 0) {
@@ -344,6 +355,31 @@ export async function getLemmaTranslations(
         ),
       );
     rows = joined.map((r) => r.translation as Translation);
+  }
+  if (rows.length === 0) {
+    // #318: Run the nukta-stripped tier even when the linked
+    // lemma's own headword has no nukta. The strict tier above
+    // matched on `headword = X`, so it missed any sibling whose
+    // headword has nuktas X lacks (e.g. linked lemma is `पढना` and
+    // the canonical entry under `पढ़ना` ships the gloss). The
+    // stripped column is nukta-free on both sides, so it catches
+    // both directions of the mismatch.
+    const stripped = stripNukta(lemmaTyped.headword);
+    const joinedStripped = await db
+      .select({ translation: schema.translations })
+      .from(schema.translations)
+      .innerJoin(
+        schema.lemmas,
+        eq(schema.translations.lemmaId, schema.lemmas.id),
+      )
+      .where(
+        and(
+          eq(schema.lemmas.language, lemmaTyped.language),
+          eq(schema.lemmas.headwordNuktaStripped, stripped),
+          ne(schema.lemmas.id, lemmaId),
+        ),
+      );
+    rows = joinedStripped.map((r) => r.translation as Translation);
   }
 
   const rowsWithVotes = await attachVoteData(rows, viewer);

--- a/apps/web/src/lib/server/dictionary/test-support.ts
+++ b/apps/web/src/lib/server/dictionary/test-support.ts
@@ -13,7 +13,7 @@
  * - `findTranslation` / `findLemmaBySource` do linear scans, which is
  *   fine at fixture scale.
  */
-import type { LanguageCode } from '@ciareader/shared-types';
+import { stripNukta, type LanguageCode } from '@ciareader/shared-types';
 
 import type { Lemma, Translation } from '../db/schema.js';
 
@@ -45,7 +45,18 @@ export class InMemoryDictionaryRepo implements DictionaryRepo {
   readonly audit: ImportRunAudit[] = [];
 
   seedCuratorLocked(
-    key: Omit<Lemma, 'createdAt' | 'updatedAt' | 'curatorLocked' | 'id'> & {
+    // `headwordNuktaStripped` is computed by Postgres for real rows
+    // (#318); the in-memory fake mirrors that by deriving it from
+    // `headword` via the shared `stripNukta` helper, so callers
+    // never need to provide it.
+    key: Omit<
+      Lemma,
+      | 'createdAt'
+      | 'updatedAt'
+      | 'curatorLocked'
+      | 'id'
+      | 'headwordNuktaStripped'
+    > & {
       id?: string;
     },
   ): Lemma {
@@ -64,6 +75,7 @@ export class InMemoryDictionaryRepo implements DictionaryRepo {
       curatorLocked: true,
       createdAt: nowUtc(),
       updatedAt: nowUtc(),
+      headwordNuktaStripped: stripNukta(key.headword),
     };
     this.lemmas.set(id, row);
     return row;
@@ -98,6 +110,7 @@ export class InMemoryDictionaryRepo implements DictionaryRepo {
       curatorLocked: false,
       createdAt: nowUtc(),
       updatedAt: nowUtc(),
+      headwordNuktaStripped: stripNukta(payload.headword),
     };
     this.lemmas.set(id, row);
     return row;
@@ -121,6 +134,7 @@ export class InMemoryDictionaryRepo implements DictionaryRepo {
       sourceAttribution: payload.sourceAttribution,
       sourceId: payload.sourceId,
       updatedAt: nowUtc(),
+      headwordNuktaStripped: stripNukta(payload.headword),
     };
     this.lemmas.set(id, next);
     return next;

--- a/apps/web/src/lib/text/strip-nukta.test.ts
+++ b/apps/web/src/lib/text/strip-nukta.test.ts
@@ -1,0 +1,116 @@
+// @vitest-environment node
+/**
+ * Unit tests for the shared-types `stripNukta` / `hasNukta` helpers
+ * (#318). The helpers live in `@ciareader/shared-types` (pure
+ * data-only package, no test infra of its own); we colocate the
+ * tests under apps/web so they run inside the existing Vitest setup.
+ *
+ * Coverage targets the two encodings every nukta consonant has —
+ * atomic precomposed codepoint (e.g. `U+0958` क़) vs. base + U+093C —
+ * and the lossy nature of the strip (intentional: `ज़रा` and `जरा` map
+ * to the same key, which is the whole point of the fallback tier).
+ */
+import { describe, expect, it } from 'vitest';
+
+import { hasNukta, stripNukta } from '@ciareader/shared-types';
+
+describe('stripNukta', () => {
+  it('removes a decomposed nukta on a verb stem', () => {
+    expect(stripNukta('पढ़ना')).toBe('पढना');
+    expect(stripNukta('बढ़ना')).toBe('बढना');
+    expect(stripNukta('चढ़ना')).toBe('चढना');
+  });
+
+  it('leaves non-nukta input unchanged', () => {
+    expect(stripNukta('कहना')).toBe('कहना');
+    expect(stripNukta('जाना')).toBe('जाना');
+  });
+
+  it('maps atomic precomposed nukta consonants to their base', () => {
+    // Each entry uses the U+0958..U+095F (+ U+0929 ऩ) atomic codepoints.
+    const cases: Array<[string, string]> = [
+      ['क़ाम', 'काम'], // क़ाम → काम
+      ['ख़ास', 'खास'], // ख़ास → खास
+      ['ग़रीब', 'गरीब'], // ग़रीब → गरीब
+      ['ज़रा', 'जरा'], // ज़रा → जरा
+      ['ड़ा', 'डा'], // ड़ा → डा
+      ['ढ़ा', 'ढा'], // ढ़ा → ढा
+      ['फ़ल', 'फल'], // फ़ल → फल
+      ['य़ा', 'या'], // य़ा → या
+      ['ऩ', 'न'], // ऩ → न
+    ];
+    for (const [atomic, base] of cases) {
+      expect(stripNukta(atomic)).toBe(base);
+    }
+  });
+
+  it('handles both encodings on the same input identically', () => {
+    // ज़रा encoded two ways: atomic U+095B vs base U+091C + U+093C.
+    const atomic = 'ज़रा';
+    const decomposed = 'ज़रा';
+    expect(stripNukta(atomic)).toBe(stripNukta(decomposed));
+    expect(stripNukta(atomic)).toBe('जरा');
+  });
+
+  it('strips every nukta in a multi-nukta word', () => {
+    // ज़ख़्म "wound" — two nuktas. Encoded with atomic ज़ + ख़.
+    expect(stripNukta('ज़ख़्म')).toBe('जख्म');
+  });
+
+  it('is the lossy-by-design tier: ज़रा and जरा collapse to the same key', () => {
+    // The "did you mean" hint exists exactly because of this. Pinned
+    // here so a future change can't quietly make the two distinguish.
+    expect(stripNukta('ज़रा')).toBe(stripNukta('जरा'));
+  });
+
+  it('preserves non-Devanagari surrounding text', () => {
+    // Mixed scripts come up in the curator search box (e.g. someone
+    // pastes a romanized English gloss alongside a Hindi headword).
+    expect(stripNukta('see पढ़ना (verb)')).toBe('see पढना (verb)');
+  });
+
+  it('returns empty string for empty / null-ish input', () => {
+    expect(stripNukta('')).toBe('');
+    // Defensive: the type signature is string but we want crashes
+    // ruled out for callers that forget to check upstream.
+    expect(stripNukta(undefined as unknown as string)).toBe('');
+    expect(stripNukta(null as unknown as string)).toBe('');
+  });
+
+  it('is idempotent — stripping a stripped value yields the same string', () => {
+    const once = stripNukta('पढ़ना');
+    expect(stripNukta(once)).toBe(once);
+  });
+
+  it('produces NFC output (no leftover combining nukta)', () => {
+    const result = stripNukta('ज़रा');
+    expect(result).toBe(result.normalize('NFC'));
+    expect(result.includes('़')).toBe(false);
+  });
+});
+
+describe('hasNukta', () => {
+  it('detects decomposed nukta', () => {
+    expect(hasNukta('पढ़ना')).toBe(true);
+  });
+
+  it('detects atomic precomposed nukta consonants', () => {
+    expect(hasNukta('ज़रा')).toBe(true); // ज़रा
+    expect(hasNukta('ऩ')).toBe(true); // ऩ
+  });
+
+  it('returns false for nukta-free Devanagari', () => {
+    expect(hasNukta('कहना')).toBe(false);
+    expect(hasNukta('जरा')).toBe(false);
+  });
+
+  it('returns false for empty / null-ish input', () => {
+    expect(hasNukta('')).toBe(false);
+    expect(hasNukta(undefined as unknown as string)).toBe(false);
+    expect(hasNukta(null as unknown as string)).toBe(false);
+  });
+
+  it('returns false for non-Devanagari text', () => {
+    expect(hasNukta('hello world')).toBe(false);
+  });
+});

--- a/apps/web/src/routes/api/v1/dictionary/[language]/lemmas/+server.ts
+++ b/apps/web/src/routes/api/v1/dictionary/[language]/lemmas/+server.ts
@@ -60,5 +60,10 @@ export const GET: RequestHandler = async ({ params, url }) => {
     totalCount: result.totalCount,
     limit: result.limit,
     offset: result.offset,
+    // #318: API consumers (the curator dictionary editor, the
+    // correction modal) need the same signal the SSR pages use so
+    // they can render their own "showing nukta-agnostic results"
+    // hint without re-deriving it from the input.
+    usedNuktaFallback: result.usedNuktaFallback,
   });
 };

--- a/apps/web/src/routes/dictionary/[language]/+page.server.ts
+++ b/apps/web/src/routes/dictionary/[language]/+page.server.ts
@@ -57,6 +57,10 @@ export const load: PageServerLoad = async ({ params, url }) => {
     totalCount: result.totalCount,
     limit: result.limit,
     offset: result.offset,
+    // #318: Surface the nukta-agnostic fallback so the page can
+    // render a hint when an exact-match search missed and we showed
+    // the user the closest nukta-stripped match instead.
+    usedNuktaFallback: result.usedNuktaFallback,
     query: {
       q: q ?? '',
       pos,

--- a/apps/web/src/routes/dictionary/[language]/+page.svelte
+++ b/apps/web/src/routes/dictionary/[language]/+page.svelte
@@ -61,6 +61,19 @@
     <button type="submit">Search</button>
   </form>
 
+  {#if data.usedNuktaFallback}
+    <!--
+      #318: Nukta-agnostic fallback fired. Tell the user the strict
+      match missed and we found these by ignoring nuktas — `ज़रा` and
+      `जरा` collapse to the same key, so the user might be looking at
+      a different word than they typed.
+    -->
+    <p class="nukta-fallback" role="status">
+      No exact matches for <strong>{data.query.q}</strong> — showing
+      nukta-agnostic results.
+    </p>
+  {/if}
+
   {#if data.lemmas.length === 0}
     <p class="empty">No lemmas match.</p>
   {:else}
@@ -193,6 +206,15 @@
   .empty {
     margin: 2rem 0;
     color: var(--color-fg-muted);
+  }
+  .nukta-fallback {
+    margin: 0 0 1rem;
+    padding: 0.6rem 0.85rem;
+    border-radius: 6px;
+    background: var(--color-info-bg, #eef5ff);
+    color: var(--color-info-fg, var(--color-fg));
+    border-left: 3px solid var(--color-accent);
+    font-size: 0.9rem;
   }
   .pager {
     display: flex;

--- a/apps/web/src/routes/moderation/dictionary/+page.server.ts
+++ b/apps/web/src/routes/moderation/dictionary/+page.server.ts
@@ -37,6 +37,7 @@ export const load: PageServerLoad = async ({ url, parent }) => {
       totalCount: 0,
       limit: DEFAULT_PAGE_SIZE,
       offset: 0,
+      usedNuktaFallback: false,
       query: { q: '' },
       isAdmin: moderator.role === 'admin',
     };
@@ -80,6 +81,7 @@ export const load: PageServerLoad = async ({ url, parent }) => {
     totalCount: result.totalCount,
     limit: result.limit,
     offset: result.offset,
+    usedNuktaFallback: result.usedNuktaFallback,
     query: { q: q ?? '' },
     isAdmin: moderator.role === 'admin',
   };

--- a/apps/web/src/routes/moderation/dictionary/+page.svelte
+++ b/apps/web/src/routes/moderation/dictionary/+page.svelte
@@ -67,6 +67,20 @@
       <button type="submit">Search</button>
     </form>
 
+    {#if data.usedNuktaFallback}
+      <!--
+        #318: Curators see the same fallback hint readers do — extra
+        salient here because they're often hunting for a specific
+        canonical entry to merge or edit. The hint surfaces the
+        possibility that the entry under their cursor is a
+        different word that just shares the nukta-stripped key.
+      -->
+      <p class="nukta-fallback" role="status">
+        No exact matches for <strong>{data.query.q}</strong> — showing
+        nukta-agnostic results.
+      </p>
+    {/if}
+
     {#if data.lemmas.length === 0}
       <p class="empty">No lemmas match.</p>
     {:else}
@@ -214,6 +228,15 @@
   .empty {
     margin: 2rem 0;
     color: var(--color-fg-muted);
+  }
+  .nukta-fallback {
+    margin: 0 0 1rem;
+    padding: 0.6rem 0.85rem;
+    border-radius: 6px;
+    background: var(--color-info-bg, #eef5ff);
+    color: var(--color-info-fg, var(--color-fg));
+    border-left: 3px solid var(--color-accent);
+    font-size: 0.9rem;
   }
   .pager {
     display: flex;

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -7,7 +7,8 @@
   "types": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
-    "./languages": "./src/languages.ts"
+    "./languages": "./src/languages.ts",
+    "./nukta": "./src/nukta.ts"
   },
   "scripts": {
     "lint": "echo 'shared-types: no lint yet'",

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -1,1 +1,2 @@
 export * from './languages.js';
+export * from './nukta.js';

--- a/packages/shared-types/src/nukta.ts
+++ b/packages/shared-types/src/nukta.ts
@@ -1,0 +1,97 @@
+/**
+ * Nukta-stripping helper (#318).
+ *
+ * The Devanagari nukta (U+093C COMBINING DEVANAGARI SIGN NUKTA) marks
+ * a small set of consonants borrowed from Persian/Arabic vocabulary —
+ * `ज़` (z) vs `ज` (j), `फ़` (f) vs `फ` (ph), `ड़` / `ढ़` for the retroflex
+ * flap consonants in native verbs (`पढ़ना` "to read", `बढ़ना` "to grow"),
+ * and a handful of less-common Persianate consonants `क़` / `ख़` / `ग़` /
+ * `य़` / `ऩ`. In published text the nukta is usually written; in casual
+ * typing — and across many user-generated dictionary sources — it gets
+ * dropped with no fixed convention. `पढ़ना` and `पढना` are observed in
+ * the wild for the same word.
+ *
+ * `stripNukta` removes that distinction so a search/lookup can fall
+ * back to a nukta-agnostic match when an exact match misses. **It is a
+ * lossy normalization**: `ज़रा` "a little" and `जरा` "old age" are
+ * genuinely different words that strip to the same key. Callers MUST
+ * try the exact form first and only consult the stripped form when the
+ * exact tier returns no hits — and ideally surface a "showing
+ * nukta-agnostic results" hint to the user so the lossy step is
+ * visible.
+ *
+ * Behavior:
+ *  - NFC-normalize first so the two equivalent encodings of every
+ *    nukta consonant (atomic precomposed codepoint vs. base + U+093C)
+ *    funnel through the same path.
+ *  - Map every atomic precomposed nukta consonant (`U+0958` क़ ..
+ *    `U+095F` य़, plus `U+0929` ऩ) to its non-nukta base.
+ *  - Remove every standalone U+093C left over after that step
+ *    (covers the decomposed encoding and any unusual NFC behavior).
+ *
+ * The result is itself NFC and contains no U+093C nor any of the
+ * atomic nukta codepoints, which is the property the
+ * `headword_nukta_stripped` Postgres generated column relies on for a
+ * direct equality check between the JS-side `stripNukta(query)` and
+ * the DB-side stored value.
+ */
+
+const NUKTA = '़';
+
+// Atomic precomposed nukta consonants → non-nukta base.
+// Order is the Unicode codepoint order; this map is exhaustive for
+// Devanagari nukta letters as of Unicode 16.
+const ATOMIC_TO_BASE: Readonly<Record<string, string>> = Object.freeze({
+  'ऩ': 'न', // ऩ → न
+  'क़': 'क', // क़ → क
+  'ख़': 'ख', // ख़ → ख
+  'ग़': 'ग', // ग़ → ग
+  'ज़': 'ज', // ज़ → ज
+  'ड़': 'ड', // ड़ → ड
+  'ढ़': 'ढ', // ढ़ → ढ
+  'फ़': 'फ', // फ़ → फ
+  'य़': 'य', // य़ → य
+});
+
+/**
+ * Return `input` with every nukta-marking removed. See module
+ * docstring for the rationale and the (intentional) lossiness.
+ *
+ * Empty / null-ish input passes through as the empty string so
+ * callers can use this on optional query fragments without
+ * special-casing.
+ */
+export function stripNukta(input: string): string {
+  if (!input) return '';
+  // NFC first so an atomic ज़ stays atomic and a decomposed ज + U+093C
+  // collapses to its canonical form before we consider it. Postgres
+  // composition exclusions mean NFC actually keeps decomposed ज+U+093C
+  // as decomposed (it does NOT recompose to U+095B); that's fine —
+  // the per-character pass below handles both cases.
+  const normalized = input.normalize('NFC');
+  let out = '';
+  for (const ch of normalized) {
+    if (ch === NUKTA) continue;
+    const base = ATOMIC_TO_BASE[ch];
+    out += base ?? ch;
+  }
+  return out;
+}
+
+/**
+ * True when stripping a nukta from `input` would actually change it —
+ * i.e. the input contains at least one nukta marker, atomic or
+ * decomposed. UI surfaces use this to decide whether to show a
+ * "nukta-agnostic" hint at all (when the user already typed a
+ * nukta-free query, the fallback isn't lossy and there's nothing to
+ * surface).
+ */
+export function hasNukta(input: string): boolean {
+  if (!input) return false;
+  const normalized = input.normalize('NFC');
+  for (const ch of normalized) {
+    if (ch === NUKTA) return true;
+    if (ch in ATOMIC_TO_BASE) return true;
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary

- Two-tier match in `listDictionaryLemmas` (`apps/web/src/lib/server/dictionary/browse.ts`): strict ILIKE prefix on `headword` first; if zero hits, re-run against a new `headword_nukta_stripped` Postgres generated column (`translate(normalize("headword", NFD), '़', '')`). Result advertises `usedNuktaFallback: true` and the public + curator dictionary pages render a "showing nukta-agnostic results" hint so the lossy step is visible.
- New shared helper `stripNukta` / `hasNukta` in `@ciareader/shared-types` (and a `./nukta` subpath export). NFC-normalize + map atomic precomposed nukta consonants (`U+0958..U+095F`, plus `U+0929`) to their bases + drop standalone U+093C. JS-side mirror of the Postgres expression so query and column reduce to the same key.
- Extends T-3.14's sibling-translation fallback in `getLemmaTranslations` (`lookups.ts:331-374`) with the same stripped tier: catches the case where the linked lemma is e.g. pre-#316 `पढना` and the canonical entry under `पढ़ना` ships the gloss (or vice-versa). Both reduce to the same nukta-free key.
- Strict equality stays the default — `ज़/ज`, `ड़/ड`, `फ़/फ` are phonemically distinct in standard Hindi (`ज़रा` "a little" vs `जरा` "old age"); always-on stripping would conflate them. Two tiers keeps exact wins clean while staying forgiving for typos.
- Drizzle migration 0025 adds the generated column + `lemmas_language_headword_stripped_idx` index. Drizzle-kit generates the SQL cleanly because both `normalize` and `translate` are IMMUTABLE in Postgres 13+.
- Out of scope (intentionally): form-lemma-overrides lookup and parse-report dedup keep strict equality (overrides encode a specific corrected `(surface, context)` pair — different nukta variants are different reports). Dispatcher lemma resolution is a separate transition aid tracked in #320.

## Test plan

- [x] `pnpm test` — 1015 tests passed across 119 files, including 14 new (10 for `stripNukta`/`hasNukta`, 4 for the two-tier search, 1 for the lookups stripped fallback).
- [x] `pnpm run check` — no type errors. Schema's `headwordNuktaStripped` is required-on-read but auto-omitted from inserts; in-memory `InMemoryDictionaryRepo` mirrors Postgres by computing the value via `stripNukta` so test fixtures stay clean.
- [x] `pnpm lint` — clean.
- [x] Helper coverage: both decompositions of every nukta consonant, idempotency, lossy collapse (`ज़रा` and `जरा` map to the same key), surrounding non-Devanagari preserved.
- [x] Search coverage: both directions of mismatch (query has nukta vs DB has nukta), no-fallback when strict succeeds, no-fallback advertise when both tiers empty.
- [ ] Manual: `pnpm db:migrate` against a populated dev DB (verify the generated column + index land cleanly on existing rows).
- [ ] Manual: smoke the public dictionary search box and the curator dictionary list — confirm the hint banner renders only when the fallback fires.

Closes #318