### PR TITLE
T-14.3 — Reader span rendering + popup phrase mode

### DIFF
--- a/apps/web/src/lib/components/reader/ChapterBody.svelte
+++ b/apps/web/src/lib/components/reader/ChapterBody.svelte
@@ -22,7 +22,10 @@
   import {
     paragraphsOfServerTokens,
     paragraphsOfTokens,
+    segmentParagraphPhrases,
+    statusToCode,
     tokenize,
+    type ChapterPhraseSpan,
     type ChapterView,
     type ServerToken,
   } from './types.js';
@@ -103,6 +106,36 @@
       : paragraphsOfTokens(tokenize(chapter.body)),
   );
 
+  // T-14.3: phrase spans are segmented per paragraph at render
+  // time. The resolver (T-14.2) emits at most one span per
+  // (startIdx, phraseId), and longest-wins is applied here for the
+  // visible `<phrase>` wrapper — shorter overlapping spans ride
+  // along as `overlaps` so the popup (T-14.4) can surface them as
+  // alternatives. An empty `phraseSpans` array (chapter processed,
+  // no matches) costs one Map allocation per paragraph; a `null`
+  // value (chapter not yet processed) renders as bare tokens.
+  const phraseSpans = $derived(chapter.phraseSpans ?? []);
+  const segmentedParagraphs = $derived.by(() => {
+    if (!serverParagraphs) return null;
+    return serverParagraphs.map((paragraph) =>
+      segmentParagraphPhrases(paragraph, phraseSpans),
+    );
+  });
+  // Map from phraseId to its rendered span — used by the popup
+  // when the user clicks a token inside a phrase wrapper.
+  const phraseSpanById = $derived.by(() => {
+    const map = new Map<string, ChapterPhraseSpan>();
+    for (const s of phraseSpans) {
+      const existing = map.get(s.phraseId);
+      // The same phrase may appear multiple times in a chapter;
+      // any occurrence is sufficient for the popup header (which
+      // surfaces phrase-level metadata, not occurrence-specific
+      // info).
+      if (!existing) map.set(s.phraseId, s);
+    }
+    return map;
+  });
+
   // Lookup helper — server tokens are keyed by id.
   const tokensById = $derived.by(() => {
     if (!tokensWithOverrides) return new Map<string, ServerToken>();
@@ -119,6 +152,20 @@
     bottom: number;
     right: number;
   } | null>(null);
+  // T-14.3: when the click target is inside a `<phrase>` wrapper,
+  // the popup opens with the phrase header above the token body.
+  // Cleared whenever the click lands on a bare token or the popup
+  // is closed.
+  let activePhrase = $state<ChapterPhraseSpan | null>(null);
+
+  function findPhrase(target: HTMLElement | null): ChapterPhraseSpan | null {
+    if (!target) return null;
+    const wrapper = target.closest('[data-phrase-id]') as HTMLElement | null;
+    if (!wrapper) return null;
+    const phraseId = wrapper.getAttribute('data-phrase-id');
+    if (!phraseId) return null;
+    return phraseSpanById.get(phraseId) ?? null;
+  }
 
   let hoverToken = $state<ServerToken | null>(null);
   let hoverRect = $state<{
@@ -155,6 +202,10 @@
       bottom: rect.bottom,
       right: rect.right,
     };
+    // T-14.3: surface the containing phrase (if any) so the popup
+    // can render its phrase header above the token body. A click on
+    // a bare token clears any prior phrase context.
+    activePhrase = findPhrase(event.target as HTMLElement);
     // Hide the hover tooltip so it doesn't double up with the panel.
     hoverToken = null;
     hoverRect = null;
@@ -221,6 +272,7 @@
   function closePopup() {
     activeToken = null;
     activeRect = null;
+    activePhrase = null;
   }
 
   // T-5.1c: long-press as a tap alternative on touch devices. A
@@ -239,6 +291,7 @@
       bottom: rect.bottom,
       right: rect.right,
     };
+    activePhrase = findPhrase(target as HTMLElement | null);
     hoverToken = null;
     hoverRect = null;
   });
@@ -318,14 +371,25 @@
   ontouchend={onTouchEnd}
   ontouchcancel={onTouchEnd}
 >
