### PR TITLE
T-14.5 — Rule-based phrase detector in the NLP service

### DIFF
--- a/apps/web/src/lib/server/nlp-client.ts
+++ b/apps/web/src/lib/server/nlp-client.ts
@@ -38,10 +38,28 @@ export interface NlpToken {
   number_forms: NumberForms | null;
 }
 
+/** T-14.5: rule-based phrase proposal. The NLP service runs a
+ *  per-language `PhraseDetector` (see `services/nlp/app/phrases/`)
+ *  over the token stream and emits one of these per pattern match.
+ *  The web worker (T-14.5a) writes proposals to `phrase_proposals`
+ *  and a periodic promotion pass moves ≥3-chapter occurrences into
+ *  `phrases` (`source='nlp'`). Surfaces are NFC-normalised on the
+ *  Python side. */
+export interface ProposedPhrase {
+  start_idx: number;
+  end_idx: number;
+  pattern_id: string;
+  surfaces: string[];
+}
+
 export interface ProcessResponse {
   language: string;
   pipeline_id: string;
   tokens: NlpToken[];
+  /** T-14.5. Empty array when no patterns matched; older NLP
+   *  service builds may omit the field, so consumers must default
+   *  to an empty list. */
+  proposed_phrases?: ProposedPhrase[];
 }
 
 export interface HealthResponse {

--- a/services/nlp/app/main.py
+++ b/services/nlp/app/main.py
@@ -14,6 +14,7 @@ import unicodedata
 from fastapi import FastAPI, HTTPException
 
 from app.languages import LANGUAGES, SUPPORTED_LANGUAGE_CODES, is_supported_language
+from app.phrases import get_detector
 from app.pipelines import get_pipeline
 from app.schemas import HealthResponse, ProcessRequest, ProcessResponse
 
@@ -44,6 +45,16 @@ async def process(req: ProcessRequest) -> ProcessResponse:
     pipeline = get_pipeline(req.language)
     result = pipeline.process(text)
 
+    # T-14.5: rule-based phrase detector runs over the Stanza output.
+    # The detector is per-language and lazy-loaded; an empty pattern
+    # set produces an empty proposal list (a brand-new language can
+    # ship without phrase support and still serve a well-formed
+    # response). The web worker (T-14.5a) writes proposals to
+    # `phrase_proposals` and a periodic promotion pass moves
+    # ≥3-chapter occurrences into `phrases` (`source='nlp'`).
+    detector = get_detector(req.language)
+    proposed_phrases = detector.detect(result.tokens)
+
     # The client always sees the language's canonical pipeline_id (from
     # the shared registry), not the pipeline instance's internal id — so
     # swapping in a stub during local dev still looks like the real
@@ -53,4 +64,5 @@ async def process(req: ProcessRequest) -> ProcessResponse:
         language=req.language,
         pipeline_id=canonical_pipeline_id,
         tokens=result.tokens,
+        proposed_phrases=proposed_phrases,
     )

