### PR TITLE
chore: auto-load apps/web/.env in standalone scripts and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,11 @@ clean:
 # Native dev: data services in docker, web + nlp on the host. Use when
 # docker buildx can't reach pypi/npm registries (corp DNS, VPN, etc.).
 #
-# Each var defers to the caller's environment first (`${VAR:-default}` shell
-# expansion) so you can override any value via `export FOO=...` in your shell
-# or a per-command prefix (`FOO=... make dev-native-db`). The defaults match
-# the docker-compose host-port defaults.
+# Recipes auto-source apps/web/.env first (the same file Vite, drizzle-kit
+# and the standalone scripts read), then fall back to defaults via
+# `${VAR:-default}` shell expansion. So setting DATABASE_URL once in
+# apps/web/.env is enough — no need to export anything in your shell.
+NATIVE_DOTENV = set -a; [ -f apps/web/.env ] && . apps/web/.env; set +a;
 NATIVE_ENV = \
 	NLP_SERVICE_URL=$${NLP_SERVICE_URL:-http://localhost:8000} \
 	DATABASE_URL=$${DATABASE_URL:-postgres://ciareader:ciareader@localhost:5432/ciareader} \
@@ -70,10 +71,10 @@ dev-native-down:
 	docker compose -f infra/docker-compose.yml stop postgres redis mailpit
 
 dev-native-db:
-	cd apps/web && $(NATIVE_ENV) pnpm exec drizzle-kit migrate
+	$(NATIVE_DOTENV) cd apps/web && $(NATIVE_ENV) pnpm exec drizzle-kit migrate
 
 dev-native-nlp:
 	cd services/nlp && PYTHONPATH=../../packages/shared-types/python:. .venv/bin/uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
 
 dev-native-web:
-	cd apps/web && $(NATIVE_ENV) pnpm dev
+	$(NATIVE_DOTENV) cd apps/web && $(NATIVE_ENV) pnpm dev

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -38,6 +38,7 @@
     "@types/node": "^22.7.5",
     "@types/nodemailer": "^6.4.16",
     "@vitest/coverage-v8": "^2.1.3",
+    "dotenv": "^16.4.5",
     "drizzle-kit": "^0.26.2",
     "eslint": "^9.12.0",
     "eslint-plugin-svelte": "^2.44.1",

--- a/apps/web/scripts/import-dictionary.ts
+++ b/apps/web/scripts/import-dictionary.ts
@@ -15,6 +15,10 @@
  * `(language, source, source_id)` and writes a `dictionary_imports`
  * audit row each run.
  */
+import { config as loadEnv } from 'dotenv';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
 import { drizzle } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
 
@@ -22,6 +26,8 @@ import * as schema from '../src/lib/server/db/schema.js';
 import { dictionarySources, findSource } from '../src/lib/server/dictionary/sources/index.js';
 import { DrizzleDictionaryRepo } from '../src/lib/server/dictionary/drizzle-repo.js';
 import { runDictionaryImport } from '../src/lib/server/dictionary/runner.js';
+
+loadEnv({ path: resolve(dirname(fileURLToPath(import.meta.url)), '..', '.env') });
 
 // The runtime `db/index.ts` reads its DATABASE_URL through SvelteKit's
 // `$env/dynamic/private`, which only resolves inside a SvelteKit

--- a/apps/web/scripts/reprocess-text.mjs
+++ b/apps/web/scripts/reprocess-text.mjs
@@ -8,9 +8,15 @@
 // Reads DATABASE_URL + NLP_SERVICE_URL from the environment with the
 // same defaults as $lib/server/env.ts.
 
+import { config as loadEnv } from 'dotenv';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
 import postgres from 'postgres';
 import { drizzle } from 'drizzle-orm/postgres-js';
 import { eq } from 'drizzle-orm';
+
+loadEnv({ path: resolve(dirname(fileURLToPath(import.meta.url)), '..', '.env') });
 
 const DATABASE_URL =
   process.env.DATABASE_URL ??

--- a/apps/web/scripts/seed-form-overrides.mjs
+++ b/apps/web/scripts/seed-form-overrides.mjs
@@ -11,7 +11,13 @@
 // Usage:
 //   node apps/web/scripts/seed-form-overrides.mjs
 
+import { config as loadEnv } from 'dotenv';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
 import postgres from 'postgres';
+
+loadEnv({ path: resolve(dirname(fileURLToPath(import.meta.url)), '..', '.env') });
 
 const DATABASE_URL =
   process.env.DATABASE_URL ??

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^2.1.3
         version: 2.1.9(vitest@2.1.9(@types/node@22.19.17)(jsdom@25.0.1))
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.6.1
       drizzle-kit:
         specifier: ^0.26.2
         version: 0.26.2
@@ -1478,6 +1481,10 @@ packages:
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
 
   drizzle-kit@0.26.2:
     resolution: {integrity: sha512-cMq8omEKywjIy5KcqUo6LvEFxkl8/zYHsgYjFVXjmPWWtuW4blcz+YW9+oIhoaALgs2ebRjzXwsJgN9i6P49Dw==}
@@ -3600,6 +3607,8 @@ snapshots:
   devalue@5.7.1: {}
 
   dom-accessibility-api@0.5.16: {}
+
+  dotenv@16.6.1: {}
 
   drizzle-kit@0.26.2:
     dependencies:


### PR DESCRIPTION
## Summary

Follow-up to #365. The compose stack and SvelteKit/drizzle-kit already auto-load `apps/web/.env`, but the three standalone scripts under `apps/web/scripts/` and the Makefile's `dev-native-*` recipes don't — so overriding `DATABASE_URL` (e.g. to use a non-default Postgres host port) still required exporting it in the shell or prefixing every command. After this PR, every entry point reads the same `.env`.

- **`apps/web/package.json`** — add `dotenv ^16.4.5` to devDependencies.
- **`apps/web/scripts/{import-dictionary.ts,reprocess-text.mjs,seed-form-overrides.mjs}`** — load `apps/web/.env` via an explicit path derived from the script's own location (`dirname(import.meta.url) + '/..'`). That way the loader works whether the script is invoked from `apps/web/` (e.g. `pnpm dictionary:import`) or from the repo root (e.g. `node apps/web/scripts/reprocess-text.mjs <textId>`, as the script's own header suggests).
- **`Makefile`** — new `NATIVE_DOTENV` macro that sources `apps/web/.env` in each `dev-native-{db,web}` recipe before `NATIVE_ENV`'s `${VAR:-default}` expansion runs. `set -a` / `set +a` wraps the source so every key in the `.env` is exported to the recipe's child shell, and the `[ -f apps/web/.env ]` guard means a fresh checkout with no `.env` still works (defaults apply).

`dev-native-nlp` is unchanged — it doesn't read web-app env vars.

## Test plan

- [x] `make -n dev-native-db` emits `set -a; [ -f apps/web/.env ] && . apps/web/.env; set +a; cd apps/web && ... pnpm exec drizzle-kit migrate`.
- [x] With a synthetic `apps/web/.env` containing `DATABASE_URL=postgres://from-env:55432/db`, the recipe shell sees that value via `${DATABASE_URL:-default}` (verified via `bash -c '<sourced recipe>'`).
- [x] The dotenv loader in scripts resolves `apps/web/.env` correctly when invoked from both `apps/web/` and the repo root (verified with a synthetic `TEST_MARKER` env var).
- [x] `node --check` on both `.mjs` scripts; `tsx` import smoke-test on `import-dictionary.ts` — no syntax/import errors.
- [ ] Reviewer: confirm `pnpm dictionary:import` still works when `apps/web/.env` is absent (defaults should apply).