-  {#if serverParagraphs}
-    {#each serverParagraphs as paragraph, pIdx (pIdx)}
+  {#if segmentedParagraphs}
+    {#each segmentedParagraphs as paragraph, pIdx (pIdx)}
       <p class="body">
-        {#each paragraph as token (token.id)}<TokenSpan
-            {token}
-            {showRomanization}
-            isAnchor={activeToken?.id === token.id}
-          />{/each}
+        {#each paragraph as segment, sIdx (sIdx)}{#if segment.kind === 'token'}<TokenSpan
+              token={segment.token}
+              {showRomanization}
+              isAnchor={activeToken?.id === segment.token.id}
+            />{:else}<phrase
+              class="phrase"
+              data-phrase-id={segment.span.phraseId}
+              data-s={statusToCode(segment.span.status)}
+              data-phrase-overlap={segment.overlaps.length > 0
+                ? segment.overlaps.map((o) => o.phraseId).join(' ')
+                : undefined}
+              >{#each segment.tokens as token (token.id)}<TokenSpan
+                  {token}
+                  {showRomanization}
+                  isAnchor={activeToken?.id === token.id}
+                />{/each}</phrase>{/if}{/each}
       </p>
     {/each}
   {:else if fallbackParagraphs}
@@ -349,6 +413,7 @@
      prompt based on whether `token` is null. -->
 <WordPopup
   token={activeToken}
+  phrase={activePhrase}
   anchorRect={activeRect ?? undefined}
   {language}
   {isOwner}
@@ -378,5 +443,22 @@
   }
   .word:hover {
     background: color-mix(in srgb, var(--color-accent) 12%, transparent);
+  }
+  /* T-14.3: phrase wrappers are an unknown element so we have to
+     opt them into inline display explicitly. The visible
+     highlight is layered via `data-s` matching the existing
+     `.status-*` rules in `tokens.css` — phrase status wins over
+     per-token status when both are non-default. */
+  .phrase {
+    display: inline;
+    border-bottom: 1px dotted color-mix(in srgb, var(--color-accent) 35%, transparent);
+  }
+  .phrase[data-s='4'] {
+    /* known phrase — quiet highlight, mirrors the lemma 'known'
+       treatment but applied to the run rather than each token. */
+    border-bottom-color: color-mix(in srgb, var(--color-accent) 60%, transparent);
+  }
+  .phrase[data-s='5'] {
+    border-bottom-style: none;
   }
 </style>

--- a/apps/web/src/lib/components/reader/ReaderContinuous.svelte
+++ b/apps/web/src/lib/components/reader/ReaderContinuous.svelte
@@ -57,12 +57,18 @@
     fetcher?: ChapterTokenFetcher;
   } = $props();
 
-  // Map of chapterIdx → fetched body + tokens. SSR only includes the
-  // active chapter's body, so siblings hydrate their text on demand.
-  // Seeded with the initial chapter so re-renders don't trigger an
-  // unnecessary network round-trip for the chapter we already have.
+  // Map of chapterIdx → fetched body + tokens + phrase spans. SSR
+  // only includes the active chapter's body, so siblings hydrate
+  // their text on demand. Seeded with the initial chapter so re-
+  // renders don't trigger an unnecessary network round-trip for
+  // the chapter we already have. T-14.3: phraseSpans rides on the
+  // same fetch so a sibling chapter scrolled into view repaints
+  // with phrase highlights on the next $derived pass.
   let lazyChapters = $state(
-    new Map<number, Pick<ChapterTokensResponse, 'body' | 'tokens'>>(),
+    new Map<
+      number,
+      Pick<ChapterTokensResponse, 'body' | 'tokens' | 'phraseSpans'>
+    >(),
   );
 
   const loader = $derived(new LazyTokenLoader(textId, fetcher));
@@ -74,7 +80,12 @@
       if (c.tokens != null && c.body != null) return c;
       const fetched = lazyChapters.get(c.idx);
       if (fetched === undefined) return c;
-      return { ...c, body: fetched.body, tokens: fetched.tokens };
+      return {
+        ...c,
+        body: fetched.body,
+        tokens: fetched.tokens,
+        phraseSpans: fetched.phraseSpans,
+      };
     });
   });
 
@@ -88,14 +99,18 @@
       .load(chapterIdx)
       .then((chapter) => {
         const next = new Map(untrack(() => lazyChapters));
-        next.set(chapterIdx, { body: chapter.body, tokens: chapter.tokens });
+        next.set(chapterIdx, {
+          body: chapter.body,
+          tokens: chapter.tokens,
+          phraseSpans: chapter.phraseSpans,
+        });
         lazyChapters = next;
       })
       .catch(() => {
         // Swallow — the chapter still renders via the whitespace
         // fallback, just without lemma colouring. A retry happens
         // automatically the next time the observer trips because
-        // we never wrote to `lazyTokens`.
+        // we never wrote to `lazyChapters`.
       });
   }
 

--- a/apps/web/src/lib/components/reader/WordPopup.svelte
+++ b/apps/web/src/lib/components/reader/WordPopup.svelte
@@ -73,6 +73,7 @@
   // the user hasn't picked a word yet.
   let {
     token,
+    phrase = null,
     language,
     isOwner,
     onClose,
@@ -80,6 +81,12 @@
     onCorrectionApplied,
   }: {
     token: ServerToken | null;
+    /** T-14.3: surface the longest phrase containing the click
+     *  target. When non-null, the popup renders a phrase banner
+     *  (status flips + gloss + headword) above the existing token
+     *  body. The component lemma stays underneath so a click on a
+     *  phrase token still surfaces the lemma's translations. */
+    phrase?: import('./types.js').ChapterPhraseSpan | null;
     /** Drives the CorrectionModal's dictionary search + script
      *  selection. Required from T-6.2 forward. */
     language: LanguageCode;
@@ -94,6 +101,42 @@
      *  the reader reflects the correction without a page reload. */
     onCorrectionApplied?: (tokenId: string, chosenLemmaId: string | null) => void;
   } = $props();
