### PR TITLE
T-12.5: Audit mobile payload shapes

### DIFF
--- a/apps/web/src/lib/components/reader/ChapterBody.svelte
+++ b/apps/web/src/lib/components/reader/ChapterBody.svelte
@@ -98,7 +98,9 @@
     tokensWithOverrides ? paragraphsOfServerTokens(tokensWithOverrides) : null,
   );
   const fallbackParagraphs = $derived(
-    chapter.tokens ? null : paragraphsOfTokens(tokenize(chapter.body)),
+    chapter.tokens || chapter.body == null
+      ? null
+      : paragraphsOfTokens(tokenize(chapter.body)),
   );
 
   // Lookup helper — server tokens are keyed by id.

--- a/apps/web/src/lib/components/reader/ReaderContinuous.svelte
+++ b/apps/web/src/lib/components/reader/ReaderContinuous.svelte
@@ -19,7 +19,11 @@
   import { onMount, tick, untrack } from 'svelte';
 
   import ChapterBody from './ChapterBody.svelte';
-  import { LazyTokenLoader, type ChapterTokenFetcher } from './lazy-tokens.js';
+  import {
+    LazyTokenLoader,
+    type ChapterTokenFetcher,
+    type ChapterTokensResponse,
+  } from './lazy-tokens.js';
   import type { ProgressAnchor } from './progress-client.js';
   import {
     computePctRead,
@@ -28,7 +32,7 @@
     readableRect,
     readerTopInset,
   } from './reader-progress.js';
-  import type { ChapterView, ServerToken } from './types.js';
+  import type { ChapterView } from './types.js';
 
   let {
     chapters,
@@ -53,11 +57,13 @@
     fetcher?: ChapterTokenFetcher;
   } = $props();
 
-  // Map of chapterIdx → fetched tokens (or `null` if the worker
-  // hasn't run for that chapter — same fallback as the SSR path).
+  // Map of chapterIdx → fetched body + tokens. SSR only includes the
+  // active chapter's body, so siblings hydrate their text on demand.
   // Seeded with the initial chapter so re-renders don't trigger an
   // unnecessary network round-trip for the chapter we already have.
-  let lazyTokens = $state(new Map<number, ServerToken[] | null>());
+  let lazyChapters = $state(
+    new Map<number, Pick<ChapterTokensResponse, 'body' | 'tokens'>>(),
+  );
 
   const loader = $derived(new LazyTokenLoader(textId, fetcher));
 
@@ -65,10 +71,10 @@
   // their tokens patched in once the lazy loader resolves them.
   const renderedChapters = $derived.by(() => {
     return chapters.map((c) => {
-      if (c.tokens != null) return c;
-      const fetched = lazyTokens.get(c.idx);
+      if (c.tokens != null && c.body != null) return c;
+      const fetched = lazyChapters.get(c.idx);
       if (fetched === undefined) return c;
-      return { ...c, tokens: fetched };
+      return { ...c, body: fetched.body, tokens: fetched.tokens };
     });
   });
 
@@ -77,13 +83,13 @@
     // or we've already fetched / are fetching this idx.
     const existing = chapters.find((c) => c.idx === chapterIdx);
     if (!existing || existing.tokens != null) return;
-    if (lazyTokens.has(chapterIdx)) return;
+    if (lazyChapters.has(chapterIdx)) return;
     void loader
       .load(chapterIdx)