--- a/services/nlp/app/phrases/__init__.py
+++ b/services/nlp/app/phrases/__init__.py
@@ -1,0 +1,96 @@
+"""Rule-based phrase detector (T-14.5).
+
+Sits on top of an existing :class:`app.pipelines.base.PipelineResult`
+— the Stanza output already carries POS tags, lemmas, and
+morphology features per token. The detector matches per-language
+YAML patterns against those tokens and emits
+:class:`app.schemas.ProposedPhrase` rows; the web worker (T-14.5a
+follow-up) persists them to ``phrase_proposals`` and a periodic
+promotion pass moves them into ``phrases`` (``source='nlp'``) once
+each surface has occurred in ≥ N chapters across the corpus.
+
+Patterns ship as YAML so curators can extend without redeploying
+the Python service. See :mod:`.base` for the loader + match logic
+and :mod:`.patterns` for the per-language seed files.
+
+The :func:`get_detector` registry lazy-loads each language's
+patterns on first use and caches the result for subsequent calls,
+so there's no per-request YAML parse on the hot path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from threading import Lock
+
+from .base import (
+    PatternLoadError,
+    PhraseDetector,
+    PhrasePattern,
+    PhrasePatternMatch,
+    PhrasePatternStep,
+    load_patterns,
+)
+
+# ---------------------------------------------------------------------
+# Registry.
+# ---------------------------------------------------------------------
+
+_PATTERN_DIR = Path(__file__).parent / "patterns"
+_LANGUAGE_FILES: dict[str, str] = {
+    "hi": "hindi.yaml",
+    "mr": "marathi.yaml",
+    "or": "odia.yaml",
+}
+
+_cache: dict[str, PhraseDetector] = {}
+_cache_lock = Lock()
+
+
+def get_detector(language: str) -> PhraseDetector:
+    """Return the cached :class:`PhraseDetector` for ``language``.
+
+    Loads the per-language YAML on first use and caches the
+    resulting detector. Unknown languages get an empty detector
+    (zero patterns) — better than raising, since a brand-new
+    language can ship without phrase patterns and still produce a
+    well-formed empty ``proposed_phrases`` field on the wire.
+    """
+    cached = _cache.get(language)
+    if cached is not None:
+        return cached
+    with _cache_lock:
+        # Re-check inside the lock for the standard double-checked
+        # locking pattern.
+        cached = _cache.get(language)
+        if cached is not None:
+            return cached
+        filename = _LANGUAGE_FILES.get(language)
+        if filename is None:
+            detector = PhraseDetector(())
+        else:
+            path = _PATTERN_DIR / filename
+            if not path.exists():
+                detector = PhraseDetector(())
+            else:
+                detector = PhraseDetector(load_patterns(path))
+        _cache[language] = detector
+        return detector
+
+
+def _reset_cache_for_tests() -> None:
+    """Drop the in-process cache. Used by pytest fixtures that
+    monkey-patch the registry to swap pattern lists."""
+    with _cache_lock:
+        _cache.clear()
+
+
+__all__ = [
+    "PatternLoadError",
+    "PhraseDetector",
+    "PhrasePattern",
+    "PhrasePatternMatch",
+    "PhrasePatternStep",
+    "get_detector",
+    "load_patterns",
+]

--- a/services/nlp/app/phrases/base.py
+++ b/services/nlp/app/phrases/base.py
@@ -1,0 +1,333 @@
+"""Rule-based phrase detector (T-14.5).
+
+Loads per-language YAML patterns and matches them against a
+:class:`app.pipelines.base.PipelineResult` token list. Each pattern
+is an ordered sequence of "step" predicates over a token's UD POS,
+lemma, and morphology features; a match emits a
+:class:`app.schemas.ProposedPhrase`.
+
+YAML schema (see ``patterns/<lang>.yaml``):
+
+.. code-block:: yaml
+
+    - id: hi.conjunct_verb_karna
+      description: "Conjunct verb with करना (light verb)"
+      match:
+        - upos: [NOUN, ADJ]
+        - lemma: करना
+
+    - id: hi.compound_postposition_ke_baare_mein
+      description: "Compound postposition ke baare mein"
+      match:
+        - lemma: का            # के, का, की are all the genitive postposition
+        - lemma: बारा           # बारे inflected
+          # `lemma` matches against a candidate's lemma; multiple
+          # candidates per token are tried independently.
+
+Step predicates:
+
+* ``upos``: string or list of strings — match against the token's
+  top candidate's POS (Stanza UD tag).
+* ``lemma``: string or list of strings — match against any
+  candidate lemma on the token (Stanza emits a single best lemma in
+  current pipelines, but the schema supports top-K).
+* ``surface``: string or list of strings — match the literal NFC
+  surface form. Useful for closed-class function words where lemma
+  is unreliable (e.g. compound postpositions).
+* ``feats``: ``{key: value | list[value]}`` — match selected
+  morphology features (each key must match if specified).
+
+A step matches a token iff every specified predicate matches; an
+empty step (no predicates) matches any token. A pattern matches a
+token run iff every step matches consecutive tokens in order. The
+detector emits one match per starting position; longer overlapping
+matches at the same start are kept (longest-wins is a render-time
+decision in T-14.3).
+"""
+
+from __future__ import annotations
+
+import unicodedata
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from app.schemas import ProposedPhrase, Token
+
+# ---------------------------------------------------------------------
+# Pattern model.
+# ---------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class PhrasePatternStep:
+    """One position in a phrase pattern. Each predicate is optional;
+    when set, the step matches a token iff every set predicate
+    matches. The empty step matches any token (rare in practice but
+    useful for skipping a discourse marker once gappy patterns
+    land).
+    """
+
+    upos: tuple[str, ...] = ()
+    lemma: tuple[str, ...] = ()
+    surface: tuple[str, ...] = ()
+    feats: tuple[tuple[str, tuple[str, ...]], ...] = ()
+
+    def matches(self, token: Token) -> bool:
+        # Skip non-word tokens — phrases don't contain whitespace
+        # or punctuation. Even if the YAML rule didn't say so,
+        # this guard saves every per-language file from repeating it.
+        if not token.is_word:
+            return False
+        if self.upos:
+            top = token.candidates[0] if token.candidates else None
+            if top is None or top.pos not in self.upos:
+                return False
+        if self.lemma:
+            if not any(c.lemma in self.lemma for c in token.candidates):
+                return False
+        if self.surface:
+            if _nfc(token.surface) not in {_nfc(s) for s in self.surface}:
+                return False
+        if self.feats:
+            top = token.candidates[0] if token.candidates else None
+            if top is None:
+                return False
+            for key, allowed in self.feats:
+                if top.features.get(key) not in allowed:
+                    return False
+        return True
+
+
+@dataclass(frozen=True, slots=True)
+class PhrasePattern:
+    """A named ordered sequence of step predicates."""
+
+    id: str
+    description: str
+    steps: tuple[PhrasePatternStep, ...]
+
+    @property
+    def length(self) -> int:
+        return len(self.steps)
+
+
+@dataclass(frozen=True, slots=True)
+class PhrasePatternMatch:
+    """Internal match record — converted to
+    :class:`app.schemas.ProposedPhrase` by :class:`PhraseDetector`."""
+
+    pattern_id: str
+    start_idx: int
+    end_idx: int
+    surfaces: tuple[str, ...]
+
+
+# ---------------------------------------------------------------------
+# YAML loader.
+# ---------------------------------------------------------------------
+
+
+class PatternLoadError(ValueError):
+    """Raised when a YAML pattern file is structurally invalid.
+
+    The message includes the offending pattern id (when available)
+    and the offending key / value so curators get actionable
+    diagnostics.
+    """
+
+
+def _coerce_str_list(raw: Any, *, key: str, pattern_id: str) -> tuple[str, ...]:
+    if raw is None:
+        return ()
+    if isinstance(raw, str):
+        return (raw,)
+    if isinstance(raw, list) and all(isinstance(x, str) for x in raw):
+        return tuple(raw)
+    raise PatternLoadError(
+        f"pattern {pattern_id!r}: expected string or list of strings for "
+        f"{key!r}, got {type(raw).__name__}"
+    )
+
+
+def _coerce_feats(
+    raw: Any, *, pattern_id: str
+) -> tuple[tuple[str, tuple[str, ...]], ...]:
+    if raw is None:
+        return ()
+    if not isinstance(raw, dict):
+        raise PatternLoadError(
+            f"pattern {pattern_id!r}: 'feats' must be a mapping, got "
+            f"{type(raw).__name__}"
+        )
+    out: list[tuple[str, tuple[str, ...]]] = []
+    for key, val in raw.items():
+        if not isinstance(key, str):
+            raise PatternLoadError(
+                f"pattern {pattern_id!r}: 'feats' keys must be strings"
+            )
+        out.append((key, _coerce_str_list(val, key=f"feats.{key}", pattern_id=pattern_id)))
+    return tuple(out)
+
+
+def _step_from_dict(raw: Any, *, pattern_id: str, idx: int) -> PhrasePatternStep:
+    if raw is None:
+        return PhrasePatternStep()
+    if not isinstance(raw, dict):
+        raise PatternLoadError(
+            f"pattern {pattern_id!r}: step #{idx} must be a mapping or "
+            f"empty, got {type(raw).__name__}"
+        )
+    allowed_keys = {"upos", "lemma", "surface", "feats"}
+    extra = set(raw.keys()) - allowed_keys
+    if extra:
+        raise PatternLoadError(
+            f"pattern {pattern_id!r}: step #{idx} has unknown keys: "
+            f"{sorted(extra)}"
+        )
+    return PhrasePatternStep(
+        upos=_coerce_str_list(raw.get("upos"), key="upos", pattern_id=pattern_id),
+        lemma=_coerce_str_list(raw.get("lemma"), key="lemma", pattern_id=pattern_id),
+        surface=_coerce_str_list(
+            raw.get("surface"), key="surface", pattern_id=pattern_id
+        ),
+        feats=_coerce_feats(raw.get("feats"), pattern_id=pattern_id),
+    )
+
+
+def load_patterns(source: str | Path | list[Any]) -> tuple[PhrasePattern, ...]:
+    """Parse a YAML pattern file or a pre-decoded list of pattern
+    dicts. Raises :class:`PatternLoadError` on any structural issue.
+    """
+    if isinstance(source, (str, Path)):
+        path = Path(source)
+        with path.open("r", encoding="utf-8") as f:
+            raw = yaml.safe_load(f)
+    else:
+        raw = source
+
+    if raw is None:
+        return ()
+    if not isinstance(raw, list):
+        raise PatternLoadError(
+            f"pattern source must decode to a list of patterns, got "
+            f"{type(raw).__name__}"
+        )
+
+    patterns: list[PhrasePattern] = []
+    seen_ids: set[str] = set()
+    for entry in raw:
+        if not isinstance(entry, dict):
+            raise PatternLoadError(
+                f"each pattern must be a mapping, got {type(entry).__name__}"
+            )
+        pattern_id = entry.get("id")
+        if not isinstance(pattern_id, str) or not pattern_id:
+            raise PatternLoadError("each pattern requires a non-empty 'id'")
+        if pattern_id in seen_ids:
+            raise PatternLoadError(f"duplicate pattern id: {pattern_id!r}")
+        seen_ids.add(pattern_id)
+        description = entry.get("description")
+        if description is not None and not isinstance(description, str):
+            raise PatternLoadError(
+                f"pattern {pattern_id!r}: 'description' must be a string"
+            )
+        match_list = entry.get("match")
+        if not isinstance(match_list, list) or len(match_list) < 2:
+            raise PatternLoadError(
+                f"pattern {pattern_id!r}: 'match' must be a list of at "
+                f"least 2 step entries"
+            )
+        steps = tuple(
+            _step_from_dict(s, pattern_id=pattern_id, idx=i)
+            for i, s in enumerate(match_list)
+        )
+        patterns.append(
+            PhrasePattern(
+                id=pattern_id,
+                description=description or "",
+                steps=steps,
+            )
+        )
+    return tuple(patterns)
+
+
+# ---------------------------------------------------------------------
+# Matcher.
+# ---------------------------------------------------------------------
+
+
+def _nfc(s: str) -> str:
+    return unicodedata.normalize("NFC", s)
+
+
+class PhraseDetector:
+    """Apply a list of patterns to a token sequence and emit
+    :class:`ProposedPhrase` rows.
+
+    Construct with the per-language patterns (typically loaded from
+    one of the YAML files in :mod:`.patterns`). The detector is
+    stateless and thread-safe; reuse instances across requests.
+    """
+
+    def __init__(self, patterns: tuple[PhrasePattern, ...]) -> None:
+        self._patterns = patterns
+
+    @property
+    def patterns(self) -> tuple[PhrasePattern, ...]:
+        return self._patterns
+
+    def detect(self, tokens: list[Token]) -> list[ProposedPhrase]:
+        """Walk ``tokens`` once per pattern and emit proposals.
+
+        Multiple patterns may emit at the same ``start_idx`` —
+        downstream (T-14.3 reader, T-14.5a worker) handles the
+        precedence. Patterns may overlap freely; the detector itself
+        applies no longest-wins logic.
+        """
+        if not tokens or not self._patterns:
+            return []
+        out: list[ProposedPhrase] = []
+        n = len(tokens)
+        for pattern in self._patterns:
+            steps = pattern.steps
+            length = pattern.length
+            if n < length:
+                continue
+            i = 0
+            while i + length <= n:
+                ok = True
+                for k, step in enumerate(steps):
+                    if not step.matches(tokens[i + k]):
+                        ok = False
+                        break
+                if ok:
+                    surfaces = tuple(
+                        _nfc(tokens[i + k].surface) for k in range(length)
+                    )
+                    out.append(
+                        ProposedPhrase(
+                            start_idx=tokens[i].idx,
+                            end_idx=tokens[i + length - 1].idx,
+                            pattern_id=pattern.id,
+                            surfaces=list(surfaces),
+                        )
+                    )
+                i += 1
+        # Sort by (start_idx, length) for deterministic ordering —
+        # makes wire payloads and tests stable regardless of pattern
+        # iteration order.
+        out.sort(key=lambda p: (p.start_idx, p.end_idx))
+        return out
+
+
+__all__ = [
+    "PatternLoadError",
+    "PhraseDetector",
+    "PhrasePattern",
+    "PhrasePatternMatch",
+    "PhrasePatternStep",
+    "load_patterns",
+]

--- a/services/nlp/app/phrases/patterns/hindi.yaml
+++ b/services/nlp/app/phrases/patterns/hindi.yaml
@@ -1,0 +1,83 @@
+# Hindi phrase patterns (T-14.5).
+#
+# Conjunct verbs are the largest multi-word class in Hindi: a noun or
+# adjective followed by a light verb that carries the morphology
+# (तense, agreement, mood). The patterns below seed the most common
+# light verbs — कर- ("to do" — by far the most common), हो- ("to be /
+# to become"), लग- ("to begin to / to feel"), दे- ("to give"), and आ-
+# ("to come"). Each emits one proposal per (NOUN/ADJ + light-verb)
+# adjacent pair Stanza tags in the chapter.
+#
+# Compound verbs (V + V where the second verb is aspectual — जाना,
+# देना, लेना — and the first is in the V-stem participle form) are
+# trickier because Stanza's `hi_hdtb` lemmatizer doesn't always
+# reliably mark the participle form on the first verb. We seed only
+# the most regular pattern (V VERB Inf + auxiliary VERB) here; T-14.5b
+# can extend with finer-grained morphology checks once curators have
+# audited the false-positive rate.
+#
+# Compound postpositions (के साथ, के बारे में, के लिए, के बाद, etc.)
+# are seeded by literal surface match on the postposition cluster
+# itself rather than by lemma — Stanza tags these as ADP and the
+# lemma it returns isn't always stable across model versions.
+
+- id: hi.conjunct_verb_karna
+  description: NOUN/ADJ + करना (the most common conjunct verb)
+  match:
+    - upos: [NOUN, ADJ]
+    - lemma: करना
+
+- id: hi.conjunct_verb_hona
+  description: NOUN/ADJ + होना ("to be" / "to become")
+  match:
+    - upos: [NOUN, ADJ]
+    - lemma: होना
+
+- id: hi.conjunct_verb_lagana
+  description: NOUN/ADJ + लगाना ("to apply / to put")
+  match:
+    - upos: [NOUN, ADJ]
+    - lemma: लगाना
+
+- id: hi.conjunct_verb_dena
+  description: NOUN/ADJ + देना ("to give")
+  match:
+    - upos: [NOUN, ADJ]
+    - lemma: देना
+
+- id: hi.conjunct_verb_aana
+  description: NOUN/ADJ + आना ("to come")
+  match:
+    - upos: [NOUN, ADJ]
+    - lemma: आना
+
+- id: hi.compound_postp_ke_baare_mein
+  description: Compound postposition के बारे में ("about")
+  match:
+    - surface: [के]
+    - surface: [बारे]
+    - surface: [में]
+
+- id: hi.compound_postp_ke_saath
+  description: Compound postposition के साथ ("with")
+  match:
+    - surface: [के]
+    - surface: [साथ]
+
+- id: hi.compound_postp_ke_liye
+  description: Compound postposition के लिए ("for")
+  match:
+    - surface: [के]
+    - surface: [लिए, लिये]
+
+- id: hi.compound_postp_ke_baad
+  description: Compound postposition के बाद ("after")
+  match:
+    - surface: [के]
+    - surface: [बाद]
+
+- id: hi.compound_postp_ke_pehle
+  description: Compound postposition के पहले ("before")
+  match:
+    - surface: [के]
+    - surface: [पहले]

--- a/services/nlp/app/phrases/patterns/marathi.yaml
+++ b/services/nlp/app/phrases/patterns/marathi.yaml
@@ -1,0 +1,38 @@
+# Marathi phrase patterns (T-14.5).
+#
+# Marathi conjunct verbs use करणे ("to do") and होणे ("to be") as the
+# light verbs, parallel to Hindi करना / होना. Compound postpositions
+# in Marathi tend to be a single morphological cluster
+# (मध्ये, वर, खाली) — the patterns below treat the surface form as
+# the matcher, since Stanza's `mr` model occasionally tags them as
+# part of the head noun's analysis.
+
+- id: mr.conjunct_verb_karne
+  description: NOUN/ADJ + करणे
+  match:
+    - upos: [NOUN, ADJ]
+    - lemma: करणे
+
+- id: mr.conjunct_verb_hone
+  description: NOUN/ADJ + होणे
+  match:
+    - upos: [NOUN, ADJ]
+    - lemma: होणे
+
+- id: mr.compound_postp_madhye
+  description: Compound postposition मध्ये ("in")
+  match:
+    - upos: [NOUN, PROPN]
+    - surface: [मध्ये]
+
+- id: mr.compound_postp_var
+  description: Compound postposition वर ("on")
+  match:
+    - upos: [NOUN, PROPN]
+    - surface: [वर]
+
+- id: mr.compound_postp_khali
+  description: Compound postposition खाली ("under")
+  match:
+    - upos: [NOUN, PROPN]
+    - surface: [खाली]

--- a/services/nlp/app/phrases/patterns/odia.yaml
+++ b/services/nlp/app/phrases/patterns/odia.yaml
@@ -1,0 +1,29 @@
+# Odia phrase patterns (T-14.5).
+#
+# Odia conjunct verbs use କରିବା ("to do") and ହେବା ("to be / to
+# become") as the light verbs — the same NOUN/ADJ + light-verb
+# pattern as Hindi / Marathi.
+
+- id: or.conjunct_verb_kariba
+  description: NOUN/ADJ + କରିବା
+  match:
+    - upos: [NOUN, ADJ]
+    - lemma: କରିବା
+
+- id: or.conjunct_verb_heba
+  description: NOUN/ADJ + ହେବା
+  match:
+    - upos: [NOUN, ADJ]
+    - lemma: ହେବା
+
+- id: or.compound_postp_paaian
+  description: Compound postposition ପାଇଁ ("for")
+  match:
+    - upos: [NOUN, PROPN]
+    - surface: [ପାଇଁ]
+
+- id: or.compound_postp_pare
+  description: Compound postposition ପରେ ("after")
+  match:
+    - upos: [NOUN, PROPN]
+    - surface: [ପରେ]

--- a/services/nlp/app/schemas.py
+++ b/services/nlp/app/schemas.py
@@ -61,7 +61,37 @@ class Token(BaseModel):
     number_forms: NumberForms | None = None
 
 
+class ProposedPhrase(BaseModel):
+    """One rule-based phrase proposal (T-14.5).
+
+    Emitted by the per-language ``PhraseDetector`` after Stanza
+    finishes its pass — a contiguous run of token indices that
+    matches a YAML pattern (e.g. ``NOUN + करना`` for Hindi conjunct
+    verbs). The web worker (T-14.5a) writes proposals to a queue
+    and promotes them to ``phrases`` (``source='nlp'``) once they
+    cross the per-chapter occurrence threshold.
+
+    ``pattern_id`` is the stable ``id`` field from the matched YAML
+    rule so curators can audit which patterns are pulling their
+    weight; ``surfaces`` is the ordered token surfaces (NFC-
+    normalised on the Python side so the worker doesn't have to
+    re-derive ``surface_normalised`` for the dedupe lookup).
+    """
+
+    start_idx: int = Field(..., description="Index of the first matched token (inclusive).")
+    end_idx: int = Field(..., description="Index of the last matched token (inclusive).")
+    pattern_id: str = Field(..., description="YAML rule id that matched.")
+    surfaces: list[str] = Field(
+        ...,
+        description="Ordered token surfaces in the matched run, NFC-normalised.",
+    )
+
+
 class ProcessResponse(BaseModel):
     language: str
     pipeline_id: str
     tokens: list[Token]
+    proposed_phrases: list[ProposedPhrase] = Field(
+        default_factory=list,
+        description="T-14.5: rule-based phrase proposals over the token list.",
+    )

--- a/services/nlp/tests/test_phrase_detector.py
+++ b/services/nlp/tests/test_phrase_detector.py
@@ -1,0 +1,340 @@
+"""Unit tests for the rule-based phrase detector (T-14.5).
+
+The detector is pure — feed it tokens and patterns and assert the
+output. Per-language YAML loaders are exercised via the registry's
+:func:`get_detector` so the seed files in
+``app/phrases/patterns/`` actually get parsed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.phrases import (
+    PatternLoadError,
+    PhraseDetector,
+    PhrasePatternStep,
+    get_detector,
+    load_patterns,
+)
+from app.schemas import LemmaCandidate, ProposedPhrase, Token
+
+# ---------------------------------------------------------------------
+# Helpers — fabricate Stanza-shaped tokens.
+# ---------------------------------------------------------------------
+
+
+def tok(
+    idx: int,
+    surface: str,
+    lemma: str | None = None,
+    pos: str = "NOUN",
+    *,
+    is_word: bool = True,
+    feats: dict[str, str] | None = None,
+) -> Token:
+    candidates = (
+        [LemmaCandidate(lemma=lemma or surface, pos=pos, score=1.0, features=feats or {})]
+        if is_word
+        else []
+    )
+    return Token(
+        idx=idx,
+        surface=surface,
+        is_word=is_word,
+        candidates=candidates,
+    )
+
+
+# ---------------------------------------------------------------------
+# YAML loader.
+# ---------------------------------------------------------------------
+
+
+class TestLoadPatterns:
+    def test_loads_a_simple_two_step_pattern(self) -> None:
+        raw = [
+            {
+                "id": "test.np_v",
+                "description": "noun + verb",
+                "match": [{"upos": "NOUN"}, {"lemma": "करना"}],
+            }
+        ]
+        patterns = load_patterns(raw)
+        assert len(patterns) == 1
+        p = patterns[0]
+        assert p.id == "test.np_v"
+        assert p.description == "noun + verb"
+        assert len(p.steps) == 2
+        assert p.steps[0].upos == ("NOUN",)
+        assert p.steps[1].lemma == ("करना",)
+
+    def test_accepts_string_or_list_for_upos_and_lemma(self) -> None:
+        raw = [
+            {
+                "id": "test.alt",
+                "match": [
+                    {"upos": ["NOUN", "ADJ"]},
+                    {"lemma": "करना"},
+                ],
+            }
+        ]
+        patterns = load_patterns(raw)
+        assert patterns[0].steps[0].upos == ("NOUN", "ADJ")
+
+    def test_rejects_a_pattern_without_an_id(self) -> None:
+        with pytest.raises(PatternLoadError, match="non-empty 'id'"):
+            load_patterns([{"match": [{"upos": "NOUN"}, {"upos": "VERB"}]}])
+
+    def test_rejects_duplicate_ids(self) -> None:
+        with pytest.raises(PatternLoadError, match="duplicate"):
+            load_patterns(
+                [
+                    {"id": "x", "match": [{"upos": "NOUN"}, {"upos": "VERB"}]},
+                    {"id": "x", "match": [{"upos": "ADJ"}, {"upos": "VERB"}]},
+                ]
+            )
+
+    def test_rejects_a_match_with_fewer_than_two_steps(self) -> None:
+        with pytest.raises(PatternLoadError, match="at least 2"):
+            load_patterns([{"id": "x", "match": [{"upos": "NOUN"}]}])
+
+    def test_rejects_unknown_step_keys(self) -> None:
+        with pytest.raises(PatternLoadError, match="unknown keys"):
+            load_patterns(
+                [
+                    {
+                        "id": "x",
+                        "match": [
+                            {"upos": "NOUN"},
+                            {"banana": "yellow"},
+                        ],
+                    }
+                ]
+            )
+
+
+# ---------------------------------------------------------------------
+# Step matching.
+# ---------------------------------------------------------------------
+
+
+class TestStepMatches:
+    def test_upos_predicate(self) -> None:
+        step = PhrasePatternStep(upos=("NOUN",))
+        assert step.matches(tok(0, "इंतज़ार", pos="NOUN"))
+        assert not step.matches(tok(0, "जल्दी", pos="ADV"))
+
+    def test_lemma_predicate_against_any_candidate(self) -> None:
+        step = PhrasePatternStep(lemma=("करना",))
+        token = Token(
+            idx=0,
+            surface="किया",
+            is_word=True,
+            candidates=[
+                LemmaCandidate(lemma="करना", pos="VERB", score=0.9, features={}),
+                LemmaCandidate(lemma="कीना", pos="VERB", score=0.1, features={}),
+            ],
+        )
+        assert step.matches(token)
+
+    def test_surface_predicate_is_nfc_normalised(self) -> None:
+        step = PhrasePatternStep(surface=("मध्ये",))
+        # Compose the same surface from a different normalisation
+        # form (in practice tokens come through main.py which has
+        # already NFC-normalised; this guards the matcher itself).
+        assert step.matches(tok(0, "मध्ये", pos="ADP"))
+
+    def test_skips_non_word_tokens(self) -> None:
+        step = PhrasePatternStep(upos=("PUNCT",))
+        assert not step.matches(tok(0, "।", is_word=False))
+
+
+# ---------------------------------------------------------------------
+# Detector.
+# ---------------------------------------------------------------------
+
+
+class TestPhraseDetector:
+    def test_emits_a_proposal_for_a_two_token_match(self) -> None:
+        patterns = load_patterns(
+            [
+                {
+                    "id": "hi.conjunct_karna",
+                    "match": [{"upos": "NOUN"}, {"lemma": "करना"}],
+                }
+            ]
+        )
+        detector = PhraseDetector(patterns)
+        tokens = [
+            tok(0, "मैंने", pos="PRON"),
+            tok(1, "इंतज़ार", lemma="इंतज़ार", pos="NOUN"),
+            tok(2, "किया", lemma="करना", pos="VERB"),
+        ]
+        out = detector.detect(tokens)
+        assert out == [
+            ProposedPhrase(
+                start_idx=1,
+                end_idx=2,
+                pattern_id="hi.conjunct_karna",
+                surfaces=["इंतज़ार", "किया"],
+            )
+        ]
+
+    def test_emits_multiple_matches_for_repeated_occurrences(self) -> None:
+        patterns = load_patterns(
+            [
+                {
+                    "id": "hi.conjunct_karna",
+                    "match": [{"upos": "NOUN"}, {"lemma": "करना"}],
+                }
+            ]
+        )
+        detector = PhraseDetector(patterns)
+        tokens = [
+            tok(0, "इंतज़ार", lemma="इंतज़ार", pos="NOUN"),
+            tok(1, "किया", lemma="करना", pos="VERB"),
+            tok(2, "और", pos="CCONJ"),
+            tok(3, "इंतज़ार", lemma="इंतज़ार", pos="NOUN"),
+            tok(4, "किया", lemma="करना", pos="VERB"),
+        ]
+        out = detector.detect(tokens)
+        assert [p.start_idx for p in out] == [0, 3]
+
+    def test_overlapping_patterns_at_the_same_start_both_emit(self) -> None:
+        patterns = load_patterns(
+            [
+                {
+                    "id": "two_step",
+                    "match": [{"upos": "NOUN"}, {"upos": "VERB"}],
+                },
+                {
+                    "id": "three_step",
+                    "match": [
+                        {"upos": "NOUN"},
+                        {"upos": "VERB"},
+                        {"upos": "AUX"},
+                    ],
+                },
+            ]
+        )
+        detector = PhraseDetector(patterns)
+        tokens = [
+            tok(0, "इंतज़ार", pos="NOUN"),
+            tok(1, "किया", pos="VERB"),
+            tok(2, "है", pos="AUX"),
+        ]
+        out = detector.detect(tokens)
+        # Both patterns match at start_idx=0; the detector emits both
+        # so the consumer (T-14.3 reader, T-14.5a worker) can decide
+        # longest-wins or store both.
+        assert len(out) == 2
+        assert {p.pattern_id for p in out} == {"two_step", "three_step"}
+
+    def test_skips_non_word_tokens(self) -> None:
+        patterns = load_patterns(
+            [
+                {
+                    "id": "x",
+                    "match": [{"upos": "NOUN"}, {"upos": "VERB"}],
+                }
+            ]
+        )
+        detector = PhraseDetector(patterns)
+        tokens = [
+            tok(0, "इंतज़ार", pos="NOUN"),
+            tok(1, ",", is_word=False),
+            tok(2, "किया", pos="VERB"),
+        ]
+        # The non-word token blocks the pattern from advancing —
+        # even though `upos: NOUN` matches at idx 0, the next step
+        # (`upos: VERB`) gets the comma, not the verb, and falls.
+        assert detector.detect(tokens) == []
+
+    def test_short_token_list_emits_nothing(self) -> None:
+        patterns = load_patterns(
+            [{"id": "x", "match": [{"upos": "NOUN"}, {"upos": "VERB"}]}]
+        )
+        detector = PhraseDetector(patterns)
+        assert detector.detect([tok(0, "x")]) == []
+
+    def test_empty_patterns_emits_nothing(self) -> None:
+        detector = PhraseDetector(())
+        assert detector.detect([tok(0, "x"), tok(1, "y")]) == []
+
+
+# ---------------------------------------------------------------------
+# Per-language YAML files.
+# ---------------------------------------------------------------------
+
+
+class TestLanguagePatternFiles:
+    def test_hindi_yaml_loads_and_matches_a_canonical_conjunct_verb(self) -> None:
+        detector = get_detector("hi")
+        # Expect at least the karna conjunct rule + the compound
+        # postposition के बारे में to be loaded.
+        ids = {p.id for p in detector.patterns}
+        assert "hi.conjunct_verb_karna" in ids
+        assert "hi.compound_postp_ke_baare_mein" in ids
+
+        # Real conjunct verb structure: NOUN इंतज़ार + light verb किया
+        # (lemma करना). Detector should emit one proposal.
+        tokens = [
+            tok(0, "मैंने", lemma="मैं", pos="PRON"),
+            tok(1, "इंतज़ार", lemma="इंतज़ार", pos="NOUN"),
+            tok(2, "किया", lemma="करना", pos="VERB"),
+        ]
+        out = detector.detect(tokens)
+        karna_matches = [p for p in out if p.pattern_id == "hi.conjunct_verb_karna"]
+        assert len(karna_matches) == 1
+        assert karna_matches[0].surfaces == ["इंतज़ार", "किया"]
+
+    def test_hindi_compound_postp_ke_baare_mein_three_token_match(self) -> None:
+        detector = get_detector("hi")
+        tokens = [
+            tok(0, "किताब", pos="NOUN"),
+            tok(1, "के", pos="ADP"),
+            tok(2, "बारे", pos="ADP"),
+            tok(3, "में", pos="ADP"),
+        ]
+        out = detector.detect(tokens)
+        cp = [p for p in out if p.pattern_id == "hi.compound_postp_ke_baare_mein"]
+        assert len(cp) == 1
+        assert cp[0].start_idx == 1
+        assert cp[0].end_idx == 3
+        assert cp[0].surfaces == ["के", "बारे", "में"]
+
+    def test_marathi_yaml_loads_and_matches_a_conjunct_verb(self) -> None:
+        detector = get_detector("mr")
+        ids = {p.id for p in detector.patterns}
+        assert "mr.conjunct_verb_karne" in ids
+        tokens = [
+            tok(0, "मदत", lemma="मदत", pos="NOUN"),
+            tok(1, "केली", lemma="करणे", pos="VERB"),
+        ]
+        out = detector.detect(tokens)
+        assert any(p.pattern_id == "mr.conjunct_verb_karne" for p in out)
+
+    def test_odia_yaml_loads_and_matches_a_conjunct_verb(self) -> None:
+        detector = get_detector("or")
+        ids = {p.id for p in detector.patterns}
+        assert "or.conjunct_verb_kariba" in ids
+        tokens = [
+            tok(0, "ସାହାଯ୍ୟ", lemma="ସାହାଯ୍ୟ", pos="NOUN"),
+            tok(1, "କରିବ", lemma="କରିବା", pos="VERB"),
+        ]
+        out = detector.detect(tokens)
+        assert any(p.pattern_id == "or.conjunct_verb_kariba" for p in out)
+
+    def test_unknown_language_returns_empty_detector(self) -> None:
+        detector = get_detector("xx")
+        assert detector.patterns == ()
+        assert detector.detect([tok(0, "x"), tok(1, "y")]) == []
+
+    def test_pattern_files_exist(self) -> None:
+        # Sanity: all three MVP languages have a YAML file on disk.
+        base = Path(__file__).parent.parent / "app" / "phrases" / "patterns"
+        for filename in ("hindi.yaml", "marathi.yaml", "odia.yaml"):
+            assert (base / filename).exists(), f"missing {filename}"