+
+  // T-14.3: optimistic phrase status, mirroring the lemma path.
+  // Re-syncs from the prop whenever the user clicks into a
+  // different phrase. The PATCH happens against
+  // /api/v1/me/known-phrases/:phraseId.
+  let optimisticPhraseStatus = $state<
+    'unknown' | 'learning' | 'known' | 'ignored'
+  >(untrack(() => phrase?.status ?? 'unknown'));
+  let phraseStatusError = $state<string | null>(null);
+  $effect(() => {
+    optimisticPhraseStatus = phrase?.status ?? 'unknown';
+    phraseStatusError = null;
+  });
+
+  async function setPhraseStatus(
+    next: 'unknown' | 'learning' | 'known' | 'ignored',
+  ) {
+    if (!phrase) return;
+    const prev = optimisticPhraseStatus;
+    optimisticPhraseStatus = next;
+    phraseStatusError = null;
+    try {
+      const res = await fetch(`/api/v1/me/known-phrases/${phrase.phraseId}`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ status: next }),
+      });
+      if (!res.ok) {
+        optimisticPhraseStatus = prev;
+        phraseStatusError = `Could not update phrase status (${res.status})`;
+      }
+    } catch (e) {
+      optimisticPhraseStatus = prev;
+      phraseStatusError = `Network error: ${(e as Error).message}`;
+    }
+  }
 
   let payload = $state<LemmaPayload | null>(null);
   let loadError = $state<string | null>(null);
@@ -496,6 +539,54 @@
      The panel is always open on desktop (static right column) and
      conditional on mobile (slides up only when a word is picked). -->
 <Sheet open={sheetOpen} onClose={onClose} title="" dimmed={false}>
+  {#if phrase}
+    <!-- T-14.3: phrase banner. Sits above the token body so the
+         user sees the multi-word entry first, with the component
+         lemma's translations available underneath. The `Customize`
+         + translation list for the phrase itself land in T-14.4. -->
+    <section class="sp-phrase" data-testid="word-popup-phrase">
+      <header class="sp-phrase-head">
+        <span class="sp-phrase-eyebrow">Phrase</span>
+        {#if phrase.glossDefault}
+          <p class="sp-phrase-gloss">{phrase.glossDefault}</p>
+        {:else}
+          <p class="sp-phrase-gloss muted">No phrase gloss yet.</p>
+        {/if}
+      </header>
+      {#if isOwner}
+        <div
+          class="sp-status sp-phrase-status"
+          role="group"
+          aria-label="Mark phrase status"
+        >
+          <button
+            type="button"
+            data-active={optimisticPhraseStatus === 'learning' ? '1' : '0'}
+            onclick={() => setPhraseStatus('learning')}
+          >
+            Learning
+          </button>
+          <button
+            type="button"
+            data-active={optimisticPhraseStatus === 'known' ? '1' : '0'}
+            onclick={() => setPhraseStatus('known')}
+          >
+            Known
+          </button>
+          <button
+            type="button"
+            data-active={optimisticPhraseStatus === 'ignored' ? '1' : '0'}
+            onclick={() => setPhraseStatus('ignored')}
+          >
+            Ignored
+          </button>
+        </div>
+        {#if phraseStatusError}
+          <p class="err small">{phraseStatusError}</p>
+        {/if}
+      {/if}
+    </section>
+  {/if}
   {#if !token}
     <div class="sp-empty" data-testid="word-popup-empty">
       <p>Click a word to see its definition.</p>
@@ -837,6 +928,38 @@
     font-style: italic;
     text-align: center;
     padding: 1.5rem 0.5rem;
+  }
+  /* T-14.3: phrase banner. Sits above the token block when the
+     user clicked inside a phrase wrapper. Lightweight visual
+     treatment so it doesn't compete with the (richer) token /
+     lemma section underneath. */
+  .sp-phrase {
+    margin: 0 0 1rem;
+    padding: 0.5rem 0.75rem 0.6rem;
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--color-accent) 6%, transparent);
+  }
+  .sp-phrase-head {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+  }
+  .sp-phrase-eyebrow {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--ink-3, var(--color-fg-muted));
+  }
+  .sp-phrase-gloss {
+    margin: 0;
+    font-size: 0.95rem;
+  }
+  .sp-phrase-gloss.muted {
+    color: var(--ink-3, var(--color-fg-muted));
+    font-style: italic;
+  }
+  .sp-phrase-status {
+    margin-top: 0.5rem;
   }
   .sp-head {
     position: relative;

--- a/apps/web/src/lib/components/reader/lazy-tokens.test.ts
+++ b/apps/web/src/lib/components/reader/lazy-tokens.test.ts
@@ -33,12 +33,14 @@ describe('LazyTokenLoader', () => {
         chapterIdx: idx,
         body: `body ${idx}`,
         tokens: fakeTokens(2),
+        phraseSpans: [],
       }));
     const loader = new LazyTokenLoader('text-1', fetcher);
     const a = await loader.load(2);
     const b = await loader.load(2);
     expect(a.tokens).toHaveLength(2);
     expect(a.body).toBe('body 2');
+    expect(a.phraseSpans).toEqual([]);
     expect(b).toEqual(a);
     expect(fetcher).toHaveBeenCalledTimes(1);
   });
@@ -52,10 +54,17 @@ describe('LazyTokenLoader', () => {
     const loader = new LazyTokenLoader('t1', fetcher);
     const p1 = loader.load(1);
     const p2 = loader.load(1);
-    resolveFn!({ chapterId: 'c1', chapterIdx: 1, body: 'body 1', tokens: null });
+    resolveFn!({
+      chapterId: 'c1',
+      chapterIdx: 1,
+      body: 'body 1',
+      tokens: null,
+      phraseSpans: null,
+    });
     const [a, b] = await Promise.all([p1, p2]);
     expect(a.tokens).toBeNull();
     expect(a.body).toBe('body 1');
+    expect(a.phraseSpans).toBeNull();
     expect(b).toEqual(a);
     expect(fetcher).toHaveBeenCalledTimes(1);
   });
