### PR TITLE
Dispatcher lemma resolution: nukta-agnostic fallback (stacked on #342)

### DIFF
--- a/apps/web/src/lib/server/texts/in-process-dispatcher.test.ts
+++ b/apps/web/src/lib/server/texts/in-process-dispatcher.test.ts
@@ -370,6 +370,144 @@ describe('processTextNow', () => {
     expect(tokenInsert[0]!.numberForms?.value).toBe(1_013_322);
   });
 
+  it('resolves a post-#316 nukta candidate onto an existing pre-#316 lemma row (#320)', async () => {
+    // The transition scenario: the lemmas table has an old `पढना`
+    // (no nukta) row from before the lemma-restoration fix.
+    // Post-fix, the NLP pipeline emits `पढ़ना` (with nukta) as the
+    // candidate. Without the third tier the dispatcher would
+    // mint a duplicate row and split known-words tracking.
+    stage([{ id: 'text-1', language: 'hi' }]);
+    stage([{ id: 'chap-1', body: 'वह पढ़ती है।' }]);
+    // lemma index: only the pre-#316 row exists.
+    stage([{ id: 'lemma-padhna-old', headword: 'पढना', pos: 'VERB' }]);
+    stage([]); // form_lemma_overrides
+
+    nlpProcess.mockResolvedValueOnce({
+      language: 'hi',
+      pipeline_id: 'stanza-hi',
+      tokens: [
+        {
+          idx: 0,
+          surface: 'पढ़ती',
+          is_word: true,
+          is_ambiguous: false,
+          is_oov: false,
+          romanization: 'paṛhtī',
+          // Post-#316 lemma carries the nukta — strict-POS and
+          // loose-headword tiers both miss the `पढना` row; the
+          // nukta-stripped tier catches it.
+          candidates: [
+            { lemma: 'पढ़ना', pos: 'VERB', score: 1.0, features: {} },
+          ],
+        },
+      ],
+    });
+
+    await processTextNow('text-1');
+
+    const inserts = calls.filter(
+      (c): c is Extract<Call, { kind: 'insert' }> => c.kind === 'insert',
+    );
+    // One insert: the text_tokens batch. No ensureLemma path —
+    // the third tier already had the answer.
+    expect(inserts).toHaveLength(1);
+    const tokenInsert = inserts[0]!.values as Array<{
+      lemmaId: string | null;
+      surface: string;
+    }>;
+    expect(tokenInsert[0]!.lemmaId).toBe('lemma-padhna-old');
+  });
+
+  it('resolves a pre-#316 nukta-free candidate onto an existing canonical lemma row (#320)', async () => {
+    // Inverse: lemma table has the canonical `पढ़ना` row, but the
+    // candidate this run produced lacks the nukta (could be a
+    // legacy text re-process after the fix landed but before the
+    // pipeline was rolled out, or a fallback path elsewhere). Same
+    // tier collapse — third tier matches both directions.
+    stage([{ id: 'text-1', language: 'hi' }]);
+    stage([{ id: 'chap-1', body: 'पढती है।' }]);
+    stage([{ id: 'lemma-padhna-canon', headword: 'पढ़ना', pos: 'VERB' }]);
+    stage([]); // overrides
+
+    nlpProcess.mockResolvedValueOnce({
+      language: 'hi',
+      pipeline_id: 'stanza-hi',
+      tokens: [
+        {
+          idx: 0,
+          surface: 'पढती',
+          is_word: true,
+          is_ambiguous: false,
+          is_oov: false,
+          romanization: 'paṛhtī',
+          candidates: [
+            { lemma: 'पढना', pos: 'VERB', score: 1.0, features: {} },
+          ],
+        },
+      ],
+    });
+
+    await processTextNow('text-1');
+
+    const inserts = calls.filter(
+      (c): c is Extract<Call, { kind: 'insert' }> => c.kind === 'insert',
+    );
+    expect(inserts).toHaveLength(1);
+    const tokenInsert = inserts[0]!.values as Array<{
+      lemmaId: string | null;
+    }>;
+    expect(tokenInsert[0]!.lemmaId).toBe('lemma-padhna-canon');
+  });
+
+  it('still prefers a strict-POS match over the nukta-stripped tier (#320)', async () => {
+    // Both rows are loaded: one nukta-free `पढना VERB` and one
+    // canonical `पढ़ना VERB`. A candidate that exactly matches the
+    // canonical row's `headword` + `pos` should resolve to it via
+    // the strict tier — the third tier's lossy collapse mustn't
+    // shadow an exact win.
+    stage([{ id: 'text-1', language: 'hi' }]);
+    stage([{ id: 'chap-1', body: 'वह पढ़ती है।' }]);
+    stage([
+      // Insertion order: nukta-free first. The third-tier map
+      // would key both `पढना` and `पढ़ना` to the same stripped
+      // string `पढना` — first-row-wins means the legacy row
+      // would win the third-tier lookup. The strict tier must
+      // beat that for the canonical candidate.
+      { id: 'lemma-padhna-old', headword: 'पढना', pos: 'VERB' },
+      { id: 'lemma-padhna-canon', headword: 'पढ़ना', pos: 'VERB' },
+    ]);
+    stage([]); // overrides
+
+    nlpProcess.mockResolvedValueOnce({
+      language: 'hi',
+      pipeline_id: 'stanza-hi',
+      tokens: [
+        {
+          idx: 0,
+          surface: 'पढ़ती',
+          is_word: true,
+          is_ambiguous: false,
+          is_oov: false,
+          romanization: 'paṛhtī',
+          candidates: [
+            { lemma: 'पढ़ना', pos: 'VERB', score: 1.0, features: {} },
+          ],
+        },
+      ],
+    });
+
+    await processTextNow('text-1');
+
+    const inserts = calls.filter(
+      (c): c is Extract<Call, { kind: 'insert' }> => c.kind === 'insert',
+    );
+    const tokenInsert = inserts[0]!.values as Array<{
+      lemmaId: string | null;
+    }>;
+    // Strict-POS wins → canonical row, not the legacy duplicate.
+    expect(tokenInsert[0]!.lemmaId).toBe('lemma-padhna-canon');
+  });
+
   it('marks the text failed when the NLP service throws', async () => {
     stage([{ id: 'text-1', language: 'hi' }]);
     stage([{ id: 'chap-1', body: 'oops' }]);

--- a/apps/web/src/lib/server/texts/in-process-dispatcher.ts
+++ b/apps/web/src/lib/server/texts/in-process-dispatcher.ts
@@ -19,8 +19,23 @@
  * lookup — useful for the stub pipeline (every candidate `pos:'X'`)
  * and real-world POS disagreements (e.g. Stanza tagging a
  * participle VERB while the dictionary stores ADJ).
+ *
+ * Nukta-agnostic third tier (#320): once #316 landed, the Hindi
+ * pipeline emits `पढ़ना` (with nukta) for verbs whose lemmas Stanza
+ * had previously been stripping. Pre-#316 `lemmas` rows were stored
+ * without the nukta as `पढना`, and a strict `byHeadword` lookup
+ * misses them — `ensureLemma` would mint a duplicate row and split
+ * known-words tracking + translations across two lemma IDs. The
+ * third tier reduces both candidate and stored headword to their
+ * nukta-free form (via `stripNukta` from `@ciareader/shared-types`)
+ * so the two variants collapse to the same key. This is a transition
+ * aid: long-term, a one-shot dedup migration can fold pre-#316
+ * duplicates into the canonical with-nukta row and the tier becomes
+ * a no-op.
  */
 import { and, eq } from 'drizzle-orm';
+
+import { stripNukta } from '@ciareader/shared-types';
 
 import { db, schema } from '../db/index.js';
 import { nlpClient, type NlpToken } from '../nlp-client.js';
@@ -43,6 +58,14 @@ type LemmaIndex = {
   byHeadwordPos: Map<string, string>;
   /** `headword` → id (first row wins). Loose fallback. */
   byHeadword: Map<string, string>;
+  /**
+   * `stripNukta(headword)` → id (first row wins). #320 transition
+   * tier so post-#316 candidates (`पढ़ना`) collapse onto pre-#316
+   * lemma rows (`पढना`) — and vice-versa — instead of triggering
+   * an auto-create. Both directions of the mismatch reduce to the
+   * same nukta-free key.
+   */
+  byNuktaStrippedHeadword: Map<string, string>;
   /**
    * `surface_nfc` → chosen lemma id, applied BEFORE Stanza's
    * candidate is consulted (T-2.7). Curator seeds + crowdsourced
@@ -74,9 +97,19 @@ async function loadLemmaIndex(
   >;
   const byHeadwordPos = new Map<string, string>();
   const byHeadword = new Map<string, string>();
+  const byNuktaStrippedHeadword = new Map<string, string>();
   for (const r of rows) {
     byHeadwordPos.set(`${r.headword} ${r.pos}`, r.id);
     if (!byHeadword.has(r.headword)) byHeadword.set(r.headword, r.id);
+    // Same first-row-wins rule as `byHeadword`. We compute the
+    // stripped key in JS rather than reading the Postgres-side
+    // generated column (#318) so the dispatcher doesn't need a
+    // schema migration for this tier — and the helper is the
+    // single source of truth for the strip rule.
+    const stripped = stripNukta(r.headword);
+    if (!byNuktaStrippedHeadword.has(stripped)) {
+      byNuktaStrippedHeadword.set(stripped, r.id);
+    }
   }
   // T-2.7 overrides — pre-load every wildcard-context row for the
   // language. Signature-keyed rows (T-6.7's aggregation output)
@@ -101,7 +134,12 @@ async function loadLemmaIndex(
       overridesBySurface.set(r.surfaceNfc, r.chosenLemmaId);
     }
   }
-  return { byHeadwordPos, byHeadword, overridesBySurface };
+  return {
+    byHeadwordPos,
+    byHeadword,
+    byNuktaStrippedHeadword,
+    overridesBySurface,
+  };
 }
 
 // Each MVP language has a single canonical script today (multi-script
@@ -120,6 +158,9 @@ function lookupCandidate(
   return (
     index.byHeadwordPos.get(`${c.lemma} ${c.pos}`) ??
     index.byHeadword.get(c.lemma) ??
+    // #320 third tier — collapse nukta variants onto the canonical
+    // row regardless of which side has the nukta.
+    index.byNuktaStrippedHeadword.get(stripNukta(c.lemma)) ??
     null
   );
 }
@@ -164,10 +205,7 @@ async function ensureLemma(
     .returning()) as Lemma[];
 
   if (row) {
-    index.byHeadwordPos.set(`${headword} ${pos}`, row.id);
-    if (!index.byHeadword.has(headword)) {
-      index.byHeadword.set(headword, row.id);
-    }
+    cacheRow(index, headword, pos, row.id);
     return row.id;
   }
 
@@ -184,13 +222,32 @@ async function ensureLemma(
     )
     .limit(1)) as Lemma[];
   if (found) {
-    index.byHeadwordPos.set(`${headword} ${pos}`, found.id);
-    if (!index.byHeadword.has(headword)) {
-      index.byHeadword.set(headword, found.id);
-    }
+    cacheRow(index, headword, pos, found.id);
     return found.id;
   }
   return null;
+}
+
+/**
+ * Refresh the in-memory lemma index after a row is inserted (or
+ * read back from the DB on a race). Centralized so all three tiers
+ * (#320 added the third) stay populated in lockstep — a future
+ * tier addition only has to update this one helper.
+ */
+function cacheRow(
+  index: LemmaIndex,
+  headword: string,
+  pos: string,
+  id: string,
+): void {
+  index.byHeadwordPos.set(`${headword} ${pos}`, id);
+  if (!index.byHeadword.has(headword)) {
+    index.byHeadword.set(headword, id);
+  }
+  const stripped = stripNukta(headword);
+  if (!index.byNuktaStrippedHeadword.has(stripped)) {
+    index.byNuktaStrippedHeadword.set(stripped, id);
+  }
 }
 
 async function pickLemmaId(
@@ -227,6 +284,17 @@ async function pickLemmaId(
   for (const c of token.candidates) {
     const loose = index.byHeadword.get(c.lemma);
     if (loose) return loose;
+  }
+  // #320 nukta-stripped fallback. Catches the post-#316 / pre-#316
+  // mismatch where the candidate's headword has nuktas the stored
+  // row lacks (e.g. candidate `पढ़ना` against pre-fix `पढना`), or
+  // the inverse. Both reduce to the same nukta-free key. Done as a
+  // separate pass so the strict-POS and loose-headword tiers above
+  // always win when they could — the stripped tier is intentionally
+  // lossy (`ज़रा` and `जरा` collapse) so it goes last.
+  for (const c of token.candidates) {
+    const stripped = index.byNuktaStrippedHeadword.get(stripNukta(c.lemma));
+    if (stripped) return stripped;
   }
   // Last resort — auto-create a lemma row from the top candidate so
   // the user can attach translations to it. Stub-pipeline candidates


### PR DESCRIPTION
## Summary

- Adds a third tier `byNuktaStrippedHeadword` to the in-process dispatcher's lemma index (`apps/web/src/lib/server/texts/in-process-dispatcher.ts`). Reduces both candidate and stored headword to their nukta-free form via the shared `stripNukta` helper introduced in #342, so post-#316 candidates (`पढ़ना`) collapse onto pre-#316 lemma rows (`पढना`) — and vice-versa — instead of triggering an `ensureLemma` auto-create that would split known-words tracking + translations across duplicate IDs.
- Order is strict-POS → loose-headword → nukta-stripped. The new tier is intentionally lossy (`ज़रा` and `जरा` collapse) so it only fires when the two stricter tiers couldn't pick a winner. Pinned by a regression test that exercises both rows in the index simultaneously and confirms the strict-POS tier still wins for an exact candidate match.
- Centralized index updates after `ensureLemma` insert / race-recovery into a `cacheRow` helper so all three tiers stay in lockstep when a row lands. A future tier addition only has to update that one helper.
- Transition aid only: long-term, a one-shot dedup migration can fold pre-#316 duplicates into the canonical with-nukta row and this tier becomes a no-op. Tracking that as a future ticket.

## Stacked on #342

The `stripNukta` helper this PR consumes lives on the #342 branch (closes #318). This PR's base is `feat/318-dict-nukta-fallback`; once #342 merges to `main`, I'll rebase this branch and re-target it at `main`. GitHub will show the diff against the stacked base for now.

## Test plan

- [x] `pnpm test` — 1018 tests passed (3 new dispatcher tests covering both directions of the nukta mismatch + a regression test that strict-POS still beats the lossy tier).
- [x] `pnpm run check` — no type errors.
- [x] `pnpm lint` — clean.
- [ ] Manual: trigger a re-process on a text with nukta verbs against a DB that has pre-#316 lemma rows; confirm tokens land on the existing rows, no duplicate auto-creates in `lemmas`.

Closes #320

Refs #316, #318