### PR TITLE
Admin "Reprocess" button on the reader page

### DIFF
--- a/apps/web/src/routes/reader/[textId]/+page.server.ts
+++ b/apps/web/src/routes/reader/[textId]/+page.server.ts
@@ -222,6 +222,12 @@ export const load: PageServerLoad = async ({ params, locals, url }) => {
     // a session-only live preview.
     canPersistSettings: locals.user != null,
     isOwner: Boolean(locals.user && locals.user.id === result.text.ownerId),
+    // T-2.8: surface admin status so the reader chrome can offer the
+    // reprocess affordance to admins on any text (owners get the
+    // existing per-text controls; reprocess is admin-only because it
+    // re-runs NLP and overwrites token rows). Curators don't get it
+    // — they can edit the dictionary, not rerun pipelines.
+    isAdmin: locals.user?.role === 'admin',
     collectionContext: collectionContext
       ? {
           collectionId: collectionContext.collection.id,

--- a/apps/web/src/routes/reader/[textId]/+page.svelte
+++ b/apps/web/src/routes/reader/[textId]/+page.svelte
@@ -57,6 +57,49 @@
   });
   let settingsOpen = $state(false);
 
+  // T-2.8: admin-only "Reprocess this text" affordance. Re-runs the
+  // NLP pipeline (POSTs `/api/v1/admin/texts/:id/reprocess`) and
+  // refreshes the reader once the worker has rewritten `text_tokens`.
+  // Useful after a parser / dispatcher upgrade so a previously-
+  // uploaded text picks up new fields (e.g. number_forms after the
+  // T-2.8 fix) without the owner having to re-upload.
+  let reprocessing = $state(false);
+  let reprocessFeedback = $state<{
+    kind: 'ok' | 'err';
+    text: string;
+  } | null>(null);
+
+  async function reprocessText() {
+    if (reprocessing) return;
+    reprocessing = true;
+    reprocessFeedback = null;
+    try {
+      const res = await fetch(
+        `/api/v1/admin/texts/${data.text.id}/reprocess`,
+        { method: 'POST' },
+      );
+      if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        throw new Error(text || `HTTP ${res.status}`);
+      }
+      const body = (await res.json()) as { tokensWritten: number };
+      reprocessFeedback = {
+        kind: 'ok',
+        text: `Reprocessed — ${body.tokensWritten} tokens written.`,
+      };
+      // Refresh the page-data so the new tokens render in place
+      // without a full reload.
+      await invalidateAll();
+    } catch (e) {
+      reprocessFeedback = {
+        kind: 'err',
+        text: `Reprocess failed: ${(e as Error).message}`,
+      };
+    } finally {
+      reprocessing = false;
+    }
+  }
+
   // CSS-variable string applied to the reader root so every reader
   // mode picks up the setting without each one having to know about
   // every CSS variable. Keeping the math in JS lets the popover's
@@ -359,6 +402,19 @@
         Aa
       </button>
 
