### PR TITLE
chore: make dev-stack host ports configurable via .env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,15 +39,20 @@ clean:
 
 # Native dev: data services in docker, web + nlp on the host. Use when
 # docker buildx can't reach pypi/npm registries (corp DNS, VPN, etc.).
+#
+# Each var defers to the caller's environment first (`${VAR:-default}` shell
+# expansion) so you can override any value via `export FOO=...` in your shell
+# or a per-command prefix (`FOO=... make dev-native-db`). The defaults match
+# the docker-compose host-port defaults.
 NATIVE_ENV = \
-	NLP_SERVICE_URL=http://localhost:8000 \
-	DATABASE_URL=postgres://ciareader:ciareader@localhost:5432/ciareader \
-	REDIS_URL=redis://localhost:6379 \
-	AUTH_SECRET=dev-only-secret-replace-in-prod-0000000000000000000000000000000 \
-	APP_BASE_URL=http://localhost:5173 \
-	SMTP_HOST=localhost \
-	SMTP_PORT=1025 \
-	SMTP_FROM=no-reply@ciareader.local
+	NLP_SERVICE_URL=$${NLP_SERVICE_URL:-http://localhost:8000} \
+	DATABASE_URL=$${DATABASE_URL:-postgres://ciareader:ciareader@localhost:5432/ciareader} \
+	REDIS_URL=$${REDIS_URL:-redis://localhost:6379} \
+	AUTH_SECRET=$${AUTH_SECRET:-dev-only-secret-replace-in-prod-0000000000000000000000000000000} \
+	APP_BASE_URL=$${APP_BASE_URL:-http://localhost:5173} \
+	SMTP_HOST=$${SMTP_HOST:-localhost} \
+	SMTP_PORT=$${SMTP_PORT:-1025} \
+	SMTP_FROM=$${SMTP_FROM:-no-reply@ciareader.local}
 
 dev-native: dev-native-services dev-native-db
 	@echo ""
@@ -65,7 +70,7 @@ dev-native-down:
 	docker compose -f infra/docker-compose.yml stop postgres redis mailpit
 
 dev-native-db:
-	cd apps/web && $(NATIVE_ENV) pnpm exec drizzle-kit push --verbose
+	cd apps/web && $(NATIVE_ENV) pnpm exec drizzle-kit migrate
 
 dev-native-nlp:
 	cd services/nlp && PYTHONPATH=../../packages/shared-types/python:. .venv/bin/uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload

--- a/README.md
+++ b/README.md
@@ -40,6 +40,24 @@ That boots postgres + redis + the NLP service + the SvelteKit dev server (with h
 - Client API reference: http://localhost:5173/docs/api/
 - API versioning policy: [docs/api-versioning.md](docs/api-versioning.md)
 
+### Custom host ports
+
+If any of the default ports collide with another local service (e.g. another Postgres on `5432`), copy [`infra/.env.example`](infra/.env.example) to `infra/.env` and override only what you need — `docker compose` reads `infra/.env` automatically. Example:
+
+```
+# infra/.env
+POSTGRES_HOST_PORT=55432
+```
+
+When you change the Postgres host port, also point the web app at it via `apps/web/.env`:
+
+```
+# apps/web/.env
+DATABASE_URL=postgres://ciareader:ciareader@localhost:55432/ciareader
+```
+
+Both `.env` files are gitignored.
+
 Smoke test (proves the full pipe works):
 
 ```

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -1,0 +1,10 @@
+# Override host-side port mappings for `docker compose -f infra/docker-compose.yml ...`.
+# Copy to `infra/.env` (gitignored) and edit only what you need.
+# All values are optional — defaults match the README.
+
+POSTGRES_HOST_PORT=5432
+REDIS_HOST_PORT=6379
+MAILPIT_SMTP_HOST_PORT=1025
+MAILPIT_UI_HOST_PORT=8025
+NLP_HOST_PORT=8000
+WEB_HOST_PORT=5173

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: ciareader
       POSTGRES_DB: ciareader
     ports:
-      - "5432:5432"
+      - "${POSTGRES_HOST_PORT:-5432}:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
     healthcheck:
@@ -20,7 +20,7 @@ services:
   redis:
     image: redis:7-alpine
     ports:
-      - "6379:6379"
+      - "${REDIS_HOST_PORT:-6379}:6379"
     volumes:
       - redis-data:/data
     healthcheck:
@@ -32,8 +32,8 @@ services:
   mailpit:
     image: axllent/mailpit:latest
     ports:
-      - "1025:1025" # SMTP
-      - "8025:8025" # Web UI
+      - "${MAILPIT_SMTP_HOST_PORT:-1025}:1025" # SMTP
+      - "${MAILPIT_UI_HOST_PORT:-8025}:8025" # Web UI
     healthcheck:
       test: ["CMD", "nc", "-z", "localhost", "1025"]
       interval: 5s
@@ -49,7 +49,7 @@ services:
       - ../services/nlp/tests:/srv/nlp/tests
       - ../packages/shared-types/python:/opt/shared-types
     ports:
-      - "8000:8000"
+      - "${NLP_HOST_PORT:-8000}:8000"
     environment:
       PYTHONPATH: /opt/shared-types:/srv/nlp
     healthcheck:
@@ -90,12 +90,12 @@ services:
       SMTP_PORT: "1025"
       SMTP_FROM: no-reply@ciareader.local
     ports:
-      - "5173:5173"
+      - "${WEB_HOST_PORT:-5173}:5173"
     command:
       - sh
       - -c
       - |
-        pnpm --filter @ciareader/web exec drizzle-kit push --verbose &&
+        pnpm --filter @ciareader/web exec drizzle-kit migrate &&
         pnpm --filter @ciareader/web dev
 
 volumes:


### PR DESCRIPTION
## Summary

- **`infra/docker-compose.yml`** — parameterize host-side port mappings (`POSTGRES_HOST_PORT`, `REDIS_HOST_PORT`, `MAILPIT_SMTP_HOST_PORT`, `MAILPIT_UI_HOST_PORT`, `NLP_HOST_PORT`, `WEB_HOST_PORT`). Defaults match today's hardcoded values, so zero-config dev is unchanged. Compose auto-loads `infra/.env`.
- **`infra/.env.example`** — new file documenting every override.
- **`Makefile`** — `NATIVE_ENV` now uses `${VAR:-default}` shell expansion so an exported `DATABASE_URL` (or any of the other vars) wins over the default. `dev-native-db` now runs `drizzle-kit migrate` instead of `push --verbose` — same swap in the docker `web` service command. `migrate` replays authored migrations from `apps/web/drizzle/`; `push` diffs `schema.ts` against the live DB and can prompt to truncate tables. Tickets are not the right place for that footgun.
- **`README.md`** — short "Custom host ports" subsection showing the `infra/.env` + `apps/web/.env` workflow for collisions like a second Postgres on `5432`.

Motivation: today, sidestepping a port collision on `5432` required editing 8 hardcoded fallbacks (`infra/docker-compose.yml`, `Makefile`, `README.md`, `apps/web/drizzle.config.ts`, `apps/web/src/lib/server/env.ts`, `apps/web/scripts/import-dictionary.ts`, `apps/web/scripts/reprocess-text.mjs`, `apps/web/scripts/seed-form-overrides.mjs`) — those files all already read `process.env.DATABASE_URL` first, so all that was needed was a way to set it without touching tracked code. After this PR, copy `infra/.env.example` to `infra/.env`, override what you need, and put a matching `DATABASE_URL` in `apps/web/.env` (auto-loaded by SvelteKit and drizzle-kit).

## Test plan

- [x] `docker compose -f infra/docker-compose.yml config` (no env): every published port matches today's defaults.
- [x] `POSTGRES_HOST_PORT=55432 docker compose -f infra/docker-compose.yml config`: Postgres `published: "55432"`, others unchanged.
- [x] `make -n dev-native-db`: emits `DATABASE_URL=${DATABASE_URL:-...}` so the caller's exported value wins; recipe now invokes `drizzle-kit migrate`.
- [ ] Reviewer: confirm `infra/.env` is auto-loaded by your local docker compose (project dir = `infra/`).
- [ ] Reviewer: spot-check the README diff renders cleanly.