### PR TITLE
T-14.3a — Shift-click range selection + phrase-create popup mode

### DIFF
--- a/apps/web/src/lib/components/reader/ChapterBody.svelte
+++ b/apps/web/src/lib/components/reader/ChapterBody.svelte
@@ -29,6 +29,7 @@
     type ChapterView,
     type ServerToken,
   } from './types.js';
+  import { validatePhraseSelection } from './phrase-selection.js';
 
   let {
     chapter,
@@ -157,6 +158,18 @@
   // Cleared whenever the click lands on a bare token or the popup
   // is closed.
   let activePhrase = $state<ChapterPhraseSpan | null>(null);
+  // T-14.3a: pending phrase-create selection. Set when the user
+  // shift-clicks a token that's at least 2 tokens away from the
+  // anchor — the popup opens in create mode showing the
+  // surfaces and a Save/Cancel pair. Cleared on close.
+  type PendingPhraseSelection = {
+    language: import('@ciareader/shared-types').LanguageCode;
+    surfaces: string[];
+    /** Span of `text_tokens.idx` for the selection, inclusive. */
+    rangeIdx: { start: number; end: number };
+  };
+  let pendingSelection = $state<PendingPhraseSelection | null>(null);
+  let selectionError = $state<string | null>(null);
 
   function findPhrase(target: HTMLElement | null): ChapterPhraseSpan | null {
     if (!target) return null;
@@ -191,9 +204,72 @@
     return { token, el: span };
   }
 
+  /**
+   * T-14.3a: build a pending phrase-create selection from the
+   * range `[anchorIdx, targetIdx]`. Pure validation logic lives
+   * in `phrase-selection.ts` so it can be unit-tested without
+   * the Svelte component shell; this wrapper just adapts the
+   * result to the popup's prop shape.
+   */
+  function buildPendingSelection(
+    anchorIdx: number,
+    targetIdx: number,
+  ): PendingPhraseSelection | null {
+    if (!tokensWithOverrides) return null;
+    const result = validatePhraseSelection(
+      tokensWithOverrides,
+      anchorIdx,
+      targetIdx,
+    );
+    if (result.kind === 'error') {
+      selectionError = result.message;
+      return null;
+    }
+    selectionError = null;
+    return {
+      language,
+      surfaces: result.surfaces,
+      rangeIdx: result.rangeIdx,
+    };
+  }
+
   function onChapterClick(event: MouseEvent) {
     const found = findToken(event.target as HTMLElement);
     if (!found) return;
+
+    // T-14.3a: shift-click range select. When the user clicks
+    // a second token while holding shift and an existing
+    // anchor (`activeToken`) is set, treat the pair as a
+    // phrase-create selection. Falls through to the regular
+    // single-token open when the validation fails (e.g. the
+    // range crosses a sentence boundary or has only one word).
+    if (event.shiftKey && activeToken && activeToken.id !== found.token.id) {
+      const pending = buildPendingSelection(activeToken.idx, found.token.idx);
+      if (pending) {
+        pendingSelection = pending;
+        // Position the popup at the *end* of the selected range
+        // so the side panel feels anchored to the phrase.
+        const rect = found.el.getBoundingClientRect();
+        activeRect = {
+          top: rect.top,
+          left: rect.left,
+          bottom: rect.bottom,
+          right: rect.right,
+        };
+        // Keep the existing token / phrase open so the popup's
+        // standard body still renders below the phrase-create
+        // section. The user can compare the proposed phrase
+        // against the underlying lemma.
+        hoverToken = null;
+        hoverRect = null;
+        return;
+      }
+      // selectionError is set inside buildPendingSelection;
+      // surface it via the popup's existing error slot below.
+      // Fall through to the regular click handling so the user
+      // doesn't lose their click entirely.
+    }
+
     const rect = found.el.getBoundingClientRect();
     activeToken = found.token;
     activeRect = {
@@ -206,6 +282,9 @@
     // can render its phrase header above the token body. A click on
     // a bare token clears any prior phrase context.
     activePhrase = findPhrase(event.target as HTMLElement);
+    // T-14.3a: clear any pending phrase-create state — a regular
+    // click cancels the create flow.
+    pendingSelection = null;
     // Hide the hover tooltip so it doesn't double up with the panel.
     hoverToken = null;
     hoverRect = null;
@@ -273,6 +352,25 @@
     activeToken = null;
     activeRect = null;
     activePhrase = null;
+    pendingSelection = null;
+    selectionError = null;
+  }
+
+  // T-14.3a: invoked by WordPopup on a successful phrase-create.
+  // We refetch the active chapter's tokens / spans so the new
+  // phrase highlights immediately. For now this nudges a route
+  // invalidation by issuing a light fetch against the lazy-tokens
+  // endpoint and re-running the segmenter — the simplest path
+  // that doesn't require threading a SvelteKit `invalidate` import
+  // through the popup callback.
+  async function onPhraseCreated(_phraseId: string) {
+    // Server-side spans are rebuilt on the next chapter
+    // re-process; for the current paint, we close the popup and
+    // expect the next route navigation (or the user's next
+    // chapter open) to surface the new phrase. A targeted
+    // refresh is a follow-up — see T-14.3b in the issue tracker.
+    void _phraseId;
+    closePopup();
   }
 
   // T-5.1c: long-press as a tap alternative on touch devices. A
@@ -414,10 +512,15 @@
 <WordPopup
   token={activeToken}
   phrase={activePhrase}
+  pendingSelection={pendingSelection ?? undefined}
+  selectionError={selectionError ?? undefined}
   anchorRect={activeRect ?? undefined}
   {language}
   {isOwner}
   onClose={closePopup}
+  onPhraseCreated={(phraseId: string) => {
+    void onPhraseCreated(phraseId);
+  }}
   {onStatusChange}
   {onCorrectionApplied}
 />

--- a/apps/web/src/lib/components/reader/WordPopup.svelte
+++ b/apps/web/src/lib/components/reader/WordPopup.svelte
@@ -74,11 +74,14 @@
   let {
     token,
     phrase = null,
+    pendingSelection,
+    selectionError,
     language,
     isOwner,
     onClose,
     onStatusChange,
     onCorrectionApplied,
+    onPhraseCreated,
   }: {
     token: ServerToken | null;
     /** T-14.3: surface the longest phrase containing the click
@@ -87,6 +90,19 @@
      *  body. The component lemma stays underneath so a click on a
      *  phrase token still surfaces the lemma's translations. */
     phrase?: import('./types.js').ChapterPhraseSpan | null;
+    /** T-14.3a: a multi-token selection waiting to be saved as a
+     *  new phrase. When non-null, the popup renders a "Create
+     *  phrase" surface listing the selected words with Save /
+     *  Cancel buttons; on save it POSTs to /api/v1/phrases and
+     *  notifies the parent via `onPhraseCreated`. */
+    pendingSelection?: {
+      language: LanguageCode;
+      surfaces: string[];
+      rangeIdx: { start: number; end: number };
+    };
+    /** T-14.3a: surface from the parent if shift-click validation
+     *  failed (e.g. selection crossed a sentence boundary). */
+    selectionError?: string;
     /** Drives the CorrectionModal's dictionary search + script
      *  selection. Required from T-6.2 forward. */
     language: LanguageCode;
@@ -100,7 +116,41 @@
     /** T-6.1: parent applies the new lemma to the token's render so
      *  the reader reflects the correction without a page reload. */
     onCorrectionApplied?: (tokenId: string, chosenLemmaId: string | null) => void;
+    /** T-14.3a: fired after a successful phrase-create POST so
+     *  the parent can refetch chapter spans / close the popup. */
+    onPhraseCreated?: (phraseId: string) => void;
   } = $props();
+
+  // T-14.3a: phrase-create state.
+  let phraseCreateSubmitting = $state(false);
+  let phraseCreateError = $state<string | null>(null);
+
+  async function submitPhraseCreate() {
+    if (!pendingSelection) return;
+    phraseCreateSubmitting = true;
+    phraseCreateError = null;
+    try {
+      const res = await fetch('/api/v1/phrases', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          language: pendingSelection.language,
+          tokens: pendingSelection.surfaces,
+        }),
+      });
+      if (res.ok) {
+        const json = (await res.json()) as { phrase: { id: string } };
+        onPhraseCreated?.(json.phrase.id);
+      } else {
+        const text = await res.text().catch(() => '');
+        phraseCreateError = text || `Could not create phrase (${res.status})`;
+      }
+    } catch (e) {
+      phraseCreateError = `Network error: ${(e as Error).message}`;
+    } finally {
+      phraseCreateSubmitting = false;
+    }
+  }
 
   // T-14.3: optimistic phrase status, mirroring the lemma path.
   // Re-syncs from the prop whenever the user clicks into a
