### PR TITLE
T-12.1: OpenAPI 3.1 docs

### DIFF
--- a/apps/web/src/lib/server/openapi/generator.test.ts
+++ b/apps/web/src/lib/server/openapi/generator.test.ts
@@ -1,0 +1,33 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+
+import {
+  discoverSvelteKitApiOperations,
+  generateOpenApiDocument,
+} from './generator.js';
+
+describe('OpenAPI generator', () => {
+  it('emits OpenAPI 3.1 with web and NLP paths', async () => {
+    const doc = await generateOpenApiDocument();
+
+    expect(doc.openapi).toBe('3.1.0');
+    expect(doc.paths['/api/v1/auth/login']?.post).toBeDefined();
+    expect(doc.paths['/api/v1/me/profile']?.get).toBeDefined();
+    expect(doc.paths['/nlp/process']?.post).toBeDefined();
+  });
+
+  it('represents every exported SvelteKit API handler with schemas', async () => {
+    const operations = await discoverSvelteKitApiOperations();
+    const doc = await generateOpenApiDocument();
+
+    expect(operations.length).toBeGreaterThan(40);
+    for (const op of operations) {
+      const documented = doc.paths[op.path]?.[op.method];
+      expect(documented, `${op.method.toUpperCase()} ${op.path}`).toBeDefined();
+      expect(documented?.responses).toBeDefined();
+      if (op.method !== 'get' && op.method !== 'delete') {
+        expect(documented?.requestBody).toBeDefined();
+      }
+    }
+  });
+});