@@ -87,11 +96,13 @@ describe('LazyTokenLoader', () => {
       chapterIdx: 1,
       body: 'fallback body',
       tokens: null,
+      phraseSpans: null,
     });
     const loader = new LazyTokenLoader('t1', fetcher);
     expect(await loader.load(1)).toMatchObject({
       body: 'fallback body',
       tokens: null,
+      phraseSpans: null,
     });
     expect(loader.state(1)).toEqual({
       kind: 'loaded',
@@ -99,6 +110,7 @@ describe('LazyTokenLoader', () => {
       chapterIdx: 1,
       body: 'fallback body',
       tokens: null,
+      phraseSpans: null,
     });
   });
 });

--- a/apps/web/src/lib/components/reader/lazy-tokens.ts
+++ b/apps/web/src/lib/components/reader/lazy-tokens.ts
@@ -13,13 +13,17 @@
  * which matches the reader's data flow (status overrides happen
  * client-side via WordPopup, not by re-pulling rows).
  */
-import type { ServerToken } from './types.js';
+import type { ChapterPhraseSpan, ServerToken } from './types.js';
 
 export type ChapterTokensResponse = {
   chapterId: string;
   chapterIdx: number;
   body: string;
   tokens: ServerToken[] | null;
+  /** T-14.3: phrase spans, hydrated alongside tokens by the same
+   *  endpoint. Empty array when the chapter has tokens but no phrase
+   *  matches; null when tokens is also null (unprocessed chapter). */
+  phraseSpans: ChapterPhraseSpan[] | null;
 };
 
 export type FetchState =
@@ -31,6 +35,10 @@ export type FetchState =
       chapterIdx: number;
       body: string;
       tokens: ServerToken[] | null;
+      /** T-14.3: cached alongside tokens so a sibling chapter
+       *  scrolled into view repaints with the right phrase
+       *  highlights on the next $derived pass. */
+      phraseSpans: ChapterPhraseSpan[] | null;
     }
   | { kind: 'error'; message: string };
 
