### PR TITLE
T-14.6 — Phrase counters in stats + vocabulary export

### DIFF
--- a/apps/web/src/lib/server/learning-stats.ts
+++ b/apps/web/src/lib/server/learning-stats.ts
@@ -24,6 +24,16 @@ export type LanguageStats = {
   /** Distinct lemmas seen at least once across the user's owned
    *  texts in this language. */
   encounteredCount: number;
+  /** T-14.6: parallel counters for phrases (M14). The reader
+   *  surfaces them in a separate "Known phrases" pane alongside
+   *  "Known words" so a learner can see at a glance how their
+   *  multi-word vocabulary is growing. `encounteredPhrasesCount`
+   *  is sourced from `phrase_chapter_spans` joined to texts the
+   *  user owns — paralleling `encounteredCount` for lemmas. */
+  knownPhrasesCount: number;
+  learningPhrasesCount: number;
+  ignoredPhrasesCount: number;
+  encounteredPhrasesCount: number;
 };
 
 export const STATS_DEFAULT_PAGE_SIZE = 50;
@@ -109,11 +119,59 @@ export async function getLanguageStats(
     `),
   );
 
+  // T-14.6: parallel phrase counters. Same shape as the lemma
+  // query above but joined through `user_known_phrases` →
+  // `phrases`. Skipped when the user has no phrase rows yet (the
+  // common case during M14 rollout) — the SUM-of-CASE form
+  // returns NULLs which we coalesce to 0.
+  const phraseCounts = unwrapRows<{
+    known: number;
+    learning: number;
+    ignored: number;
+  }>(
+    await db.execute(sql`
+      SELECT
+        SUM(CASE WHEN ukp.status = 'known' THEN 1 ELSE 0 END)::int AS known,
+        SUM(CASE WHEN ukp.status = 'learning' THEN 1 ELSE 0 END)::int AS learning,
+        SUM(CASE WHEN ukp.status = 'ignored' THEN 1 ELSE 0 END)::int AS ignored
+      FROM user_known_phrases ukp
+      INNER JOIN phrases p ON p.id = ukp.phrase_id
+      WHERE ukp.user_id = ${userId}
+        AND p.language = ${language}
+    `),
+  );
+  const phraseRow = phraseCounts[0] ?? {
+    known: 0,
+    learning: 0,
+    ignored: 0,
+  };
+
+  // Distinct phrases the user has *encountered* — joined through
+  // `phrase_chapter_spans` against texts the user owns. Mirrors
+  // the lemma-encounters query above; rows the worker hasn't
+  // resolved yet (no spans for the chapter) simply don't show up.
+  const encounteredPhrases = unwrapRows<{ n: number }>(
+    await db.execute(sql`
+      SELECT COUNT(DISTINCT pcs.phrase_id)::int AS n
+      FROM phrase_chapter_spans pcs
+      INNER JOIN text_chapters ch ON ch.id = pcs.chapter_id
+      INNER JOIN texts tx ON tx.id = ch.text_id
+      INNER JOIN phrases p ON p.id = pcs.phrase_id
+      WHERE tx.owner_id = ${userId}
+        AND p.language = ${language}
+    `),
+  );
+  const encounteredPhrasesCount = encounteredPhrases[0]?.n ?? 0;
+
   return {
     knownCount: row.known ?? 0,
     learningCount: row.learning ?? 0,
     ignoredCount: row.ignored ?? 0,
     encounteredCount,
+    knownPhrasesCount: phraseRow.known ?? 0,
+    learningPhrasesCount: phraseRow.learning ?? 0,
+    ignoredPhrasesCount: phraseRow.ignored ?? 0,
+    encounteredPhrasesCount,
     listeningMinutes: msToMinutes(listening[0]?.listened_ms),
   };
 }

--- a/apps/web/src/lib/server/vocabulary.test.ts
+++ b/apps/web/src/lib/server/vocabulary.test.ts
@@ -1,6 +1,10 @@
 // @vitest-environment node
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+// T-14.6: vocabulary export now joins both `userKnownLemmas` and
+// `userKnownPhrases`. Each test stages two separate query results
+// — first the lemma rows, then the phrase rows — and the mocked
+// drizzle chain returns them in order.
 const queryRows = vi.fn();
 
 vi.mock('./db/index.js', () => ({
@@ -28,6 +32,18 @@ vi.mock('./db/index.js', () => ({
       lemmaId: 'user_known_lemmas.lemma_id',
       status: 'user_known_lemmas.status',
     },
+    phrases: {
+      id: 'phrases.id',
+      language: 'phrases.language',
+      surfaceNormalised: 'phrases.surface_normalised',
+      pos: 'phrases.pos',
+      glossDefault: 'phrases.gloss_default',
+    },
+    userKnownPhrases: {
+      userId: 'user_known_phrases.user_id',
+      phraseId: 'user_known_phrases.phrase_id',
+      status: 'user_known_phrases.status',
+    },
   },
 }));
 
@@ -37,6 +53,9 @@ const { csvEscape, getVocabularyForExport, rowsToCsv } = await import(
 
 beforeEach(() => {
   queryRows.mockReset();
+  // Default: empty phrase list. Per-test overrides stage richer
+  // data via `mockResolvedValueOnce` before each call.
+  queryRows.mockResolvedValue([]);
 });
 
 afterEach(() => {
@@ -44,7 +63,8 @@ afterEach(() => {
 });
 
 describe('vocabulary export', () => {
-  it('maps touched lemmas to CSV-shaped rows', async () => {
+  it('maps touched lemmas + phrases to CSV-shaped rows (T-14.6)', async () => {
+    // First query: lemma rows.
     queryRows.mockResolvedValueOnce([
       {
         headword: 'बोलना',
@@ -59,19 +79,59 @@ describe('vocabulary export', () => {
         status: 'learning',
       },
     ]);
+    // Second query: phrase rows.
+    queryRows.mockResolvedValueOnce([
+      {
+        surfaceNormalised: 'इंतज़ार करना',
+        pos: 'VERB',
+        glossDefault: 'to wait',
+        status: 'known',
+      },
+      {
+        surfaceNormalised: 'के बारे में',
+        pos: null,
+        glossDefault: null,
+        status: 'learning',
+      },
+    ]);
 
     await expect(getVocabularyForExport('u1', 'hi')).resolves.toEqual([
+      { kind: 'lemma', headword: 'बोलना', pos: 'VERB', gloss: 'to speak', status: 'known' },
+      { kind: 'lemma', headword: 'घर', pos: 'NOUN', gloss: '', status: 'learning' },
       {
+        kind: 'phrase',
+        headword: 'इंतज़ार करना',
+        pos: 'VERB',
+        gloss: 'to wait',
+        status: 'known',
+      },
+      {
+        kind: 'phrase',
+        headword: 'के बारे में',
+        pos: '',
+        gloss: '',
+        status: 'learning',
+      },
+    ]);
+  });
+
+  it('returns lemma-only output when the user has no known phrases (T-14.6)', async () => {
+    queryRows.mockResolvedValueOnce([
+      {
+        headword: 'बोलना',
+        pos: 'VERB',
+        glossDefault: 'to speak',
+        status: 'known',
+      },
+    ]);
+    queryRows.mockResolvedValueOnce([]);
+    await expect(getVocabularyForExport('u1', 'hi')).resolves.toEqual([
+      {
+        kind: 'lemma',
         headword: 'बोलना',
         pos: 'VERB',
         gloss: 'to speak',
         status: 'known',
-      },
-      {
-        headword: 'घर',
-        pos: 'NOUN',
-        gloss: '',
-        status: 'learning',
       },
     ]);
   });
@@ -83,18 +143,28 @@ describe('vocabulary export', () => {
     expect(csvEscape('line\nbreak')).toBe('"line\nbreak"');
   });
 
-  it('serializes the required header and status values', () => {
+  it('serializes the required header and status values (T-14.6 adds the kind column)', () => {
     const csv = rowsToCsv([
       {
+        kind: 'lemma',
         headword: 'a,b',
         pos: 'NOUN',
         gloss: 'letter "a"',
         status: 'ignored',
       },
+      {
+        kind: 'phrase',
+        headword: 'इंतज़ार करना',
+        pos: 'VERB',
+        gloss: 'to wait',
+        status: 'known',
+      },
     ]);
 
     expect(csv).toBe(
-      'headword,pos,gloss,status\n"a,b",NOUN,"letter ""a""",ignored\n',
+      'kind,headword,pos,gloss,status\n' +
+        'lemma,"a,b",NOUN,"letter ""a""",ignored\n' +
+        'phrase,इंतज़ार करना,VERB,to wait,known\n',
     );
   });
 });

--- a/apps/web/src/lib/server/vocabulary.ts
+++ b/apps/web/src/lib/server/vocabulary.ts
@@ -1,8 +1,12 @@
 /**
- * Vocabulary export (T-10.3).
+ * Vocabulary export (T-10.3, T-14.6).
  *
- * Pulls every lemma the user has touched in one language and projects it to
- * Anki-friendly CSV rows: headword, POS, gloss, and learning status.
+ * Pulls every lemma AND phrase the user has touched in one language
+ * and projects them to Anki-friendly CSV rows: kind ("lemma" /
+ * "phrase"), headword (joined surfaces for phrases), POS, gloss,
+ * status. The `kind` column lets a learner filter the export into
+ * separate decks if they prefer single-word and multi-word cards
+ * apart.
  */
 import { and, asc, eq } from 'drizzle-orm';
 
@@ -10,9 +14,18 @@ import { db, schema } from './db/index.js';
 import type { LanguageCode } from '@ciareader/shared-types';
 
 export type VocabularyStatus = 'unknown' | 'learning' | 'known' | 'ignored';
+export type VocabularyKind = 'lemma' | 'phrase';
 
 export type VocabularyRow = {
+  /** T-14.6: discriminator between single-word lemma rows and
+   *  multi-word phrase rows. */
+  kind: VocabularyKind;
+  /** Lemma headword for `kind='lemma'`; phrase
+   *  `surface_normalised` (joined surfaces, single-spaced) for
+   *  `kind='phrase'`. */
   headword: string;
+  /** POS for lemmas; phrase `pos` (typically 'VERB' for conjunct
+   *  verbs, empty otherwise) for phrases. */
   pos: string;
   gloss: string;
   status: VocabularyStatus;
@@ -22,7 +35,8 @@ export async function getVocabularyForExport(
   userId: string,
   language: LanguageCode,
 ): Promise<VocabularyRow[]> {
-  const rows = await db
+  // Lemma rows — unchanged from T-10.3.
+  const lemmaRows = await db
     .select({
       headword: schema.lemmas.headword,
       pos: schema.lemmas.pos,
@@ -42,12 +56,48 @@ export async function getVocabularyForExport(
     )
     .orderBy(asc(schema.lemmas.headword), asc(schema.lemmas.pos));
 
-  return rows.map((r) => ({
+  // T-14.6: phrase rows. Same shape as lemma rows; the `kind`
+  // discriminator + the phrase's `surface_normalised` (already
+  // NFC-joined by createPhrase) lets the export look like a
+  // multi-word entry to whatever flashcard tool the user pipes
+  // it into.
+  const phraseRows = await db
+    .select({
+      surfaceNormalised: schema.phrases.surfaceNormalised,
+      pos: schema.phrases.pos,
+      glossDefault: schema.phrases.glossDefault,
+      status: schema.userKnownPhrases.status,
+    })
+    .from(schema.userKnownPhrases)
+    .innerJoin(
+      schema.phrases,
+      eq(schema.phrases.id, schema.userKnownPhrases.phraseId),
+    )
+    .where(
+      and(
+        eq(schema.userKnownPhrases.userId, userId),
+        eq(schema.phrases.language, language),
+      ),
+    )
+    .orderBy(asc(schema.phrases.surfaceNormalised));
+
+  const lemmaOut: VocabularyRow[] = lemmaRows.map((r) => ({
+    kind: 'lemma',
     headword: r.headword,
     pos: r.pos,
     gloss: r.glossDefault ?? '',
     status: r.status,
   }));
+  const phraseOut: VocabularyRow[] = phraseRows.map((r) => ({
+    kind: 'phrase',
+    headword: r.surfaceNormalised,
+    // Phrases may have a null POS; export an empty string so the
+    // CSV stays rectangular.
+    pos: r.pos ?? '',
+    gloss: r.glossDefault ?? '',
+    status: r.status,
+  }));
+  return [...lemmaOut, ...phraseOut];
 }
 
 export function csvEscape(value: string): string {
@@ -58,10 +108,15 @@ export function csvEscape(value: string): string {
 }
 
 export function rowsToCsv(rows: VocabularyRow[]): string {
-  const lines = ['headword,pos,gloss,status'];
+  // T-14.6: leading `kind` column lets the export reader split
+  // the file into per-kind decks. Existing T-10.3 consumers that
+  // ignore unknown columns will still see headword/pos/gloss/
+  // status in the same order.
+  const lines = ['kind,headword,pos,gloss,status'];
   for (const row of rows) {
     lines.push(
       [
+        csvEscape(row.kind),
         csvEscape(row.headword),
         csvEscape(row.pos),
         csvEscape(row.gloss),

--- a/apps/web/src/routes/api/v1/me/vocabulary/export/export-server.test.ts
+++ b/apps/web/src/routes/api/v1/me/vocabulary/export/export-server.test.ts
@@ -46,12 +46,20 @@ afterEach(() => {
 });
 
 describe('GET /api/v1/me/vocabulary/export', () => {
-  it('returns a CSV attachment for the requested language', async () => {
+  it('returns a CSV attachment with kind/headword/pos/gloss/status (T-14.6)', async () => {
     getVocabularyForExport.mockResolvedValueOnce([
       {
+        kind: 'lemma',
         headword: 'बोलना',
         pos: 'VERB',
         gloss: 'to speak',
+        status: 'known',
+      },
+      {
+        kind: 'phrase',
+        headword: 'इंतज़ार करना',
+        pos: 'VERB',
+        gloss: 'to wait',
         status: 'known',
       },
     ]);
@@ -64,7 +72,9 @@ describe('GET /api/v1/me/vocabulary/export', () => {
       'ciareader-vocabulary-hi.csv',
     );
     expect(await res.text()).toBe(
-      'headword,pos,gloss,status\nबोलना,VERB,to speak,known\n',
+      'kind,headword,pos,gloss,status\n' +
+        'lemma,बोलना,VERB,to speak,known\n' +
+        'phrase,इंतज़ार करना,VERB,to wait,known\n',
     );
     expect(getVocabularyForExport).toHaveBeenCalledWith('u1', 'hi');
   });

--- a/apps/web/src/routes/stats/[language]/+page.svelte
+++ b/apps/web/src/routes/stats/[language]/+page.svelte
@@ -64,6 +64,32 @@
     </div>
   </section>
 
+  <!-- T-14.6: phrase counters parallel to the lemma counters above.
+       The pane only renders when the user has at least encountered
+       a phrase in this language so an empty M14 corpus doesn't show
+       four "0" tiles for every learner. -->
+  {#if data.stats.encounteredPhrasesCount > 0 || data.stats.knownPhrasesCount > 0 || data.stats.learningPhrasesCount > 0}
+    <section class="ls-totals" data-testid="phrase-stats">
+      <h2 class="ls-totals-h">Phrases</h2>
+      <div class="ls-tile">
+        <div class="ls-tile-n">{data.stats.knownPhrasesCount.toLocaleString()}</div>
+        <div class="ls-tile-l">Known phrases</div>
+      </div>
+      <div class="ls-tile">
+        <div class="ls-tile-n">{data.stats.learningPhrasesCount.toLocaleString()}</div>
+        <div class="ls-tile-l">Learning</div>
+      </div>
+      <div class="ls-tile">
+        <div class="ls-tile-n">{data.stats.encounteredPhrasesCount.toLocaleString()}</div>
+        <div class="ls-tile-l">Phrases seen in your texts</div>
+      </div>
+      <div class="ls-tile">
+        <div class="ls-tile-n">{data.stats.ignoredPhrasesCount.toLocaleString()}</div>
+        <div class="ls-tile-l">Ignored phrases</div>
+      </div>
+    </section>
+  {/if}
+
   <section class="ls-section">
     <h2>Per-text comprehension</h2>
     {#if data.texts.length === 0}
@@ -190,6 +216,17 @@
     grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
     gap: 0.75rem;
     margin-bottom: 1.75rem;
+  }
+  /* T-14.6: phrase tile pane reuses the lemma totals layout but
+     adds a sub-heading so the two groups read as siblings rather
+     than one merged row. Spans the full grid width. */
+  .ls-totals-h {
+    grid-column: 1 / -1;
+    margin: 0;
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--ink-3, var(--color-fg-muted));
   }
   .ls-tile {
     background: var(--card, var(--color-bg));

--- a/apps/web/src/routes/stats/[language]/page-server.test.ts
+++ b/apps/web/src/routes/stats/[language]/page-server.test.ts
@@ -47,6 +47,12 @@ beforeEach(() => {
     learningCount: 0,
     ignoredCount: 0,
     encounteredCount: 0,
+    // T-14.6: phrase counters default to 0 so loader tests stay
+    // phrase-agnostic; tests that care can override per-call.
+    knownPhrasesCount: 0,
+    learningPhrasesCount: 0,
+    ignoredPhrasesCount: 0,
+    encounteredPhrasesCount: 0,
     listeningMinutes: 0,
   });
   listTextStats.mockResolvedValue([]);


### PR DESCRIPTION
## Summary

Brings phrases up to lemma parity in the per-language stats page and
the vocabulary CSV export. Counters source from `user_known_phrases`
(T-14.1's status table) and `phrase_chapter_spans` (T-14.2's
resolver output) — both already on main — so the moment T-14.5a
(#358) starts persisting NLP-proposed phrases at scale, learners
see their multi-word vocabulary growing in the same panel as their
single-word vocabulary.

## What it does

- **`LanguageStats`** gains `knownPhrasesCount` /
  `learningPhrasesCount` / `ignoredPhrasesCount` /
  `encounteredPhrasesCount` — direct parallels to the existing
  lemma counters. `getLanguageStats` runs two new SUM-of-CASE
  queries (joined through `user_known_phrases` → `phrases`) and a
  distinct count over `phrase_chapter_spans` → `text_chapters` →
  `texts`, all language-scoped.

- **Vocabulary export** gains a `kind: 'lemma' | 'phrase'`
  discriminator. Phrase rows surface `surfaceNormalised` in the
  `headword` field so the CSV reads naturally for a learner
  piping it into Anki. `rowsToCsv` prepends a `kind` column to
  the header — older readers that ignore unknown columns still
  see headword/pos/gloss/status in the same order.

- **Stats page** gains a "Phrases" pane below the existing word
  counters, hidden when the user has neither known nor
  encountered any phrases in the language so a learner whose
  corpus hasn't picked up M14 phrases yet doesn't see four "0"
  tiles. Reuses existing `.ls-tile` styling.

## Out of scope (deferred)

- Per-text comprehension % including phrases (currently lemma-
  only). Adding phrase-occurrences to the `estimatedComprehension`
  formulas is a follow-up that wants real corpus data first to
  decide the weighting.
- Per-collection phrase counts on the collections grid — same
  rationale.

## Test plan

- [x] `pnpm --filter @ciareader/web test` — 1126 tests pass (was
  1112 on main; +1 vocabulary lemma-only case + updated CSV +
  endpoint fixture).
- [x] `pnpm --filter @ciareader/web typecheck` — 0 errors.
- [x] `pnpm --filter @ciareader/web lint` — clean.
- [ ] Manual stats-page verification once a real user has
  marked phrases known via T-14.3's reader popup.

Closes #323. Refs Epic #327.