--- a/apps/web/src/lib/server/openapi/generator.ts
+++ b/apps/web/src/lib/server/openapi/generator.ts
@@ -1,0 +1,387 @@
+/**
+ * OpenAPI generator (T-12.1).
+ *
+ * The v1 API surface is defined by SvelteKit route files. Rather than keep a
+ * parallel hand-written path list, this generator scans `src/routes/api/v1`
+ * for exported HTTP handlers and emits an OpenAPI 3.1 operation for each one.
+ * Route-specific Zod schemas still live beside handlers today; M12's later
+ * contract tests can tighten individual JSON shapes without losing this
+ * coverage guard.
+ */
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HTTP_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'] as const;
+type HttpMethod = (typeof HTTP_METHODS)[number];
+
+type JsonSchema = Record<string, unknown>;
+
+export type OpenApiDocument = {
+  openapi: '3.1.0';
+  info: {
+    title: string;
+    version: string;
+    description: string;
+  };
+  servers: Array<{ url: string; description: string }>;
+  tags: Array<{ name: string; description: string }>;
+  components: {
+    securitySchemes: Record<string, JsonSchema>;
+    schemas: Record<string, JsonSchema>;
+    responses: Record<string, JsonSchema>;
+  };
+  paths: Record<string, Record<string, JsonSchema>>;
+};
+
+export type RouteOperation = {
+  file: string;
+  path: string;
+  method: Lowercase<HttpMethod>;
+  operationId: string;
+};
+
+const WEB_ROOT = path.resolve(
+  fileURLToPath(new URL('../../../..', import.meta.url)),
+);
+const V1_ROUTES_DIR = path.join(WEB_ROOT, 'src/routes/api/v1');
+
+const jsonContent = {
+  'application/json': {
+    schema: { $ref: '#/components/schemas/JsonObject' },
+  },
+};
+
+function routeSegmentToOpenApi(segment: string): string {
+  if (segment.startsWith('[...') && segment.endsWith(']')) {
+    return `{${segment.slice(4, -1)}}`;
+  }
+  if (segment.startsWith('[') && segment.endsWith(']')) {
+    return `{${segment.slice(1, -1)}}`;
+  }
+  return segment;
+}
+
+function routeFileToPath(file: string): string {
+  const rel = path.relative(path.join(WEB_ROOT, 'src/routes'), file);
+  const parts = rel.split(path.sep).slice(0, -1).map(routeSegmentToOpenApi);
+  return `/${parts.join('/')}`;
+}
+
+function operationIdFor(apiPath: string, method: string): string {
+  const suffix = apiPath
+    .replace(/^\/api\//, '')
+    .replace(/[{}]/g, '')
+    .split('/')
+    .filter(Boolean)
+    .map((part) => part.replace(/[^a-zA-Z0-9]+/g, ' '))
+    .flatMap((part) => part.split(' '))
+    .filter(Boolean)
+    .map((part) => part[0]!.toUpperCase() + part.slice(1))
+    .join('');
+  return `${method.toLowerCase()}${suffix}`;
+}
+
+function tagFor(apiPath: string): string {
+  const parts = apiPath.split('/').filter(Boolean);
+  if (parts[2] === 'admin') return 'Admin';
+  if (parts[2] === 'auth') return 'Auth';
+  if (parts[2] === 'me') return 'Me';
+  if (parts[2] === 'texts') return 'Texts';
+  if (parts[2] === 'collections') return 'Collections';
+  if (parts[2] === 'groups') return 'Groups';
+  if (parts[2] === 'dictionary' || parts[2] === 'lemmas') return 'Dictionary';
+  if (parts[2] === 'translations') return 'Translations';
+  if (parts[2] === 'audio') return 'Audio';
+  return 'System';
+}
+
+function summaryFor(apiPath: string, method: string): string {
+  const humanPath = apiPath
+    .replace(/^\/api\/v1\//, '')
+    .replace(/[{}]/g, '')
+    .replace(/[-/]/g, ' ');
+  return `${method.toUpperCase()} ${humanPath}`;
+}
+
+async function walk(dir: string): Promise<string[]> {
+  const out: string[] = [];
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const abs = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...(await walk(abs)));
+    } else if (entry.name === '+server.ts') {
+      out.push(abs);
+    }
+  }
+  return out.sort();
+}
+
+export async function discoverSvelteKitApiOperations(
+  rootDir: string = V1_ROUTES_DIR,
+): Promise<RouteOperation[]> {
+  const files = await walk(rootDir);
+  const operations: RouteOperation[] = [];
+  for (const file of files) {
+    const source = await readFile(file, 'utf8');
+    const apiPath = routeFileToPath(file);
+    for (const method of HTTP_METHODS) {
+      if (new RegExp(`export\\s+const\\s+${method}\\b`).test(source)) {
+        operations.push({
+          file,
+          path: apiPath,
+          method: method.toLowerCase() as Lowercase<HttpMethod>,
+          operationId: operationIdFor(apiPath, method),
+        });
+      }
+    }
+  }
+  return operations;
+}
+
+function requestBodyFor(method: string): JsonSchema | undefined {
+  if (method === 'get' || method === 'delete') return undefined;
+  return {
+    required: true,
+    content: jsonContent,
+  };
+}
+
+function responsesFor(method: string): JsonSchema {
+  const successStatus = method === 'post' ? '201' : '200';
+  const responses: JsonSchema = {
+    [successStatus]: {
+      description: 'Successful response',
+      content: jsonContent,
+    },
+    '400': { $ref: '#/components/responses/BadRequest' },
+    '401': { $ref: '#/components/responses/Unauthorized' },
+    '403': { $ref: '#/components/responses/Forbidden' },
+    '404': { $ref: '#/components/responses/NotFound' },
+  };
+  if (method === 'delete') {
+    delete responses[successStatus];
+    responses['204'] = { description: 'Deleted' };
+  }
+  return responses;
+}
+
+function operationFor(op: RouteOperation): JsonSchema {
+  const requestBody = requestBodyFor(op.method);
+  return {
+    operationId: op.operationId,
+    tags: [tagFor(op.path)],
+    summary: summaryFor(op.path, op.method),
+    description:
+      'Generated from the matching SvelteKit API route. Endpoint-specific request validation is implemented with local Zod schemas in the route/service layer.',
+    security: [{ bearerAuth: [] }, { cookieAuth: [] }],
+    ...(requestBody ? { requestBody } : {}),
+    responses: responsesFor(op.method),
+    'x-source-file': path.relative(WEB_ROOT, op.file),
+  };
+}
+
+function nlpOperations(): Record<string, Record<string, JsonSchema>> {
+  return {
+    '/nlp/health': {
+      get: {
+        operationId: 'getNlpHealth',
+        tags: ['NLP'],
+        summary: 'GET NLP health',
+        description: 'FastAPI NLP service health endpoint.',
+        responses: {
+          '200': {
+            description: 'NLP service status and supported language codes',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/NlpHealthResponse' },
+              },
+            },
+          },
+        },
+        'x-source-file': 'services/nlp/app/main.py',
+      },
+    },
+    '/nlp/process': {
+      post: {
+        operationId: 'postNlpProcess',
+        tags: ['NLP'],
+        summary: 'POST NLP process',
+        description:
+          'FastAPI endpoint that tokenizes and lemmatizes supported language text.',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/NlpProcessRequest' },
+            },
+          },
+        },
+        responses: {
+          '200': {
+            description: 'Processed token payload',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/NlpProcessResponse' },
+              },
+            },
+          },
+          '400': { $ref: '#/components/responses/BadRequest' },
+          '422': { $ref: '#/components/responses/ValidationError' },
+        },
+        'x-source-file': 'services/nlp/app/main.py',
+      },
+    },
+  };
+}
+
+export async function generateOpenApiDocument(): Promise<OpenApiDocument> {
+  const operations = await discoverSvelteKitApiOperations();
+  const paths: OpenApiDocument['paths'] = {};
+  for (const op of operations) {
+    paths[op.path] ??= {};
+    paths[op.path]![op.method] = operationFor(op);
+  }
+  Object.assign(paths, nlpOperations());
+
+  return {
+    openapi: '3.1.0',
+    info: {
+      title: 'CIA Reader API',
+      version: '1.0.0',
+      description:
+        'Stable v1 web/mobile API plus the internal NLP FastAPI service surface.',
+    },
+    servers: [
+      { url: '/', description: 'CIA Reader web app' },
+      { url: 'http://nlp:8000', description: 'NLP service in docker compose' },
+    ],
+    tags: [
+      { name: 'Auth', description: 'Login, registration, token refresh' },
+      { name: 'Me', description: 'Authenticated user profile and learning data' },
+      { name: 'Texts', description: 'Text upload, status, chapters, sharing' },
+      { name: 'Collections', description: 'Collections, course items, sharing' },
+      { name: 'Groups', description: 'Groups and memberships' },
+      { name: 'Dictionary', description: 'Dictionary and lemma lookups' },
+      { name: 'Translations', description: 'Community translation endpoints' },
+      { name: 'Audio', description: 'Audio files and alignments' },
+      { name: 'Admin', description: 'Admin and curator endpoints' },
+      { name: 'NLP', description: 'FastAPI NLP service endpoints' },
+      { name: 'System', description: 'Smoke and health endpoints' },
+    ],
+    components: {
+      securitySchemes: {
+        bearerAuth: { type: 'http', scheme: 'bearer', bearerFormat: 'JWT' },
+        cookieAuth: { type: 'apiKey', in: 'cookie', name: 'ciar_session' },
+      },
+      responses: {
+        BadRequest: {
+          description: 'Invalid request',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/ErrorEnvelope' },
+            },
+          },
+        },
+        Unauthorized: {
+          description: 'Authentication required',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/ErrorEnvelope' },
+            },
+          },
+        },
+        Forbidden: {
+          description: 'Authenticated caller lacks access',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/ErrorEnvelope' },
+            },
+          },
+        },
+        NotFound: {
+          description: 'Resource not found',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/ErrorEnvelope' },
+            },
+          },
+        },
+        ValidationError: {
+          description: 'Request validation failed',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/ErrorEnvelope' },
+            },
+          },
+        },
+      },
+      schemas: {
+        JsonObject: {
+          type: 'object',
+          additionalProperties: true,
+        },
+        ErrorEnvelope: {
+          type: 'object',
+          required: ['message'],
+          properties: {
+            message: { type: 'string' },
+            code: { type: 'string' },
+            issues: { type: 'array', items: { type: 'object' } },
+          },
+          additionalProperties: true,
+        },
+        NlpHealthResponse: {
+          type: 'object',
+          required: ['status', 'languages'],
+          properties: {
+            status: { type: 'string', enum: ['ok'] },
+            languages: {
+              type: 'array',
+              items: { type: 'string', enum: ['hi', 'mr', 'or'] },
+            },
+          },
+        },
+        NlpProcessRequest: {
+          type: 'object',
+          required: ['language', 'text'],
+          properties: {
+            language: { type: 'string', enum: ['hi', 'mr', 'or'] },
+            text: { type: 'string', minLength: 1 },
+          },
+        },
+        NlpProcessResponse: {
+          type: 'object',
+          required: ['language', 'pipeline_id', 'tokens'],
+          properties: {
+            language: { type: 'string' },
+            pipeline_id: { type: 'string' },
+            tokens: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/NlpToken' },
+            },
+          },
+        },
+        NlpToken: {
+          type: 'object',
+          required: ['idx', 'surface', 'is_word', 'candidates'],
+          properties: {
+            idx: { type: 'integer' },
+            surface: { type: 'string' },
+            is_word: { type: 'boolean' },
+            candidates: {
+              type: 'array',
+              items: { type: 'object', additionalProperties: true },
+            },
+            is_ambiguous: { type: 'boolean' },
+            is_oov: { type: 'boolean' },
+            romanization: { type: ['string', 'null'] },
+            number_forms: { type: ['object', 'null'], additionalProperties: true },
+          },
+        },
+      },
+    },
+    paths,
+  };
+}