+      {#if data.isAdmin}
+        <button
+          type="button"
+          class="reprocess-toggle"
+          onclick={reprocessText}
+          disabled={reprocessing}
+          title="Re-run the NLP pipeline on this text (admin only)"
+          data-testid="admin-reprocess"
+        >
+          {reprocessing ? 'Reprocessing…' : 'Reprocess'}
+        </button>
+      {/if}
+
       <button
         type="button"
         class="settings-toggle"
@@ -393,6 +449,17 @@
 
   {#if liveStatus === 'failed' && liveError}
     <p class="err" role="alert">Processing error: {liveError}</p>
+  {/if}
+
+  {#if reprocessFeedback}
+    <p
+      class="reprocess-feedback"
+      class:err={reprocessFeedback.kind === 'err'}
+      data-testid="reprocess-feedback"
+      role={reprocessFeedback.kind === 'err' ? 'alert' : 'status'}
+    >
+      {reprocessFeedback.text}
+    </p>
   {/if}
 
   {#if data.mode === 'page'}
@@ -652,6 +719,33 @@
     background: var(--accent-soft, var(--color-accent));
     border-color: var(--accent, var(--color-accent));
     color: var(--accent-ink, var(--color-accent-fg, #fff));
+  }
+  .reprocess-toggle {
+    height: 32px;
+    padding: 0 0.7rem;
+    border: 1px solid var(--rule, var(--color-border));
+    border-radius: 8px;
+    background: transparent;
+    color: var(--ink-2, var(--color-fg-muted));
+    font: inherit;
+    font-size: 0.78rem;
+    cursor: pointer;
+  }
+  .reprocess-toggle:hover:not([disabled]) {
+    background: color-mix(in oklch, var(--ink, var(--color-fg)) 5%, transparent);
+    color: var(--ink, var(--color-fg));
+  }
+  .reprocess-toggle[disabled] {
+    opacity: 0.55;
+    cursor: progress;
+  }
+  .reprocess-feedback {
+    margin: 0.5rem 1.25rem 0;
+    padding: 0.55rem 0.85rem;
+    font-size: 0.82rem;
+    border-radius: 8px;
+    background: color-mix(in oklch, var(--ink, var(--color-fg)) 5%, transparent);
+    color: var(--ink-2, var(--color-fg));
   }
   /* T-5.26: the immersive-toggle button moved to AppShell as a
      hamburger icon. The selector is gone but the Esc-to-exit

--- a/apps/web/src/routes/reader/[textId]/page-server.test.ts
+++ b/apps/web/src/routes/reader/[textId]/page-server.test.ts
@@ -81,12 +81,13 @@ vi.mock('$lib/server/db/index.js', () => {
 type LoadFn = (typeof import('./+page.server.js'))['load'];
 
 const VALID_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
-const USER = { id: 'user-1', role: 'user' as const };
+type TestUser = { id: string; role: 'user' | 'curator' | 'admin' };
+const USER: TestUser = { id: 'user-1', role: 'user' };
 
 async function callLoad(
   url: string,
   textId = VALID_ID,
-  user: typeof USER | null = USER,
+  user: TestUser | null = USER,
 ) {
   const { load } = await import('./+page.server.js');
   const event = {
@@ -253,6 +254,41 @@ describe('/reader/[textId] loader', () => {
       status: number;
     };
     expect(res.status).toBe(404);
+  });
+
+  it('exposes isAdmin=true only for users with role=admin (T-2.8)', async () => {
+    getReadableText.mockResolvedValueOnce(ownedTextWithChapters(1));
+    const adminData = (await callLoad(`http://x/reader/${VALID_ID}`, VALID_ID, {
+      id: USER.id,
+      role: 'admin',
+    })) as { isAdmin: boolean };
+    expect(adminData.isAdmin).toBe(true);
+
+    getReadableText.mockResolvedValueOnce(ownedTextWithChapters(1));
+    const userData = (await callLoad(`http://x/reader/${VALID_ID}`)) as {
+      isAdmin: boolean;
+    };
+    expect(userData.isAdmin).toBe(false);
+
+    getReadableText.mockResolvedValueOnce(ownedTextWithChapters(1));
+    const curatorData = (await callLoad(`http://x/reader/${VALID_ID}`, VALID_ID, {
+      id: USER.id,
+      role: 'curator',
+    })) as { isAdmin: boolean };
+    // Curators get dictionary access, not pipeline reruns.
+    expect(curatorData.isAdmin).toBe(false);
+
+    const fixture = ownedTextWithChapters(1);
+    getReadableText.mockResolvedValueOnce({
+      ...fixture,
+      text: { ...fixture.text, ownerId: null, visibility: 'official' },
+    });
+    const anonData = (await callLoad(
+      `http://x/reader/${VALID_ID}`,
+      VALID_ID,
+      null,
+    )) as { isAdmin: boolean };
+    expect(anonData.isAdmin).toBe(false);
   });
 
   it('lets anonymous viewers read official texts and reports isOwner=false', async () => {


### PR DESCRIPTION
Surface the existing \`POST /api/v1/admin/texts/:id/reprocess\` endpoint in the reader chrome so admins can re-run NLP on a stale text without hand-rolling a curl + session cookie.

The trigger case is straightforward: a parser / dispatcher upgrade lands (e.g. the T-2.8 number-form work), texts uploaded before the upgrade still have null \`number_forms\` / bogus auto-created NUM lemmas in the DB, and the only fix today is a re-upload or a direct DB poke. With this button the admin just clicks "Reprocess" and the page-data invalidates once the dispatcher returns.

## Scope

- \`/reader/[textId]\` page-data exposes \`isAdmin: locals.user?.role === 'admin'\`. Curators don't get the button — they edit the dictionary, they don't rerun pipelines.
- The button sits next to the existing romanization / settings toggles in the reader chrome; admin-only via \`{#if data.isAdmin}\`.
- Click flow: POST the admin endpoint, show an inline pill (success — N tokens written / error — message) above the reader body, then \`invalidateAll()\` so the new tokens render in place without a hard reload.
- Disabled state during the in-flight POST, with "Reprocessing…" copy.

The endpoint itself is unchanged — it already enforces \`role === 'admin'\` via \`isAdmin()\`, validates the UUID, and runs \`processTextNow()\` synchronously. \`reprocess-server.test.ts\` already covers the auth + UUID + happy path; no need to retest the same surface from a new angle.

## Test plan

- [x] Loader exposes \`isAdmin\` correctly for admin / user / curator / anon roles (4 new cases in \`page-server.test.ts\`).
- [x] vitest 1045 / 1045, svelte-check clean.

## Notes

- \`crush@test.local\` already has \`role = 'admin'\` in the dev DB; no migration needed.
- The user's existing text was reprocessed manually as part of triaging this — DB now shows 175 / 175 number tokens with proper \`number_forms\` and zero bogus \`lemma_id\`.