@@ -68,10 +76,11 @@ export class LazyTokenLoader {
 
   /**
    * Kick off (or join) a fetch for `chapterIdx`. Resolves to the
-   * fetched body plus tokens, or null tokens if the worker hasn't run
-   * for that chapter yet. The SSR loader only includes the active
-   * chapter body; this on-demand shape lets continuous mode hydrate
-   * sibling chapters without bloating first paint.
+   * fetched body plus tokens (and T-14.3 phrase spans), or null
+   * tokens / null spans if the worker hasn't run for that chapter
+   * yet. The SSR loader only includes the active chapter body;
+   * this on-demand shape lets continuous mode hydrate sibling
+   * chapters without bloating first paint.
    */
   async load(chapterIdx: number): Promise<ChapterTokensResponse> {
     const existing = this.states.get(chapterIdx);
@@ -81,6 +90,7 @@ export class LazyTokenLoader {
         chapterIdx: existing.chapterIdx,
         body: existing.body,
         tokens: existing.tokens,
+        phraseSpans: existing.phraseSpans,
       };
     }
     const existingPromise = this.inflight.get(chapterIdx);
@@ -98,6 +108,7 @@ export class LazyTokenLoader {
         chapterIdx: r.chapterIdx,
         body: r.body,
         tokens: r.tokens,
+        phraseSpans: r.phraseSpans,
       });
       return r;
     } catch (err) {

--- a/apps/web/src/lib/components/reader/segment-phrases.test.ts
+++ b/apps/web/src/lib/components/reader/segment-phrases.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  segmentParagraphPhrases,
+  type ChapterPhraseSpan,
+  type ServerToken,
+} from './types.js';
+
+/**
+ * Unit tests for `segmentParagraphPhrases` (T-14.3).
+ *
+ * The renderer in `ChapterBody.svelte` walks the segments and emits
+ * either a bare `TokenSpan` or a `<phrase>` wrapper around a run of
+ * `TokenSpan`s. These tests pin the segmentation invariants:
+ *   - bare-token paragraphs round-trip when no spans match,
+ *   - a single span produces one wrapped segment + bare flanks,
+ *   - longest-wins picks the longer of two spans sharing a start,
+ *   - shorter overlaps survive on the winner's `overlaps` list,
+ *   - defensive bail-out when a span runs past the paragraph end.
+ */
+
+function tok(idx: number, surface: string): ServerToken {
+  return {
+    id: `t-${idx}`,
+    idx,
+    surface,
+    isWord: true,
+    isAmbiguous: false,
+    isOov: false,
+    lemmaId: null,
+    romanization: null,
+    glossDefault: null,
+    candidates: [],
+    numberForms: null,
+    status: 'unknown',
+  };
+}
+
+function span(
+  phraseId: string,
+  startTokenIdx: number,
+  endTokenIdx: number,
+): ChapterPhraseSpan {
+  return {
+    phraseId,
+    startTokenIdx,
+    endTokenIdx,
+    glossDefault: null,
+    status: 'unknown',
+  };
+}
+
+describe('segmentParagraphPhrases', () => {
+  it('returns a flat list of bare tokens when no spans match', () => {
+    const paragraph = [tok(0, 'a'), tok(1, 'b'), tok(2, 'c')];
+    const out = segmentParagraphPhrases(paragraph, []);
+    expect(out).toHaveLength(3);
+    expect(out.every((s) => s.kind === 'token')).toBe(true);
+  });
+
+  it('wraps a contiguous run when a span covers it', () => {
+    const paragraph = [
+      tok(0, 'a'),
+      tok(1, 'इंतज़ार'),
+      tok(2, 'करना'),
+      tok(3, 'd'),
+    ];
+    const out = segmentParagraphPhrases(paragraph, [span('phr-1', 1, 2)]);
+    // bare 'a', phrase wrapping idx 1+2, bare 'd'
+    expect(out).toHaveLength(3);
+    expect(out[0]).toEqual({ kind: 'token', token: paragraph[0] });
+    expect(out[1]?.kind).toBe('phrase');
+    if (out[1]?.kind !== 'phrase') throw new Error('unreachable');
+    expect(out[1].span.phraseId).toBe('phr-1');
+    expect(out[1].tokens.map((t) => t.idx)).toEqual([1, 2]);
+    expect(out[1].overlaps).toEqual([]);
+    expect(out[2]).toEqual({ kind: 'token', token: paragraph[3] });
+  });
+
+  it('picks the longest span when two share a start (overlaps surface the rest)', () => {
+    const paragraph = [tok(0, 'मदद'), tok(1, 'करना'), tok(2, 'है')];
+    const out = segmentParagraphPhrases(paragraph, [
+      span('phr-short', 0, 1),
+      span('phr-long', 0, 2),
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.kind).toBe('phrase');
+    if (out[0]?.kind !== 'phrase') throw new Error('unreachable');
+    expect(out[0].span.phraseId).toBe('phr-long');
+    expect(out[0].tokens.map((t) => t.idx)).toEqual([0, 1, 2]);
+    expect(out[0].overlaps).toHaveLength(1);
+    expect(out[0].overlaps[0]?.phraseId).toBe('phr-short');
+  });
+
+  it('emits multiple wrapped segments when the same phrase occurs twice', () => {
+    const paragraph = [
+      tok(0, 'इंतज़ार'),
+      tok(1, 'करना'),
+      tok(2, ','),
+      tok(3, 'इंतज़ार'),
+      tok(4, 'करना'),
+    ];
+    const out = segmentParagraphPhrases(paragraph, [
+      span('phr-1', 0, 1),
+      span('phr-1', 3, 4),
+    ]);
+    const phraseSegments = out.filter((s) => s.kind === 'phrase');
+    expect(phraseSegments).toHaveLength(2);
+  });
+
+  it('falls back to bare tokens when a span endIdx falls outside the paragraph', () => {
+    // Defensive case: e.g. the resolver wrote a span pointing at an
+    // idx that no longer exists after a re-process. Renderer must
+    // not crash and must continue with bare tokens.
+    const paragraph = [tok(0, 'a'), tok(1, 'b')];
+    const out = segmentParagraphPhrases(paragraph, [span('phr-x', 0, 99)]);
+    expect(out.every((s) => s.kind === 'token')).toBe(true);
+  });
+
+  it('preserves token order across consecutive overlapping spans', () => {
+    // Spans that touch end-to-end should still produce contiguous
+    // bare-or-phrase output.
+    const paragraph = [tok(0, 'a'), tok(1, 'b'), tok(2, 'c'), tok(3, 'd')];
+    const out = segmentParagraphPhrases(paragraph, [
+      span('phr-1', 0, 1),
+      span('phr-2', 2, 3),
+    ]);
+    expect(out).toHaveLength(2);
+    expect(out[0]?.kind).toBe('phrase');
+    expect(out[1]?.kind).toBe('phrase');
+  });
+});

--- a/apps/web/src/lib/components/reader/types.ts
+++ b/apps/web/src/lib/components/reader/types.ts
@@ -91,6 +91,27 @@ export type ServerToken = {
   status: 'known' | 'learning' | 'ignored' | 'unknown';
 };
 
+/**
+ * One occurrence of a phrase inside a chapter (T-14.3, M14
+ * phrase-level translations). The reader wraps the run of tokens
+ * from `startTokenIdx` through `endTokenIdx` (inclusive) in a
+ * `<phrase>` element so the per-phrase status and gloss can drive
+ * highlighting + the popup header.
+ *
+ * Multiple spans may share `startTokenIdx` (one short, one long) —
+ * the renderer picks the longest as the visible wrapper and keeps
+ * shorter spans in `data-phrase-overlap` so the popup can offer
+ * them as alternatives. Lifecycle parallel to T-14.2's server-side
+ * `phrase_chapter_spans` table.
+ */
+export type ChapterPhraseSpan = {
+  phraseId: string;
+  startTokenIdx: number;
+  endTokenIdx: number;
+  glossDefault: string | null;
+  status: 'known' | 'learning' | 'ignored' | 'unknown';
+};
+
 export type ChapterView = {
   id: string;
   idx: number;
@@ -98,6 +119,10 @@ export type ChapterView = {
   body: string | null;
   tokenCount: number;
   tokens: ServerToken[] | null;
+  /** T-14.3: phrase spans for this chapter — empty array when none,
+   *  null when the chapter hasn't been processed yet (sibling to
+   *  `tokens` null state). */
+  phraseSpans: ChapterPhraseSpan[] | null;
 };
 
 export type ReaderLayoutMode = 'page' | 'paged_scroll' | 'continuous';
@@ -208,5 +233,95 @@ export function paragraphsOfServerTokens(
     current.push(t);
   }
   if (current.length > 0) out.push(current);
+  return out;
+}
+
+/**
+ * One slot in a paragraph after T-14.3 phrase segmentation. Either
+ * a bare token (no phrase covers this idx) or a run of tokens
+ * wrapped by the longest phrase that starts at this idx. Shorter
+ * overlapping spans are exposed via `overlaps` so the popup can
+ * offer them as alternatives without changing the visible wrapper.
+ */
+export type ParagraphSegment =
+  | { kind: 'token'; token: ServerToken }
+  | {
+      kind: 'phrase';
+      span: ChapterPhraseSpan;
+      tokens: ServerToken[];
+      /** Other spans that start at the same idx but are strictly
+       *  shorter than the visible one. Empty when no overlaps. */
+      overlaps: ChapterPhraseSpan[];
+    };
+
+/**
+ * Segment a paragraph into bare-token / phrase-wrapped slots so the
+ * renderer can wrap phrase spans in `<phrase>` elements without
+ * conditional template logic per token. T-14.2's resolver only
+ * emits spans within a single sentence, and paragraphs are
+ * supersets of sentences, so a span never crosses a paragraph
+ * boundary in practice. The defensive bail-out below handles the
+ * theoretical case where a span's `endTokenIdx` lies outside the
+ * provided paragraph (a re-process race) by treating those tokens
+ * as bare.
+ */
+export function segmentParagraphPhrases(
+  paragraph: ServerToken[],
+  spans: ChapterPhraseSpan[],
+): ParagraphSegment[] {
+  if (spans.length === 0) {
+    return paragraph.map((token) => ({ kind: 'token', token }));
+  }
+  const spansByStart = new Map<number, ChapterPhraseSpan[]>();
+  for (const s of spans) {
+    let bucket = spansByStart.get(s.startTokenIdx);
+    if (!bucket) {
+      bucket = [];
+      spansByStart.set(s.startTokenIdx, bucket);
+    }
+    bucket.push(s);
+  }
+
+  const out: ParagraphSegment[] = [];
+  let i = 0;
+  while (i < paragraph.length) {
+    const t = paragraph[i]!;
+    const candidates = spansByStart.get(t.idx);
+    if (candidates && candidates.length > 0) {
+      // Longest span wins for the visible wrapper; any shorter
+      // siblings sharing the start ride along as overlaps.
+      const sorted = [...candidates].sort(
+        (a, b) =>
+          b.endTokenIdx - b.startTokenIdx - (a.endTokenIdx - a.startTokenIdx),
+      );
+      const winner = sorted[0]!;
+      // Collect tokens up to winner.endTokenIdx (inclusive) that
+      // are still in this paragraph.
+      const phraseTokens: ServerToken[] = [];
+      let j = i;
+      while (
+        j < paragraph.length &&
+        paragraph[j]!.idx <= winner.endTokenIdx
+      ) {
+        phraseTokens.push(paragraph[j]!);
+        j += 1;
+      }
+      const last = phraseTokens[phraseTokens.length - 1];
+      if (last && last.idx === winner.endTokenIdx) {
+        out.push({
+          kind: 'phrase',
+          span: winner,
+          tokens: phraseTokens,
+          overlaps: sorted.slice(1),
+        });
+        i = j;
+        continue;
+      }
+      // Span endTokenIdx fell outside this paragraph (defensive
+      // path) — fall through to bare-token rendering.
+    }
+    out.push({ kind: 'token', token: t });
+    i += 1;
+  }
   return out;
 }

--- a/apps/web/src/routes/api/v1/texts/[id]/chapters/[idx]/tokens/+server.ts
+++ b/apps/web/src/routes/api/v1/texts/[id]/chapters/[idx]/tokens/+server.ts
@@ -16,6 +16,7 @@ import { error, json } from '@sveltejs/kit';
 
 import { getReadableText } from '$lib/server/texts/upload.js';
 import { loadChapterTokens } from '$lib/server/texts/tokens.js';
+import { loadChapterPhraseSpans } from '$lib/server/texts/phrase-spans.js';
 import type { RequestHandler } from './$types';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -35,10 +36,17 @@ export const GET: RequestHandler = async ({ params, locals }) => {
   if (!chapter) throw error(404, 'Chapter not found');
 
   const tokens = await loadChapterTokens(chapter.id, viewer?.id ?? null);
+  // T-14.3: spans ride alongside tokens. Empty array when the
+  // chapter has been processed but contains no phrase matches;
+  // null when tokens are also null (unprocessed chapter).
+  const phraseSpans = tokens
+    ? await loadChapterPhraseSpans(chapter.id, viewer?.id ?? null)
+    : null;
   return json({
     chapterId: chapter.id,
     chapterIdx: chapter.idx,
     body: chapter.body,
     tokens,
+    phraseSpans,
   });
 };

--- a/apps/web/src/routes/api/v1/texts/[id]/chapters/[idx]/tokens/tokens-server.test.ts
+++ b/apps/web/src/routes/api/v1/texts/[id]/chapters/[idx]/tokens/tokens-server.test.ts
@@ -8,6 +8,7 @@ import { jsonContract } from '$lib/test/json-contract.js';
 
 const getReadableText = vi.fn();
 const loadChapterTokens = vi.fn();
+const loadChapterPhraseSpans = vi.fn();
 
 vi.mock('$lib/server/texts/upload.js', async () => {
   const actual = await vi.importActual<typeof import('$lib/server/texts/upload.js')>(
@@ -27,6 +28,20 @@ vi.mock('$lib/server/texts/tokens.js', async () => {
   return {
     ...actual,
     loadChapterTokens: (...a: unknown[]) => loadChapterTokens(...a),
+  };
+});
+
+// T-14.3: phrase spans ride alongside tokens; mock the loader so
+// existing tests stay focused on the lazy-token path. The default
+// resolves to an empty array so the endpoint shape includes
+// `phraseSpans: []` without each test having to stage it.
+vi.mock('$lib/server/texts/phrase-spans.js', async () => {
+  const actual = await vi.importActual<
+    typeof import('$lib/server/texts/phrase-spans.js')
+  >('$lib/server/texts/phrase-spans.js');
+  return {
+    ...actual,
+    loadChapterPhraseSpans: (...a: unknown[]) => loadChapterPhraseSpans(...a),
   };
 });
 
@@ -68,6 +83,8 @@ beforeEach(() => {
   getReadableText.mockReset();
   loadChapterTokens.mockReset();
   loadChapterTokens.mockResolvedValue(null);
+  loadChapterPhraseSpans.mockReset();
+  loadChapterPhraseSpans.mockResolvedValue([]);
 });
 
 afterEach(() => {
@@ -110,6 +127,7 @@ describe('GET /api/v1/texts/:id/chapters/:idx/tokens', () => {
         "body": "string",
         "chapterId": "string",
         "chapterIdx": "number",
+        "phraseSpans": "array",
         "tokens": [
           {
             "candidates": "array",

--- a/apps/web/src/routes/reader/[textId]/+page.server.ts
+++ b/apps/web/src/routes/reader/[textId]/+page.server.ts
@@ -23,6 +23,7 @@ import { and, eq } from 'drizzle-orm';
 
 import { getReadableText } from '$lib/server/texts/upload.js';
 import { loadChapterTokens } from '$lib/server/texts/tokens.js';
+import { loadChapterPhraseSpans } from '$lib/server/texts/phrase-spans.js';
 import { getTextProgress } from '$lib/server/texts/progress.js';
 import { readerCollectionContext } from '$lib/server/collections.js';
 import { listAudioForText } from '$lib/server/audio/audio.js';
@@ -152,6 +153,14 @@ export const load: PageServerLoad = async ({ params, locals, url }) => {
   const activeTokens = activeChapter
     ? await loadChapterTokens(activeChapter.id, viewerId)
     : null;
+  // T-14.3: phrase spans for the active chapter, joined with the
+  // viewer's known-phrase status. Empty array when the chapter
+  // has tokens but no phrase matches (the common case during
+  // M14 rollout); null for unprocessed chapters so the reader
+  // chrome can still render via the whitespace fallback.
+  const activeChapterSpans = activeChapter && activeTokens
+    ? await loadChapterPhraseSpans(activeChapter.id, viewerId)
+    : null;
 
   // T-8.3: if this text is a member of a collection, surface the
   // collection title + prev / next text ids in the reader chrome.
@@ -205,6 +214,10 @@ export const load: PageServerLoad = async ({ params, locals, url }) => {
       // Siblings carry `tokens: null`; the lazy endpoint returns both
       // body and tokens when a sibling needs to render.
       tokens: c.idx === chapterIdx ? activeTokens : null,
+      // T-14.3: phrase spans ride alongside tokens with the same
+      // active-only / lazy-fill posture. Sibling chapters get null
+      // until the lazy fetch lands.
+      phraseSpans: c.idx === chapterIdx ? activeChapterSpans : null,
     })),
     anchor: {
       chapterIdx,

--- a/apps/web/src/routes/reader/[textId]/page-server.test.ts
+++ b/apps/web/src/routes/reader/[textId]/page-server.test.ts
@@ -11,6 +11,7 @@ import {
 
 const getReadableText = vi.fn();
 const loadChapterTokens = vi.fn();
+const loadChapterPhraseSpans = vi.fn();
 
 vi.mock('$lib/server/texts/upload.js', async () => {
   const actual = await vi.importActual<typeof import('$lib/server/texts/upload.js')>(
@@ -30,6 +31,19 @@ vi.mock('$lib/server/texts/tokens.js', async () => {
   return {
     ...actual,
     loadChapterTokens: (...a: unknown[]) => loadChapterTokens(...a),
+  };
+});
+
+// T-14.3: phrase spans ride alongside the active chapter. Default
+// the loader to an empty array so existing tests stay focused on
+// the chapter / token / progress surfaces.
+vi.mock('$lib/server/texts/phrase-spans.js', async () => {
+  const actual = await vi.importActual<
+    typeof import('$lib/server/texts/phrase-spans.js')
+  >('$lib/server/texts/phrase-spans.js');
+  return {
+    ...actual,
+    loadChapterPhraseSpans: (...a: unknown[]) => loadChapterPhraseSpans(...a),
   };
 });
 
@@ -133,11 +147,15 @@ function ownedTextWithChapters(n: number) {
 beforeEach(() => {
   getReadableText.mockReset();
   loadChapterTokens.mockReset();
+  loadChapterPhraseSpans.mockReset();
   getTextProgress.mockReset();
   // The token loader is called once per chapter; default to "no
   // tokens written yet" so the loader falls back to client-side
   // tokenization in tests that don't care.
   loadChapterTokens.mockResolvedValue(null);
+  // T-14.3: phrase spans default to an empty array — existing
+  // tests stay phrase-agnostic.
+  loadChapterPhraseSpans.mockResolvedValue([]);
   // No saved progress unless a test stages it.
   getTextProgress.mockResolvedValue(null);
   // No persisted reader settings unless a test stages a row.
@@ -425,5 +443,54 @@ describe('/reader/[textId] loader', () => {
     expect(loadChapterTokens).toHaveBeenCalledTimes(1);
     expect(loadChapterTokens).toHaveBeenCalledWith('c3', USER.id);
     expect(data.chapters.map((c) => c.tokens)).toEqual([null, null, null, null, null]);
+  });
+
+  it('attaches phrase spans to the active chapter only (T-14.3)', async () => {
+    getReadableText.mockResolvedValueOnce(ownedTextWithChapters(3));
+    loadChapterTokens.mockResolvedValueOnce([
+      {
+        id: 't0',
+        idx: 0,
+        surface: 'इंतज़ार',
+        isWord: true,
+        isAmbiguous: false,
+        isOov: false,
+        lemmaId: null,
+        lemmaCandidates: [],
+        features: {},
+        sentenceIdx: 0,
+        romanization: null,
+        numberForms: null,
+      },
+    ]);
+    loadChapterPhraseSpans.mockResolvedValueOnce([
+      {
+        phraseId: 'phr-1',
+        startTokenIdx: 0,
+        endTokenIdx: 1,
+        glossDefault: 'to wait',
+        status: 'unknown',
+      },
+    ]);
+    const data = (await callLoad(`http://x/reader/${VALID_ID}`)) as {
+      chapters: Array<{ phraseSpans: unknown }>;
+    };
+    expect(data.chapters[0]!.phraseSpans).toHaveLength(1);
+    // Sibling chapters carry null until the lazy fetch fills them.
+    expect(data.chapters[1]!.phraseSpans).toBeNull();
+    expect(data.chapters[2]!.phraseSpans).toBeNull();
+    // Loader is called once with the active chapter id + viewer id.
+    expect(loadChapterPhraseSpans).toHaveBeenCalledTimes(1);
+    expect(loadChapterPhraseSpans).toHaveBeenCalledWith('c0', USER.id);
+  });
+
+  it('skips phraseSpans loading when the chapter has no tokens (T-14.3)', async () => {
+    getReadableText.mockResolvedValueOnce(ownedTextWithChapters(1));
+    loadChapterTokens.mockResolvedValueOnce(null);
+    const data = (await callLoad(`http://x/reader/${VALID_ID}`)) as {
+      chapters: Array<{ phraseSpans: unknown }>;
+    };
+    expect(data.chapters[0]!.phraseSpans).toBeNull();
+    expect(loadChapterPhraseSpans).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Renders the per-chapter `phrase_chapter_spans` material from
T-14.2 in the reader. **Stacks on T-14.1 (#346) + T-14.2 (#350)** —
please merge those first; this PR's diff includes their commits
until then.

A phrase wraps its run of tokens in a `<phrase
data-phrase-id data-s>` element so the visual + click target line
up, and the popup picks up the containing phrase to render a
phrase header (with status flips) above the existing token body.

## What it does

- **Data flow.** `ChapterView` gains `phraseSpans:
  ChapterPhraseSpan[] | null` alongside `tokens`. The reader
  page-server and the lazy-tokens API both call
  `loadChapterPhraseSpans` from T-14.2; `LazyTokenLoader` returns
  `{tokens, phraseSpans}` so streamed sibling chapters render
  with spans on the next `$derived` pass.
- **Per-paragraph segmenter** (`segmentParagraphPhrases` in
  `types.ts`) walks tokens in idx order and emits either a bare
  `{kind: 'token'}` segment or a `{kind: 'phrase', span, tokens,
  overlaps}` segment. Longest-wins picks the visible wrapper;
  shorter overlapping spans surface on `overlaps` for T-14.4's
  alternatives affordance.
- **Phrase wrapper** in `ChapterBody.svelte`: emits `<phrase>`
  around the segment's `TokenSpan` children. Per-token
  `data-token-id` stays intact, so existing T-5.18 hover and
  T-6.4 correction handlers fire unchanged.
- **Popup phrase mode** in `WordPopup.svelte`: new `phrase`
  prop. When set, the popup renders a phrase banner above the
  existing token body — eyebrow label, `gloss_default`, three
  Learning / Known / Ignored buttons that PATCH
  `/api/v1/me/known-phrases/:phraseId`. Optimistic update with
  rollback on failure mirrors the lemma status path.

## Out of scope (follow-up T-14.3a)

- **Multi-token selection gesture** (drag / shift-click) for
  user phrase creation. Requires a non-trivial selection-state
  machine + a new "create phrase" UI surface in `WordPopup`,
  larger than the rest of T-14.3 combined. Filed as a follow-up
  so this slice can ship rendering + popup without blocking
  T-14.4 (curator editor) and T-14.5 (NLP detector).
- Render-time per-user filtering (honouring `mark_not_a_word`
  corrections from T-6.4 to drop spans that cross such tokens).
  Spans are per-chapter today.

## Test plan

- [x] `pnpm --filter @ciareader/web test` — 1101 tests pass
  (was 1093 on T-14.2 base; +6 segmenter, +2 page-server
  hydration cases).
- [x] `pnpm --filter @ciareader/web typecheck` — 0 errors.
- [x] `pnpm --filter @ciareader/web lint` — clean.
- [ ] Manual reader verification: click a token inside a phrase
  → popup banner shows; hit Known → counter increments + reload
  preserves; click on a bare token → popup banner does not show.

Refs T-14.1 (#346 / closes #315), T-14.2 (#350 / closes #317).
Closes #319. Refs Epic #327.