--- a/apps/web/src/routes/api/docs/+page.svelte
+++ b/apps/web/src/routes/api/docs/+page.svelte
@@ -1,0 +1,255 @@
+<svelte:head>
+  <title>API Docs — CIA Reader</title>
+  <meta
+    name="description"
+    content="CIA Reader OpenAPI 3.1 reference for v1 web/mobile clients."
+  />
+  <link
+    rel="stylesheet"
+    href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css"
+  />
+</svelte:head>
+
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  const specUrl = '/api/openapi.json';
+  const swaggerScriptUrl =
+    'https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js';
+
+  type SwaggerUIBundle = (config: {
+    url: string;
+    dom_id: string;
+    deepLinking: boolean;
+    layout: string;
+  }) => unknown;
+
+  type ApiOperation = {
+    operationId?: string;
+    summary?: string;
+    tags?: string[];
+  };
+
+  type ApiSpec = {
+    paths: Record<string, Record<string, ApiOperation>>;
+  };
+
+  type Row = {
+    method: string;
+    path: string;
+    summary: string;
+    tag: string;
+  };
+
+  let rows = $state<Row[]>([]);
+  let error = $state<string | null>(null);
+  let swaggerMounted = $state(false);
+
+  function loadScript(src: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const existing = document.querySelector(`script[src="${src}"]`);
+      if (existing) {
+        resolve();
+        return;
+      }
+
+      const script = document.createElement('script');
+      script.src = src;
+      script.async = true;
+      script.addEventListener('load', () => resolve(), { once: true });
+      script.addEventListener(
+        'error',
+        () => reject(new Error('Swagger UI failed to load')),
+        { once: true },
+      );
+      document.head.append(script);
+    });
+  }
+
+  async function loadFallbackRows() {
+    const res = await fetch(specUrl);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const spec = (await res.json()) as ApiSpec;
+    rows = Object.entries(spec.paths)
+      .flatMap(([path, methods]) =>
+        Object.entries(methods).map(([method, op]) => ({
+          method: method.toUpperCase(),
+          path,
+          summary: op.summary ?? op.operationId ?? path,
+          tag: op.tags?.[0] ?? 'API',
+        })),
+      )
+      .sort(
+        (a, b) =>
+          a.path.localeCompare(b.path) || a.method.localeCompare(b.method),
+      );
+  }
+
+  onMount(() => {
+    void (async () => {
+      try {
+        await loadScript(swaggerScriptUrl);
+        const swaggerWindow = window as typeof globalThis & {
+          SwaggerUIBundle?: SwaggerUIBundle;
+        };
+        swaggerWindow.SwaggerUIBundle?.({
+          url: specUrl,
+          dom_id: '#swagger-ui',
+          deepLinking: true,
+          layout: 'BaseLayout',
+        });
+        swaggerMounted = true;
+      } catch (e) {
+        try {
+          await loadFallbackRows();
+        } catch (fallbackError) {
+          error =
+            fallbackError instanceof Error
+              ? fallbackError.message
+              : (e as Error).message;
+        }
+      }
+    })();
+  });
+</script>
+
+<main class="api-docs">
+  <header>
+    <div>
+      <p class="eyebrow">OpenAPI 3.1</p>
+      <h1>CIA Reader API</h1>
+    </div>
+    <a href={specUrl}>JSON</a>
+  </header>
+
+  <section class="viewer" aria-label="OpenAPI reference">
+    <div id="swagger-ui" class:mounted={swaggerMounted}></div>
+
+    {#if swaggerMounted}
+      <span class="sr-only">Swagger UI loaded</span>
+    {:else if error}
+      <p class="empty">Could not load OpenAPI spec: {error}</p>
+    {:else if rows.length === 0}
+      <p class="empty">Loading…</p>
+    {:else}
+      <table>
+        <thead>
+          <tr>
+            <th>Method</th>
+            <th>Path</th>
+            <th>Area</th>
+            <th>Summary</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each rows as row (`${row.method}-${row.path}`)}
+            <tr>
+              <td><span class="method">{row.method}</span></td>
+              <td><code>{row.path}</code></td>
+              <td>{row.tag}</td>
+              <td>{row.summary}</td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    {/if}
+  </section>
+</main>
+
+<style>
+  .api-docs {
+    min-height: 100vh;
+    background: var(--paper, var(--color-bg));
+    color: var(--ink, var(--color-fg));
+  }
+  header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 1rem 1.25rem;
+    border-bottom: 1px solid var(--rule, var(--color-border));
+  }
+  h1 {
+    margin: 0.1rem 0 0;
+    font-size: 1.25rem;
+    font-family: var(--font-serif, system-ui);
+  }
+  .eyebrow {
+    margin: 0;
+    font-size: 0.68rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--ink-3, var(--color-fg-muted));
+  }
+  a {
+    color: inherit;
+    text-decoration: none;
+    border: 1px solid var(--rule, var(--color-border));
+    border-radius: 7px;
+    padding: 0.4rem 0.65rem;
+    font-size: 0.82rem;
+  }
+  .viewer {
+    padding: 0 0 2rem;
+    overflow-x: auto;
+  }
+  #swagger-ui {
+    display: none;
+  }
+  #swagger-ui.mounted {
+    display: block;
+  }
+  table {
+    margin: 1rem 1.25rem 0;
+    width: calc(100% - 2.5rem);
+    border-collapse: collapse;
+    background: var(--card, var(--color-bg));
+    border: 1px solid var(--rule, var(--color-border));
+  }
+  th,
+  td {
+    padding: 0.55rem 0.7rem;
+    border-bottom: 1px solid var(--rule-2, var(--color-border));
+    text-align: left;
+    font-size: 0.84rem;
+    vertical-align: top;
+  }
+  th {
+    font-size: 0.72rem;
+    color: var(--ink-3, var(--color-fg-muted));
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    background: color-mix(in oklch, var(--ink, var(--color-fg)) 4%, transparent);
+  }
+  code {
+    font-family: var(--font-mono-display, var(--font-mono));
+    font-size: 0.78rem;
+    white-space: nowrap;
+  }
+  .method {
+    display: inline-flex;
+    min-width: 4.2rem;
+    justify-content: center;
+    border-radius: 7px;
+    border: 1px solid var(--rule, var(--color-border));
+    padding: 0.15rem 0.35rem;
+    font-family: var(--font-mono-display, var(--font-mono));
+    font-size: 0.7rem;
+  }
+  .empty {
+    color: var(--ink-3, var(--color-fg-muted));
+    padding: 1rem 1.25rem;
+  }
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+</style>