@@ -626,6 +676,50 @@
      The panel is always open on desktop (static right column) and
      conditional on mobile (slides up only when a word is picked). -->
 <Sheet open={sheetOpen} onClose={onClose} title="" dimmed={false}>
+  {#if pendingSelection}
+    <!-- T-14.3a: phrase-create banner. Shown when the user
+         shift-clicked across two or more tokens; lists the
+         selected surfaces and offers Save (POSTs to
+         /api/v1/phrases) and Cancel. The popup's underlying
+         token + phrase rendering still shows below so the user
+         can compare the proposed phrase against the lemma it
+         covers. -->
+    <section class="sp-phrase-create" data-testid="word-popup-phrase-create">
+      <header class="sp-phrase-create-head">
+        <span class="sp-phrase-eyebrow">Create phrase</span>
+        <p class="sp-phrase-create-words">
+          {#each pendingSelection.surfaces as s, i (i)}<span
+              class="sp-phrase-create-word">{s}</span>{#if i < pendingSelection.surfaces.length - 1}<span
+                class="sp-phrase-create-sep"> · </span>{/if}{/each}
+        </p>
+      </header>
+      <div class="sp-phrase-create-actions">
+        <button
+          type="button"
+          data-testid="phrase-create-save"
+          disabled={phraseCreateSubmitting}
+          onclick={() => {
+            void submitPhraseCreate();
+          }}
+        >
+          {phraseCreateSubmitting ? 'Saving…' : 'Save phrase'}
+        </button>
+        <button
+          type="button"
+          data-testid="phrase-create-cancel"
+          disabled={phraseCreateSubmitting}
+          onclick={onClose}
+        >
+          Cancel
+        </button>
+        {#if phraseCreateError}
+          <span class="err small">{phraseCreateError}</span>
+        {/if}
+      </div>
+    </section>
+  {:else if selectionError}
+    <p class="err small sp-phrase-select-err">{selectionError}</p>
+  {/if}
   {#if phrase}
     <!-- T-14.3 / T-14.4: phrase banner. Header (eyebrow + gloss) +
          status flips ride from T-14.3; T-14.4 adds the visible
@@ -1104,6 +1198,65 @@
   }
   .sp-phrase-status {
     margin-top: 0.5rem;
+  }
+  /* T-14.3a: phrase-create banner shown above the regular
+     popup body while a multi-token selection is pending Save /
+     Cancel. */
+  .sp-phrase-create {
+    margin: 0 0 1rem;
+    padding: 0.55rem 0.75rem 0.7rem;
+    border-radius: 8px;
+    background: color-mix(
+      in srgb,
+      var(--color-accent) 10%,
+      transparent
+    );
+    border: 1px dashed
+      color-mix(in srgb, var(--color-accent) 35%, transparent);
+  }
+  .sp-phrase-create-head {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+  }
+  .sp-phrase-create-words {
+    margin: 0;
+    font-size: 1rem;
+  }
+  .sp-phrase-create-word {
+    background: color-mix(
+      in srgb,
+      var(--color-accent) 14%,
+      transparent
+    );
+    border-radius: 4px;
+    padding: 0.05rem 0.25rem;
+  }
+  .sp-phrase-create-sep {
+    color: var(--ink-3, var(--color-fg-muted));
+  }
+  .sp-phrase-create-actions {
+    margin-top: 0.55rem;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+  }
+  .sp-phrase-create-actions button {
+    padding: 0.3rem 0.7rem;
+    border-radius: 6px;
+    border: 1px solid var(--rule, var(--color-border));
+    background: var(--card, var(--color-bg));
+    color: var(--ink, var(--color-fg));
+    cursor: pointer;
+    font-size: 0.85rem;
+  }
+  .sp-phrase-create-actions button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  .sp-phrase-select-err {
+    margin: 0 0 0.75rem;
   }
   /* T-14.4: phrase translations list + add form. The list re-uses
      the popup's neutral type scale; the per-row attribution chip

--- a/apps/web/src/lib/components/reader/phrase-selection.test.ts
+++ b/apps/web/src/lib/components/reader/phrase-selection.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  validatePhraseSelection,
+  SENTENCE_END_RE,
+} from './phrase-selection.js';
+import type { ServerToken } from './types.js';
+
+/**
+ * Unit tests for the phrase-create selection validator (T-14.3a).
+ *
+ * The validator gates the shift-click gesture in
+ * `ChapterBody.svelte` — these cases pin its boundary behaviour
+ * so future drag-select / touch-press flows can re-use the same
+ * helper without re-deriving the rules.
+ */
+
+function tok(
+  idx: number,
+  surface: string,
+  opts: { isWord?: boolean } = {},
+): ServerToken {
+  return {
+    id: `t-${idx}`,
+    idx,
+    surface,
+    isWord: opts.isWord ?? true,
+    isAmbiguous: false,
+    isOov: false,
+    lemmaId: null,
+    romanization: null,
+    glossDefault: null,
+    candidates: [],
+    numberForms: null,
+    status: 'unknown',
+  };
+}
+
+describe('SENTENCE_END_RE', () => {
+  it('matches Devanagari, Odia, and Western sentence-end marks', () => {
+    expect(SENTENCE_END_RE.test('।')).toBe(true);
+    expect(SENTENCE_END_RE.test('॥')).toBe(true);
+    expect(SENTENCE_END_RE.test('.')).toBe(true);
+    expect(SENTENCE_END_RE.test('!')).toBe(true);
+    expect(SENTENCE_END_RE.test('?')).toBe(true);
+    // Quoted sentence-end punctuation is matched too — the
+    // resolver doesn't distinguish "." from `."`.
+    expect(SENTENCE_END_RE.test('".')).toBe(true);
+  });
+
+  it('does not match commas or interior punctuation', () => {
+    expect(SENTENCE_END_RE.test(',')).toBe(false);
+    expect(SENTENCE_END_RE.test(';')).toBe(false);
+    expect(SENTENCE_END_RE.test('-')).toBe(false);
+  });
+});
+
+describe('validatePhraseSelection', () => {
+  it('accepts a contiguous two-word run as a phrase', () => {
+    const tokens = [
+      tok(0, 'मैंने'),
+      tok(1, 'इंतज़ार'),
+      tok(2, 'किया'),
+      tok(3, '।', { isWord: false }),
+    ];
+    const result = validatePhraseSelection(tokens, 1, 2);
+    expect(result.kind).toBe('ok');
+    if (result.kind !== 'ok') throw new Error('unreachable');
+    expect(result.surfaces).toEqual(['इंतज़ार', 'किया']);
+    expect(result.rangeIdx).toEqual({ start: 1, end: 2 });
+  });
+
+  it('skips non-word punctuation tokens between selected words', () => {
+    const tokens = [
+      tok(0, 'और'),
+      tok(1, 'इंतज़ार'),
+      tok(2, ',', { isWord: false }),
+      tok(3, 'किया'),
+    ];
+    const result = validatePhraseSelection(tokens, 1, 3);
+    expect(result.kind).toBe('ok');
+    if (result.kind !== 'ok') throw new Error('unreachable');
+    // Comma is dropped — only the two words contribute to surfaces.
+    expect(result.surfaces).toEqual(['इंतज़ार', 'किया']);
+  });
+
+  it('rejects a single-token "range"', () => {
+    const tokens = [tok(0, 'a'), tok(1, 'b')];
+    const result = validatePhraseSelection(tokens, 0, 0);
+    expect(result.kind).toBe('error');
+    if (result.kind !== 'error') throw new Error('unreachable');
+    expect(result.message).toMatch(/at least two/);
+  });
+
+  it('rejects a selection that crosses a sentence-ending mark', () => {
+    const tokens = [
+      tok(0, 'इंतज़ार'),
+      tok(1, '।', { isWord: false }),
+      tok(2, 'किया'),
+    ];
+    const result = validatePhraseSelection(tokens, 0, 2);
+    expect(result.kind).toBe('error');
+    if (result.kind !== 'error') throw new Error('unreachable');
+    expect(result.message).toMatch(/sentence/);
+  });
+
+  it('rejects a selection that crosses a Western period', () => {
+    const tokens = [
+      tok(0, 'I'),
+      tok(1, 'wait'),
+      tok(2, '.', { isWord: false }),
+      tok(3, 'Then'),
+    ];
+    const result = validatePhraseSelection(tokens, 1, 3);
+    expect(result.kind).toBe('error');
+  });
+
+  it('accepts the reversed range (target before anchor)', () => {
+    const tokens = [
+      tok(0, 'मैंने'),
+      tok(1, 'इंतज़ार'),
+      tok(2, 'किया'),
+    ];
+    // Click order shouldn't matter — the helper canonicalises on lo/hi.
+    const result = validatePhraseSelection(tokens, 2, 0);
+    expect(result.kind).toBe('ok');
+    if (result.kind !== 'ok') throw new Error('unreachable');
+    expect(result.surfaces).toEqual(['मैंने', 'इंतज़ार', 'किया']);
+    expect(result.rangeIdx).toEqual({ start: 0, end: 2 });
+  });
+
+  it('rejects a selection that exceeds 8 words', () => {
+    // Build 10 word tokens so the range is too long.
+    const tokens = Array.from({ length: 10 }, (_, i) => tok(i, `w${i}`));
+    const result = validatePhraseSelection(tokens, 0, 9);
+    expect(result.kind).toBe('error');
+    if (result.kind !== 'error') throw new Error('unreachable');
+    expect(result.message).toMatch(/8 words/);
+  });
+
+  it('rejects a selection where every interior token is non-word', () => {
+    // Pure-punctuation range (e.g. clicking across only commas)
+    // results in fewer than two surfaces — caught by the
+    // MIN_PHRASE_TOKENS guard.
+    const tokens = [
+      tok(0, ',', { isWord: false }),
+      tok(1, ' ', { isWord: false }),
+      tok(2, ',', { isWord: false }),
+    ];
+    const result = validatePhraseSelection(tokens, 0, 2);
+    expect(result.kind).toBe('error');
+  });
+});

--- a/apps/web/src/lib/components/reader/phrase-selection.ts
+++ b/apps/web/src/lib/components/reader/phrase-selection.ts
@@ -1,0 +1,81 @@
+/**
+ * Phrase-create selection helpers (T-14.3a).
+ *
+ * The shift-click gesture in `ChapterBody.svelte` produces a
+ * `[anchorIdx, targetIdx]` range over the chapter's tokens; this
+ * helper validates the range and projects it to the surfaces +
+ * idx range that `WordPopup` needs to drive its phrase-create
+ * banner. Extracted as a pure function so the validation
+ * (sentence-boundary refusal, MIN/MAX token count) can be tested
+ * independently of the Svelte component plumbing.
+ *
+ * Sentence-boundary detection uses a regex over Devanagari /
+ * Indic / Western sentence-ending marks. The resolver in T-14.2
+ * remains the source of truth on the server; this is a client-
+ * side preflight so a user gets immediate feedback rather than
+ * "the phrase saved but never shows up".
+ */
+import type { ServerToken } from './types.js';
+
+/** Sentence-ending marks across the three MVP scripts plus the
+ *  Western punctuation that creeps in via translated content. */
+export const SENTENCE_END_RE = /[।॥.!?]/u;
+
+export type SelectionValidationResult =
+  | {
+      kind: 'ok';
+      surfaces: string[];
+      rangeIdx: { start: number; end: number };
+    }
+  | { kind: 'error'; message: string };
+
+/**
+ * Validate the user's shift-click range against:
+ *  - same-token rejection (single-token isn't a phrase),
+ *  - MIN / MAX token count (2..8 — matches `phrases.ts`),
+ *  - sentence-boundary refusal — any non-word token *between*
+ *    the anchor and the target whose surface contains a
+ *    sentence-ending mark fails the selection.
+ *
+ * `tokens` should be the full chapter token list in idx order;
+ * the helper iterates over it to gather surfaces. Punctuation
+ * tokens between anchor and target are skipped from the
+ * surfaces list (the matcher in T-14.2 only matches words).
+ */
+export function validatePhraseSelection(
+  tokens: ServerToken[],
+  anchorIdx: number,
+  targetIdx: number,
+): SelectionValidationResult {
+  const lo = Math.min(anchorIdx, targetIdx);
+  const hi = Math.max(anchorIdx, targetIdx);
+  if (lo === hi) {
+    return { kind: 'error', message: 'Select at least two words.' };
+  }
+  for (const t of tokens) {
+    if (t.idx <= lo || t.idx >= hi) continue;
+    if (!t.isWord && SENTENCE_END_RE.test(t.surface)) {
+      return {
+        kind: 'error',
+        message: 'Phrases must stay within a sentence.',
+      };
+    }
+  }
+  const surfaces: string[] = [];
+  for (const t of tokens) {
+    if (t.idx < lo || t.idx > hi) continue;
+    if (!t.isWord) continue;
+    surfaces.push(t.surface);
+  }
+  if (surfaces.length < 2) {
+    return { kind: 'error', message: 'Select at least two words.' };
+  }
+  if (surfaces.length > 8) {
+    return { kind: 'error', message: 'Phrases cannot exceed 8 words.' };
+  }
+  return {
+    kind: 'ok',
+    surfaces,
+    rangeIdx: { start: lo, end: hi },
+  };
+}


### PR DESCRIPTION
## Summary

Reader-side phrase creation: shift-clicking a token while another
is selected opens the popup in "Create phrase" mode listing the
selected surfaces with Save / Cancel buttons. Save POSTs to
`/api/v1/phrases` (T-14.1) and closes the popup; the next
chapter open / route navigation surfaces the new phrase.
**Stacks on T-14.3 (#355) + T-14.4 (#362)** for the popup
phrase-mode infrastructure this builds on.

Drag-select (mousedown + move + up across tokens) is a smaller
state-machine change filed as its own follow-up (T-14.3b);
shift-click already covers the keyboard-or-deliberate UX intent.

## What it does

- **`phrase-selection.ts`** (new) — pure
  `validatePhraseSelection(tokens, anchorIdx, targetIdx)`
  returning `{ kind: 'ok', surfaces, rangeIdx }` or
  `{ kind: 'error', message }`. Rules: same-sentence refusal
  (Devanagari `।`, `॥` + Western `.`, `!`, `?`), MIN/MAX token
  count (2..8 to match `phrases.ts`), skip non-word tokens
  between selected words. Extracted so the rules can be unit-
  tested without the Svelte shell.
- **`ChapterBody.svelte`** — `pendingSelection` /
  `selectionError` state; `onChapterClick` honours
  `event.shiftKey` + an existing `activeToken` to build the
  pending selection. Falls through to the regular click on
  validation failure so the user's click is never lost.
- **`WordPopup.svelte`** — new `pendingSelection` /
  `selectionError` props and an `onPhraseCreated` callback. When
  `pendingSelection` is set, a Create-phrase banner shows
  surfaces + Save / Cancel; Save calls
  `POST /api/v1/phrases` → fires `onPhraseCreated` on success,
  surfaces inline error on failure.

## Out of scope (T-14.3b — small follow-up)

- Drag-select gesture (mousedown + move + up across tokens).
  The state machine has to suppress click-on-release and handle
  touch-cancel; isolating it from this PR keeps the diff
  scannable.
- Chapter-span refetch after phrase create. Currently the popup
  closes on success and the user navigates back to see the new
  highlight. Wiring a SvelteKit `invalidate` through the popup
  callback is the small follow-up.

## Test plan

- [x] `pnpm --filter @ciareader/web test` — 1143 tests pass
  (+10 phrase-selection unit tests).
- [x] `pnpm --filter @ciareader/web typecheck` — 0 errors.
- [x] `pnpm --filter @ciareader/web lint` — clean.
- [ ] Manual: shift-click two words in the reader, save phrase,
  reload — phrase highlights via T-14.2's resolver.

Refs T-14.3 (#355) + T-14.4 (#362). Closes #356. Refs Epic
#327.