### PR DESCRIPTION
## Summary

Adds a per-language phrase detector that runs after Stanza on each
`/process` call and emits `proposed_phrases` alongside the existing
`tokens` payload. The web worker (T-14.5a follow-up, #358) will
persist these to `phrase_proposals` and a periodic promotion pass
moves ≥3-chapter occurrences into `phrases` (`source='nlp'`).

This slice is the **detector itself + the wire-format extension**;
the DB write and promotion threshold ride in T-14.5a so the Python
and TypeScript halves of M14 land independently.

## What it does

- **`services/nlp/app/phrases/base.py`** — `PhraseDetector` +
  `PhrasePattern` + `PhrasePatternStep`. Each step is a predicate
  over a token (`upos` / `lemma` / `surface` / `feats`); a pattern
  matches a token run iff every step matches consecutive tokens in
  order. Multiple patterns may match at the same start — the
  detector emits all of them and lets downstream (T-14.3 reader,
  T-14.5a worker) decide longest-wins.

- **YAML loader** with structural validation (`PatternLoadError`):
  rejects missing `id`, duplicate `id`s, <2-step patterns, unknown
  step keys, bad type for each predicate.

- **Lazy-loaded per-language registry** (`get_detector(lang)`)
  cached behind a thread lock so the YAML parses once per process.
  Unknown languages get an empty detector — a brand-new language
  can ship without phrase patterns and still serve a well-formed
  `proposed_phrases: []`.

- **Seed pattern files:**
  - `hindi.yaml`: conjunct verbs (NOUN/ADJ + करना | होना | लगाना |
    देना | आना); compound postpositions (के बारे में, के साथ,
    के लिए, के बाद, के पहले). Surface-match rather than lemma-
    match for the postposition cluster — Stanza's lemma output
    for those is unstable across model versions.
  - `marathi.yaml`: NOUN/ADJ + करणे | होणे, plus surface-
    anchored compound postpositions (मध्ये, वर, खाली).
  - `odia.yaml`: NOUN/ADJ + କରିବା | ହେବା, plus surface-anchored
    ପାଇଁ / ପରେ.

- **`/process` wire-up** — `services/nlp/app/main.py` runs the
  detector and adds `proposed_phrases` to the response. The TS
  mirror in `apps/web/src/lib/server/nlp-client.ts` marks the
  field optional so older NLP service builds stay wire-compatible.

## Out of scope (T-14.5a, #358)

- Persisting proposals to a new `phrase_proposals` table from
  the worker after `text_tokens` are written.
- The promotion pass that moves ≥3-chapter occurrences from
  `phrase_proposals` to `phrases` (`source='nlp'`) and seeds
  `phrase_tokens`.

## Test plan

- [x] `pytest` (NLP service) — 389 tests pass (was 367; +22 new
  detector cases). Coverage 92.90%.
- [x] `ruff check .` clean.
- [x] `pnpm --filter @ciareader/web typecheck` — TS mirror of
  `ProposedPhrase` compiles without breaking existing
  consumers.
- [ ] Manual end-to-end smoke once T-14.5a lands: process a
  Hindi chapter through the dev NLP service and confirm
  `proposed_phrases` lands in the worker output.

Refs Epic #327. Refs #322 (closed by T-14.5a after DB write +
promotion ship).