--- a/apps/web/src/routes/api/openapi.json/+server.ts
+++ b/apps/web/src/routes/api/openapi.json/+server.ts
@@ -1,0 +1,13 @@
+import { json } from '@sveltejs/kit';
+
+import { generateOpenApiDocument } from '$lib/server/openapi/generator.js';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async () => {
+  const doc = await generateOpenApiDocument();
+  return json(doc, {
+    headers: {
+      'cache-control': 'public, max-age=300',
+    },
+  });
+};

--- a/apps/web/src/routes/api/openapi.json/openapi-json-server.test.ts
+++ b/apps/web/src/routes/api/openapi.json/openapi-json-server.test.ts
@@ -1,0 +1,19 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+
+type GetFn = (typeof import('./+server.js'))['GET'];
+
+describe('GET /api/openapi.json', () => {
+  it('serves the generated OpenAPI document', async () => {
+    const { GET } = await import('./+server.js');
+    const res = (await GET({
+      request: new Request('http://x/api/openapi.json'),
+    } as unknown as Parameters<GetFn>[0])) as Response;
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('cache-control')).toContain('max-age=300');
+    const body = await res.json();
+    expect(body.openapi).toBe('3.1.0');
+    expect(body.paths['/api/v1/smoke'].get).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add an OpenAPI 3.1 generator for SvelteKit v1 API routes plus the FastAPI NLP service
- publish `/api/openapi.json` and a Swagger UI-backed `/api/docs` page with a table fallback
- add CI-coverable tests that fail when an exported SvelteKit API handler is missing from the generated spec

## Tests
- `pnpm --filter @ciareader/web test -- generator.test.ts openapi-json-server.test.ts`
- `pnpm --filter @ciareader/web check`
- `pnpm --filter @ciareader/web lint`
- `pnpm --filter @ciareader/web build`

Closes #103