### PR TITLE
T-2.8: stop polluting the lemmas table with NUM surfaces

### DIFF
--- a/apps/web/src/lib/components/reader/WordPopup.svelte
+++ b/apps/web/src/lib/components/reader/WordPopup.svelte
@@ -23,7 +23,7 @@
   import CorrectionModal from './CorrectionModal.svelte';
   import { customizableOfficialIds } from './customize-eligibility.js';
   import type { LanguageCode } from '@ciareader/shared-types';
-  import type { ServerToken } from './types.js';
+  import { looksLikeNumberToken, type ServerToken } from './types.js';
 
   type Provenance =
     | { kind: 'personal'; attribution: null }
@@ -224,6 +224,17 @@
       payload?.translations.official ?? [],
       payload?.translations.personal ?? [],
     ),
+  );
+
+  // T-2.8: a token is treated as a number whenever the NLP service
+  // populated `numberForms` OR the raw surface looks like one.
+  // The second arm catches chapters processed before the comma-fix
+  // landed (their text_tokens.number_forms column is null even though
+  // the surface is clearly a number) so the popup doesn't fall back
+  // to the bogus auto-created lemma row for those tokens.
+  const isNumberToken = $derived(
+    token != null &&
+      (token.numberForms != null || looksLikeNumberToken(token.surface)),
   );
 
   const numberDisplay = $derived((): NumberDisplay | null => {
@@ -522,6 +533,16 @@
             <span class="num-roman">{numberDisplay()?.romanized}</span>
           </div>
         </div>
+      {:else if isNumberToken}
+        <!-- T-2.8: legacy token from a chapter processed before the
+             number-form support landed. We can detect that the surface
+             is a number but the worker never wrote per-language
+             spelled-out forms, so we deliberately suppress the (almost
+             always wrong) auto-created lemma row and ask the owner to
+             reprocess the text. -->
+        <p class="muted small" data-testid="number-needs-reprocess">
+          Reprocess this text to see written-out number forms in each language.
+        </p>
       {:else}
         {#if token.romanization}
           <p class="sp-roman">{token.romanization}</p>
@@ -545,7 +566,7 @@
       {/if}
     </header>
 
-    {#if !token.numberForms}
+    {#if !isNumberToken}
     {#if isOwner && token.lemmaId}
       <div class="sp-status" role="group" aria-label="Mark status">
         <button

--- a/apps/web/src/lib/components/reader/WordPopup.test.ts
+++ b/apps/web/src/lib/components/reader/WordPopup.test.ts
@@ -134,4 +134,28 @@ describe('WordPopup — number-only token block (T-2.8)', () => {
       document.body.querySelector('[data-testid="word-popup"]'),
     ).not.toBeNull();
   });
+
+  it('shows a reprocess hint for legacy number tokens whose numberForms column is null', () => {
+    // Pre-#340 chapter: the dispatcher auto-created a "1,013,322 / NUM"
+    // lemma row, so lemmaId is set. The popup must NOT render that
+    // bogus lemma block; it must show the reprocess hint instead.
+    render(WordPopup, {
+      token: makeToken({
+        surface: '1,013,322',
+        lemmaId: 'auto-created-lem',
+        numberForms: null,
+      }),
+      language: 'hi',
+      isOwner: true,
+      onClose: vi.fn(),
+    });
+    expect(
+      document.body.querySelector('[data-testid="number-needs-reprocess"]'),
+    ).not.toBeNull();
+    // No misleading "Lemma 1,013,322" / status / translations / Fix.
+    expect(document.body.querySelector('.sp-row')).toBeNull();
+    expect(document.body.querySelector('.sp-status')).toBeNull();
+    expect(document.body.querySelector('.translations')).toBeNull();
+    expect(document.body.querySelector('.fix-toggle')).toBeNull();
+  });
 });

--- a/apps/web/src/lib/components/reader/WordTooltip.svelte
+++ b/apps/web/src/lib/components/reader/WordTooltip.svelte
@@ -10,7 +10,11 @@
 -->
 <script lang="ts">
   import type { LanguageCode } from '@ciareader/shared-types';
-  import type { ServerToken, ServerNumberLanguageForm } from './types.js';
+  import {
+    looksLikeNumberToken,
+    type ServerToken,
+    type ServerNumberLanguageForm,
+  } from './types.js';
   import { placeTooltip, type AnchorRect } from './tooltip-position.js';
 
   interface Props {
@@ -37,6 +41,15 @@
             ? token.numberForms.odia
             : null
       : null,
+  );
+
+  // T-2.8: legacy data fallback. The chapter was processed before the
+  // worker started writing number_forms, so we have no spelled-out
+  // payload — but we can at least recognize the surface as a number
+  // and stop the tooltip from claiming "No translations" / "No
+  // dictionary match", which is misleading.
+  const isLegacyNumber = $derived(
+    !token.numberForms && looksLikeNumberToken(token.surface),
   );
 
   let tipEl: HTMLDivElement | null = $state(null);
@@ -104,8 +117,9 @@
     <!-- T-2.8: for number tokens the romanization field carries the
          literal digit string ("123" → "123") which is just noise in
          the head; suppress it and let the spelled-out form below do
-         the work. -->
-    {#if token.romanization && !numberForm}
+         the work. Same suppression for legacy number tokens whose
+         numberForms payload is missing. -->
+    {#if token.romanization && !numberForm && !isLegacyNumber}
       <span class="tip-roman">{token.romanization}</span>
     {/if}
   </div>
@@ -117,6 +131,8 @@
       {numberForm.spelled}
       <span class="tip-roman num-roman">{numberForm.romanized}</span>
     </div>
+  {:else if isLegacyNumber}
+    <div class="tip-def empty" data-testid="legacy-number">Number</div>
   {:else if token.isOov}
     <!-- T-5.20: surface the top translation when we have one, fall
          back to an italic "No translations" otherwise so the user

--- a/apps/web/src/lib/components/reader/WordTooltip.test.ts
+++ b/apps/web/src/lib/components/reader/WordTooltip.test.ts
@@ -172,4 +172,23 @@ describe('WordTooltip — number tokens (T-2.8)', () => {
     const def = document.body.querySelector('.tip-def');
     expect(def?.classList.contains('empty')).toBe(true);
   });
+
+  it('marks legacy number tokens (no numberForms payload) as a Number rather than "No translations"', () => {
+    render(WordTooltip, {
+      token: makeToken({
+        surface: '1,013,322',
+        // Pre-#340 chapter: dispatcher auto-created a lemma. Without
+        // the legacy detection the tooltip would fall through to "No
+        // translations" (lemmaId set + glossDefault null).
+        lemmaId: 'auto-created-lem',
+        numberForms: null,
+      }),
+      anchorRect: ANCHOR,
+      language: 'hi',
+    });
+    expect(
+      document.body.querySelector('[data-testid="legacy-number"]'),
+    ).not.toBeNull();
+    expect(document.body.querySelector('.tip-def')?.textContent).toBe('Number');
+  });
 });

--- a/apps/web/src/lib/components/reader/types.test.ts
+++ b/apps/web/src/lib/components/reader/types.test.ts
@@ -1,6 +1,47 @@
 import { describe, expect, it } from 'vitest';
 
-import { STATUS_TO_CODE, paragraphsOfTokens, statusToCode, tokenize } from './types.js';
+import {
+  STATUS_TO_CODE,
+  looksLikeNumberToken,
+  paragraphsOfTokens,
+  statusToCode,
+  tokenize,
+} from './types.js';
+
+describe('looksLikeNumberToken (T-2.8)', () => {
+  it.each([
+    '0',
+    '123',
+    '1,000',
+    '12,345',
+    '1,00,000',
+    '1,234,567',
+    '१२३',
+    '१,२३४',
+    '१,००,०००',
+    '୧୨୩',
+    '୧,୨୩୪',
+  ])('accepts %s', (s) => {
+    expect(looksLikeNumberToken(s)).toBe(true);
+  });
+
+  it.each([
+    '',
+    'abc',
+    '12a',
+    '१23', // mixed script
+    '1२3',
+    '1,२३४', // mixed script across comma groups
+    '-1',
+    '1.5',
+    ',1',
+    '1,',
+    '1,,000',
+    ',',
+  ])('rejects %s', (s) => {
+    expect(looksLikeNumberToken(s)).toBe(false);
+  });
+});
 
 describe('tokenize', () => {
   it('splits on word boundaries while preserving whitespace + punctuation', () => {

--- a/apps/web/src/lib/components/reader/types.ts
+++ b/apps/web/src/lib/components/reader/types.ts
@@ -21,6 +21,29 @@ export type ServerCandidate = {
   features: Record<string, string>;
 };
 
+/** T-2.8: cheap surface-level detector — does this token *look* like a
+ *  digit-only number, possibly with thousands / lakh separators?
+ *  Latin (0–9), Devanagari (०–९), and Odia (୦–୯) digit ranges all
+ *  qualify. Mixed-script doesn't. Used both by the dispatcher (skip
+ *  lemma auto-create for these surfaces so the lemmas table doesn't
+ *  fill with "1,013,322"-style entries) and by the popup / tooltip
+ *  (treat as a number even when the older `numberForms` column is
+ *  null because the chapter was processed before the comma fix
+ *  landed). The full Python parser in `services/nlp/app/numbers.py`
+ *  is the source of truth for actually generating the spelled-out
+ *  forms; this helper just gates UI branching on the client. */
+// Each alternation pins a single script across all comma-separated
+// groups so mixed-script input ("1,२३४") doesn't sneak through.
+const _NUMBER_RE =
+  /^(?:[0-9]+(?:,[0-9]+)*|[०-९]+(?:,[०-९]+)*|[୦-୯]+(?:,[୦-୯]+)*)$/u;
+export function looksLikeNumberToken(surface: string): boolean {
+  if (!surface) return false;
+  // Reject leading / trailing comma without paying for a regex run.
+  if (surface.startsWith(',') || surface.endsWith(',')) return false;
+  if (surface.includes(',,')) return false;
+  return _NUMBER_RE.test(surface);
+}
+
 /** T-2.8: per-language spelled-out + ISO 15919 romanization for a
  *  digit-only NUM token. Mirrors `RenderedNumberForms` in
  *  `$lib/server/texts/tokens.ts`. */

--- a/apps/web/src/lib/server/texts/in-process-dispatcher.test.ts
+++ b/apps/web/src/lib/server/texts/in-process-dispatcher.test.ts
@@ -313,6 +313,63 @@ describe('processTextNow', () => {
     expect(tokenInsert[0]!.surface).toBe('है');
   });
 
+  it('does not auto-create a lemma row for digit-only number tokens (T-2.8)', async () => {
+    // Stanza tags "1,013,322" as NUM with lemma=surface. Without the
+    // looksLikeNumberToken short-circuit, ensureLemma would write a
+    // "1,013,322 / NUM" row to the lemmas table, and the popup would
+    // pull that row instead of (or in addition to) the spelled-out
+    // number_forms payload — which is what triggered the user-visible
+    // "Lemma 1013,3" bug. The dispatcher must skip lemma resolution
+    // for this surface and leave lemma_id null.
+    stage([{ id: 'text-1', language: 'hi' }]);
+    stage([{ id: 'chap-1', body: 'about 1,013,322 people' }]);
+    stage([]); // empty lemma index
+    stage([]); // empty overrides
+
+    nlpProcess.mockResolvedValueOnce({
+      language: 'hi',
+      pipeline_id: 'stanza-hi',
+      tokens: [
+        {
+          idx: 0,
+          surface: '1,013,322',
+          is_word: true,
+          is_ambiguous: false,
+          is_oov: false,
+          romanization: '1,013,322',
+          number_forms: {
+            value: 1_013_322,
+            digits_latin: '1,013,322',
+            digits_deva: '१,०१३,३२२',
+            digits_orya: '୧,୦୧୩,୩୨୨',
+            hi: { spelled: 'दस लाख तेरह हज़ार तीन सौ बाईस', romanized: 'das lākh terah hazār tīn sau bāīs' },
+            mr: { spelled: 'दहा लाख तेरा हजार तीनशे बावीस', romanized: 'dahā lākha tērā hajāra tīnaśē bāvīsa' },
+            odia: { spelled: 'ଦଶ ଲକ୍ଷ ତେର ହଜାର ତିନି ଶହ ବାଇଶ', romanized: 'daśa lakṣa tēra hajāra tini śaha bāiśa' },
+          },
+          candidates: [
+            { lemma: '1,013,322', pos: 'NUM', score: 1.0, features: {} },
+          ],
+        },
+      ],
+    });
+
+    await processTextNow('text-1');
+
+    const inserts = calls.filter(
+      (c): c is Extract<Call, { kind: 'insert' }> => c.kind === 'insert',
+    );
+    // Just the text_tokens batch — no auto-created lemma row.
+    expect(inserts).toHaveLength(1);
+    const tokenInsert = inserts[0]!.values as Array<{
+      lemmaId: string | null;
+      surface: string;
+      numberForms: { value: number } | null;
+    }>;
+    expect(tokenInsert[0]!.lemmaId).toBeNull();
+    expect(tokenInsert[0]!.surface).toBe('1,013,322');
+    expect(tokenInsert[0]!.numberForms?.value).toBe(1_013_322);
+  });
+
   it('marks the text failed when the NLP service throws', async () => {
     stage([{ id: 'text-1', language: 'hi' }]);
     stage([{ id: 'chap-1', body: 'oops' }]);

--- a/apps/web/src/lib/server/texts/in-process-dispatcher.ts
+++ b/apps/web/src/lib/server/texts/in-process-dispatcher.ts
@@ -24,6 +24,7 @@ import { and, eq } from 'drizzle-orm';
 
 import { db, schema } from '../db/index.js';
 import { nlpClient, type NlpToken } from '../nlp-client.js';
+import { looksLikeNumberToken } from '$lib/components/reader/types.js';
 import type {
   Lemma,
   Text,
@@ -198,6 +199,13 @@ async function pickLemmaId(
   index: LemmaIndex,
 ): Promise<string | null> {
   if (!token.is_word) return null;
+  // T-2.8: digit-only surfaces (with or without comma separators)
+  // get rendered as numbers in the popup, not as lemmas. Skip lemma
+  // resolution + auto-create for them so the lemmas table doesn't
+  // collect "1,013,322 / NUM" rows the curator has to clean up later.
+  // The number_forms column on the token row carries the per-language
+  // spelled-out payload that drives the popup.
+  if (looksLikeNumberToken(token.surface)) return null;
   // T-2.7: form_lemma_overrides wins over Stanza. Curator seeds for
   // treebank quirks (Hindi finite copulas → होना and friends) +
   // T-6.7's crowdsourced promotions land here. The lookup is keyed


### PR DESCRIPTION
Reported on the post-#340 build: clicking a large number like \`1,013,322\` or \`2,965,309\` in the reader popped up "Lemma 1013,3" / "Part of speech NUM" instead of the spelled-out forms.

## Root cause

Two compounding problems:

1. **In-process dispatcher's \`pickLemmaId\` auto-created a lemma row for every is_word=true token whose candidate didn't match the dictionary.** Stanza tags NUM tokens as is_word=true with lemma=surface, so the dispatcher would write a "1,013,322 / NUM" row into \`lemmas\` and the popup would render that bogus row's lemma block instead of the number block. The lemmas table accumulates junk rows the curator has to prune.

2. **Chapters processed before #340 landed have \`number_forms = NULL\` on disk.** Even after the parser fix, those legacy tokens still have \`lemma_id\` pointing at the bogus auto-created row, so the popup falls through to the lemma block instead of the number block.

## Fix

- Shared \`looksLikeNumberToken(surface)\` helper in \`apps/web/src/lib/components/reader/types.ts\` — single source of truth, used by both the dispatcher and the popup / tooltip. Per-script comma groups (Latin, Devanagari, Odia); rejects mixed-script-across-comma-groups, leading / trailing / doubled commas.
- \`pickLemmaId\` short-circuits to \`null\` when \`looksLikeNumberToken(token.surface)\` matches. No more auto-created NUM lemmas.
- \`WordPopup\` branches: \`numberForms\` set → existing block, else if surface looks like a number → reprocess hint and suppress the lemma row / status / translations / Fix, else existing flow.
- \`WordTooltip\` mirrors: legacy number tokens render "Number" instead of the misleading "No translations".

## Reprocessing existing texts

The dispatcher fix only affects newly-processed chapters. Texts uploaded before #340 still have stale rows in the DB. Owners can hit the existing T-6.8 admin reprocess endpoint, or the legacy popup / tooltip paths gracefully degrade to the reprocess hint.

## Tests

- 22 cases on \`looksLikeNumberToken\` (each script, comma groups, mixed-script reject).
- Popup test for the legacy-number reprocess hint.
- Tooltip test for the "Number" copy on legacy tokens.
- Dispatcher test asserting no auto-created lemma row when surface is digit-only.

vitest 1020 / 1020, svelte-check clean.

Refs #304, #313, #340.