### PR TITLE
T-12.6: Freeze v1 API contracts

### DIFF
--- a/apps/web/src/lib/test/json-contract.test.ts
+++ b/apps/web/src/lib/test/json-contract.test.ts
@@ -1,0 +1,22 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+
+import { jsonContract } from './json-contract.js';
+
+describe('jsonContract', () => {
+  it('produces stable sorted structural signatures', () => {
+    expect(
+      jsonContract({
+        z: [{ n: 1, ok: true }],
+        a: null,
+      }),
+    ).toEqual({
+      a: 'null',
+      z: [{ n: 'number', ok: 'boolean' }],
+    });
+  });
+
+  it('marks empty arrays without inventing an item shape', () => {
+    expect(jsonContract({ items: [] })).toEqual({ items: 'array' });
+  });
+});

--- a/apps/web/src/lib/test/json-contract.ts
+++ b/apps/web/src/lib/test/json-contract.ts
@@ -1,0 +1,34 @@
+type JsonContract =
+  | 'array'
+  | 'boolean'
+  | 'null'
+  | 'number'
+  | 'string'
+  | { readonly [key: string]: JsonContract }
+  | readonly [JsonContract];
+
+export function jsonContract(value: unknown): JsonContract {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) {
+    return value.length === 0 ? 'array' : [jsonContract(value[0])];
+  }
+  if (typeof value === 'object') {
+    const out: Record<string, JsonContract> = {};
+    for (const [key, nested] of Object.entries(value).sort(([a], [b]) =>
+      a.localeCompare(b),
+    )) {
+      out[key] = jsonContract(nested);
+    }
+    return out;
+  }
+  if (typeof value === 'string') {
+    return 'string';
+  }
+  if (typeof value === 'number') {
+    return 'number';
+  }
+  if (typeof value === 'boolean') {
+    return 'boolean';
+  }
+  throw new TypeError(`Unsupported JSON contract value: ${typeof value}`);
+}

