### PR TITLE
T-12.2: API versioning policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ That boots postgres + redis + the NLP service + the SvelteKit dev server (with h
 - NLP: http://localhost:8000 (health at `/health`)
 - Postgres: `localhost:5432` (user `ciareader`, password `ciareader`, db `ciareader`)
 - Redis: `localhost:6379`
+- API docs: http://localhost:5173/api/docs
+- API versioning policy: [docs/api-versioning.md](docs/api-versioning.md)
 
 Smoke test (proves the full pipe works):
 

--- a/apps/web/src/lib/server/api-versioning.test.ts
+++ b/apps/web/src/lib/server/api-versioning.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+
+import {
+  API_DEPRECATION_HEADER,
+  buildApiDeprecationHeaders,
+  isStableApiPath,
+  minimumDeprecationSunsetDate,
+} from './api-versioning.js';
+
+describe('API versioning policy', () => {
+  it('treats only /api/v1 paths as stable public API paths', () => {
+    expect(isStableApiPath('/api/v1')).toBe(true);
+    expect(isStableApiPath('/api/v1/texts')).toBe(true);
+    expect(isStableApiPath('/api/v10/texts')).toBe(false);
+    expect(isStableApiPath('/api/openapi.json')).toBe(false);
+  });
+
+  it('calculates the six-month minimum support date', () => {
+    expect(minimumDeprecationSunsetDate('2026-04-30')).toBe('2026-10-30');
+    expect(minimumDeprecationSunsetDate('2026-08-31')).toBe('2027-02-28');
+  });
+
+  it('builds API-Deprecation headers for deprecated v1 endpoints', () => {
+    const headers = buildApiDeprecationHeaders({
+      since: '2026-04-30',
+      sunset: '2026-10-30',
+      replacement: '/api/v2/texts',
+      message: 'Use the v2 text payload shape.',
+    });
+
+    expect(headers[API_DEPRECATION_HEADER]).toContain('deprecated');
+    expect(headers[API_DEPRECATION_HEADER]).toContain('since="2026-04-30"');
+    expect(headers[API_DEPRECATION_HEADER]).toContain('sunset="2026-10-30"');
+    expect(headers[API_DEPRECATION_HEADER]).toContain(
+      'replacement="/api/v2/texts"',
+    );
+    expect(headers.Sunset).toBe('Fri, 30 Oct 2026 23:59:59 GMT');
+    expect(headers.Link).toBe('</api/v2/texts>; rel="successor-version"');
+  });
+
+  it('rejects deprecation windows shorter than six months', () => {
+    expect(() =>
+      buildApiDeprecationHeaders({
+        since: '2026-04-30',
+        sunset: '2026-10-29',
+      }),
+    ).toThrow('at least 2026-10-30');
+  });
+});

--- a/apps/web/src/lib/server/api-versioning.ts
+++ b/apps/web/src/lib/server/api-versioning.ts
@@ -1,0 +1,97 @@
+export const STABLE_API_PREFIX = '/api/v1';
+export const NEXT_BREAKING_API_PREFIX = '/api/v2';
+export const API_DEPRECATION_HEADER = 'API-Deprecation';
+export const API_DEPRECATION_MIN_SUPPORT_MONTHS = 6;
+
+export type ApiDeprecationNotice = {
+  since: string;
+  sunset: string;
+  replacement?: string;
+  message?: string;
+};
+
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
+function parseDateOnly(value: string): Date {
+  if (!DATE_ONLY.test(value)) {
+    throw new Error(`Expected YYYY-MM-DD date, got "${value}"`);
+  }
+
+  const [year, month, day] = value.split('-').map(Number) as [
+    number,
+    number,
+    number,
+  ];
+  const date = new Date(Date.UTC(year, month - 1, day));
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  ) {
+    throw new Error(`Invalid date "${value}"`);
+  }
+  return date;
+}
+
+function formatDateOnly(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function lastDayOfUtcMonth(year: number, monthIndex: number): number {
+  return new Date(Date.UTC(year, monthIndex + 1, 0)).getUTCDate();
+}
+
+function quoteHeaderParam(value: string): string {
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+export function minimumDeprecationSunsetDate(since: string): string {
+  const date = parseDateOnly(since);
+  const targetMonth = date.getUTCMonth() + API_DEPRECATION_MIN_SUPPORT_MONTHS;
+  const targetYear = date.getUTCFullYear() + Math.floor(targetMonth / 12);
+  const normalizedMonth = targetMonth % 12;
+  const clampedDay = Math.min(
+    date.getUTCDate(),
+    lastDayOfUtcMonth(targetYear, normalizedMonth),
+  );
+
+  return formatDateOnly(
+    new Date(Date.UTC(targetYear, normalizedMonth, clampedDay)),
+  );
+}
+
+export function isStableApiPath(path: string): boolean {
+  return path === STABLE_API_PREFIX || path.startsWith(`${STABLE_API_PREFIX}/`);
+}
+
+export function buildApiDeprecationHeaders(
+  notice: ApiDeprecationNotice,
+): Record<string, string> {
+  const minimumSunset = minimumDeprecationSunsetDate(notice.since);
+  const sunset = parseDateOnly(notice.sunset);
+  if (sunset < parseDateOnly(minimumSunset)) {
+    throw new Error(
+      `Deprecated v1 API routes must remain supported until at least ${minimumSunset}`,
+    );
+  }
+
+  const parts = [
+    'deprecated',
+    `since=${quoteHeaderParam(notice.since)}`,
+    `sunset=${quoteHeaderParam(notice.sunset)}`,
+  ];
+  if (notice.replacement) {
+    parts.push(`replacement=${quoteHeaderParam(notice.replacement)}`);
+  }
+  if (notice.message) parts.push(`message=${quoteHeaderParam(notice.message)}`);
+
+  const headers: Record<string, string> = {
+    [API_DEPRECATION_HEADER]: parts.join('; '),
+    Sunset: new Date(`${notice.sunset}T23:59:59.000Z`).toUTCString(),
+  };
+  if (notice.replacement) {
+    headers.Link = `<${notice.replacement}>; rel="successor-version"`;
+  }
+
+  return headers;
+}

--- a/apps/web/src/lib/server/openapi/generator.test.ts
+++ b/apps/web/src/lib/server/openapi/generator.test.ts
@@ -2,6 +2,11 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  API_DEPRECATION_HEADER,
+  STABLE_API_PREFIX,
+} from '$lib/server/api-versioning.js';
+
+import {
   discoverSvelteKitApiOperations,
   generateOpenApiDocument,
 } from './generator.js';
@@ -14,6 +19,11 @@ describe('OpenAPI generator', () => {
     expect(doc.paths['/api/v1/auth/login']?.post).toBeDefined();
     expect(doc.paths['/api/v1/me/profile']?.get).toBeDefined();
     expect(doc.paths['/nlp/process']?.post).toBeDefined();
+    expect(doc['x-api-versioning']).toMatchObject({
+      stablePrefix: STABLE_API_PREFIX,
+      deprecationHeader: API_DEPRECATION_HEADER,
+    });
+    expect(doc.components.headers[API_DEPRECATION_HEADER]).toBeDefined();
   });
 
   it('represents every exported SvelteKit API handler with schemas', async () => {
@@ -29,5 +39,14 @@ describe('OpenAPI generator', () => {
         expect(documented?.requestBody).toBeDefined();
       }
     }
+  });
+
+  it('only treats /api/v1 SvelteKit routes as stable public API paths', async () => {
+    const operations = await discoverSvelteKitApiOperations();
+
+    expect(operations).not.toHaveLength(0);
+    expect(operations.every((op) => op.path.startsWith(`${STABLE_API_PREFIX}/`))).toBe(
+      true,
+    );
   });
 });

