### PR TITLE
T-14.1 — Phrase + translation schema + service core

### DIFF
--- a/apps/web/drizzle/0026_little_vertigo.sql
+++ b/apps/web/drizzle/0026_little_vertigo.sql
@@ -1,0 +1,73 @@
+CREATE TYPE "public"."translation_target_type" AS ENUM('lemma', 'phrase');--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "phrase_tokens" (
+	"phrase_id" uuid NOT NULL,
+	"position" integer NOT NULL,
+	"surface" text NOT NULL,
+	"lemma_id" uuid,
+	CONSTRAINT "phrase_tokens_phrase_id_position_pk" PRIMARY KEY("phrase_id","position")
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "phrases" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"language" "language" NOT NULL,
+	"surface_normalised" text NOT NULL,
+	"pos" text,
+	"gloss_default" text,
+	"frequency_rank" integer,
+	"source" "translation_source" NOT NULL,
+	"source_attribution" text,
+	"source_id" text,
+	"curator_locked" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "user_known_phrases" (
+	"user_id" uuid NOT NULL,
+	"phrase_id" uuid NOT NULL,
+	"status" "known_lemma_status" DEFAULT 'learning' NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "user_known_phrases_user_id_phrase_id_pk" PRIMARY KEY("user_id","phrase_id")
+);
+--> statement-breakpoint
+ALTER TABLE "translations" ALTER COLUMN "lemma_id" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "translations" ADD COLUMN "target_type" "translation_target_type" DEFAULT 'lemma' NOT NULL;--> statement-breakpoint
+-- T-14.1: target_id is added nullable, backfilled from lemma_id for
+-- every legacy row (target_type='lemma'), then made NOT NULL. This
+-- ordering is required so the migration is safe to apply against
+-- a table that already has rows.
+ALTER TABLE "translations" ADD COLUMN "target_id" uuid;--> statement-breakpoint
+UPDATE "translations" SET "target_id" = "lemma_id" WHERE "target_id" IS NULL;--> statement-breakpoint
+ALTER TABLE "translations" ALTER COLUMN "target_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "user_languages" ADD COLUMN "known_phrases_count_cache" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "phrase_tokens" ADD CONSTRAINT "phrase_tokens_phrase_id_phrases_id_fk" FOREIGN KEY ("phrase_id") REFERENCES "public"."phrases"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "phrase_tokens" ADD CONSTRAINT "phrase_tokens_lemma_id_lemmas_id_fk" FOREIGN KEY ("lemma_id") REFERENCES "public"."lemmas"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "user_known_phrases" ADD CONSTRAINT "user_known_phrases_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "user_known_phrases" ADD CONSTRAINT "user_known_phrases_phrase_id_phrases_id_fk" FOREIGN KEY ("phrase_id") REFERENCES "public"."phrases"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "phrase_tokens_surface_idx" ON "phrase_tokens" USING btree ("surface");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "phrases_language_surface_idx" ON "phrases" USING btree ("language","surface_normalised");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "phrases_language_idx" ON "phrases" USING btree ("language");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "phrases_language_frequency_idx" ON "phrases" USING btree ("language","frequency_rank");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "phrases_source_lookup_idx" ON "phrases" USING btree ("language","source","source_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "user_known_phrases_user_idx" ON "user_known_phrases" USING btree ("user_id","status");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "translations_target_idx" ON "translations" USING btree ("target_type","target_id","source");

--- a/apps/web/drizzle/meta/0026_snapshot.json
+++ b/apps/web/drizzle/meta/0026_snapshot.json
@@ -1,0 +1,4623 @@
+{
+  "id": "247d1be6-ab47-44d2-8417-853a4c9c766f",
+  "prevId": "913e1df8-db10-439b-9a78-ce7c3ab0e15d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audio_alignments": {
+      "name": "audio_alignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "audio_file_id": {
+          "name": "audio_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_ms": {
+          "name": "start_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_ms": {
+          "name": "end_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "alignment_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audio_alignments_timeline_idx": {
+          "name": "audio_alignments_timeline_idx",
+          "columns": [
+            {
+              "expression": "audio_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audio_alignments_audio_file_id_audio_files_id_fk": {
+          "name": "audio_alignments_audio_file_id_audio_files_id_fk",
+          "tableFrom": "audio_alignments",
+          "tableTo": "audio_files",
+          "columnsFrom": [
+            "audio_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audio_alignments_token_id_text_tokens_id_fk": {
+          "name": "audio_alignments_token_id_text_tokens_id_fk",
+          "tableFrom": "audio_alignments",
+          "tableTo": "text_tokens",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "audio_alignments_audio_file_id_token_id_uq": {
+          "name": "audio_alignments_audio_file_id_token_id_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "audio_file_id",
+            "token_id"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.audio_files": {
+      "name": "audio_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime": {
+          "name": "mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license": {
+          "name": "license",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by_id": {
+          "name": "uploaded_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audio_files_text_idx": {
+          "name": "audio_files_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audio_files_chapter_idx": {
+          "name": "audio_files_chapter_idx",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audio_files_text_id_texts_id_fk": {
+          "name": "audio_files_text_id_texts_id_fk",
+          "tableFrom": "audio_files",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audio_files_chapter_id_text_chapters_id_fk": {
+          "name": "audio_files_chapter_id_text_chapters_id_fk",
+          "tableFrom": "audio_files",
+          "tableTo": "text_chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audio_files_uploaded_by_id_users_id_fk": {
+          "name": "audio_files_uploaded_by_id_users_id_fk",
+          "tableFrom": "audio_files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.collection_items": {
+      "name": "collection_items",
+      "schema": "",
+      "columns": {
+        "collection_id": {
+          "name": "collection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collection_items_order_idx": {
+          "name": "collection_items_order_idx",
+          "columns": [
+            {
+              "expression": "collection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collection_items_collection_id_collections_id_fk": {
+          "name": "collection_items_collection_id_collections_id_fk",
+          "tableFrom": "collection_items",
+          "tableTo": "collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collection_items_text_id_texts_id_fk": {
+          "name": "collection_items_text_id_texts_id_fk",
+          "tableFrom": "collection_items",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "collection_items_collection_id_text_id_pk": {
+          "name": "collection_items_collection_id_text_id_pk",
+          "columns": [
+            "collection_id",
+            "text_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.collection_shares": {
+      "name": "collection_shares",
+      "schema": "",
+      "columns": {
+        "collection_id": {
+          "name": "collection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shared_with_user_id": {
+          "name": "shared_with_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by_id": {
+          "name": "granted_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collection_shares_recipient_idx": {
+          "name": "collection_shares_recipient_idx",
+          "columns": [
+            {
+              "expression": "shared_with_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collection_shares_collection_id_collections_id_fk": {
+          "name": "collection_shares_collection_id_collections_id_fk",
+          "tableFrom": "collection_shares",
+          "tableTo": "collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collection_shares_shared_with_user_id_users_id_fk": {
+          "name": "collection_shares_shared_with_user_id_users_id_fk",
+          "tableFrom": "collection_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "shared_with_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collection_shares_granted_by_id_users_id_fk": {
+          "name": "collection_shares_granted_by_id_users_id_fk",
+          "tableFrom": "collection_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "collection_shares_collection_id_shared_with_user_id_pk": {
+          "name": "collection_shares_collection_id_shared_with_user_id_pk",
+          "columns": [
+            "collection_id",
+            "shared_with_user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.collections": {
+      "name": "collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "collection_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'chapter_book'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "collection_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collections_owner_idx": {
+          "name": "collections_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collections_visibility_idx": {
+          "name": "collections_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collections_owner_id_users_id_fk": {
+          "name": "collections_owner_id_users_id_fk",
+          "tableFrom": "collections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.curator_languages": {
+      "name": "curator_languages",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "curator_languages_user_idx": {
+          "name": "curator_languages_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "curator_languages_user_id_users_id_fk": {
+          "name": "curator_languages_user_id_users_id_fk",
+          "tableFrom": "curator_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "curator_languages_granted_by_users_id_fk": {
+          "name": "curator_languages_granted_by_users_id_fk",
+          "tableFrom": "curator_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "curator_languages_user_id_language_pk": {
+          "name": "curator_languages_user_id_language_pk",
+          "columns": [
+            "user_id",
+            "language"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.dictionary_imports": {
+      "name": "dictionary_imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_name": {
+          "name": "source_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_at": {
+          "name": "run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lemmas_created": {
+          "name": "lemmas_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lemmas_updated": {
+          "name": "lemmas_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lemmas_skipped_curator_locked": {
+          "name": "lemmas_skipped_curator_locked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "translations_created": {
+          "name": "translations_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "translations_updated": {
+          "name": "translations_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "dictionary_imports_language_idx": {
+          "name": "dictionary_imports_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.form_lemma_overrides": {
+      "name": "form_lemma_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_nfc": {
+          "name": "surface_nfc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_signature": {
+          "name": "context_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "chosen_lemma_id": {
+          "name": "chosen_lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "promoted_at": {
+          "name": "promoted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "promoted_by": {
+          "name": "promoted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "form_lemma_overrides_lookup_idx": {
+          "name": "form_lemma_overrides_lookup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface_nfc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "form_lemma_overrides_chosen_lemma_id_lemmas_id_fk": {
+          "name": "form_lemma_overrides_chosen_lemma_id_lemmas_id_fk",
+          "tableFrom": "form_lemma_overrides",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "chosen_lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_lemma_overrides_promoted_by_users_id_fk": {
+          "name": "form_lemma_overrides_promoted_by_users_id_fk",
+          "tableFrom": "form_lemma_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "promoted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "form_lemma_overrides_lang_surface_ctx_uq": {
+          "name": "form_lemma_overrides_lang_surface_ctx_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "language",
+            "surface_nfc",
+            "context_signature"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.group_memberships": {
+      "name": "group_memberships",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by_id": {
+          "name": "added_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_memberships_user_idx": {
+          "name": "group_memberships_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_memberships_group_id_groups_id_fk": {
+          "name": "group_memberships_group_id_groups_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_memberships_user_id_users_id_fk": {
+          "name": "group_memberships_user_id_users_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_memberships_added_by_id_users_id_fk": {
+          "name": "group_memberships_added_by_id_users_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "added_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "group_memberships_group_id_user_id_pk": {
+          "name": "group_memberships_group_id_user_id_pk",
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "groups_owner_idx": {
+          "name": "groups_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_owner_id_users_id_fk": {
+          "name": "groups_owner_id_users_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemma_edit_history": {
+      "name": "lemma_edit_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "editor_id": {
+          "name": "editor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "lemma_edit_change_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change": {
+          "name": "change",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_edit_history_lemma_idx": {
+          "name": "lemma_edit_history_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_edit_history_editor_idx": {
+          "name": "lemma_edit_history_editor_idx",
+          "columns": [
+            {
+              "expression": "editor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_edit_history_lemma_id_lemmas_id_fk": {
+          "name": "lemma_edit_history_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_edit_history",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lemma_edit_history_editor_id_users_id_fk": {
+          "name": "lemma_edit_history_editor_id_users_id_fk",
+          "tableFrom": "lemma_edit_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "editor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemma_forms": {
+      "name": "lemma_forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "romanization": {
+          "name": "romanization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_forms_lemma_idx": {
+          "name": "lemma_forms_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_forms_surface_idx": {
+          "name": "lemma_forms_surface_idx",
+          "columns": [
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_forms_lemma_id_lemmas_id_fk": {
+          "name": "lemma_forms_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_forms",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemma_proposals": {
+      "name": "lemma_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "proposer_id": {
+          "name": "proposer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headword": {
+          "name": "headword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos": {
+          "name": "pos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gloss_default": {
+          "name": "gloss_default",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "lemma_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "promoted_lemma_id": {
+          "name": "promoted_lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_id": {
+          "name": "reviewer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_note": {
+          "name": "reviewer_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_proposals_lang_status_idx": {
+          "name": "lemma_proposals_lang_status_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_proposals_headword_idx": {
+          "name": "lemma_proposals_headword_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "headword",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pos",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_proposals_proposer_id_users_id_fk": {
+          "name": "lemma_proposals_proposer_id_users_id_fk",
+          "tableFrom": "lemma_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "proposer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "lemma_proposals_promoted_lemma_id_lemmas_id_fk": {
+          "name": "lemma_proposals_promoted_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_proposals",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "promoted_lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "lemma_proposals_reviewer_id_users_id_fk": {
+          "name": "lemma_proposals_reviewer_id_users_id_fk",
+          "tableFrom": "lemma_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemmas": {
+      "name": "lemmas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headword": {
+          "name": "headword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos": {
+          "name": "pos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script": {
+          "name": "script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gloss_default": {
+          "name": "gloss_default",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_rank": {
+          "name": "frequency_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "translation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "curator_locked": {
+          "name": "curator_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "headword_nukta_stripped": {
+          "name": "headword_nukta_stripped",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "translate(normalize(\"headword\", NFD), '़', '')",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "lemmas_language_headword_pos_idx": {
+          "name": "lemmas_language_headword_pos_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "headword",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pos",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_language_idx": {
+          "name": "lemmas_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_language_frequency_idx": {
+          "name": "lemmas_language_frequency_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "frequency_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_source_lookup_idx": {
+          "name": "lemmas_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_language_headword_stripped_idx": {
+          "name": "lemmas_language_headword_stripped_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "headword_nukta_stripped",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.magic_links": {
+      "name": "magic_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "magic_links_user_idx": {
+          "name": "magic_links_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "magic_links_expires_idx": {
+          "name": "magic_links_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "magic_links_user_id_users_id_fk": {
+          "name": "magic_links_user_id_users_id_fk",
+          "tableFrom": "magic_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.nlp_jobs": {
+      "name": "nlp_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "nlp_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nlp_jobs_text_idx": {
+          "name": "nlp_jobs_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nlp_jobs_status_idx": {
+          "name": "nlp_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nlp_jobs_text_id_texts_id_fk": {
+          "name": "nlp_jobs_text_id_texts_id_fk",
+          "tableFrom": "nlp_jobs",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.parse_reports": {
+      "name": "parse_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_nfc": {
+          "name": "surface_nfc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_signature": {
+          "name": "context_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "original_candidates": {
+          "name": "original_candidates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "corrected_lemma_id": {
+          "name": "corrected_lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "correction_type": {
+          "name": "correction_type",
+          "type": "token_correction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "parse_report_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "assigned_reviewer_id": {
+          "name": "assigned_reviewer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_note": {
+          "name": "resolution_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duplicate_count": {
+          "name": "duplicate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parse_reports_lang_status_idx": {
+          "name": "parse_reports_lang_status_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parse_reports_dedup_idx": {
+          "name": "parse_reports_dedup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface_nfc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_signature",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "corrected_lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parse_reports_token_id_text_tokens_id_fk": {
+          "name": "parse_reports_token_id_text_tokens_id_fk",
+          "tableFrom": "parse_reports",
+          "tableTo": "text_tokens",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "parse_reports_corrected_lemma_id_lemmas_id_fk": {
+          "name": "parse_reports_corrected_lemma_id_lemmas_id_fk",
+          "tableFrom": "parse_reports",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "corrected_lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "parse_reports_reporter_id_users_id_fk": {
+          "name": "parse_reports_reporter_id_users_id_fk",
+          "tableFrom": "parse_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "parse_reports_assigned_reviewer_id_users_id_fk": {
+          "name": "parse_reports_assigned_reviewer_id_users_id_fk",
+          "tableFrom": "parse_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_reviewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.phrase_tokens": {
+      "name": "phrase_tokens",
+      "schema": "",
+      "columns": {
+        "phrase_id": {
+          "name": "phrase_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "phrase_tokens_surface_idx": {
+          "name": "phrase_tokens_surface_idx",
+          "columns": [
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "phrase_tokens_phrase_id_phrases_id_fk": {
+          "name": "phrase_tokens_phrase_id_phrases_id_fk",
+          "tableFrom": "phrase_tokens",
+          "tableTo": "phrases",
+          "columnsFrom": [
+            "phrase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "phrase_tokens_lemma_id_lemmas_id_fk": {
+          "name": "phrase_tokens_lemma_id_lemmas_id_fk",
+          "tableFrom": "phrase_tokens",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "phrase_tokens_phrase_id_position_pk": {
+          "name": "phrase_tokens_phrase_id_position_pk",
+          "columns": [
+            "phrase_id",
+            "position"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.phrases": {
+      "name": "phrases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_normalised": {
+          "name": "surface_normalised",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos": {
+          "name": "pos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gloss_default": {
+          "name": "gloss_default",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_rank": {
+          "name": "frequency_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "translation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "curator_locked": {
+          "name": "curator_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "phrases_language_surface_idx": {
+          "name": "phrases_language_surface_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface_normalised",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "phrases_language_idx": {
+          "name": "phrases_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "phrases_language_frequency_idx": {
+          "name": "phrases_language_frequency_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "frequency_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "phrases_source_lookup_idx": {
+          "name": "phrases_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by": {
+          "name": "replaced_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "refresh_tokens_user_idx": {
+          "name": "refresh_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_expires_idx": {
+          "name": "refresh_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.text_chapters": {
+      "name": "text_chapters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idx": {
+          "name": "idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "text_chapters_text_idx": {
+          "name": "text_chapters_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_chapters_text_id_texts_id_fk": {
+          "name": "text_chapters_text_id_texts_id_fk",
+          "tableFrom": "text_chapters",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "text_chapters_text_idx_uq": {
+          "name": "text_chapters_text_idx_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "text_id",
+            "idx"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.text_group_shares": {
+      "name": "text_group_shares",
+      "schema": "",
+      "columns": {
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by_id": {
+          "name": "granted_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "text_group_shares_group_idx": {
+          "name": "text_group_shares_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_group_shares_text_id_texts_id_fk": {
+          "name": "text_group_shares_text_id_texts_id_fk",
+          "tableFrom": "text_group_shares",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_group_shares_group_id_groups_id_fk": {
+          "name": "text_group_shares_group_id_groups_id_fk",
+          "tableFrom": "text_group_shares",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_group_shares_granted_by_id_users_id_fk": {
+          "name": "text_group_shares_granted_by_id_users_id_fk",
+          "tableFrom": "text_group_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "text_group_shares_text_id_group_id_pk": {
+          "name": "text_group_shares_text_id_group_id_pk",
+          "columns": [
+            "text_id",
+            "group_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.text_shares": {
+      "name": "text_shares",
+      "schema": "",
+      "columns": {
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shared_with_user_id": {
+          "name": "shared_with_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "text_share_permission",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'read'"
+        },
+        "granted_by_id": {
+          "name": "granted_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "text_shares_recipient_idx": {
+          "name": "text_shares_recipient_idx",
+          "columns": [
+            {
+              "expression": "shared_with_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_shares_text_id_texts_id_fk": {
+          "name": "text_shares_text_id_texts_id_fk",
+          "tableFrom": "text_shares",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_shares_shared_with_user_id_users_id_fk": {
+          "name": "text_shares_shared_with_user_id_users_id_fk",
+          "tableFrom": "text_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "shared_with_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_shares_granted_by_id_users_id_fk": {
+          "name": "text_shares_granted_by_id_users_id_fk",
+          "tableFrom": "text_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "text_shares_text_id_shared_with_user_id_pk": {
+          "name": "text_shares_text_id_shared_with_user_id_pk",
+          "columns": [
+            "text_id",
+            "shared_with_user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.text_tokens": {
+      "name": "text_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idx": {
+          "name": "idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lemma_candidates": {
+          "name": "lemma_candidates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_ambiguous": {
+          "name": "is_ambiguous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_oov": {
+          "name": "is_oov",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_word": {
+          "name": "is_word",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sentence_idx": {
+          "name": "sentence_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "romanization": {
+          "name": "romanization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_forms": {
+          "name": "number_forms",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "text_tokens_chapter_scan_idx": {
+          "name": "text_tokens_chapter_scan_idx",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "text_tokens_lemma_idx": {
+          "name": "text_tokens_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_tokens_chapter_id_text_chapters_id_fk": {
+          "name": "text_tokens_chapter_id_text_chapters_id_fk",
+          "tableFrom": "text_tokens",
+          "tableTo": "text_chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_tokens_lemma_id_lemmas_id_fk": {
+          "name": "text_tokens_lemma_id_lemmas_id_fk",
+          "tableFrom": "text_tokens",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "text_tokens_chapter_idx_uq": {
+          "name": "text_tokens_chapter_idx_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chapter_id",
+            "idx"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.texts": {
+      "name": "texts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "status_error": {
+          "name": "status_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "texts_owner_idx": {
+          "name": "texts_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "texts_visibility_idx": {
+          "name": "texts_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "texts_owner_id_users_id_fk": {
+          "name": "texts_owner_id_users_id_fk",
+          "tableFrom": "texts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.token_corrections": {
+      "name": "token_corrections",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "token_correction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chosen_lemma_id": {
+          "name": "chosen_lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "token_corrections_token_idx": {
+          "name": "token_corrections_token_idx",
+          "columns": [
+            {
+              "expression": "token_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "token_corrections_chosen_lemma_idx": {
+          "name": "token_corrections_chosen_lemma_idx",
+          "columns": [
+            {
+              "expression": "chosen_lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "token_corrections_user_id_users_id_fk": {
+          "name": "token_corrections_user_id_users_id_fk",
+          "tableFrom": "token_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "token_corrections_token_id_text_tokens_id_fk": {
+          "name": "token_corrections_token_id_text_tokens_id_fk",
+          "tableFrom": "token_corrections",
+          "tableTo": "text_tokens",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "token_corrections_chosen_lemma_id_lemmas_id_fk": {
+          "name": "token_corrections_chosen_lemma_id_lemmas_id_fk",
+          "tableFrom": "token_corrections",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "chosen_lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "token_corrections_user_id_token_id_pk": {
+          "name": "token_corrections_user_id_token_id_pk",
+          "columns": [
+            "user_id",
+            "token_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.translation_votes": {
+      "name": "translation_votes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "translation_id": {
+          "name": "translation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "translation_vote_value",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "translation_votes_translation_idx": {
+          "name": "translation_votes_translation_idx",
+          "columns": [
+            {
+              "expression": "translation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translation_votes_user_idx": {
+          "name": "translation_votes_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "translation_votes_user_id_users_id_fk": {
+          "name": "translation_votes_user_id_users_id_fk",
+          "tableFrom": "translation_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "translation_votes_translation_id_translations_id_fk": {
+          "name": "translation_votes_translation_id_translations_id_fk",
+          "tableFrom": "translation_votes",
+          "tableTo": "translations",
+          "columnsFrom": [
+            "translation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "translation_votes_user_id_translation_id_pk": {
+          "name": "translation_votes_user_id_translation_id_pk",
+          "columns": [
+            "user_id",
+            "translation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.translations": {
+      "name": "translations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "translation_target_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'lemma'"
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "translation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_translation_id": {
+          "name": "parent_translation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_language": {
+          "name": "target_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_rank": {
+          "name": "display_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "translations_lemma_idx": {
+          "name": "translations_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translations_target_idx": {
+          "name": "translations_target_idx",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translations_submitted_by_idx": {
+          "name": "translations_submitted_by_idx",
+          "columns": [
+            {
+              "expression": "submitted_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translations_source_lookup_idx": {
+          "name": "translations_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "translations_lemma_id_lemmas_id_fk": {
+          "name": "translations_lemma_id_lemmas_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "translations_submitted_by_users_id_fk": {
+          "name": "translations_submitted_by_users_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "translations_parent_translation_id_translations_id_fk": {
+          "name": "translations_parent_translation_id_translations_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "translations",
+          "columnsFrom": [
+            "parent_translation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_audio_listening": {
+      "name": "user_audio_listening",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audio_file_id": {
+          "name": "audio_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "listened_ms": {
+          "name": "listened_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_listened_at": {
+          "name": "last_listened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_audio_listening_user_text_idx": {
+          "name": "user_audio_listening_user_text_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_audio_listening_text_idx": {
+          "name": "user_audio_listening_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_audio_listening_user_id_users_id_fk": {
+          "name": "user_audio_listening_user_id_users_id_fk",
+          "tableFrom": "user_audio_listening",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_audio_listening_audio_file_id_audio_files_id_fk": {
+          "name": "user_audio_listening_audio_file_id_audio_files_id_fk",
+          "tableFrom": "user_audio_listening",
+          "tableTo": "audio_files",
+          "columnsFrom": [
+            "audio_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_audio_listening_text_id_texts_id_fk": {
+          "name": "user_audio_listening_text_id_texts_id_fk",
+          "tableFrom": "user_audio_listening",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_audio_listening_user_id_audio_file_id_pk": {
+          "name": "user_audio_listening_user_id_audio_file_id_pk",
+          "columns": [
+            "user_id",
+            "audio_file_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_known_lemmas": {
+      "name": "user_known_lemmas",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "known_lemma_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'learning'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_known_lemmas_user_idx": {
+          "name": "user_known_lemmas_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_known_lemmas_user_id_users_id_fk": {
+          "name": "user_known_lemmas_user_id_users_id_fk",
+          "tableFrom": "user_known_lemmas",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_known_lemmas_lemma_id_lemmas_id_fk": {
+          "name": "user_known_lemmas_lemma_id_lemmas_id_fk",
+          "tableFrom": "user_known_lemmas",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_known_lemmas_user_id_lemma_id_pk": {
+          "name": "user_known_lemmas_user_id_lemma_id_pk",
+          "columns": [
+            "user_id",
+            "lemma_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_known_phrases": {
+      "name": "user_known_phrases",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phrase_id": {
+          "name": "phrase_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "known_lemma_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'learning'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_known_phrases_user_idx": {
+          "name": "user_known_phrases_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_known_phrases_user_id_users_id_fk": {
+          "name": "user_known_phrases_user_id_users_id_fk",
+          "tableFrom": "user_known_phrases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_known_phrases_phrase_id_phrases_id_fk": {
+          "name": "user_known_phrases_phrase_id_phrases_id_fk",
+          "tableFrom": "user_known_phrases",
+          "tableTo": "phrases",
+          "columnsFrom": [
+            "phrase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_known_phrases_user_id_phrase_id_pk": {
+          "name": "user_known_phrases_user_id_phrase_id_pk",
+          "columns": [
+            "user_id",
+            "phrase_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_languages": {
+      "name": "user_languages",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script_preference": {
+          "name": "script_preference",
+          "type": "script_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "romanization_scheme": {
+          "name": "romanization_scheme",
+          "type": "romanization_scheme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'iso15919'"
+        },
+        "known_words_count_cache": {
+          "name": "known_words_count_cache",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "known_phrases_count_cache": {
+          "name": "known_phrases_count_cache",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reader_layout_mode": {
+          "name": "reader_layout_mode",
+          "type": "reader_layout_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'page'"
+        },
+        "words_per_page": {
+          "name": "words_per_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 250
+        },
+        "font_family": {
+          "name": "font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_size": {
+          "name": "font_size",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 18
+        },
+        "line_spacing": {
+          "name": "line_spacing",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1.6
+        },
+        "highlight_style": {
+          "name": "highlight_style",
+          "type": "highlight_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'background'"
+        },
+        "reading_width": {
+          "name": "reading_width",
+          "type": "reading_width",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "baseline": {
+          "name": "baseline",
+          "type": "language_baseline",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_languages_user_id_users_id_fk": {
+          "name": "user_languages_user_id_users_id_fk",
+          "tableFrom": "user_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_languages_user_id_language_pk": {
+          "name": "user_languages_user_id_language_pk",
+          "columns": [
+            "user_id",
+            "language"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_text_progress": {
+      "name": "user_text_progress",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_chapter_idx": {
+          "name": "last_chapter_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_token_idx": {
+          "name": "last_token_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pct_read": {
+          "name": "pct_read",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_text_progress_user_idx": {
+          "name": "user_text_progress_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_text_progress_user_id_users_id_fk": {
+          "name": "user_text_progress_user_id_users_id_fk",
+          "tableFrom": "user_text_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_text_progress_text_id_texts_id_fk": {
+          "name": "user_text_progress_text_id_texts_id_fk",
+          "tableFrom": "user_text_progress",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_text_progress_user_id_text_id_pk": {
+          "name": "user_text_progress_user_id_text_id_pk",
+          "columns": [
+            "user_id",
+            "text_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_preference": {
+          "name": "theme_preference",
+          "type": "theme_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarded_at": {
+          "name": "onboarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    }
+  },
+  "enums": {
+    "public.alignment_source": {
+      "name": "alignment_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "imported",
+        "whisper"
+      ]
+    },
+    "public.collection_kind": {
+      "name": "collection_kind",
+      "schema": "public",
+      "values": [
+        "chapter_book",
+        "course",
+        "anthology"
+      ]
+    },
+    "public.collection_visibility": {
+      "name": "collection_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "shared",
+        "official"
+      ]
+    },
+    "public.highlight_style": {
+      "name": "highlight_style",
+      "schema": "public",
+      "values": [
+        "underline",
+        "background",
+        "colored_text"
+      ]
+    },
+    "public.known_lemma_status": {
+      "name": "known_lemma_status",
+      "schema": "public",
+      "values": [
+        "unknown",
+        "learning",
+        "known",
+        "ignored"
+      ]
+    },
+    "public.language": {
+      "name": "language",
+      "schema": "public",
+      "values": [
+        "hi",
+        "mr",
+        "or"
+      ]
+    },
+    "public.language_baseline": {
+      "name": "language_baseline",
+      "schema": "public",
+      "values": [
+        "none",
+        "beginner",
+        "intermediate"
+      ]
+    },
+    "public.lemma_edit_change_type": {
+      "name": "lemma_edit_change_type",
+      "schema": "public",
+      "values": [
+        "lemma_update",
+        "lemma_unlock",
+        "lemma_lock",
+        "translation_insert",
+        "translation_update",
+        "translation_hide",
+        "translation_unhide",
+        "form_insert",
+        "form_delete",
+        "lemma_merge",
+        "lemma_split",
+        "translation_reorder"
+      ]
+    },
+    "public.lemma_proposal_status": {
+      "name": "lemma_proposal_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.nlp_job_status": {
+      "name": "nlp_job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.parse_report_status": {
+      "name": "parse_report_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "triaged",
+        "resolved",
+        "rejected",
+        "duplicate",
+        "deferred"
+      ]
+    },
+    "public.reader_layout_mode": {
+      "name": "reader_layout_mode",
+      "schema": "public",
+      "values": [
+        "page",
+        "paged_scroll",
+        "continuous"
+      ]
+    },
+    "public.reading_width": {
+      "name": "reading_width",
+      "schema": "public",
+      "values": [
+        "narrow",
+        "medium",
+        "wide"
+      ]
+    },
+    "public.romanization_scheme": {
+      "name": "romanization_scheme",
+      "schema": "public",
+      "values": [
+        "iso15919",
+        "iast",
+        "hunterian",
+        "itrans"
+      ]
+    },
+    "public.script_preference": {
+      "name": "script_preference",
+      "schema": "public",
+      "values": [
+        "native",
+        "native_with_romanization",
+        "romanization_only"
+      ]
+    },
+    "public.text_share_permission": {
+      "name": "text_share_permission",
+      "schema": "public",
+      "values": [
+        "read"
+      ]
+    },
+    "public.text_source_type": {
+      "name": "text_source_type",
+      "schema": "public",
+      "values": [
+        "paste",
+        "txt",
+        "epub"
+      ]
+    },
+    "public.text_status": {
+      "name": "text_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.text_visibility": {
+      "name": "text_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "shared",
+        "official"
+      ]
+    },
+    "public.theme_preference": {
+      "name": "theme_preference",
+      "schema": "public",
+      "values": [
+        "system",
+        "light",
+        "dark"
+      ]
+    },
+    "public.token_correction_type": {
+      "name": "token_correction_type",
+      "schema": "public",
+      "values": [
+        "pick_candidate",
+        "manual_lemma",
+        "new_lemma",
+        "mark_proper_noun",
+        "mark_foreign",
+        "mark_not_a_word"
+      ]
+    },
+    "public.translation_source": {
+      "name": "translation_source",
+      "schema": "public",
+      "values": [
+        "official_dictionary",
+        "curator",
+        "user"
+      ]
+    },
+    "public.translation_target_type": {
+      "name": "translation_target_type",
+      "schema": "public",
+      "values": [
+        "lemma",
+        "phrase"
+      ]
+    },
+    "public.translation_vote_value": {
+      "name": "translation_vote_value",
+      "schema": "public",
+      "values": [
+        "up",
+        "down"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "curator",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1777514311003,
       "tag": "0025_nukta_stripped_headword",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1777515171894,
+      "tag": "0026_little_vertigo",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/src/lib/server/db/schema.ts
+++ b/apps/web/src/lib/server/db/schema.ts
@@ -184,6 +184,10 @@ export const userLanguages = pgTable(
     scriptPreference: scriptPreference('script_preference').notNull().default('native'),
     romanizationScheme: romanizationScheme('romanization_scheme').notNull().default('iso15919'),
     knownWordsCountCache: integer('known_words_count_cache').notNull().default(0),
+    // T-14.1: parallel counter for phrases (M14). `setKnownPhraseStatus`
+    // recomputes this in the same transaction as the status flip,
+    // mirroring the words counter. Surfaced in T-14.6's stats panes.
+    knownPhrasesCountCache: integer('known_phrases_count_cache').notNull().default(0),
     readerLayoutMode: readerLayoutMode('reader_layout_mode').notNull().default('page'),
     wordsPerPage: integer('words_per_page').notNull().default(250),
     fontFamily: text('font_family'),
@@ -214,6 +218,25 @@ export const translationSource = pgEnum('translation_source', [
 export const translationVoteValue = pgEnum('translation_vote_value', [
   'up',
   'down',
+]);
+
+/**
+ * Polymorphic target for `translations` (T-14.1).
+ *
+ * A translation row attaches to either a single `lemmas` row (the
+ * legacy default — every pre-M14 row was implicitly 'lemma') or to a
+ * `phrases` row (M14 phrase-level translations). The (target_type,
+ * target_id) pair is the canonical join key going forward; the
+ * legacy `lemma_id` column on `translations` is kept populated for
+ * 'lemma' rows during T-14.1's overlap window and dropped in T-14.7.
+ *
+ * No native Postgres FK on `target_id` because it points at two
+ * tables — application layer (`translations.ts` / `phrases.ts`)
+ * enforces target existence on every write.
+ */
+export const translationTargetType = pgEnum('translation_target_type', [
+  'lemma',
+  'phrase',
 ]);
 
 /**
@@ -318,23 +341,122 @@ export const lemmaForms = pgTable(
 );
 
 /**
- * Translation rows for a lemma. Officials, curator edits, and user
- * submissions all live here and are distinguished by `source`. A user can
- * fork an official into a personal copy via `parent_translation_id` (T-3.5)
- * — the fork is visible only to the forker and renders at the top of the
- * pop-up for them specifically.
+ * Multi-word dictionary entries (T-14.1, M14 phrase-level translations).
  *
- * `hidden` is the moderation switch for community translations; officials
- * are edited in place (with an audit trail in T-3.4's `lemma_edit_history`)
- * rather than hidden.
+ * A phrase is identified by its ordered token sequence (see
+ * `phrase_tokens`) — `surface_normalised` is only the dedupe lookup
+ * column (joined surfaces, NFC, single-space). Per-source duplicates
+ * are allowed by design (mirrors lemmas merge story from T-3.10): a
+ * curator phrase and a Kaikki-imported phrase with the same surface
+ * are kept as separate rows and reconciled via the merge UI in T-14.7.
+ *
+ * Sources reuse the existing `translation_source` enum. T-14.5
+ * extends that enum with `'nlp'` for compound/conjunct verb
+ * proposals from the rule-based detector.
+ *
+ * `curator_locked = true` mirrors the same flag on `lemmas`: a human
+ * has touched this row and importers must not clobber it.
+ */
+export const phrases = pgTable(
+  'phrases',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    language: language('language').notNull(),
+    // NFC-normalised, single-spaced join of `phrase_tokens.surface`
+    // ordered by `position`. Dedup lookup only — the canonical key
+    // is the ordered phrase_tokens rows.
+    surfaceNormalised: text('surface_normalised').notNull(),
+    pos: text('pos'),
+    glossDefault: text('gloss_default'),
+    frequencyRank: integer('frequency_rank'),
+    source: translationSource('source').notNull(),
+    sourceAttribution: text('source_attribution'),
+    sourceId: text('source_id'),
+    curatorLocked: boolean('curator_locked').notNull().default(false),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    // Non-unique by design — per-source duplication is reconciled in
+    // T-14.7's merge UI, same as lemmas (T-3.10).
+    surfaceIdx: index('phrases_language_surface_idx').on(t.language, t.surfaceNormalised),
+    languageIdx: index('phrases_language_idx').on(t.language),
+    frequencyIdx: index('phrases_language_frequency_idx').on(t.language, t.frequencyRank),
+    // Idempotent re-import: an importer finds its own previously-
+    // written row by (language, source, source_id).
+    sourceIdx: index('phrases_source_lookup_idx').on(t.language, t.source, t.sourceId),
+  }),
+);
+
+/**
+ * Ordered token components of a phrase (T-14.1). The canonical
+ * identity of a phrase is the ordered `(surface)` rows here — the
+ * `phrases.surface_normalised` column is just a fast dedupe lookup.
+ *
+ * `lemma_id` is a *soft hint*, not a join key — `इंतज़ार करना` ≠
+ * `इंतज़ार` + `करना` semantically. Cross-linking to a lemma drives
+ * the popup's "see component lemmas" affordance and lets the
+ * frequency-rank scorer inherit data, but it never participates in
+ * matching. Set to NULL on lemma deletion so cascading lemma merges
+ * never silently rewrite phrase identity.
+ */
+export const phraseTokens = pgTable(
+  'phrase_tokens',
+  {
+    phraseId: uuid('phrase_id')
+      .notNull()
+      .references(() => phrases.id, { onDelete: 'cascade' }),
+    position: integer('position').notNull(),
+    surface: text('surface').notNull(),
+    lemmaId: uuid('lemma_id').references(() => lemmas.id, {
+      onDelete: 'set null',
+    }),
+  },
+  (t) => ({
+    pk: primaryKey({ columns: [t.phraseId, t.position] }),
+    // Drives the chapter-span resolver in T-14.2: "every phrase
+    // whose first surface is X" is a single index lookup.
+    surfaceIdx: index('phrase_tokens_surface_idx').on(t.surface),
+  }),
+);
+
+/**
+ * Translation rows for a lemma OR a phrase (T-14.1 polymorphic).
+ * Officials, curator edits, and user submissions all live here and
+ * are distinguished by `source`. A user can fork an official into a
+ * personal copy via `parent_translation_id` (T-3.5) — the fork is
+ * visible only to the forker and renders at the top of the pop-up
+ * for them specifically.
+ *
+ * `hidden` is the moderation switch for community translations;
+ * officials are edited in place (with an audit trail in T-3.4's
+ * `lemma_edit_history`) rather than hidden.
+ *
+ * Polymorphic target (T-14.1): the canonical join key is
+ * `(target_type, target_id)`. For legacy 'lemma' rows the value of
+ * `target_id` equals `lemma_id`; the column is kept on the row so
+ * existing readers (T-3.3, T-3.5, the reader pop-up) keep working
+ * during the overlap window. T-14.7 drops `lemma_id` once every
+ * read path moves to `target_type` / `target_id`.
+ *
+ * No native FK on `target_id` because it points at two tables —
+ * the service layer (`translations.ts` / `phrases.ts`) enforces
+ * target existence on every write.
  */
 export const translations = pgTable(
   'translations',
   {
     id: uuid('id').primaryKey().defaultRandom(),
-    lemmaId: uuid('lemma_id')
-      .notNull()
-      .references(() => lemmas.id, { onDelete: 'cascade' }),
+    // Legacy lemma FK. Nullable as of T-14.1 so phrase-target rows
+    // can be inserted without a lemma. For target_type='lemma'
+    // rows, this still equals `target_id`. Dropped in T-14.7.
+    lemmaId: uuid('lemma_id').references(() => lemmas.id, {
+      onDelete: 'cascade',
+    }),
+    targetType: translationTargetType('target_type').notNull().default('lemma'),
+    // Canonical polymorphic target. For legacy rows this is
+    // backfilled to equal `lemma_id` in migration 0024.
+    targetId: uuid('target_id').notNull(),
     source: translationSource('source').notNull(),
     submittedBy: uuid('submitted_by').references(() => users.id, { onDelete: 'set null' }),
     parentTranslationId: uuid('parent_translation_id').references(
@@ -357,7 +479,14 @@ export const translations = pgTable(
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => ({
+    // Legacy index on lemma_id — kept for the overlap window so any
+    // un-migrated read path stays cheap. Dropped in T-14.7 once
+    // every consumer uses target_type/target_id.
     lemmaIdx: index('translations_lemma_idx').on(t.lemmaId),
+    // T-14.1 canonical lookup index. Reader pop-up + dictionary
+    // editor read by (target_type, target_id) and re-import dedup
+    // adds `source` as the third column for the importer fast path.
+    targetIdx: index('translations_target_idx').on(t.targetType, t.targetId, t.source),
     submittedByIdx: index('translations_submitted_by_idx').on(t.submittedBy),
     // The (lemma, source, source_id) triple is how a re-import finds its
     // own previously-written row to update.
@@ -772,6 +901,8 @@ export type MagicLink = InferSelectModel<typeof magicLinks>;
 export type UserLanguage = InferSelectModel<typeof userLanguages>;
 export type Lemma = InferSelectModel<typeof lemmas>;
 export type LemmaForm = InferSelectModel<typeof lemmaForms>;
+export type Phrase = InferSelectModel<typeof phrases>;
+export type PhraseToken = InferSelectModel<typeof phraseTokens>;
 export type Translation = InferSelectModel<typeof translations>;
 export type TranslationVote = InferSelectModel<typeof translationVotes>;
 export type DictionaryImport = InferSelectModel<typeof dictionaryImports>;
@@ -927,6 +1058,34 @@ export const userKnownLemmas = pgTable(
   (t) => ({
     pk: primaryKey({ columns: [t.userId, t.lemmaId] }),
     userIdx: index('user_known_lemmas_user_idx').on(t.userId, t.status),
+  }),
+);
+
+/**
+ * Per-user known-status for phrases (T-14.1). Direct parallel to
+ * `user_known_lemmas` — the `known_lemma_status` enum is reused
+ * because the semantics (unknown / learning / known / ignored) are
+ * identical for phrases. `setKnownPhraseStatus` updates this table
+ * and recomputes `user_languages.known_phrases_count_cache` in the
+ * same transaction.
+ */
+export const userKnownPhrases = pgTable(
+  'user_known_phrases',
+  {
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    phraseId: uuid('phrase_id')
+      .notNull()
+      .references(() => phrases.id, { onDelete: 'cascade' }),
+    status: knownLemmaStatus('status').notNull().default('learning'),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => ({
+    pk: primaryKey({ columns: [t.userId, t.phraseId] }),
+    userIdx: index('user_known_phrases_user_idx').on(t.userId, t.status),
   }),
 );
 
@@ -1270,6 +1429,7 @@ export type TextChapter = InferSelectModel<typeof textChapters>;
 export type NlpJob = InferSelectModel<typeof nlpJobs>;
 export type TextToken = InferSelectModel<typeof textTokens>;
 export type UserKnownLemma = InferSelectModel<typeof userKnownLemmas>;
+export type UserKnownPhrase = InferSelectModel<typeof userKnownPhrases>;
 export type UserTextProgress = InferSelectModel<typeof userTextProgress>;
 export type FormLemmaOverride = InferSelectModel<typeof formLemmaOverrides>;
 export type TokenCorrection = InferSelectModel<typeof tokenCorrections>;

--- a/apps/web/src/lib/server/dictionary/bulk.test.ts
+++ b/apps/web/src/lib/server/dictionary/bulk.test.ts
@@ -154,6 +154,11 @@ function translationRow(overrides: Record<string, unknown> = {}) {
   return {
     id: 'tr-1',
     lemmaId: 'lemma-1',
+    // T-14.1: bulk operations only run on lemma-target translations;
+    // every fixture row gets the polymorphic columns mirrored from
+    // lemma_id. Phrase-target bulk paths land in T-14.7.
+    targetType: 'lemma',
+    targetId: 'lemma-1',
     source: 'user',
     submittedBy: 'user-42',
     parentTranslationId: null,

--- a/apps/web/src/lib/server/dictionary/bulk.ts
+++ b/apps/web/src/lib/server/dictionary/bulk.ts
@@ -189,6 +189,10 @@ export async function bulkImportTranslations(
       .insert(schema.translations)
       .values({
         lemmaId: lemma.id,
+        // T-14.1: bulk-curator inserts are always lemma-target.
+        // Phrase bulk import is a follow-up under T-14.4.
+        targetType: 'lemma',
+        targetId: lemma.id,
         source: 'curator',
         submittedBy: editor.id,
         body,
@@ -279,6 +283,13 @@ export async function bulkPromoteTranslations(
       // Same one-way guard as updateTranslation: imported rows must be
       // edited directly, not re-tagged.
       skipped.push({ id, reason: 'imported officials cannot be re-tagged' });
+      continue;
+    }
+    // T-14.1: bulk promote operates on lemma-target translations only.
+    // Phrase-target community translations move through the phrase
+    // editor (T-14.4 / T-14.7).
+    if (row.targetType !== 'lemma' || !row.lemmaId) {
+      skipped.push({ id, reason: 'phrase-target translations not supported here' });
       continue;
     }
 
@@ -405,6 +416,9 @@ export async function bulkUpdateAttribution(
     );
 
   for (const row of before) {
+    // T-14.1: bulk-attribution audit only fires for lemma-target
+    // rows; phrase-target rebrands happen in T-14.7's phrase editor.
+    if (row.targetType !== 'lemma' || !row.lemmaId) continue;
     await recordLemmaEdit({
       lemmaId: row.lemmaId,
       editorId: editor.id,

--- a/apps/web/src/lib/server/dictionary/curator.test.ts
+++ b/apps/web/src/lib/server/dictionary/curator.test.ts
@@ -157,6 +157,11 @@ function translationRow(overrides: Record<string, unknown> = {}) {
   return {
     id: 'tr-1',
     lemmaId: 'lemma-1',
+    // T-14.1: every translation row in the fixture is lemma-target;
+    // the polymorphic columns mirror lemma_id during the overlap
+    // window. Phrase-target curator flows are tested in T-14.4.
+    targetType: 'lemma',
+    targetId: 'lemma-1',
     source: 'user',
     submittedBy: 'user-42',
     parentTranslationId: null,

--- a/apps/web/src/lib/server/dictionary/curator.ts
+++ b/apps/web/src/lib/server/dictionary/curator.ts
@@ -299,6 +299,15 @@ export async function updateTranslation(
 ): Promise<Translation> {
   validateTranslationPatch(patch);
   const existing = await loadTranslation(translationId);
+  // T-14.1: curator dictionary editor today only handles lemma-
+  // target translations. Phrase-target moderation lands in T-14.7
+  // (curator merge + moderation parity for M14).
+  if (existing.targetType !== 'lemma' || !existing.lemmaId) {
+    throw new CuratorValidationError(
+      'Phrase-target translations are managed via the phrase editor (T-14.4 / T-14.7)',
+      409,
+    );
+  }
   const parentLemma = await loadLemma(existing.lemmaId);
   await requireCanEditDictionary(editor, parentLemma.language);
 
@@ -354,6 +363,14 @@ export async function setTranslationHidden(
   now: Date = new Date(),
 ): Promise<Translation> {
   const existing = await loadTranslation(translationId);
+  // T-14.1: same guard as `updateTranslation` above. Phrase-target
+  // moderation goes through T-14.7's curator surface.
+  if (existing.targetType !== 'lemma' || !existing.lemmaId) {
+    throw new CuratorValidationError(
+      'Phrase-target translations are managed via the phrase editor (T-14.4 / T-14.7)',
+      409,
+    );
+  }
   const parentLemma = await loadLemma(existing.lemmaId);
   await requireCanEditDictionary(editor, parentLemma.language);
 

--- a/apps/web/src/lib/server/dictionary/drizzle-repo.ts
+++ b/apps/web/src/lib/server/dictionary/drizzle-repo.ts
@@ -113,6 +113,10 @@ export class DrizzleDictionaryRepo implements DictionaryRepo {
       .insert(translations)
       .values({
         lemmaId: payload.lemmaId,
+        // T-14.1: importer-driven inserts are lemma-target. Phrase
+        // imports go through the phrase service (T-14.5 NLP path).
+        targetType: 'lemma',
+        targetId: payload.lemmaId,
         source: payload.source,
         body: payload.body,
         targetLanguage: payload.targetLanguage,

--- a/apps/web/src/lib/server/dictionary/test-support.ts
+++ b/apps/web/src/lib/server/dictionary/test-support.ts
@@ -158,6 +158,11 @@ export class InMemoryDictionaryRepo implements DictionaryRepo {
     const row: Translation = {
       id,
       lemmaId: payload.lemmaId,
+      // T-14.1: in-memory test fixture mirrors the polymorphic
+      // columns. The fake repo only writes lemma-target rows
+      // (phrases use a separate service path).
+      targetType: 'lemma',
+      targetId: payload.lemmaId,
       source: payload.source,
       submittedBy: null,
       parentTranslationId: null,

--- a/apps/web/src/lib/server/dictionary/translations.polymorphic.test.ts
+++ b/apps/web/src/lib/server/dictionary/translations.polymorphic.test.ts
@@ -1,0 +1,234 @@
+// @vitest-environment node
+/**
+ * Polymorphic translation tests (T-14.1).
+ *
+ * Verifies that the new phrase-target path
+ * (`submitUserPhraseTranslation`) writes the polymorphic columns
+ * correctly and that the existing lemma-target path
+ * (`submitUserTranslation`) keeps populating both legacy `lemma_id`
+ * AND the canonical (target_type, target_id) pair during the
+ * overlap window.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Call =
+  | { kind: 'select' }
+  | { kind: 'insert'; payload?: unknown };
+const calls: Call[] = [];
+const staged: unknown[][] = [];
+
+function stage(rows: unknown[]) {
+  staged.push(rows);
+}
+function nextStaged(): unknown[] {
+  const v = staged.shift();
+  if (!v) throw new Error('Test bug: no staged result available');
+  return v;
+}
+
+function makeSelectChain() {
+  const chain: Record<string, unknown> = {};
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.limit = vi.fn(() => chain);
+  chain.then = (resolve: (v: unknown) => unknown) => resolve(nextStaged());
+  return chain as unknown;
+}
+
+function makeInsertChain() {
+  const chain = {
+    values: vi.fn((payload: unknown) => {
+      calls.push({ kind: 'insert', payload });
+      return chain;
+    }),
+    returning: vi.fn(() => nextStaged()),
+  };
+  return chain;
+}
+
+const selectFn = vi.fn(() => {
+  calls.push({ kind: 'select' });
+  return makeSelectChain();
+});
+const insertFn = vi.fn(() => makeInsertChain());
+
+vi.mock('../db/index.js', () => ({
+  db: {
+    select: () => selectFn(),
+    insert: () => insertFn(),
+  },
+  schema: {
+    lemmas: { id: 'lemmas.id' },
+    phrases: { id: 'phrases.id' },
+    translations: {
+      id: 'translations.id',
+      lemmaId: 'translations.lemma_id',
+      targetType: 'translations.target_type',
+      targetId: 'translations.target_id',
+      submittedBy: 'translations.submitted_by',
+      createdAt: 'translations.created_at',
+    },
+  },
+}));
+
+const {
+  submitUserTranslation,
+  submitUserPhraseTranslation,
+  TranslationValidationError,
+} = await import('./translations.js');
+
+beforeEach(() => {
+  calls.length = 0;
+  staged.length = 0;
+  selectFn.mockClear();
+  insertFn.mockClear();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------
+// submitUserTranslation (lemma target — overlap-window write shape)
+// ---------------------------------------------------------------
+
+describe('submitUserTranslation — polymorphic write shape', () => {
+  it('populates BOTH lemma_id and (target_type=lemma, target_id=lemmaId)', async () => {
+    stage([{ id: 'lemma-1' }]); // existence check
+    stage([{ n: 0 }]); // rate-limit count
+    stage([
+      {
+        id: 'tr-1',
+        lemmaId: 'lemma-1',
+        targetType: 'lemma',
+        targetId: 'lemma-1',
+        source: 'user',
+        submittedBy: 'user-1',
+        body: 'to speak',
+        hidden: false,
+      },
+    ]);
+
+    await submitUserTranslation('user-1', {
+      lemmaId: 'lemma-1',
+      body: 'to speak',
+    });
+
+    const insertCall = calls.find((c) => c.kind === 'insert');
+    expect(insertCall?.payload).toMatchObject({
+      lemmaId: 'lemma-1',
+      targetType: 'lemma',
+      targetId: 'lemma-1',
+      source: 'user',
+    });
+  });
+});
+
+// ---------------------------------------------------------------
+// submitUserPhraseTranslation (phrase target)
+// ---------------------------------------------------------------
+
+describe('submitUserPhraseTranslation — happy path', () => {
+  it('writes lemma_id=null + (target_type=phrase, target_id=phraseId)', async () => {
+    stage([{ id: 'phr-1' }]); // phrase existence
+    stage([{ n: 0 }]); // rate-limit
+    stage([
+      {
+        id: 'tr-1',
+        lemmaId: null,
+        targetType: 'phrase',
+        targetId: 'phr-1',
+        source: 'user',
+        submittedBy: 'user-1',
+        body: 'to wait',
+      },
+    ]);
+
+    const result = await submitUserPhraseTranslation('user-1', {
+      phraseId: 'phr-1',
+      body: 'to wait',
+    });
+
+    expect(result.targetType).toBe('phrase');
+    expect(result.targetId).toBe('phr-1');
+    expect(result.lemmaId).toBeNull();
+
+    const insertCall = calls.find((c) => c.kind === 'insert');
+    expect(insertCall?.payload).toMatchObject({
+      lemmaId: null,
+      targetType: 'phrase',
+      targetId: 'phr-1',
+      source: 'user',
+      submittedBy: 'user-1',
+      body: 'to wait',
+      targetLanguage: 'en',
+    });
+  });
+
+  it('rate-limit is shared with the lemma path (same submittedBy window)', async () => {
+    stage([{ id: 'phr-1' }]); // phrase existence
+    stage([{ n: 30 }]); // already at the cap from lemma submissions
+    await expect(
+      submitUserPhraseTranslation('user-1', { phraseId: 'phr-1', body: 'x' }),
+    ).rejects.toThrow();
+  });
+});
+
+describe('submitUserPhraseTranslation — validation errors', () => {
+  it('rejects an empty body without touching the DB', async () => {
+    await expect(
+      submitUserPhraseTranslation('user-1', { phraseId: 'phr-1', body: '   ' }),
+    ).rejects.toBeInstanceOf(TranslationValidationError);
+    expect(selectFn).not.toHaveBeenCalled();
+  });
+
+  it('returns a 404-flavoured error when the phrase does not exist', async () => {
+    stage([]); // phrase missing
+    try {
+      await submitUserPhraseTranslation('user-1', {
+        phraseId: 'phr-missing',
+        body: 'x',
+      });
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TranslationValidationError);
+      expect((err as InstanceType<typeof TranslationValidationError>).status).toBe(404);
+    }
+  });
+
+  it('rejects a parent translation that targets a different phrase', async () => {
+    stage([{ id: 'phr-1' }]); // phrase exists
+    stage([
+      {
+        id: 'parent-1',
+        targetType: 'phrase',
+        targetId: 'phr-OTHER',
+      },
+    ]); // parent on a different phrase
+    await expect(
+      submitUserPhraseTranslation('user-1', {
+        phraseId: 'phr-1',
+        body: 'x',
+        parentTranslationId: 'parent-1',
+      }),
+    ).rejects.toBeInstanceOf(TranslationValidationError);
+  });
+
+  it('rejects a parent translation that targets a lemma instead', async () => {
+    stage([{ id: 'phr-1' }]);
+    stage([
+      {
+        id: 'parent-1',
+        targetType: 'lemma',
+        targetId: 'phr-1', // value happens to match phraseId — must still reject
+      },
+    ]);
+    await expect(
+      submitUserPhraseTranslation('user-1', {
+        phraseId: 'phr-1',
+        body: 'x',
+        parentTranslationId: 'parent-1',
+      }),
+    ).rejects.toBeInstanceOf(TranslationValidationError);
+  });
+});

--- a/apps/web/src/lib/server/dictionary/translations.ts
+++ b/apps/web/src/lib/server/dictionary/translations.ts
@@ -145,6 +145,12 @@ async function assertUnderRateLimit(userId: string, now: Date): Promise<void> {
  * import by hand. `parentTranslationId` is how T-3.5 will implement
  * "customize an official translation"; the parent is kept for display
  * provenance only — the fork is a real, independently-editable row.
+ *
+ * T-14.1: writes are polymorphic-aware. For lemma-target rows the
+ * row carries both `lemma_id` (legacy column, still NOT NULL via
+ * default behaviour for callers but column-level NULLability flipped
+ * for phrase rows) and `target_type='lemma'` / `target_id=lemma_id`.
+ * Phrase-target submissions go through `submitUserPhraseTranslation`.
  */
 export async function submitUserTranslation(
   userId: string,
@@ -162,6 +168,12 @@ export async function submitUserTranslation(
     .insert(schema.translations)
     .values({
       lemmaId: input.lemmaId,
+      // T-14.1 polymorphic columns. For lemma-target rows the
+      // canonical (target_type, target_id) pair mirrors the legacy
+      // lemma_id so existing readers keep working during the
+      // overlap window before T-14.7 drops `lemma_id`.
+      targetType: 'lemma',
+      targetId: input.lemmaId,
       source: 'user',
       submittedBy: userId,
       parentTranslationId: input.parentTranslationId ?? null,
@@ -169,6 +181,99 @@ export async function submitUserTranslation(
       targetLanguage,
       // Officials carry an attribution string and an upstream id; user
       // submissions carry neither.
+      sourceAttribution: null,
+      sourceId: null,
+    })
+    .returning();
+  if (!row) throw new Error('Failed to insert translation');
+  return row as Translation;
+}
+
+// -----------------------------------------------------------------------
+// Phrase-target translations (T-14.1).
+// -----------------------------------------------------------------------
+
+export type SubmitPhraseTranslationInput = {
+  phraseId: string;
+  body: string;
+  parentTranslationId?: string | null;
+  targetLanguage?: string;
+};
+
+async function assertPhraseExists(phraseId: string): Promise<void> {
+  const [row] = await db
+    .select({ id: schema.phrases.id })
+    .from(schema.phrases)
+    .where(eq(schema.phrases.id, phraseId))
+    .limit(1);
+  if (!row) {
+    throw new TranslationValidationError(`Phrase ${phraseId} not found`, 404);
+  }
+}
+
+async function assertParentBelongsToPhrase(
+  parentId: string,
+  phraseId: string,
+): Promise<void> {
+  const [row] = await db
+    .select({
+      id: schema.translations.id,
+      targetType: schema.translations.targetType,
+      targetId: schema.translations.targetId,
+    })
+    .from(schema.translations)
+    .where(eq(schema.translations.id, parentId))
+    .limit(1);
+  if (!row) {
+    throw new TranslationValidationError(
+      `parentTranslationId ${parentId} not found`,
+      404,
+    );
+  }
+  if (row.targetType !== 'phrase' || row.targetId !== phraseId) {
+    throw new TranslationValidationError(
+      'parentTranslationId belongs to a different target',
+    );
+  }
+}
+
+/**
+ * Insert a new user-submitted *phrase* translation. Same rate-limit
+ * window and body validation as the lemma path — sharing
+ * `assertUnderRateLimit` is intentional so a translation-spam bot
+ * can't dodge the cap by alternating between targets. Writes
+ * `lemma_id=NULL`, `target_type='phrase'`, `target_id=phraseId`.
+ */
+export async function submitUserPhraseTranslation(
+  userId: string,
+  input: SubmitPhraseTranslationInput,
+  now: Date = new Date(),
+): Promise<Translation> {
+  const { body, targetLanguage } = validateInput({
+    lemmaId: 'unused',
+    body: input.body,
+    targetLanguage: input.targetLanguage,
+  });
+  await assertPhraseExists(input.phraseId);
+  if (input.parentTranslationId) {
+    await assertParentBelongsToPhrase(
+      input.parentTranslationId,
+      input.phraseId,
+    );
+  }
+  await assertUnderRateLimit(userId, now);
+
+  const [row] = await db
+    .insert(schema.translations)
+    .values({
+      lemmaId: null,
+      targetType: 'phrase',
+      targetId: input.phraseId,
+      source: 'user',
+      submittedBy: userId,
+      parentTranslationId: input.parentTranslationId ?? null,
+      body,
+      targetLanguage,
       sourceAttribution: null,
       sourceId: null,
     })
@@ -266,7 +371,13 @@ export async function deleteUserTranslation(
 export function publicTranslation(row: Translation) {
   return {
     id: row.id,
+    // T-14.1 polymorphic surface. Both the legacy `lemmaId` field
+    // and the new `targetType` / `targetId` are returned during
+    // the overlap window — clients should prefer the latter; we
+    // drop `lemmaId` from this projection in T-14.7.
     lemmaId: row.lemmaId,
+    targetType: row.targetType,
+    targetId: row.targetId,
     source: row.source,
     submittedBy: row.submittedBy,
     parentTranslationId: row.parentTranslationId,

--- a/apps/web/src/lib/server/phrases.test.ts
+++ b/apps/web/src/lib/server/phrases.test.ts
@@ -1,0 +1,414 @@
+// @vitest-environment node
+/**
+ * Unit tests for the phrase service (T-14.1).
+ *
+ * Drizzle is mocked via the staged-result chain pattern used by
+ * `dictionary/translations.test.ts` — every chained call resolves
+ * to the next staged result, so the test asserts the service hits
+ * the DB in the expected order.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Call =
+  | { kind: 'select' }
+  | { kind: 'insert'; payload?: unknown }
+  | { kind: 'update'; set?: unknown };
+const calls: Call[] = [];
+const staged: unknown[][] = [];
+
+function stage(rows: unknown[]) {
+  staged.push(rows);
+}
+
+function nextStaged(): unknown[] {
+  const v = staged.shift();
+  if (!v) throw new Error('Test bug: no staged result available');
+  return v;
+}
+
+function makeSelectChain() {
+  const chain: Record<string, unknown> = {};
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.innerJoin = vi.fn(() => chain);
+  chain.limit = vi.fn(() => chain);
+  chain.offset = vi.fn(() => chain);
+  chain.then = (resolve: (v: unknown) => unknown) => resolve(nextStaged());
+  return chain as unknown;
+}
+
+function makeInsertChain() {
+  const chain = {
+    values: vi.fn((payload: unknown) => {
+      calls.push({ kind: 'insert', payload });
+      return chain;
+    }),
+    returning: vi.fn(() => nextStaged()),
+  };
+  return chain;
+}
+
+function makeUpdateChain() {
+  const entry: Call = { kind: 'update' };
+  calls.push(entry);
+  const chain: Record<string, unknown> = {};
+  chain.set = vi.fn((v: unknown) => {
+    entry.set = v;
+    return chain;
+  });
+  chain.where = vi.fn(() => chain);
+  chain.returning = vi.fn(() => nextStaged());
+  // Not all updates use `.returning()` — the cache-recompute UPDATE
+  // is awaited directly. Resolve the chain itself for that path.
+  chain.then = (resolve: (v: unknown) => unknown) => resolve(undefined);
+  return chain;
+}
+
+const selectFn = vi.fn(() => {
+  calls.push({ kind: 'select' });
+  return makeSelectChain();
+});
+const insertFn = vi.fn(() => makeInsertChain());
+const updateFn = vi.fn(() => makeUpdateChain());
+
+vi.mock('./db/index.js', () => ({
+  db: {
+    select: () => selectFn(),
+    insert: () => insertFn(),
+    update: () => updateFn(),
+  },
+  schema: {
+    phrases: {
+      id: 'phrases.id',
+      language: 'phrases.language',
+      surfaceNormalised: 'phrases.surface_normalised',
+      source: 'phrases.source',
+    },
+    phraseTokens: {
+      phraseId: 'phrase_tokens.phrase_id',
+      surface: 'phrase_tokens.surface',
+    },
+    translations: {
+      targetType: 'translations.target_type',
+      targetId: 'translations.target_id',
+      hidden: 'translations.hidden',
+    },
+    userKnownPhrases: {
+      userId: 'user_known_phrases.user_id',
+      phraseId: 'user_known_phrases.phrase_id',
+      status: 'user_known_phrases.status',
+    },
+    userLanguages: {
+      userId: 'user_languages.user_id',
+      language: 'user_languages.language',
+    },
+  },
+}));
+
+const {
+  createPhrase,
+  getPhrase,
+  setKnownPhraseStatus,
+  PhraseValidationError,
+  MAX_PHRASE_TOKENS,
+} = await import('./phrases.js');
+
+beforeEach(() => {
+  calls.length = 0;
+  staged.length = 0;
+  selectFn.mockClear();
+  insertFn.mockClear();
+  updateFn.mockClear();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------
+// createPhrase
+// ---------------------------------------------------------------
+
+describe('createPhrase — happy path', () => {
+  it('inserts the phrase + ordered tokens and returns reused=false', async () => {
+    stage([]); // dedupe lookup — no existing match
+    stage([
+      {
+        id: 'phr-1',
+        language: 'hi',
+        surfaceNormalised: 'इंतज़ार करना',
+        source: 'user',
+      },
+    ]); // phrases insert
+    stage([
+      { phraseId: 'phr-1', position: 0, surface: 'इंतज़ार', lemmaId: null },
+      { phraseId: 'phr-1', position: 1, surface: 'करना', lemmaId: null },
+    ]); // phrase_tokens insert
+
+    const result = await createPhrase({
+      language: 'hi',
+      tokens: ['इंतज़ार', 'करना'],
+      source: 'user',
+      submittedBy: 'user-1',
+    });
+
+    expect(result.reused).toBe(false);
+    expect(result.phrase.id).toBe('phr-1');
+    expect(result.tokens).toHaveLength(2);
+    expect(result.tokens[0]?.position).toBe(0);
+    expect(result.tokens[1]?.surface).toBe('करना');
+    // Two inserts: one for the phrase, one for phrase_tokens.
+    expect(calls.filter((c) => c.kind === 'insert')).toHaveLength(2);
+  });
+
+  it('NFC-normalises and trims token surfaces before persisting', async () => {
+    stage([]); // dedupe miss
+    stage([
+      { id: 'phr-2', language: 'hi', surfaceNormalised: 'a b', source: 'user' },
+    ]);
+    stage([
+      { phraseId: 'phr-2', position: 0, surface: 'a', lemmaId: null },
+      { phraseId: 'phr-2', position: 1, surface: 'b', lemmaId: null },
+    ]);
+
+    await createPhrase({
+      language: 'hi',
+      tokens: ['  a  ', ' b '],
+      source: 'user',
+      submittedBy: 'user-1',
+    });
+
+    const phraseInsertCall = calls.filter((c) => c.kind === 'insert')[0];
+    expect((phraseInsertCall as { payload: { surfaceNormalised: string } }).payload.surfaceNormalised).toBe('a b');
+  });
+});
+
+describe('createPhrase — dedupe', () => {
+  it('returns the existing phrase + tokens with reused=true on a (lang,surface,source) hit', async () => {
+    stage([
+      {
+        id: 'phr-existing',
+        language: 'hi',
+        surfaceNormalised: 'इंतज़ार करना',
+        source: 'user',
+      },
+    ]); // dedupe hit
+    stage([
+      { phraseId: 'phr-existing', position: 0, surface: 'इंतज़ार', lemmaId: null },
+      { phraseId: 'phr-existing', position: 1, surface: 'करना', lemmaId: null },
+    ]); // existing phrase_tokens lookup
+
+    const result = await createPhrase({
+      language: 'hi',
+      tokens: ['इंतज़ार', 'करना'],
+      source: 'user',
+      submittedBy: 'user-2',
+    });
+
+    expect(result.reused).toBe(true);
+    expect(result.phrase.id).toBe('phr-existing');
+    // No insert calls — pure dedupe path.
+    expect(calls.filter((c) => c.kind === 'insert')).toHaveLength(0);
+  });
+});
+
+describe('createPhrase — validation', () => {
+  it('rejects a single-token phrase (use lemmas instead)', async () => {
+    await expect(
+      createPhrase({
+        language: 'hi',
+        tokens: ['नमस्ते'],
+        source: 'user',
+        submittedBy: 'u',
+      }),
+    ).rejects.toBeInstanceOf(PhraseValidationError);
+    expect(selectFn).not.toHaveBeenCalled();
+  });
+
+  it('rejects a phrase exceeding MAX_PHRASE_TOKENS for non-curators', async () => {
+    const tokens = Array.from({ length: MAX_PHRASE_TOKENS + 1 }, (_, i) => `t${i}`);
+    await expect(
+      createPhrase({
+        language: 'hi',
+        tokens,
+        source: 'user',
+        submittedBy: 'u',
+      }),
+    ).rejects.toBeInstanceOf(PhraseValidationError);
+  });
+
+  it('allows a curator to bypass MAX_PHRASE_TOKENS', async () => {
+    const tokens = Array.from({ length: MAX_PHRASE_TOKENS + 2 }, (_, i) => `t${i}`);
+    stage([]); // dedupe miss
+    stage([
+      {
+        id: 'phr-long',
+        language: 'hi',
+        surfaceNormalised: tokens.join(' '),
+        source: 'curator',
+      },
+    ]);
+    stage(
+      tokens.map((surface, position) => ({
+        phraseId: 'phr-long',
+        position,
+        surface,
+        lemmaId: null,
+      })),
+    );
+    const result = await createPhrase({
+      language: 'hi',
+      tokens,
+      source: 'curator',
+      bypassTokenCap: true,
+    });
+    expect(result.tokens).toHaveLength(tokens.length);
+  });
+
+  it('rejects a punctuation-only token', async () => {
+    await expect(
+      createPhrase({
+        language: 'hi',
+        tokens: ['कर', '।'],
+        source: 'user',
+        submittedBy: 'u',
+      }),
+    ).rejects.toBeInstanceOf(PhraseValidationError);
+  });
+
+  it('rejects an empty-string token after trim', async () => {
+    await expect(
+      createPhrase({
+        language: 'hi',
+        tokens: ['कर', '   '],
+        source: 'user',
+        submittedBy: 'u',
+      }),
+    ).rejects.toBeInstanceOf(PhraseValidationError);
+  });
+});
+
+// ---------------------------------------------------------------
+// getPhrase
+// ---------------------------------------------------------------
+
+describe('getPhrase', () => {
+  it('returns null when the phrase does not exist', async () => {
+    stage([]); // miss
+    const result = await getPhrase('11111111-1111-1111-1111-111111111111');
+    expect(result).toBeNull();
+  });
+
+  it('hydrates phrase + tokens (sorted by position) + visible translations', async () => {
+    stage([
+      {
+        id: 'phr-1',
+        language: 'hi',
+        surfaceNormalised: 'इंतज़ार करना',
+        source: 'user',
+      },
+    ]); // phrase
+    stage([
+      { phraseId: 'phr-1', position: 1, surface: 'करना', lemmaId: null },
+      { phraseId: 'phr-1', position: 0, surface: 'इंतज़ार', lemmaId: null },
+    ]); // tokens — out of order on purpose
+    stage([
+      {
+        id: 'tr-1',
+        targetType: 'phrase',
+        targetId: 'phr-1',
+        body: 'to wait',
+        hidden: false,
+      },
+    ]); // translations
+
+    const result = await getPhrase('phr-1');
+    expect(result?.tokens.map((t) => t.position)).toEqual([0, 1]);
+    expect(result?.translations).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------
+// setKnownPhraseStatus
+// ---------------------------------------------------------------
+
+describe('setKnownPhraseStatus', () => {
+  it('inserts a row when none exists and recomputes the language counter', async () => {
+    stage([{ id: 'phr-1', language: 'hi' }]); // phrase lookup
+    stage([]); // existing user_known_phrases for this user — none
+    stage([
+      {
+        userId: 'user-1',
+        phraseId: 'phr-1',
+        status: 'known',
+        updatedAt: new Date('2026-04-30'),
+      },
+    ]); // insert
+    stage([{ phraseId: 'phr-1', language: 'hi' }]); // counter recompute select
+    // (final UPDATE on user_languages goes to the chain.then path,
+    // resolves to undefined — no stage needed.)
+
+    const row = await setKnownPhraseStatus({
+      userId: 'user-1',
+      phraseId: 'phr-1',
+      status: 'known',
+    });
+
+    expect(row.status).toBe('known');
+    // INSERT (status row) — UPDATE happens for the cache.
+    expect(calls.filter((c) => c.kind === 'insert')).toHaveLength(1);
+    expect(calls.filter((c) => c.kind === 'update')).toHaveLength(1);
+    const updateCall = calls.find((c) => c.kind === 'update');
+    expect((updateCall as { set: { knownPhrasesCountCache: number } }).set.knownPhrasesCountCache).toBe(1);
+  });
+
+  it('updates an existing row and refreshes the counter', async () => {
+    stage([{ id: 'phr-1', language: 'hi' }]);
+    stage([
+      {
+        userId: 'user-1',
+        phraseId: 'phr-1',
+        status: 'learning',
+        updatedAt: new Date('2026-04-29'),
+      },
+    ]); // existing row
+    stage([
+      {
+        userId: 'user-1',
+        phraseId: 'phr-1',
+        status: 'known',
+        updatedAt: new Date('2026-04-30'),
+      },
+    ]); // update returning
+    stage([
+      { phraseId: 'phr-1', language: 'hi' },
+      { phraseId: 'phr-9', language: 'hi' },
+    ]); // counter recompute — two known phrases for hi
+
+    const row = await setKnownPhraseStatus({
+      userId: 'user-1',
+      phraseId: 'phr-1',
+      status: 'known',
+    });
+    expect(row.status).toBe('known');
+    // Two updates: the status row, then the counter.
+    expect(calls.filter((c) => c.kind === 'update')).toHaveLength(2);
+    const counterUpdate = calls.filter((c) => c.kind === 'update')[1];
+    expect((counterUpdate as { set: { knownPhrasesCountCache: number } }).set.knownPhrasesCountCache).toBe(2);
+  });
+
+  it('throws a 404-flavoured error when the phrase does not exist', async () => {
+    stage([]); // phrase missing
+    try {
+      await setKnownPhraseStatus({
+        userId: 'user-1',
+        phraseId: 'phr-missing',
+        status: 'known',
+      });
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(PhraseValidationError);
+      expect((err as InstanceType<typeof PhraseValidationError>).status).toBe(404);
+    }
+  });
+});

--- a/apps/web/src/lib/server/phrases.ts
+++ b/apps/web/src/lib/server/phrases.ts
@@ -1,0 +1,437 @@
+/**
+ * Phrase service (T-14.1, M14 phrase-level translations).
+ *
+ * Multi-word dictionary entries — the moral parallel to `lemmas` for
+ * units like Hindi `इंतज़ार करना` ("to wait"), Marathi `मदत करणे`, or
+ * fixed expressions like `के बारे में`. Three sources author phrases:
+ * users (multi-token select in the reader, T-14.3), curators (the
+ * dictionary editor, T-14.4), and the NLP rule-based detector (T-14.5).
+ *
+ * Identity is the ordered `phrase_tokens` rows. `surface_normalised`
+ * on `phrases` is just the dedupe lookup column — see `normalizeTokens`
+ * for how it's derived. Per-source duplication is allowed by design
+ * (mirrors lemmas merge story from T-3.10); the curator merge UI in
+ * T-14.7 reconciles duplicates.
+ *
+ * MVP matching is contiguous-only — discontinuous (gappy) phrases like
+ * `इंतज़ार ... किया` (split by an intervening adverb) are an explicit
+ * follow-up. The schema is shaped so that change is a resolver-only
+ * change with no migration.
+ */
+import { and, eq, isNull } from 'drizzle-orm';
+
+import { db, schema } from './db/index.js';
+import type {
+  Phrase,
+  PhraseToken,
+  Translation,
+  UserKnownPhrase,
+} from './db/schema.js';
+import type { LanguageCode } from '@ciareader/shared-types';
+
+// -----------------------------------------------------------------------
+// Bounds (chosen to match `submitUserTranslation` ergonomics).
+// -----------------------------------------------------------------------
+
+/** Maximum tokens per phrase. Curators bypass this (rationale: a 9+
+ *  token idiom like a proverbs entry is a curator-only artefact —
+ *  user-created phrases stay learner-sized). */
+export const MAX_PHRASE_TOKENS = 8;
+
+/** Minimum tokens. A "phrase" of length 1 is just a lemma; reject so
+ *  the data model doesn't pick up shadow entries that should have
+ *  been written to `lemmas` instead. */
+export const MIN_PHRASE_TOKENS = 2;
+
+// -----------------------------------------------------------------------
+// Errors. Mirror the validation/error shape used by `translations.ts`
+// so endpoint handlers can pattern-match a single error type per kind.
+// -----------------------------------------------------------------------
+
+export class PhraseValidationError extends Error {
+  constructor(
+    message: string,
+    public readonly status: 400 | 403 | 404 | 409 = 400,
+  ) {
+    super(message);
+    this.name = 'PhraseValidationError';
+  }
+}
+
+// -----------------------------------------------------------------------
+// Inputs.
+// -----------------------------------------------------------------------
+
+export type CreatePhraseInput = {
+  language: LanguageCode;
+  /** Ordered surface forms. Each element is a single token's surface
+   *  text — exact form as it must appear in the chapter for the
+   *  contiguous matcher (T-14.2) to pick it up. */
+  tokens: string[];
+  pos?: string | null;
+  glossDefault?: string | null;
+  source: Phrase['source'];
+  submittedBy?: string | null;
+  sourceAttribution?: string | null;
+  sourceId?: string | null;
+  frequencyRank?: number | null;
+  /** Curator/admin callers may exceed `MAX_PHRASE_TOKENS`. Defaults
+   *  to false — the user-facing API never sets this true. */
+  bypassTokenCap?: boolean;
+};
+
+export type CreatePhraseResult = {
+  phrase: Phrase;
+  tokens: PhraseToken[];
+  /** True iff the phrase already existed (dedupe hit). The endpoint
+   *  layer translates that into a 200 instead of a 201 so clients
+   *  can tell the difference. */
+  reused: boolean;
+};
+
+// -----------------------------------------------------------------------
+// Token normalisation.
+// -----------------------------------------------------------------------
+
+/**
+ * Normalise a single token surface. NFC + trim. Light-touch on
+ * purpose: matching is surface-exact for MVP, so we don't lowercase
+ * or strip diacritics. Devanagari/Odia don't carry case, and folding
+ * marks would break legitimate distinctions like nukta-bearing finals.
+ */
+function normalizeToken(s: string): string {
+  return s.normalize('NFC').trim();
+}
+
+/**
+ * Build the `surface_normalised` value from an ordered token list.
+ * Joined with a single space — the dedupe lookup is purely literal
+ * after this step. The chapter-span resolver (T-14.2) matches on the
+ * canonical `phrase_tokens` rows, NOT on this string, so this column
+ * never participates in detection.
+ */
+function joinTokens(tokens: string[]): string {
+  return tokens.join(' ');
+}
+
+const PUNCT_RE = /^[\p{P}\s]+$/u;
+
+function validateTokens(input: CreatePhraseInput): string[] {
+  const raw = input.tokens ?? [];
+  const tokens = raw.map(normalizeToken);
+  if (tokens.length < MIN_PHRASE_TOKENS) {
+    throw new PhraseValidationError(
+      `phrase requires at least ${MIN_PHRASE_TOKENS} tokens`,
+    );
+  }
+  const cap = input.bypassTokenCap ? Number.POSITIVE_INFINITY : MAX_PHRASE_TOKENS;
+  if (tokens.length > cap) {
+    throw new PhraseValidationError(
+      `phrase exceeds ${MAX_PHRASE_TOKENS}-token limit (got ${tokens.length})`,
+    );
+  }
+  for (const [i, t] of tokens.entries()) {
+    if (t.length === 0) {
+      throw new PhraseValidationError(`token at position ${i} is empty`);
+    }
+    if (PUNCT_RE.test(t)) {
+      throw new PhraseValidationError(
+        `token at position ${i} is punctuation-only`,
+      );
+    }
+  }
+  return tokens;
+}
+
+// -----------------------------------------------------------------------
+// Public API.
+// -----------------------------------------------------------------------
+
+/**
+ * Create a phrase, deduping against an existing `(language,
+ * surface_normalised, source)` triple so a second user submitting
+ * `इंतज़ार करना` reuses the original row. The `source` is part of
+ * the dedupe key on purpose — a curator phrase and a user phrase
+ * with the same surface stay as distinct rows for the merge UI
+ * (T-14.7) to reconcile, exactly like lemmas do (T-3.10).
+ *
+ * Writes are split across two tables (`phrases`, `phrase_tokens`).
+ * No native FK on `translations.target_id`; existence checks live
+ * in the translation service.
+ */
+export async function createPhrase(
+  input: CreatePhraseInput,
+  now: Date = new Date(),
+): Promise<CreatePhraseResult> {
+  const tokens = validateTokens(input);
+  const surfaceNormalised = joinTokens(tokens);
+
+  // Dedupe lookup: a row with the same (language, surface, source)
+  // is reused. Different sources for the same surface stay
+  // distinct — `T-14.7 merge` reconciles those.
+  const [existing] = (await db
+    .select()
+    .from(schema.phrases)
+    .where(
+      and(
+        eq(schema.phrases.language, input.language),
+        eq(schema.phrases.surfaceNormalised, surfaceNormalised),
+        eq(schema.phrases.source, input.source),
+      ),
+    )
+    .limit(1)) as Phrase[];
+
+  if (existing) {
+    const tokenRows = (await db
+      .select()
+      .from(schema.phraseTokens)
+      .where(eq(schema.phraseTokens.phraseId, existing.id))) as PhraseToken[];
+    tokenRows.sort((a, b) => a.position - b.position);
+    return { phrase: existing, tokens: tokenRows, reused: true };
+  }
+
+  const [phrase] = (await db
+    .insert(schema.phrases)
+    .values({
+      language: input.language,
+      surfaceNormalised,
+      pos: input.pos ?? null,
+      glossDefault: input.glossDefault ?? null,
+      frequencyRank: input.frequencyRank ?? null,
+      source: input.source,
+      sourceAttribution: input.sourceAttribution ?? null,
+      sourceId: input.sourceId ?? null,
+      curatorLocked: false,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning()) as Phrase[];
+  if (!phrase) throw new Error('phrases insert returned no row');
+
+  const tokenRows = (await db
+    .insert(schema.phraseTokens)
+    .values(
+      tokens.map((surface, position) => ({
+        phraseId: phrase.id,
+        position,
+        surface,
+        // T-14.1: lemma_id is a soft hint, not part of identity.
+        // Resolution is deferred to T-14.4's curator editor; new
+        // phrases land with NULL component lemmas.
+        lemmaId: null,
+      })),
+    )
+    .returning()) as PhraseToken[];
+  tokenRows.sort((a, b) => a.position - b.position);
+
+  // Note: callers that need the `submittedBy` audit (e.g. user
+  // submissions) should also write a row to T-14.7's
+  // lemma_edit_history with change_type='phrase_insert'. T-14.1
+  // ships the schema and core CRUD — the audit-log integration
+  // lands when `lemma_edit_change_type` is extended in T-14.7.
+  void input.submittedBy;
+
+  return { phrase, tokens: tokenRows, reused: false };
+}
+
+/**
+ * Fetch a phrase + its ordered tokens + visible translations
+ * (target_type='phrase'). `hidden` translations are filtered out at
+ * this layer; curator/admin views must use a separate path that
+ * pulls the moderation rows (lands with T-14.4).
+ */
+export async function getPhrase(
+  id: string,
+): Promise<{
+  phrase: Phrase;
+  tokens: PhraseToken[];
+  translations: Translation[];
+} | null> {
+  const [phrase] = (await db
+    .select()
+    .from(schema.phrases)
+    .where(eq(schema.phrases.id, id))
+    .limit(1)) as Phrase[];
+  if (!phrase) return null;
+
+  const tokens = (await db
+    .select()
+    .from(schema.phraseTokens)
+    .where(eq(schema.phraseTokens.phraseId, id))) as PhraseToken[];
+  tokens.sort((a, b) => a.position - b.position);
+
+  const translations = (await db
+    .select()
+    .from(schema.translations)
+    .where(
+      and(
+        eq(schema.translations.targetType, 'phrase'),
+        eq(schema.translations.targetId, id),
+        eq(schema.translations.hidden, false),
+      ),
+    )) as Translation[];
+
+  return { phrase, tokens, translations };
+}
+
+/**
+ * List phrases for a language. Pagination is offset-based to match
+ * the dictionary browse page's pattern (T-3.6); the curator editor
+ * in T-14.4 layers source/locale filters on top of this.
+ */
+export async function listPhrasesForLanguage(args: {
+  language: LanguageCode;
+  source?: Phrase['source'];
+  limit?: number;
+  offset?: number;
+}): Promise<Phrase[]> {
+  const limit = Math.min(Math.max(args.limit ?? 50, 1), 200);
+  const offset = Math.max(args.offset ?? 0, 0);
+
+  const where = args.source
+    ? and(
+        eq(schema.phrases.language, args.language),
+        eq(schema.phrases.source, args.source),
+      )
+    : eq(schema.phrases.language, args.language);
+
+  const rows = (await db
+    .select()
+    .from(schema.phrases)
+    .where(where)
+    .limit(limit)
+    .offset(offset)) as Phrase[];
+
+  return rows;
+}
+
+// -----------------------------------------------------------------------
+// User-known status (T-14.1 mirror of T-5.5 setKnownLemmaStatus).
+// -----------------------------------------------------------------------
+
+/**
+ * Upsert the user's known-status for a phrase. Mirrors
+ * `setKnownLemmaStatus` exactly — same enum values, same per-language
+ * cache recompute, same shape of returned row. Reader hooks this
+ * from a phrase-popup status button in T-14.3.
+ */
+export async function setKnownPhraseStatus(args: {
+  userId: string;
+  phraseId: string;
+  status: 'unknown' | 'learning' | 'known' | 'ignored';
+  now?: Date;
+}): Promise<UserKnownPhrase> {
+  const now = args.now ?? new Date();
+
+  const [phrase] = (await db
+    .select({ id: schema.phrases.id, language: schema.phrases.language })
+    .from(schema.phrases)
+    .where(eq(schema.phrases.id, args.phraseId))
+    .limit(1)) as Array<{ id: string; language: LanguageCode }>;
+  if (!phrase) {
+    throw new PhraseValidationError(`Phrase ${args.phraseId} not found`, 404);
+  }
+  const language = phrase.language;
+
+  // Read-then-write — composite-PK upsert with onConflictDoUpdate
+  // is awkward across our drivers; the same pattern is used in
+  // `setKnownLemmaStatus`.
+  const existing = (await db
+    .select()
+    .from(schema.userKnownPhrases)
+    .where(eq(schema.userKnownPhrases.userId, args.userId))) as UserKnownPhrase[];
+  const row = existing.find((r) => r.phraseId === args.phraseId);
+
+  let result: UserKnownPhrase;
+  if (row) {
+    const [updated] = (await db
+      .update(schema.userKnownPhrases)
+      .set({ status: args.status, updatedAt: now })
+      .where(
+        and(
+          eq(schema.userKnownPhrases.userId, args.userId),
+          eq(schema.userKnownPhrases.phraseId, args.phraseId),
+        ),
+      )
+      .returning()) as UserKnownPhrase[];
+    if (!updated) throw new Error('Failed to update user_known_phrases');
+    result = updated;
+  } else {
+    const [inserted] = (await db
+      .insert(schema.userKnownPhrases)
+      .values({
+        userId: args.userId,
+        phraseId: args.phraseId,
+        status: args.status,
+        updatedAt: now,
+      })
+      .returning()) as UserKnownPhrase[];
+    if (!inserted) throw new Error('Failed to insert user_known_phrases');
+    result = inserted;
+  }
+
+  // Recompute the per-language cache. Counted as the number of rows
+  // with status='known' for the phrases in that language. This
+  // mirrors the equivalent recompute in `setKnownLemmaStatus`.
+  const allKnown = (await db
+    .select({
+      phraseId: schema.userKnownPhrases.phraseId,
+      language: schema.phrases.language,
+    })
+    .from(schema.userKnownPhrases)
+    .innerJoin(
+      schema.phrases,
+      eq(schema.phrases.id, schema.userKnownPhrases.phraseId),
+    )
+    .where(
+      and(
+        eq(schema.userKnownPhrases.userId, args.userId),
+        eq(schema.userKnownPhrases.status, 'known'),
+        eq(schema.phrases.language, language),
+      ),
+    )) as Array<{ phraseId: string; language: string }>;
+  const knownCount = allKnown.length;
+  await db
+    .update(schema.userLanguages)
+    .set({ knownPhrasesCountCache: knownCount })
+    .where(
+      and(
+        eq(schema.userLanguages.userId, args.userId),
+        eq(schema.userLanguages.language, language),
+      ),
+    );
+
+  return result;
+}
+
+// -----------------------------------------------------------------------
+// Public projections — what the API surfaces. Mirrors `publicTranslation`
+// from `dictionary/translations.ts`.
+// -----------------------------------------------------------------------
+
+export function publicPhrase(phrase: Phrase, tokens: PhraseToken[]) {
+  const ordered = [...tokens].sort((a, b) => a.position - b.position);
+  return {
+    id: phrase.id,
+    language: phrase.language,
+    tokens: ordered.map((t) => ({
+      position: t.position,
+      surface: t.surface,
+      lemmaId: t.lemmaId,
+    })),
+    surfaceNormalised: phrase.surfaceNormalised,
+    pos: phrase.pos,
+    glossDefault: phrase.glossDefault,
+    frequencyRank: phrase.frequencyRank,
+    source: phrase.source,
+    sourceAttribution: phrase.sourceAttribution,
+    curatorLocked: phrase.curatorLocked,
+    createdAt: phrase.createdAt,
+    updatedAt: phrase.updatedAt,
+  };
+}
+
+// Suppress a noisy unused-import warning when only the typecheck
+// hits this file. `isNull` is exported for callers that want to
+// query un-resolved component-lemma rows on `phrase_tokens`.
+export { isNull };

--- a/apps/web/src/routes/api/v1/me/known-phrases/[phraseId]/+server.ts
+++ b/apps/web/src/routes/api/v1/me/known-phrases/[phraseId]/+server.ts
@@ -1,0 +1,67 @@
+/**
+ * PATCH /api/v1/me/known-phrases/:phraseId (T-14.1).
+ *
+ * Direct parallel to PATCH /api/v1/me/known-lemmas/:lemmaId (T-5.5)
+ * but for phrase-level status. Reader pop-up phrase mode (T-14.3)
+ * wires its Learning / Known / Ignored buttons through this. Body:
+ * `{ status: 'unknown' | 'learning' | 'known' | 'ignored' }`.
+ * Response: 200 with the updated row; the per-language phrases
+ * counter cache is recomputed in the same transaction so the
+ * stats card on the profile page (T-14.6) stays current without
+ * a separate fetch.
+ */
+import { error, json } from '@sveltejs/kit';
+import { z } from 'zod';
+
+import { requireUser } from '$lib/server/auth/require-user.js';
+import {
+  setKnownPhraseStatus,
+  PhraseValidationError,
+} from '$lib/server/phrases.js';
+import type { RequestHandler } from './$types';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const body = z.object({
+  status: z.enum(['unknown', 'learning', 'known', 'ignored']),
+});
+
+export const PATCH: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  const phraseId = event.params.phraseId;
+  if (!phraseId || !UUID_RE.test(phraseId)) {
+    throw error(400, 'Invalid phrase id');
+  }
+
+  let parsed: { status: 'unknown' | 'learning' | 'known' | 'ignored' };
+  try {
+    const json_body = await event.request.json();
+    const result = body.safeParse(json_body);
+    if (!result.success) throw error(400, 'Invalid body');
+    parsed = result.data;
+  } catch (e) {
+    if (e && typeof e === 'object' && 'status' in e) throw e;
+    throw error(400, 'Invalid JSON body');
+  }
+
+  try {
+    const row = await setKnownPhraseStatus({
+      userId: user.id,
+      phraseId,
+      status: parsed.status,
+    });
+    return json({
+      knownPhrase: {
+        userId: row.userId,
+        phraseId: row.phraseId,
+        status: row.status,
+        updatedAt: row.updatedAt,
+      },
+    });
+  } catch (err) {
+    if (err instanceof PhraseValidationError) {
+      throw error(err.status, err.message);
+    }
+    throw err;
+  }
+};

--- a/apps/web/src/routes/api/v1/me/known-phrases/[phraseId]/known-phrases-server.test.ts
+++ b/apps/web/src/routes/api/v1/me/known-phrases/[phraseId]/known-phrases-server.test.ts
@@ -1,0 +1,123 @@
+// @vitest-environment node
+/**
+ * Endpoint tests for PATCH /api/v1/me/known-phrases/:phraseId
+ * (T-14.1). Mirrors the structure of `known-lemmas-server.test.ts`.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const setKnownPhraseStatus = vi.fn();
+const requireUser = vi.fn();
+
+vi.mock('$lib/server/phrases.js', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/phrases.js')>(
+    '$lib/server/phrases.js',
+  );
+  return {
+    ...actual,
+    setKnownPhraseStatus: (...a: unknown[]) => setKnownPhraseStatus(...a),
+  };
+});
+
+vi.mock('$lib/server/auth/require-user.js', () => ({
+  requireUser: (...a: unknown[]) => requireUser(...a),
+}));
+
+type PatchFn = (typeof import('./+server.js'))['PATCH'];
+
+const VALID_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const USER = { id: 'user-1', role: 'user' as const };
+
+async function callPatch(
+  body: unknown,
+  phraseId = VALID_ID,
+  user: typeof USER | null = USER,
+) {
+  if (user) {
+    requireUser.mockResolvedValueOnce(user);
+  } else {
+    requireUser.mockImplementationOnce(() => {
+      throw { status: 401 };
+    });
+  }
+  const { PATCH } = await import('./+server.js');
+  const event = {
+    params: { phraseId },
+    request: new Request(`http://x/api/v1/me/known-phrases/${phraseId}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: typeof body === 'string' ? body : JSON.stringify(body),
+    }),
+  } as unknown as Parameters<PatchFn>[0];
+  try {
+    return await PATCH(event);
+  } catch (e) {
+    return e as { status: number };
+  }
+}
+
+beforeEach(() => {
+  setKnownPhraseStatus.mockReset();
+  requireUser.mockReset();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('PATCH /api/v1/me/known-phrases/:phraseId', () => {
+  it('updates the status and returns the row', async () => {
+    setKnownPhraseStatus.mockResolvedValueOnce({
+      userId: USER.id,
+      phraseId: VALID_ID,
+      status: 'known',
+      updatedAt: new Date('2026-04-30T00:00:00Z'),
+    });
+    const res = (await callPatch({ status: 'known' })) as Response;
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.knownPhrase.status).toBe('known');
+    expect(json.knownPhrase.phraseId).toBe(VALID_ID);
+    expect(setKnownPhraseStatus).toHaveBeenCalledWith({
+      userId: USER.id,
+      phraseId: VALID_ID,
+      status: 'known',
+    });
+  });
+
+  it('rejects an invalid status', async () => {
+    const res = (await callPatch({ status: 'bogus' })) as { status: number };
+    expect(res.status).toBe(400);
+    expect(setKnownPhraseStatus).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid phrase id format', async () => {
+    const res = (await callPatch({ status: 'known' }, 'not-a-uuid')) as {
+      status: number;
+    };
+    expect(res.status).toBe(400);
+    expect(setKnownPhraseStatus).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed JSON', async () => {
+    const res = (await callPatch('{ broken json')) as { status: number };
+    expect(res.status).toBe(400);
+    expect(setKnownPhraseStatus).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when no user is authenticated', async () => {
+    const res = (await callPatch({ status: 'known' }, VALID_ID, null)) as {
+      status: number;
+    };
+    expect(res.status).toBe(401);
+    expect(setKnownPhraseStatus).not.toHaveBeenCalled();
+  });
+
+  it('translates a 404 from the service into a 404 response', async () => {
+    const { PhraseValidationError } = await import('$lib/server/phrases.js');
+    setKnownPhraseStatus.mockRejectedValueOnce(
+      new PhraseValidationError('Phrase missing not found', 404),
+    );
+    const res = (await callPatch({ status: 'known' })) as { status: number };
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/web/src/routes/api/v1/phrases/+server.ts
+++ b/apps/web/src/routes/api/v1/phrases/+server.ts
@@ -1,0 +1,134 @@
+/**
+ * POST /api/v1/phrases  — create or reuse a phrase (T-14.1).
+ * GET  /api/v1/phrases  — list phrases for a language.
+ *
+ * Phrase creation dedupes against `(language, surface_normalised,
+ * source)` so a second user submitting the same surface reuses the
+ * existing row. The endpoint returns 201 for a fresh insert and 200
+ * for a dedupe hit so clients can distinguish the two without re-
+ * fetching.
+ *
+ * The `source` of the row is locked to `user` for non-curator
+ * callers — admins and curators may submit `curator` /
+ * `official_dictionary` rows via this surface; the dictionary
+ * editor in T-14.4 layers a richer admin-only path on top.
+ */
+import { error, json } from '@sveltejs/kit';
+import { z } from 'zod';
+
+import { requireUser } from '$lib/server/auth/require-user.js';
+import { parseJson } from '../auth/_helpers.js';
+import {
+  createPhrase,
+  listPhrasesForLanguage,
+  publicPhrase,
+  PhraseValidationError,
+  MAX_PHRASE_TOKENS,
+} from '$lib/server/phrases.js';
+import type { RequestHandler } from './$types';
+
+const LANGS = ['hi', 'mr', 'or'] as const;
+const SOURCES = ['user', 'curator', 'official_dictionary'] as const;
+
+const createBody = z.object({
+  language: z.enum(LANGS),
+  // Each token is a single surface form. Server enforces the
+  // detailed bounds (MIN/MAX_PHRASE_TOKENS, punctuation guard);
+  // Zod just rejects obvious garbage early.
+  tokens: z.array(z.string()).min(1).max(MAX_PHRASE_TOKENS + 4),
+  pos: z.string().max(32).nullish(),
+  glossDefault: z.string().max(500).nullish(),
+  source: z.enum(SOURCES).default('user'),
+  sourceAttribution: z.string().max(200).nullish(),
+});
+
+export const POST: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  const input = await parseJson(event.request, createBody);
+
+  // Source policy: regular users are locked to source='user'.
+  // Curator / admin may set any allowed source. The role check
+  // mirrors the existing dictionary editor (T-3.4).
+  const sourceAllowed =
+    input.source === 'user' ||
+    user.role === 'curator' ||
+    user.role === 'admin';
+  if (!sourceAllowed) {
+    throw error(
+      403,
+      'Only curators or admins may submit phrases under that source',
+    );
+  }
+
+  try {
+    const result = await createPhrase({
+      language: input.language,
+      tokens: input.tokens,
+      pos: input.pos ?? null,
+      glossDefault: input.glossDefault ?? null,
+      // The zod schema defaults `source` to 'user' when omitted,
+      // but the inferred type carries `undefined` until parse —
+      // the fallback here is belt-and-braces.
+      source: input.source ?? 'user',
+      submittedBy: user.id,
+      sourceAttribution: input.sourceAttribution ?? null,
+      bypassTokenCap: user.role === 'curator' || user.role === 'admin',
+    });
+    return json(
+      { phrase: publicPhrase(result.phrase, result.tokens), reused: result.reused },
+      { status: result.reused ? 200 : 201 },
+    );
+  } catch (err) {
+    if (err instanceof PhraseValidationError) {
+      throw error(err.status, err.message);
+    }
+    throw err;
+  }
+};
+
+const listQuery = z.object({
+  language: z.enum(LANGS),
+  source: z.enum(SOURCES).optional(),
+  limit: z.coerce.number().int().min(1).max(200).default(50),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+export const GET: RequestHandler = async (event) => {
+  // Listing is anonymous-readable — same posture as the dictionary
+  // browse page (T-3.6). The endpoint returns the phrase header
+  // only; translations are hydrated by `GET /api/v1/phrases/:id`
+  // to keep this list cheap.
+  const params = listQuery.safeParse(
+    Object.fromEntries(event.url.searchParams.entries()),
+  );
+  if (!params.success) {
+    throw error(400, 'Invalid query parameters');
+  }
+  const rows = await listPhrasesForLanguage({
+    language: params.data.language,
+    source: params.data.source,
+    limit: params.data.limit,
+    offset: params.data.offset,
+  });
+  // No tokens hydrated here — the list view shows
+  // `surface_normalised` only. Detail view does the join.
+  return json({
+    phrases: rows.map((p) =>
+      publicPhrase(p, []).tokens.length === 0
+        ? {
+            id: p.id,
+            language: p.language,
+            surfaceNormalised: p.surfaceNormalised,
+            pos: p.pos,
+            glossDefault: p.glossDefault,
+            frequencyRank: p.frequencyRank,
+            source: p.source,
+            sourceAttribution: p.sourceAttribution,
+            curatorLocked: p.curatorLocked,
+            createdAt: p.createdAt,
+            updatedAt: p.updatedAt,
+          }
+        : publicPhrase(p, []),
+    ),
+  });
+};

--- a/apps/web/src/routes/api/v1/phrases/[id]/+server.ts
+++ b/apps/web/src/routes/api/v1/phrases/[id]/+server.ts
@@ -1,0 +1,28 @@
+/**
+ * GET /api/v1/phrases/:id (T-14.1).
+ *
+ * Detail view: phrase + ordered phrase_tokens + visible (non-hidden)
+ * translations targeting the phrase. Returns 404 if the phrase id
+ * doesn't exist. Anonymous-readable like the dictionary browse
+ * detail (T-3.6).
+ */
+import { error, json } from '@sveltejs/kit';
+
+import { getPhrase, publicPhrase } from '$lib/server/phrases.js';
+import { publicTranslation } from '$lib/server/dictionary/translations.js';
+import type { RequestHandler } from './$types';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const GET: RequestHandler = async (event) => {
+  const id = event.params.id;
+  if (!id || !UUID_RE.test(id)) {
+    throw error(400, 'Invalid phrase id');
+  }
+  const result = await getPhrase(id);
+  if (!result) throw error(404, 'Phrase not found');
+  return json({
+    phrase: publicPhrase(result.phrase, result.tokens),
+    translations: result.translations.map(publicTranslation),
+  });
+};

--- a/apps/web/src/routes/api/v1/phrases/[id]/translations/+server.ts
+++ b/apps/web/src/routes/api/v1/phrases/[id]/translations/+server.ts
@@ -1,0 +1,75 @@
+/**
+ * POST /api/v1/phrases/:id/translations (T-14.1).
+ *
+ * Submits a user-authored translation against a phrase. Mirrors
+ * `POST /api/v1/translations` (T-3.2) which targets lemmas — the
+ * service surface is `submitUserPhraseTranslation` and the rate
+ * limiter is shared with the lemma path so a spam bot can't dodge
+ * caps by alternating between targets.
+ */
+import { error, json } from '@sveltejs/kit';
+import { z } from 'zod';
+
+import { requireUser } from '$lib/server/auth/require-user.js';
+import { parseJson } from '../../../auth/_helpers.js';
+import {
+  MAX_BODY_LEN,
+  publicTranslation,
+  submitUserPhraseTranslation,
+  TranslationRateLimitError,
+  TranslationValidationError,
+} from '$lib/server/dictionary/translations.js';
+import type { RequestHandler } from './$types';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const body = z.object({
+  body: z.string().min(1).max(MAX_BODY_LEN),
+  // T-3.5 customize fork applies to phrase translations too — a
+  // user can fork a curator phrase translation into their own
+  // edit; the parent stays in everyone else's view.
+  parentTranslationId: z.string().uuid().nullish(),
+  targetLanguage: z.string().min(2).max(3).optional(),
+});
+
+export const POST: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  const phraseId = event.params.id;
+  if (!phraseId || !UUID_RE.test(phraseId)) {
+    throw error(400, 'Invalid phrase id');
+  }
+  const input = await parseJson(event.request, body);
+
+  try {
+    const translation = await submitUserPhraseTranslation(user.id, {
+      phraseId,
+      body: input.body,
+      parentTranslationId: input.parentTranslationId ?? null,
+      targetLanguage: input.targetLanguage,
+    });
+    return json({ translation: publicTranslation(translation) }, { status: 201 });
+  } catch (err) {
+    if (err instanceof TranslationRateLimitError) {
+      return json(
+        {
+          error: 'rate_limited',
+          message: 'Too many translations submitted. Try again later.',
+          limit: err.limit,
+          retryAfterSeconds: err.retryAfterSeconds,
+        },
+        {
+          status: 429,
+          headers: {
+            'Retry-After': String(err.retryAfterSeconds),
+            'X-RateLimit-Limit': String(err.limit),
+            'X-RateLimit-Remaining': '0',
+          },
+        },
+      );
+    }
+    if (err instanceof TranslationValidationError) {
+      throw error(err.status, err.message);
+    }
+    throw err;
+  }
+};


### PR DESCRIPTION
## Summary

First slice of M14 phrase-level translations. Adds the `phrases` /
`phrase_tokens` / `user_known_phrases` schema, the polymorphic
`translation_target_type` extension to `translations`, the phrase
service (`createPhrase`, `getPhrase`, `listPhrasesForLanguage`,
`setKnownPhraseStatus`), and the public API endpoints. Reader UI +
curator editor land in T-14.3 / T-14.4; chapter span resolution is
T-14.2; NLP-proposed phrases are T-14.5.

## Schema (migration 0024)

- `phrases` — id, language, `surface_normalised` (dedupe lookup),
  pos, gloss_default, frequency_rank, `source` (existing
  `translation_source` enum), `curator_locked`. Non-unique
  `(language, surface_normalised)` mirrors the lemmas merge story
  from T-3.10.
- `phrase_tokens` — composite PK `(phrase_id, position)`,
  `surface`, optional `lemma_id` as a *soft hint* with `ON DELETE
  SET NULL` (इंतज़ार करना ≠ इंतज़ार + करना semantically; lemma
  cross-link is for the popup's "see component lemmas" affordance,
  never identity).
- `translations` ALTER — new `translation_target_type` enum
  (`lemma | phrase`), new `target_type` / `target_id` columns,
  canonical `(target_type, target_id, source)` index. Backfill
  `UPDATE translations SET target_id = lemma_id` baked into the
  migration sequence; `lemma_id` is now nullable (full removal
  in T-14.7).
- `user_known_phrases` — composite PK, reuses `known_lemma_status`
  enum.
- `user_languages.known_phrases_count_cache` — parallel counter
  surfaced by T-14.6.

## Service surface

- `phrases.ts` — full CRUD with dedupe, MIN/MAX_PHRASE_TOKENS
  bounds (2..8, curator bypass), NFC normalisation,
  punctuation-only token rejection, `setKnownPhraseStatus` mirror
  of T-5.5.
- `dictionary/translations.ts` — `submitUserPhraseTranslation`
  (writes `lemma_id=NULL`, `target_type='phrase'`); shared
  rate-limit window with the lemma path. Existing `bulk.ts`,
  `drizzle-repo.ts`, and `test-support.ts` insert sites populate
  the polymorphic columns.
- `dictionary/curator.ts` — `updateTranslation` /
  `setTranslationHidden` reject phrase-target rows with 409 until
  T-14.7's curator merge / moderation parity lands.

## Endpoints

```
POST   /api/v1/phrases                       — create + dedupe
GET    /api/v1/phrases?language=hi           — list
GET    /api/v1/phrases/:id                   — detail
POST   /api/v1/phrases/:id/translations      — phrase translation
PATCH  /api/v1/me/known-phrases/:phraseId    — known status
```

## Test plan

- [x] `pnpm --filter @ciareader/web test` — 1006 tests across 119 files
  pass (was 994/117 before; +13 phrase service, +7 polymorphic
  translation, +6 endpoint, no regressions in curator/bulk after
  fixture updates).
- [x] `pnpm --filter @ciareader/web typecheck` — 0 errors.
- [x] `pnpm --filter @ciareader/web lint` — clean.
- [x] Migration applied live against the dev DB: 70,373 existing
  translation rows backfilled with `target_id = lemma_id`, 0
  NULLs, 0 inconsistent rows.
- [x] SQL-level smoke: insert phrase + ordered tokens + phrase
  translation (lemma_id=NULL) + canonical index lookup all green.
- [ ] Manual verification of phrase POST/PATCH endpoints once
  T-14.3 reader UI lands and the dev server is running with this
  branch.

Closes #315. Refs Epic #327.