--- a/apps/web/src/routes/api/v1/auth/me/me-server.test.ts
+++ b/apps/web/src/routes/api/v1/auth/me/me-server.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { jsonContract } from '$lib/test/json-contract.js';
+
+const requireUser = vi.fn();
+
+vi.mock('$lib/server/auth/require-user.js', () => ({
+  requireUser: (...a: unknown[]) => requireUser(...a),
+}));
+
+type GetFn = (typeof import('./+server.js'))['GET'];
+
+async function callGet() {
+  const { GET } = await import('./+server.js');
+  const event = {
+    request: new Request('http://x/api/v1/auth/me'),
+  } as unknown as Parameters<GetFn>[0];
+  try {
+    return await GET(event);
+  } catch (e) {
+    return e as { status: number };
+  }
+}
+
+beforeEach(() => {
+  requireUser.mockReset();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('GET /api/v1/auth/me', () => {
+  it('returns the stable public user contract', async () => {
+    requireUser.mockResolvedValueOnce({
+      id: 'u1',
+      email: 'reader@example.com',
+      role: 'user',
+      createdAt: new Date('2026-04-27T00:00:00Z'),
+      updatedAt: new Date('2026-04-27T00:00:00Z'),
+    });
+
+    const res = (await callGet()) as Response;
+    expect(res.status).toBe(200);
+    const json = await res.json();
+
+    expect(jsonContract(json)).toMatchInlineSnapshot(`
+      {
+        "user": {
+          "createdAt": "string",
+          "email": "string",
+          "id": "string",
+          "role": "string",
+        },
+      }
+    `);
+  });
+});

--- a/apps/web/src/routes/api/v1/dictionary/[language]/lemmas/lemmas-server.test.ts
+++ b/apps/web/src/routes/api/v1/dictionary/[language]/lemmas/lemmas-server.test.ts
@@ -4,6 +4,8 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { jsonContract } from '$lib/test/json-contract.js';
+
 const listDictionaryLemmas = vi.fn();
 
 vi.mock('$lib/server/dictionary/browse.js', async () => {
@@ -67,6 +69,7 @@ describe('GET /api/v1/dictionary/:language/lemmas', () => {
       totalCount: 1,
       limit: 50,
       offset: 0,
+      usedNuktaFallback: false,
     });
     const res = (await callGet(
       'http://x/api/v1/dictionary/hi/lemmas?q=%E0%A4%AC%E0%A5%8B%E0%A4%B2',
@@ -80,6 +83,29 @@ describe('GET /api/v1/dictionary/:language/lemmas', () => {
     });
     expect(json.lemmas[0].sourceId).toBeUndefined();
     expect(json.totalCount).toBe(1);
+    expect(jsonContract(json)).toMatchInlineSnapshot(`
+      {
+        "language": "string",
+        "lemmas": [
+          {
+            "curatorLocked": "boolean",
+            "frequencyRank": "number",
+            "glossDefault": "string",
+            "headword": "string",
+            "id": "string",
+            "language": "string",
+            "pos": "string",
+            "provenanceSource": "string",
+            "script": "string",
+            "sourceAttribution": "string",
+          },
+        ],
+        "limit": "number",
+        "offset": "number",
+        "totalCount": "number",
+        "usedNuktaFallback": "boolean",
+      }
+    `);
   });
 
   it('returns 400 on an unsupported language', async () => {
@@ -118,6 +144,7 @@ describe('GET /api/v1/dictionary/:language/lemmas', () => {
       totalCount: 0,
       limit: 10,
       offset: 20,
+      usedNuktaFallback: false,
     });
     await callGet(
       'http://x/api/v1/dictionary/hi/lemmas?pos=verb&pos=noun&minRank=1&maxRank=1000&hasOfficialTranslation=true&limit=10&offset=20',

--- a/apps/web/src/routes/api/v1/lemmas/[id]/translations/translations-server.test.ts
+++ b/apps/web/src/routes/api/v1/lemmas/[id]/translations/translations-server.test.ts
@@ -4,6 +4,8 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { jsonContract } from '$lib/test/json-contract.js';
+
 const getLemmaTranslations = vi.fn();
 const resolveUser = vi.fn();
 
@@ -67,13 +69,70 @@ describe('GET /api/v1/lemmas/:id/translations', () => {
         glossDefault: 'water',
         frequencyRank: 120,
       },
-      translations: { personal: [], official: [], community: [] },
+      translations: {
+        personal: [],
+        official: [
+          {
+            id: 'tr-1',
+            source: 'official_dictionary',
+            submittedBy: null,
+            parentTranslationId: null,
+            body: 'water',
+            targetLanguage: 'en',
+            sourceAttribution: 'Hindi WordNet',
+            provenance: { kind: 'imported', attribution: 'Hindi WordNet' },
+            hidden: false,
+            voteScore: 2,
+            viewerVote: null,
+            createdAt: new Date('2026-04-27T00:00:00Z'),
+            updatedAt: new Date('2026-04-27T00:00:00Z'),
+          },
+        ],
+        community: [],
+      },
     });
     const res = (await callGet(VALID_LEMMA_ID)) as Response;
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.lemma.headword).toBe('पानी');
-    expect(body.translations).toEqual({ personal: [], official: [], community: [] });
+    expect(body.translations.official[0].body).toBe('water');
+    expect(jsonContract(body)).toMatchInlineSnapshot(`
+      {
+        "lemma": {
+          "frequencyRank": "number",
+          "glossDefault": "string",
+          "headword": "string",
+          "id": "string",
+          "language": "string",
+          "pos": "string",
+          "script": "string",
+        },
+        "translations": {
+          "community": "array",
+          "official": [
+            {
+              "body": "string",
+              "createdAt": "string",
+              "hidden": "boolean",
+              "id": "string",
+              "parentTranslationId": "null",
+              "provenance": {
+                "attribution": "string",
+                "kind": "string",
+              },
+              "source": "string",
+              "sourceAttribution": "string",
+              "submittedBy": "null",
+              "targetLanguage": "string",
+              "updatedAt": "string",
+              "viewerVote": "null",
+              "voteScore": "number",
+            },
+          ],
+          "personal": "array",
+        },
+      }
+    `);
     expect(getLemmaTranslations).toHaveBeenCalledWith(VALID_LEMMA_ID, null);
   });
 

--- a/apps/web/src/routes/api/v1/me/known-lemmas/[lemmaId]/known-lemmas-server.test.ts
+++ b/apps/web/src/routes/api/v1/me/known-lemmas/[lemmaId]/known-lemmas-server.test.ts
@@ -1,6 +1,8 @@
 // @vitest-environment node
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { jsonContract } from '$lib/test/json-contract.js';
+
 const setKnownLemmaStatus = vi.fn();
 const requireUser = vi.fn();
 
@@ -72,6 +74,16 @@ describe('PATCH /api/v1/me/known-lemmas/:lemmaId', () => {
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.knownLemma.status).toBe('known');
+    expect(jsonContract(json)).toMatchInlineSnapshot(`
+      {
+        "knownLemma": {
+          "lemmaId": "string",
+          "status": "string",
+          "updatedAt": "string",
+          "userId": "string",
+        },
+      }
+    `);
     expect(setKnownLemmaStatus).toHaveBeenCalledWith({
       userId: USER.id,
       lemmaId: VALID_ID,

--- a/apps/web/src/routes/api/v1/texts/[id]/chapters/[idx]/tokens/tokens-server.test.ts
+++ b/apps/web/src/routes/api/v1/texts/[id]/chapters/[idx]/tokens/tokens-server.test.ts
@@ -4,6 +4,8 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { jsonContract } from '$lib/test/json-contract.js';
+
 const getReadableText = vi.fn();
 const loadChapterTokens = vi.fn();
 
@@ -86,6 +88,8 @@ describe('GET /api/v1/texts/:id/chapters/:idx/tokens', () => {
         lemmaId: 'lem-1',
         romanization: null,
         glossDefault: null,
+        candidates: [],
+        numberForms: null,
         status: 'unknown',
       },
     ]);
@@ -101,6 +105,29 @@ describe('GET /api/v1/texts/:id/chapters/:idx/tokens', () => {
     expect(body.chapterId).toBe('c1');
     expect(body.body).toBe('body 1');
     expect(body.tokens).toHaveLength(1);
+    expect(jsonContract(body)).toMatchInlineSnapshot(`
+      {
+        "body": "string",
+        "chapterId": "string",
+        "chapterIdx": "number",
+        "tokens": [
+          {
+            "candidates": "array",
+            "glossDefault": "null",
+            "id": "string",
+            "idx": "number",
+            "isAmbiguous": "boolean",
+            "isOov": "boolean",
+            "isWord": "boolean",
+            "lemmaId": "string",
+            "numberForms": "null",
+            "romanization": "null",
+            "status": "string",
+            "surface": "string",
+          },
+        ],
+      }
+    `);
     expect(loadChapterTokens).toHaveBeenCalledWith('c1', 'user-1');
   });
 

--- a/apps/web/src/routes/api/v1/texts/[id]/status/status-server.test.ts
+++ b/apps/web/src/routes/api/v1/texts/[id]/status/status-server.test.ts
@@ -1,6 +1,8 @@
 // @vitest-environment node
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { jsonContract } from '$lib/test/json-contract.js';
+
 const getTextStatus = vi.fn();
 const requireUser = vi.fn();
 
@@ -71,6 +73,20 @@ describe('GET /api/v1/texts/:id/status', () => {
     const json = await res.json();
     expect(json.status).toBe('processing');
     expect(json.job.id).toBe('job-1');
+    expect(jsonContract(json)).toMatchInlineSnapshot(`
+      {
+        "job": {
+          "createdAt": "string",
+          "error": "null",
+          "finishedAt": "null",
+          "id": "string",
+          "startedAt": "string",
+          "status": "string",
+        },
+        "status": "string",
+        "statusError": "null",
+      }
+    `);
   });
 
   it('returns null job when no nlp_jobs row exists', async () => {

--- a/apps/web/src/routes/api/v1/texts/texts-server.test.ts
+++ b/apps/web/src/routes/api/v1/texts/texts-server.test.ts
@@ -4,6 +4,8 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { jsonContract } from '$lib/test/json-contract.js';
+
 const createPastedText = vi.fn();
 const createTxtText = vi.fn();
 const requireUser = vi.fn();
@@ -91,6 +93,21 @@ describe('POST /api/v1/texts', () => {
       visibility: 'private',
       sourceType: 'paste',
     });
+    expect(jsonContract(json)).toMatchInlineSnapshot(`
+      {
+        "chapterCount": "number",
+        "text": {
+          "createdAt": "string",
+          "id": "string",
+          "language": "string",
+          "ownerId": "string",
+          "sourceType": "string",
+          "status": "string",
+          "title": "string",
+          "visibility": "string",
+        },
+      }
+    `);
     expect(json.chapterCount).toBe(1);
     expect(createPastedText).toHaveBeenCalledWith(
       { id: USER.id },

--- a/apps/web/src/routes/api/v1/translations/translations-server.test.ts
+++ b/apps/web/src/routes/api/v1/translations/translations-server.test.ts
@@ -8,6 +8,8 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { jsonContract } from '$lib/test/json-contract.js';
+
 const submitUserTranslation = vi.fn();
 const requireUser = vi.fn();
 const consumeRateLimit = vi.fn();
@@ -83,6 +85,8 @@ describe('POST /api/v1/translations', () => {
     submitUserTranslation.mockResolvedValueOnce({
       id: 'tr-1',
       lemmaId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      targetType: 'lemma',
+      targetId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
       source: 'user',
       submittedBy: 'u1',
       parentTranslationId: null,
@@ -110,6 +114,25 @@ describe('POST /api/v1/translations', () => {
     // Never leaks sourceId on user submissions (it's always null, but
     // ensure we send the stable public shape).
     expect(json.translation.sourceId).toBeUndefined();
+    expect(jsonContract(json)).toMatchInlineSnapshot(`
+      {
+        "translation": {
+          "body": "string",
+          "createdAt": "string",
+          "hidden": "boolean",
+          "id": "string",
+          "lemmaId": "string",
+          "parentTranslationId": "null",
+          "source": "string",
+          "sourceAttribution": "null",
+          "submittedBy": "string",
+          "targetId": "string",
+          "targetLanguage": "string",
+          "targetType": "string",
+          "updatedAt": "string",
+        },
+      }
+    `);
     expect(res.headers.get('x-ratelimit-remaining')).toBe('29');
   });
 


### PR DESCRIPTION
## Summary
- add a structural JSON contract helper for route tests
- freeze key v1 response shapes for auth, text creation/status/chapter tokens, dictionary browse, lemma translations, user translations, and known-lemma updates
- add GET /api/v1/auth/me coverage for the public user contract

## Tests
- pnpm --filter @ciareader/web test -- json-contract.test.ts me-server.test.ts texts-server.test.ts status-server.test.ts tokens-server.test.ts lemmas-server.test.ts translations-server.test.ts known-lemmas-server.test.ts
- pnpm --filter @ciareader/web check
- pnpm --filter @ciareader/web lint
- pnpm --filter @ciareader/web build
- pnpm --filter @ciareader/web test

Closes #108