--- a/apps/web/src/lib/server/openapi/generator.ts
+++ b/apps/web/src/lib/server/openapi/generator.ts
@@ -12,6 +12,13 @@ import { readdir, readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import {
+  API_DEPRECATION_HEADER,
+  API_DEPRECATION_MIN_SUPPORT_MONTHS,
+  NEXT_BREAKING_API_PREFIX,
+  STABLE_API_PREFIX,
+} from '$lib/server/api-versioning.js';
+
 const HTTP_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'] as const;
 type HttpMethod = (typeof HTTP_METHODS)[number];
 
@@ -26,12 +33,20 @@ export type OpenApiDocument = {
   };
   servers: Array<{ url: string; description: string }>;
   tags: Array<{ name: string; description: string }>;
+  externalDocs: { description: string; url: string };
   components: {
     securitySchemes: Record<string, JsonSchema>;
     schemas: Record<string, JsonSchema>;
     responses: Record<string, JsonSchema>;
+    headers: Record<string, JsonSchema>;
   };
   paths: Record<string, Record<string, JsonSchema>>;
+  'x-api-versioning': {
+    stablePrefix: string;
+    nextBreakingPrefix: string;
+    deprecationHeader: string;
+    minimumDeprecatedV1SupportMonths: number;
+  };
 };
 
 export type RouteOperation = {
@@ -257,6 +272,16 @@ export async function generateOpenApiDocument(): Promise<OpenApiDocument> {
       { url: '/', description: 'CIA Reader web app' },
       { url: 'http://nlp:8000', description: 'NLP service in docker compose' },
     ],
+    externalDocs: {
+      description: 'API versioning and deprecation policy',
+      url: '/docs/api-versioning.md',
+    },
+    'x-api-versioning': {
+      stablePrefix: STABLE_API_PREFIX,
+      nextBreakingPrefix: NEXT_BREAKING_API_PREFIX,
+      deprecationHeader: API_DEPRECATION_HEADER,
+      minimumDeprecatedV1SupportMonths: API_DEPRECATION_MIN_SUPPORT_MONTHS,
+    },
     tags: [
       { name: 'Auth', description: 'Login, registration, token refresh' },
       { name: 'Me', description: 'Authenticated user profile and learning data' },
@@ -315,6 +340,15 @@ export async function generateOpenApiDocument(): Promise<OpenApiDocument> {
               schema: { $ref: '#/components/schemas/ErrorEnvelope' },
             },
           },
+        },
+      },
+      headers: {
+        [API_DEPRECATION_HEADER]: {
+          description:
+            'Present on deprecated v1 routes. Includes since, sunset, and optional replacement metadata. Deprecated v1 endpoints stay supported for at least six months after the v2 replacement ships.',
+          schema: { type: 'string' },
+          example:
+            'deprecated; since="2026-04-30"; sunset="2026-10-30"; replacement="/api/v2/texts"',
         },
       },
       schemas: {

--- a/docs/api-versioning.md
+++ b/docs/api-versioning.md
@@ -1,0 +1,48 @@
+# API Versioning Policy
+
+CIA Reader's stable web and mobile API is the SvelteKit API under `/api/v1/*`.
+Other endpoints, including `/api/openapi.json`, `/api/docs`, and the internal
+FastAPI NLP service, are support surfaces but are not the stable public client
+contract.
+
+## Stability
+
+- `/api/v1/*` is the only stable public API prefix.
+- Backward-compatible additions stay in `/api/v1/*`.
+- Breaking API changes must ship under `/api/v2/*` or a later major prefix.
+- A breaking change is any removal, rename, type change, required-field addition,
+  status-code contract change, or response-shape change that can break an
+  existing client.
+
+## Deprecation
+
+When a v1 endpoint is superseded by a v2 endpoint, the v1 endpoint remains
+supported for at least six calendar months after the v2 endpoint ships.
+
+Deprecated v1 responses include an `API-Deprecation` header. Route handlers
+should use `buildApiDeprecationHeaders` from
+`apps/web/src/lib/server/api-versioning.ts` so the six-month support window is
+enforced consistently.
+
+Example:
+
+```ts
+return json(payload, {
+  headers: buildApiDeprecationHeaders({
+    since: '2026-04-30',
+    sunset: '2026-10-30',
+    replacement: '/api/v2/texts',
+  }),
+});
+```
+
+The helper also emits `Sunset` and, when a replacement is provided, the
+`Link: <...>; rel="successor-version"` header for clients that understand those
+standard signals.
+
+## Documentation
+
+The generated OpenAPI document is published at `/api/openapi.json`, and the docs
+UI is published at `/api/docs`. The OpenAPI document declares this policy in its
+`x-api-versioning` metadata and documents the `API-Deprecation` response header
+component for deprecated operations.


### PR DESCRIPTION
## Summary
- add a documented API versioning policy: only `/api/v1/*` is stable and breaking changes move to `/api/v2/*`
- add a server-side deprecation helper that emits `API-Deprecation`, `Sunset`, and successor-version `Link` headers while enforcing the six-month v1 support window
- expose the policy in the generated OpenAPI document via `x-api-versioning` metadata and a reusable header component

## Tests
- `pnpm --filter @ciareader/web test -- api-versioning.test.ts generator.test.ts openapi-json-server.test.ts`
- `pnpm --filter @ciareader/web check`
- `pnpm --filter @ciareader/web lint`
- `pnpm --filter @ciareader/web build`

Closes #104