-      .then((tokens) => {
-        const next = new Map(untrack(() => lazyTokens));
-        next.set(chapterIdx, tokens);
-        lazyTokens = next;
+      .then((chapter) => {
+        const next = new Map(untrack(() => lazyChapters));
+        next.set(chapterIdx, { body: chapter.body, tokens: chapter.tokens });
+        lazyChapters = next;
       })
       .catch(() => {
         // Swallow — the chapter still renders via the whitespace

--- a/apps/web/src/lib/components/reader/ReaderScroll.svelte
+++ b/apps/web/src/lib/components/reader/ReaderScroll.svelte
@@ -100,7 +100,9 @@
     correctedTokens ? paragraphsOfServerTokens(correctedTokens) : null,
   );
   const fallbackParagraphs = $derived(
-    current && !current.tokens ? paragraphsOfTokens(tokenize(current.body)) : null,
+    current && !current.tokens && current.body != null
+      ? paragraphsOfTokens(tokenize(current.body))
+      : null,
   );
 
   function packServer(paragraphs: ParaServer[]): ParaServer[][] {

--- a/apps/web/src/lib/components/reader/lazy-tokens.test.ts
+++ b/apps/web/src/lib/components/reader/lazy-tokens.test.ts
@@ -31,13 +31,15 @@ describe('LazyTokenLoader', () => {
       .mockImplementation(async (_textId, idx) => ({
         chapterId: `c-${idx}`,
         chapterIdx: idx,
+        body: `body ${idx}`,
         tokens: fakeTokens(2),
       }));
     const loader = new LazyTokenLoader('text-1', fetcher);
     const a = await loader.load(2);
     const b = await loader.load(2);
-    expect(a).toHaveLength(2);
-    expect(b).toBe(a);
+    expect(a.tokens).toHaveLength(2);
+    expect(a.body).toBe('body 2');
+    expect(b).toEqual(a);
     expect(fetcher).toHaveBeenCalledTimes(1);
   });
 
@@ -50,10 +52,11 @@ describe('LazyTokenLoader', () => {
     const loader = new LazyTokenLoader('t1', fetcher);
     const p1 = loader.load(1);
     const p2 = loader.load(1);
-    resolveFn!({ chapterId: 'c1', chapterIdx: 1, tokens: null });
+    resolveFn!({ chapterId: 'c1', chapterIdx: 1, body: 'body 1', tokens: null });
     const [a, b] = await Promise.all([p1, p2]);
-    expect(a).toBeNull();
-    expect(b).toBeNull();
+    expect(a.tokens).toBeNull();
+    expect(a.body).toBe('body 1');
+    expect(b).toEqual(a);
     expect(fetcher).toHaveBeenCalledTimes(1);
   });
 
@@ -82,10 +85,20 @@ describe('LazyTokenLoader', () => {
     const fetcher = vi.fn().mockResolvedValue({
       chapterId: 'c1',
       chapterIdx: 1,
+      body: 'fallback body',
       tokens: null,
     });
     const loader = new LazyTokenLoader('t1', fetcher);
-    expect(await loader.load(1)).toBeNull();
-    expect(loader.state(1)).toEqual({ kind: 'loaded', tokens: null });
+    expect(await loader.load(1)).toMatchObject({
+      body: 'fallback body',
+      tokens: null,
+    });
+    expect(loader.state(1)).toEqual({
+      kind: 'loaded',
+      chapterId: 'c1',
+      chapterIdx: 1,
+      body: 'fallback body',
+      tokens: null,
+    });
   });
 });

--- a/apps/web/src/lib/components/reader/lazy-tokens.ts
+++ b/apps/web/src/lib/components/reader/lazy-tokens.ts
@@ -18,13 +18,20 @@ import type { ServerToken } from './types.js';
 export type ChapterTokensResponse = {
   chapterId: string;
   chapterIdx: number;
+  body: string;
   tokens: ServerToken[] | null;
 };
 
 export type FetchState =
   | { kind: 'idle' }
   | { kind: 'loading' }
-  | { kind: 'loaded'; tokens: ServerToken[] | null }
+  | {
+      kind: 'loaded';
+      chapterId: string;
+      chapterIdx: number;
+      body: string;
+      tokens: ServerToken[] | null;
+    }
   | { kind: 'error'; message: string };
 
 export type ChapterTokenFetcher = (
@@ -61,25 +68,38 @@ export class LazyTokenLoader {
 
   /**
    * Kick off (or join) a fetch for `chapterIdx`. Resolves to the
-   * fetched tokens or null if the worker hasn't run for that chapter
-   * yet — same shape the SSR loader returns for the active chapter,
-   * so callers can drop the result straight into the ChapterView.
+   * fetched body plus tokens, or null tokens if the worker hasn't run
+   * for that chapter yet. The SSR loader only includes the active
+   * chapter body; this on-demand shape lets continuous mode hydrate
+   * sibling chapters without bloating first paint.
    */
-  async load(chapterIdx: number): Promise<ServerToken[] | null> {
+  async load(chapterIdx: number): Promise<ChapterTokensResponse> {
     const existing = this.states.get(chapterIdx);
-    if (existing?.kind === 'loaded') return existing.tokens;
+    if (existing?.kind === 'loaded') {
+      return {
+        chapterId: existing.chapterId,
+        chapterIdx: existing.chapterIdx,
+        body: existing.body,
+        tokens: existing.tokens,
+      };
+    }
     const existingPromise = this.inflight.get(chapterIdx);
     if (existingPromise) {
-      const r = await existingPromise;
-      return r.tokens;
+      return await existingPromise;
     }
     this.states.set(chapterIdx, { kind: 'loading' });
     const promise = this.fetcher(this.textId, chapterIdx);
     this.inflight.set(chapterIdx, promise);
     try {
       const r = await promise;
-      this.states.set(chapterIdx, { kind: 'loaded', tokens: r.tokens });
-      return r.tokens;
+      this.states.set(chapterIdx, {
+        kind: 'loaded',
+        chapterId: r.chapterId,
+        chapterIdx: r.chapterIdx,
+        body: r.body,
+        tokens: r.tokens,
+      });
+      return r;
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Fetch failed';
       this.states.set(chapterIdx, { kind: 'error', message });

--- a/apps/web/src/lib/components/reader/types.ts
+++ b/apps/web/src/lib/components/reader/types.ts
@@ -95,7 +95,7 @@ export type ChapterView = {
   id: string;
   idx: number;
   title: string | null;
-  body: string;
+  body: string | null;
   tokenCount: number;
   tokens: ServerToken[] | null;
 };

--- a/apps/web/src/lib/server/learning-stats.ts
+++ b/apps/web/src/lib/server/learning-stats.ts
@@ -26,6 +26,27 @@ export type LanguageStats = {
   encounteredCount: number;
 };
 
+export const STATS_DEFAULT_PAGE_SIZE = 50;
+export const STATS_MAX_PAGE_SIZE = 100;
+
+export type StatsPageOptions = {
+  limit?: number;
+  offset?: number;
+};
+
+export function clampStatsPage(opts: StatsPageOptions = {}): {
+  limit: number;
+  offset: number;
+} {
+  return {
+    limit: Math.min(
+      Math.max(opts.limit ?? STATS_DEFAULT_PAGE_SIZE, 1),
+      STATS_MAX_PAGE_SIZE,
+    ),
+    offset: Math.max(opts.offset ?? 0, 0),
+  };
+}
+
 function unwrapRows<T>(out: unknown): T[] {
   if (Array.isArray(out)) return out as T[];
   if (out && typeof out === 'object' && 'rows' in out) {
@@ -122,7 +143,9 @@ export type TextStats = {
 export async function listTextStats(
   userId: string,
   language: LanguageCode,
+  opts: StatsPageOptions = {},
 ): Promise<TextStats[]> {
+  const { limit, offset } = clampStatsPage(opts);
   const list = unwrapRows<{
     text_id: string;
     title: string;
@@ -159,6 +182,8 @@ export async function listTextStats(
         AND tx.language = ${language}
       GROUP BY tx.id, tx.title, tx.language
       ORDER BY tx.created_at DESC
+      LIMIT ${limit}
+      OFFSET ${offset}
     `),
   );
   return list.map((r) => ({
@@ -320,7 +345,9 @@ export async function estimatedComprehensionForCollections(
 export async function listCollectionStats(
   userId: string,
   language: LanguageCode,
+  opts: StatsPageOptions = {},
 ): Promise<CollectionStats[]> {
+  const { limit, offset } = clampStatsPage(opts);
   const list = unwrapRows<{
     collection_id: string;
     title: string;
@@ -357,6 +384,8 @@ export async function listCollectionStats(
         AND c.language = ${language}
       GROUP BY c.id, c.title
       ORDER BY c.updated_at DESC
+      LIMIT ${limit}
+      OFFSET ${offset}
     `),
   );
   return list.map((r) => ({

--- a/apps/web/src/lib/server/payload-budget.test.ts
+++ b/apps/web/src/lib/server/payload-budget.test.ts
@@ -1,0 +1,25 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+
+import {
+  MOBILE_RESPONSE_BUDGET_BYTES,
+  jsonPayloadBytes,
+  withinMobileResponseBudget,
+} from './payload-budget.js';
+
+describe('mobile payload budget helpers', () => {
+  it('measures JSON payload bytes with utf-8 encoding', () => {
+    expect(jsonPayloadBytes({ text: 'पाठ' })).toBeGreaterThan(
+      JSON.stringify({ text: 'पाठ' }).length,
+    );
+  });
+
+  it('guards the 100KB mobile response budget', () => {
+    expect(withinMobileResponseBudget({ body: 'x'.repeat(1024) })).toBe(true);
+    expect(
+      withinMobileResponseBudget({
+        body: 'x'.repeat(MOBILE_RESPONSE_BUDGET_BYTES + 1),
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/lib/server/payload-budget.ts
+++ b/apps/web/src/lib/server/payload-budget.ts
@@ -1,0 +1,11 @@
+export const MOBILE_RESPONSE_BUDGET_BYTES = 100 * 1024;
+
+const encoder = new TextEncoder();
+
+export function jsonPayloadBytes(value: unknown): number {
+  return encoder.encode(JSON.stringify(value)).byteLength;
+}
+
+export function withinMobileResponseBudget(value: unknown): boolean {
+  return jsonPayloadBytes(value) <= MOBILE_RESPONSE_BUDGET_BYTES;
+}

--- a/apps/web/src/routes/api/v1/texts/[id]/chapters/[idx]/tokens/+server.ts
+++ b/apps/web/src/routes/api/v1/texts/[id]/chapters/[idx]/tokens/+server.ts
@@ -38,6 +38,7 @@ export const GET: RequestHandler = async ({ params, locals }) => {
   return json({
     chapterId: chapter.id,
     chapterIdx: chapter.idx,
+    body: chapter.body,
     tokens,
   });
 };

--- a/apps/web/src/routes/api/v1/texts/[id]/chapters/[idx]/tokens/tokens-server.test.ts
+++ b/apps/web/src/routes/api/v1/texts/[id]/chapters/[idx]/tokens/tokens-server.test.ts
@@ -56,7 +56,7 @@ function fixtureWithChapters(n: number) {
       id: `c${i}`,
       idx: i,
       title: null,
-      body: '',
+      body: `body ${i}`,
       tokenCount: 0,
     })),
   };
@@ -94,10 +94,12 @@ describe('GET /api/v1/texts/:id/chapters/:idx/tokens', () => {
     const body = (await res.json()) as {
       chapterId: string;
       chapterIdx: number;
+      body: string;
       tokens: unknown[] | null;
     };
     expect(body.chapterIdx).toBe(1);
     expect(body.chapterId).toBe('c1');
+    expect(body.body).toBe('body 1');
     expect(body.tokens).toHaveLength(1);
     expect(loadChapterTokens).toHaveBeenCalledWith('c1', 'user-1');
   });

--- a/apps/web/src/routes/library/+page.server.ts
+++ b/apps/web/src/routes/library/+page.server.ts
@@ -96,6 +96,11 @@ export const load: PageServerLoad = async ({ url, locals }) => {
     textCount: number;
     estimatedComprehensionPct: number | null;
   }> = [];
+  let collectionsPage = {
+    totalCount: 0,
+    limit,
+    offset,
+  };
   // T-10.2: per-card known% badge. Decorated after the page is
   // fetched so we don't push a JOIN into every list query — the
   // batch helper does one round trip regardless of card count.
@@ -122,20 +127,27 @@ export const load: PageServerLoad = async ({ url, locals }) => {
     // the most-current edit state.
     const seen = new Set<string>();
     const merged = [...ownItems, ...officialItems].filter((row) => {
+      if (language && row.collection.language !== language) return false;
       if (seen.has(row.collection.id)) return false;
       seen.add(row.collection.id);
       return true;
     });
+    const paged = merged.slice(offset, offset + limit);
+    collectionsPage = {
+      totalCount: merged.length,
+      limit,
+      offset,
+    };
     // T-10.2 collection-card badge: bulk-fetch comprehension for
-    // every collection on the page. Anonymous viewers can't have
+    // every visible collection. Anonymous viewers can't have
     // any known lemmas yet, so we skip the lookup for them.
     const compMap = locals.user
       ? await estimatedComprehensionForCollections(
           locals.user.id,
-          merged.map((m) => m.collection.id),
+          paged.map((m) => m.collection.id),
         )
       : new Map<string, number | null>();
-    collections = merged.map((row) => ({
+    collections = paged.map((row) => ({
       id: row.collection.id,
       title: row.collection.title,
       kind: row.collection.kind,
@@ -168,6 +180,7 @@ export const load: PageServerLoad = async ({ url, locals }) => {
     page,
     textComprehension: Object.fromEntries(textComprehension),
     collections,
+    collectionsPage,
     language,
     languages: Object.values(LANGUAGES).map((d) => ({
       code: d.code,

--- a/apps/web/src/routes/library/+page.svelte
+++ b/apps/web/src/routes/library/+page.svelte
@@ -14,19 +14,25 @@
 
   let { data }: { data: PageData } = $props();
 
-  const pageNum = $derived(Math.floor(data.page.offset / data.page.limit) + 1);
-  const totalPages = $derived(
-    Math.max(1, Math.ceil(data.page.totalCount / data.page.limit)),
+  const activePage = $derived(
+    data.tab === 'collections' ? data.collectionsPage : data.page,
   );
-  const prevOffset = $derived(Math.max(0, data.page.offset - data.page.limit));
-  const nextOffset = $derived(data.page.offset + data.page.limit);
+  const visibleCount = $derived(
+    data.tab === 'collections' ? data.collections.length : data.page.cards.length,
+  );
+  const pageNum = $derived(Math.floor(activePage.offset / activePage.limit) + 1);
+  const totalPages = $derived(
+    Math.max(1, Math.ceil(activePage.totalCount / activePage.limit)),
+  );
+  const prevOffset = $derived(Math.max(0, activePage.offset - activePage.limit));
+  const nextOffset = $derived(activePage.offset + activePage.limit);
 
   function hrefWith(overrides: Record<string, string | null>): string {
     const params = new URLSearchParams();
     params.set('tab', data.tab);
     if (data.language) params.set('language', data.language);
-    if (data.page.offset > 0) params.set('offset', String(data.page.offset));
-    if (data.page.limit !== 20) params.set('limit', String(data.page.limit));
+    if (activePage.offset > 0) params.set('offset', String(activePage.offset));
+    if (activePage.limit !== 20) params.set('limit', String(activePage.limit));
     for (const [k, v] of Object.entries(overrides)) {
       if (v === null) params.delete(k);
       else params.set(k, v);
@@ -187,19 +193,19 @@
     </p>
   {/if}
 
-  {#if data.page.cards.length > 0}
+  {#if visibleCount > 0}
     <nav class="pager" aria-label="Pagination">
       <span class="page-info">
         Page {pageNum} of {totalPages}
-        ({data.page.totalCount.toLocaleString()} total)
+        ({activePage.totalCount.toLocaleString()} total)
       </span>
       <span class="page-links">
-        {#if data.page.offset > 0}
+        {#if activePage.offset > 0}
           <a href={hrefWith({ offset: prevOffset > 0 ? String(prevOffset) : null })}>
             ← Previous
           </a>
         {/if}
-        {#if nextOffset < data.page.totalCount}
+        {#if nextOffset < activePage.totalCount}
           <a href={hrefWith({ offset: String(nextOffset) })}>Next →</a>
         {/if}
       </span>

--- a/apps/web/src/routes/library/page-server.test.ts
+++ b/apps/web/src/routes/library/page-server.test.ts
@@ -4,6 +4,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const listOwnedTexts = vi.fn();
 const listSharedTexts = vi.fn();
 const listOfficialTexts = vi.fn();
+const listCollectionsForUser = vi.fn();
+const listOfficialCollections = vi.fn();
+const estimatedComprehensionForTexts = vi.fn();
+const estimatedComprehensionForCollections = vi.fn();
 
 vi.mock('$lib/server/texts/library.js', async () => {
   const actual = await vi.importActual<typeof import('$lib/server/texts/library.js')>(
@@ -22,14 +26,16 @@ vi.mock('$lib/server/texts/library.js', async () => {
 // have to mock the DB. Tests that care can override the resolved
 // value.
 vi.mock('$lib/server/learning-stats.js', () => ({
-  estimatedComprehensionForTexts: async () => new Map(),
-  estimatedComprehensionForCollections: async () => new Map(),
+  estimatedComprehensionForTexts: (...a: unknown[]) =>
+    estimatedComprehensionForTexts(...a),
+  estimatedComprehensionForCollections: (...a: unknown[]) =>
+    estimatedComprehensionForCollections(...a),
 }));
 
 // T-8.5: collections tab calls into collections.js; mock to empty.
 vi.mock('$lib/server/collections.js', () => ({
-  listCollectionsForUser: async () => [],
-  listOfficialCollections: async () => [],
+  listCollectionsForUser: (...a: unknown[]) => listCollectionsForUser(...a),
+  listOfficialCollections: (...a: unknown[]) => listOfficialCollections(...a),
 }));
 
 type LoadFn = (typeof import('./+page.server.js'))['load'];
@@ -52,6 +58,14 @@ beforeEach(() => {
   listOwnedTexts.mockReset();
   listSharedTexts.mockReset();
   listOfficialTexts.mockReset();
+  listCollectionsForUser.mockReset();
+  listOfficialCollections.mockReset();
+  estimatedComprehensionForTexts.mockReset();
+  estimatedComprehensionForCollections.mockReset();
+  listCollectionsForUser.mockResolvedValue([]);
+  listOfficialCollections.mockResolvedValue([]);
+  estimatedComprehensionForTexts.mockResolvedValue(new Map());
+  estimatedComprehensionForCollections.mockResolvedValue(new Map());
 });
 
 afterEach(() => {
@@ -130,5 +144,44 @@ describe('/library loader', () => {
       status: number;
     };
     expect(res.status).toBe(400);
+  });
+
+  it('paginates collection cards before fetching comprehension (T-12.5)', async () => {
+    const collectionRows = Array.from({ length: 5 }, (_, i) => ({
+      collection: {
+        id: `c${i}`,
+        title: `Collection ${i}`,
+        kind: 'chapter_book',
+        language: 'hi',
+        visibility: 'private',
+        coverUrl: null,
+      },
+      textCount: i + 1,
+    }));
+    listCollectionsForUser.mockResolvedValueOnce(collectionRows);
+    estimatedComprehensionForCollections.mockResolvedValueOnce(
+      new Map([
+        ['c2', 40],
+        ['c3', 60],
+      ]),
+    );
+
+    const data = (await callLoad(
+      'http://x/library?tab=collections&limit=2&offset=2',
+    )) as {
+      collections: Array<{ id: string; estimatedComprehensionPct: number | null }>;
+      collectionsPage: { totalCount: number; limit: number; offset: number };
+    };
+
+    expect(data.collections.map((c) => c.id)).toEqual(['c2', 'c3']);
+    expect(data.collectionsPage).toEqual({
+      totalCount: 5,
+      limit: 2,
+      offset: 2,
+    });
+    expect(estimatedComprehensionForCollections).toHaveBeenCalledWith(
+      USER.id,
+      ['c2', 'c3'],
+    );
   });
 });

--- a/apps/web/src/routes/reader/[textId]/+page.server.ts
+++ b/apps/web/src/routes/reader/[textId]/+page.server.ts
@@ -141,14 +141,12 @@ export const load: PageServerLoad = async ({ params, locals, url }) => {
     ? readBool(url, 'roman')
     : readerSettings.scriptPreference !== 'native';
 
-  // T-5.1a: lazy chapter loading. Only the active chapter is
-  // pre-fetched server-side — a 50-chapter novel was previously
-  // shipping every chapter's token rows on first paint, blowing up
-  // the SSR payload and stalling time-to-first-byte for long books.
-  // Other chapters get `tokens: null` here; the components fetch on
-  // demand via /api/v1/texts/:id/chapters/:idx/tokens (paged-mode
-  // navigation re-runs this loader; continuous mode prefetches the
-  // next chapter near the bottom of the visible one).
+  // T-12.5: mobile payload audit. Only the active chapter ships its
+  // body and tokens on first paint; sibling chapter bodies were the
+  // remaining large field after T-5.1a made tokens lazy. Continuous
+  // mode fetches body+tokens on demand from the chapter endpoint, and
+  // page / scroll modes re-run this loader when the active chapter
+  // changes.
   const viewerId = locals.user?.id ?? null;
   const activeChapter = result.chapters[chapterIdx];
   const activeTokens = activeChapter
@@ -201,13 +199,11 @@ export const load: PageServerLoad = async ({ params, locals, url }) => {
       id: c.id,
       idx: c.idx,
       title: c.title,
-      body: c.body,
+      body: c.idx === chapterIdx ? c.body : null,
       tokenCount: c.tokenCount,
-      // Only the active chapter ships with server-rendered tokens;
-      // siblings carry `tokens: null` and are filled in client-side
-      // by the lazy-load endpoint. A null payload also still happens
-      // when the NLP worker hasn't run for this chapter — the reader
-      // components transparently fall back to whitespace tokenization.
+      // Only the active chapter ships with server-rendered tokens.
+      // Siblings carry `tokens: null`; the lazy endpoint returns both
+      // body and tokens when a sibling needs to render.
       tokens: c.idx === chapterIdx ? activeTokens : null,
     })),
     anchor: {

--- a/apps/web/src/routes/reader/[textId]/page-server.test.ts
+++ b/apps/web/src/routes/reader/[textId]/page-server.test.ts
@@ -4,6 +4,11 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import {
+  MOBILE_RESPONSE_BUDGET_BYTES,
+  jsonPayloadBytes,
+} from '$lib/server/payload-budget.js';
+
 const getReadableText = vi.fn();
 const loadChapterTokens = vi.fn();
 
@@ -373,8 +378,10 @@ describe('/reader/[textId] loader', () => {
     });
     loadChapterTokens.mockResolvedValueOnce([tokenRow('t0', 0)]);
     const data = (await callLoad(`http://x/reader/${VALID_ID}`)) as {
-      chapters: Array<{ id: string; tokens: unknown }>;
+      chapters: Array<{ id: string; body: string | null; tokens: unknown }>;
     };
+    expect(data.chapters[0]!.body).toBe('पाठ');
+    expect(data.chapters[1]!.body).toBeNull();
     expect(data.chapters[0]!.tokens).toHaveLength(1);
     expect(data.chapters[1]!.tokens).toBeNull();
     expect(data.chapters[2]!.tokens).toBeNull();
@@ -382,6 +389,29 @@ describe('/reader/[textId] loader', () => {
     // siblings get filled in client-side via the lazy-load endpoint.
     expect(loadChapterTokens).toHaveBeenCalledTimes(1);
     expect(loadChapterTokens).toHaveBeenCalledWith('c0', USER.id);
+  });
+
+  it('keeps sibling chapter bodies out of the SSR payload for mobile (T-12.5)', async () => {
+    const longBody = 'x'.repeat(30_000);
+    const fixture = ownedTextWithChapters(5);
+    getReadableText.mockResolvedValueOnce({
+      ...fixture,
+      chapters: fixture.chapters.map((chapter) => ({
+        ...chapter,
+        body: longBody,
+        tokenCount: 10_000,
+      })),
+    });
+
+    const data = (await callLoad(`http://x/reader/${VALID_ID}`)) as {
+      chapters: Array<{ body: string | null; tokens: unknown }>;
+    };
+
+    expect(data.chapters[0]!.body).toHaveLength(30_000);
+    expect(data.chapters.slice(1).every((chapter) => chapter.body === null)).toBe(
+      true,
+    );
+    expect(jsonPayloadBytes(data)).toBeLessThan(MOBILE_RESPONSE_BUDGET_BYTES);
   });
 
   it('lazy-loads only the requested chapter when ?chapter=N is set (T-5.1a)', async () => {

--- a/apps/web/src/routes/stats/[language]/+page.server.ts
+++ b/apps/web/src/routes/stats/[language]/+page.server.ts
@@ -7,6 +7,8 @@
 import { error, redirect } from '@sveltejs/kit';
 
 import {
+  STATS_DEFAULT_PAGE_SIZE,
+  clampStatsPage,
   getLanguageStats,
   listCollectionStats,
   listTextStats,
@@ -18,6 +20,13 @@ import {
 } from '@ciareader/shared-types';
 import type { PageServerLoad } from './$types';
 
+function readInt(url: URL, key: string, fallback: number): number {
+  const raw = url.searchParams.get(key);
+  if (raw == null || raw === '') return fallback;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) ? n : fallback;
+}
+
 export const load: PageServerLoad = async ({ params, locals, url }) => {
   if (!locals.user) {
     throw redirect(303, `/login?next=${encodeURIComponent(url.pathname)}`);
@@ -27,11 +36,19 @@ export const load: PageServerLoad = async ({ params, locals, url }) => {
     throw error(400, `Unsupported language '${lang}'`);
   }
   const language = lang as LanguageCode;
+  const textPage = clampStatsPage({
+    limit: readInt(url, 'textLimit', STATS_DEFAULT_PAGE_SIZE),
+    offset: readInt(url, 'textOffset', 0),
+  });
+  const collectionPage = clampStatsPage({
+    limit: readInt(url, 'collectionLimit', textPage.limit),
+    offset: readInt(url, 'collectionOffset', 0),
+  });
 
   const [stats, texts, collections] = await Promise.all([
     getLanguageStats(locals.user.id, language),
-    listTextStats(locals.user.id, language),
-    listCollectionStats(locals.user.id, language),
+    listTextStats(locals.user.id, language, textPage),
+    listCollectionStats(locals.user.id, language, collectionPage),
   ]);
 
   return {
@@ -43,6 +60,23 @@ export const load: PageServerLoad = async ({ params, locals, url }) => {
     },
     stats,
     texts,
+    textsPage: {
+      ...textPage,
+      nextOffset: texts.length === textPage.limit ? textPage.offset + textPage.limit : null,
+      prevOffset:
+        textPage.offset > 0 ? Math.max(0, textPage.offset - textPage.limit) : null,
+    },
     collections,
+    collectionsPage: {
+      ...collectionPage,
+      nextOffset:
+        collections.length === collectionPage.limit
+          ? collectionPage.offset + collectionPage.limit
+          : null,
+      prevOffset:
+        collectionPage.offset > 0
+          ? Math.max(0, collectionPage.offset - collectionPage.limit)
+          : null,
+    },
   };
 };

--- a/apps/web/src/routes/stats/[language]/+page.svelte
+++ b/apps/web/src/routes/stats/[language]/+page.svelte
@@ -6,6 +6,26 @@
   function minutes(n: number): string {
     return n.toLocaleString(undefined, { maximumFractionDigits: 1 });
   }
+
+  function statsHref(
+    patch: Partial<{
+      textOffset: number | null;
+      collectionOffset: number | null;
+    }>,
+  ): string {
+    const params = new URLSearchParams();
+    params.set('textLimit', String(data.textsPage.limit));
+    params.set('collectionLimit', String(data.collectionsPage.limit));
+    params.set(
+      'textOffset',
+      String(patch.textOffset ?? data.textsPage.offset),
+    );
+    params.set(
+      'collectionOffset',
+      String(patch.collectionOffset ?? data.collectionsPage.offset),
+    );
+    return `/stats/${data.language}?${params.toString()}`;
+  }
 </script>
 
 <svelte:head>
@@ -77,6 +97,16 @@
           {/each}
         </tbody>
       </table>
+      {#if data.textsPage.prevOffset !== null || data.textsPage.nextOffset !== null}
+        <nav class="ls-pager" aria-label="Text stats pages">
+          {#if data.textsPage.prevOffset !== null}
+            <a class="ls-page-link" href={statsHref({ textOffset: data.textsPage.prevOffset })}>Previous</a>
+          {/if}
+          {#if data.textsPage.nextOffset !== null}
+            <a class="ls-page-link" href={statsHref({ textOffset: data.textsPage.nextOffset })}>Next</a>
+          {/if}
+        </nav>
+      {/if}
     {/if}
   </section>
 
@@ -109,6 +139,16 @@
           {/each}
         </tbody>
       </table>
+      {#if data.collectionsPage.prevOffset !== null || data.collectionsPage.nextOffset !== null}
+        <nav class="ls-pager" aria-label="Collection stats pages">
+          {#if data.collectionsPage.prevOffset !== null}
+            <a class="ls-page-link" href={statsHref({ collectionOffset: data.collectionsPage.prevOffset })}>Previous</a>
+          {/if}
+          {#if data.collectionsPage.nextOffset !== null}
+            <a class="ls-page-link" href={statsHref({ collectionOffset: data.collectionsPage.nextOffset })}>Next</a>
+          {/if}
+        </nav>
+      {/if}
     </section>
   {/if}
 
@@ -217,6 +257,23 @@
   }
   .ls-link:hover {
     text-decoration: underline;
+  }
+  .ls-pager {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+    margin-top: 0.7rem;
+  }
+  .ls-page-link {
+    color: inherit;
+    border: 1px solid var(--rule, var(--color-border));
+    border-radius: 6px;
+    padding: 0.35rem 0.6rem;
+    text-decoration: none;
+    font-size: 0.82rem;
+  }
+  .ls-page-link:hover {
+    background: color-mix(in oklch, var(--ink, var(--color-fg)) 5%, transparent);
   }
   .ls-pct {
     font-feature-settings: 'tnum';

--- a/apps/web/src/routes/stats/[language]/page-server.test.ts
+++ b/apps/web/src/routes/stats/[language]/page-server.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getLanguageStats = vi.fn();
+const listTextStats = vi.fn();
+const listCollectionStats = vi.fn();
+
+vi.mock('$lib/server/learning-stats.js', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/learning-stats.js')>(
+    '$lib/server/learning-stats.js',
+  );
+  return {
+    ...actual,
+    getLanguageStats: (...a: unknown[]) => getLanguageStats(...a),
+    listTextStats: (...a: unknown[]) => listTextStats(...a),
+    listCollectionStats: (...a: unknown[]) => listCollectionStats(...a),
+  };
+});
+
+type LoadFn = (typeof import('./+page.server.js'))['load'];
+const USER = { id: 'user-1', role: 'user' as const };
+
+async function callLoad(
+  url: string,
+  language = 'hi',
+  user: typeof USER | null = USER,
+) {
+  const { load } = await import('./+page.server.js');
+  const event = {
+    params: { language },
+    locals: { user },
+    url: new URL(url),
+  } as unknown as Parameters<LoadFn>[0];
+  try {
+    return await load(event);
+  } catch (e) {
+    return e as { status: number; location?: string };
+  }
+}
+
+beforeEach(() => {
+  getLanguageStats.mockReset();
+  listTextStats.mockReset();
+  listCollectionStats.mockReset();
+  getLanguageStats.mockResolvedValue({
+    knownCount: 0,
+    learningCount: 0,
+    ignoredCount: 0,
+    encounteredCount: 0,
+    listeningMinutes: 0,
+  });
+  listTextStats.mockResolvedValue([]);
+  listCollectionStats.mockResolvedValue([]);
+});
+
+describe('/stats/[language] loader', () => {
+  it('passes capped pagination options to stats breakdown queries', async () => {
+    listTextStats.mockResolvedValueOnce(Array.from({ length: 100 }, () => ({})));
+    listCollectionStats.mockResolvedValueOnce(Array.from({ length: 100 }, () => ({})));
+
+    const data = (await callLoad(
+      'http://x/stats/hi?textLimit=500&textOffset=25&collectionOffset=10',
+    )) as {
+      textsPage: { limit: number; offset: number; nextOffset: number | null };
+      collectionsPage: { limit: number; offset: number; nextOffset: number | null };
+    };
+
+    expect(listTextStats).toHaveBeenCalledWith(USER.id, 'hi', {
+      limit: 100,
+      offset: 25,
+    });
+    expect(listCollectionStats).toHaveBeenCalledWith(USER.id, 'hi', {
+      limit: 100,
+      offset: 10,
+    });
+    expect(data.textsPage.nextOffset).toBe(125);
+    expect(data.collectionsPage.nextOffset).toBe(110);
+  });
+
+  it('redirects anonymous viewers before querying stats', async () => {
+    const res = (await callLoad('http://x/stats/hi', 'hi', null)) as {
+      status: number;
+      location: string;
+    };
+    expect(res.status).toBe(303);
+    expect(res.location).toContain('/login');
+    expect(getLanguageStats).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- keep inactive reader chapter bodies out of the initial SSR payload and lazy-load body + tokens per chapter
- add a 100KB mobile payload budget helper and tests covering reader payload shape
- cap stats breakdowns and collection library results with pagination metadata/controls

## Tests
- pnpm --filter @ciareader/web test -- payload-budget.test.ts lazy-tokens.test.ts page-server.test.ts tokens-server.test.ts
- pnpm --filter @ciareader/web check
- pnpm --filter @ciareader/web lint
- pnpm --filter @ciareader/web build
- pnpm --filter @ciareader/web test

Closes #107