### PR TITLE
T-2.8a: number-to-words negative + decimal support

### DIFF
--- a/apps/web/src/lib/components/reader/WordPopup.test.ts
+++ b/apps/web/src/lib/components/reader/WordPopup.test.ts
@@ -34,15 +34,18 @@ afterEach(() => {
     .forEach((el) => el.remove());
 });
 
-function makeNumberForms(): ServerNumberForms {
+function makeNumberForms(
+  overrides: Partial<ServerNumberForms> = {},
+): ServerNumberForms {
   return {
-    value: 123,
+    value: '123',
     digitsLatin: '123',
     digitsDeva: '१२३',
     digitsOrya: '୧୨୩',
     hi: { spelled: 'एक सौ तेईस', romanized: 'ek sau teīs' },
     mr: { spelled: 'एकशे तेवीस', romanized: 'ēkaśē tēvīsa' },
     odia: { spelled: 'ଏକ ଶହ ତେଇଶ', romanized: 'ēka śaha tēiśa' },
+    ...overrides,
   };
 }
 
@@ -133,6 +136,49 @@ describe('WordPopup — number-only token block (T-2.8)', () => {
     expect(
       document.body.querySelector('[data-testid="word-popup"]'),
     ).not.toBeNull();
+  });
+
+  it('renders a negative + decimal value end-to-end (T-2.8a)', () => {
+    // The Python parser emits the canonical sign + decimal in
+    // digitsLatin / digitsDeva / digitsOrya, and the spelled-out
+    // form already includes the language minus / point words. The
+    // popup template just renders strings, so a `-3.14` token shows
+    // the signed/decimal Latin digits in the heading and the
+    // "ऋण ... दशमलव ..." spelled-out block in the body.
+    render(WordPopup, {
+      token: makeToken({
+        surface: '-3.14',
+        numberForms: makeNumberForms({
+          value: '-3.14',
+          digitsLatin: '-3.14',
+          digitsDeva: '-३.१४',
+          digitsOrya: '-୩.୧୪',
+          hi: {
+            spelled: 'ऋण तीन दशमलव एक चार',
+            romanized: 'r̥ṇ tīn daśamlav ek cār',
+          },
+          mr: {
+            spelled: 'उणे तीन दशांश एक चार',
+            romanized: 'uṇē tīna daśāṁśa ēka cāra',
+          },
+          odia: {
+            spelled: 'ଋଣ ତିନି ଦଶମିକ ଏକ ଚାରି',
+            romanized: 'r̥ṇa tini daśamika ēka cāri',
+          },
+        }),
+      }),
+      language: 'hi',
+      isOwner: true,
+      onClose: vi.fn(),
+    });
+    const heading = document.body.querySelector('.num-title');
+    // Latin + native digits both carry the sign + decimal point.
+    expect(heading?.textContent).toContain('-3.14');
+    expect(heading?.textContent).toContain('-३.१४');
+    const block = document.body.querySelector('[data-testid="number-forms"]');
+    expect(block?.textContent).toContain('ऋण');
+    expect(block?.textContent).toContain('दशमलव');
+    expect(block?.textContent).toContain('ऋण तीन दशमलव एक चार');
   });
 
   it('shows a reprocess hint for legacy number tokens whose numberForms column is null', () => {

--- a/apps/web/src/lib/components/reader/WordTooltip.test.ts
+++ b/apps/web/src/lib/components/reader/WordTooltip.test.ts
@@ -107,7 +107,7 @@ describe('WordTooltip — number tokens (T-2.8)', () => {
       lemmaId: null,
       romanization: '123',
       numberForms: {
-        value: 123,
+        value: '123',
         digitsLatin: '123',
         digitsDeva: '१२३',
         digitsOrya: '୧୨୩',

--- a/apps/web/src/lib/components/reader/types.test.ts
+++ b/apps/web/src/lib/components/reader/types.test.ts
@@ -8,8 +8,9 @@ import {
   tokenize,
 } from './types.js';
 
-describe('looksLikeNumberToken (T-2.8)', () => {
+describe('looksLikeNumberToken (T-2.8 / T-2.8a)', () => {
   it.each([
+    // T-2.8: unsigned positive integers, with or without comma groups.
     '0',
     '123',
     '1,000',
@@ -21,6 +22,20 @@ describe('looksLikeNumberToken (T-2.8)', () => {
     '१,००,०००',
     '୧୨୩',
     '୧,୨୩୪',
+    // T-2.8a: signed integers (ASCII `-` and U+2212).
+    '-1',
+    '-123',
+    '−5',
+    '-१२३',
+    // T-2.8a: decimals (no leading or trailing dot).
+    '0.5',
+    '3.14',
+    '0.001',
+    '३.१४',
+    '୦.୫',
+    // T-2.8a: signed + decimal.
+    '-2.5',
+    '−2.5',
   ])('accepts %s', (s) => {
     expect(looksLikeNumberToken(s)).toBe(true);
   });
@@ -32,12 +47,22 @@ describe('looksLikeNumberToken (T-2.8)', () => {
     '१23', // mixed script
     '1२3',
     '1,२३४', // mixed script across comma groups
-    '-1',
-    '1.5',
+    // T-2.8a malformed — intentionally rejected.
+    '1.', // trailing dot
+    '.5', // leading dot
+    '1.2.3', // multiple dots
+    '-', // lonely sign
+    '−', // lonely U+2212
+    '--1', // doubled sign
+    '1,000.5', // comma + decimal — neither parser accepts
+    '१.5', // mixed script across the decimal
+    '1.२',
     ',1',
     '1,',
     '1,,000',
     ',',
+    '-,1',
+    '-1,',
   ])('rejects %s', (s) => {
     expect(looksLikeNumberToken(s)).toBe(false);
   });

--- a/apps/web/src/lib/components/reader/types.ts
+++ b/apps/web/src/lib/components/reader/types.ts
@@ -21,26 +21,57 @@ export type ServerCandidate = {
   features: Record<string, string>;
 };
 
-/** T-2.8: cheap surface-level detector — does this token *look* like a
- *  digit-only number, possibly with thousands / lakh separators?
+/** T-2.8 / T-2.8a: cheap surface-level detector — does this token
+ *  *look* like a numeric token? Accepts:
+ *
+ *   - unsigned positive integers, optionally with thousands / lakh
+ *     comma separators (`"123"`, `"1,000"`, `"10,00,000"`);
+ *   - T-2.8a signed integers (`"-12"`, `"−5"` with U+2212);
+ *   - T-2.8a decimals (`"3.14"`, `"0.001"`, `"-2.5"`).
+ *
  *  Latin (0–9), Devanagari (०–९), and Odia (୦–୯) digit ranges all
- *  qualify. Mixed-script doesn't. Used both by the dispatcher (skip
- *  lemma auto-create for these surfaces so the lemmas table doesn't
- *  fill with "1,013,322"-style entries) and by the popup / tooltip
- *  (treat as a number even when the older `numberForms` column is
- *  null because the chapter was processed before the comma fix
- *  landed). The full Python parser in `services/nlp/app/numbers.py`
- *  is the source of truth for actually generating the spelled-out
- *  forms; this helper just gates UI branching on the client. */
-// Each alternation pins a single script across all comma-separated
-// groups so mixed-script input ("1,२३४") doesn't sneak through.
-const _NUMBER_RE =
-  /^(?:[0-9]+(?:,[0-9]+)*|[०-९]+(?:,[०-९]+)*|[୦-୯]+(?:,[୦-୯]+)*)$/u;
+ *  qualify; each alternation pins a single script so mixed-script
+ *  input (`"1,२३४"`, `"१.5"`) doesn't sneak through. Comma separators
+ *  combined with a decimal point (e.g. `"1,000.5"`) are intentionally
+ *  out of scope — neither the unsigned-integer nor the signed-decimal
+ *  parser accepts that shape, and treating it as numeric here would
+ *  desynchronize the UI from the Python parser.
+ *
+ *  Used both by the dispatcher (skip lemma auto-create for these
+ *  surfaces so the lemmas table doesn't fill with "1,013,322"-style
+ *  entries) and by the popup / tooltip (treat as a number even when
+ *  the older `numberForms` column is null because the chapter was
+ *  processed before the comma / sign / decimal support landed). The
+ *  full Python parser in `services/nlp/app/numbers.py` is the source
+ *  of truth for actually generating the spelled-out forms; this
+ *  helper just gates UI branching on the client.
+ */
+// Two alternatives per script:
+//   - integer with optional comma groups (no decimal point)
+//   - integer + decimal point + fractional digits (no commas)
+// Both wrapped in an optional leading sign (ASCII `-` or U+2212).
+const _NUMBER_RE = new RegExp(
+  '^[-−]?(?:' +
+    '[0-9]+(?:,[0-9]+)*|[0-9]+\\.[0-9]+' +
+    '|[०-९]+(?:,[०-९]+)*|[०-९]+\\.[०-९]+' +
+    '|[୦-୯]+(?:,[୦-୯]+)*|[୦-୯]+\\.[୦-୯]+' +
+  ')$',
+  'u',
+);
 export function looksLikeNumberToken(surface: string): boolean {
   if (!surface) return false;
-  // Reject leading / trailing comma without paying for a regex run.
-  if (surface.startsWith(',') || surface.endsWith(',')) return false;
-  if (surface.includes(',,')) return false;
+  // Strip an optional leading sign before the comma-shape checks so
+  // `-,1` and `-1,` etc. still get rejected the same way as `,1` /
+  // `1,`.
+  const body =
+    surface.startsWith('-') || surface.startsWith('−')
+      ? surface.slice(1)
+      : surface;
+  if (!body) return false;
+  // Reject leading / trailing comma + doubled commas without paying
+  // for a regex run.
+  if (body.startsWith(',') || body.endsWith(',')) return false;
+  if (body.includes(',,')) return false;
   return _NUMBER_RE.test(surface);
 }
 
@@ -53,7 +84,10 @@ export type ServerNumberLanguageForm = {
 };
 
 export type ServerNumberForms = {
-  value: number;
+  /** Canonical Latin-digit string form. T-2.8a widened this from
+   *  number to string so signed + decimal numerals (`"-3.14"`,
+   *  `"0.001"`) round-trip without floating-point drift. */
+  value: string;
   digitsLatin: string;
   digitsDeva: string;
   digitsOrya: string;

--- a/apps/web/src/lib/server/db/schema.ts
+++ b/apps/web/src/lib/server/db/schema.ts
@@ -1157,7 +1157,7 @@ export const textTokens = pgTable(
      *  `NumberForms` in the Python NLP service (services/nlp/app/numbers.py)
      *  and is delivered verbatim by the in-process dispatcher. */
     numberForms: jsonb('number_forms').$type<{
-      value: number;
+      value: string;
       digits_latin: string;
       digits_deva: string;
       digits_orya: string;

--- a/apps/web/src/lib/server/nlp-client.ts
+++ b/apps/web/src/lib/server/nlp-client.ts
@@ -13,9 +13,14 @@ export interface NumberLanguageForm {
 }
 
 /** Per-token number-form payload populated by the NLP service for
- *  digit-only NUM tokens (T-2.8). Null on every other token. */
+ *  digit-only NUM tokens (T-2.8 / T-2.8a). Null on every other token.
+ *
+ *  `value` is the canonical Latin-digit string form so signed +
+ *  decimal numerals (T-2.8a) round-trip losslessly: `"-3.14"`,
+ *  `"0.001"`, `"123"` are all valid. The integer part is bounded by
+ *  10⁷; the fractional part may be arbitrarily long. */
 export interface NumberForms {
-  value: number;
+  value: string;
   digits_latin: string;
   digits_deva: string;
   digits_orya: string;

--- a/apps/web/src/lib/server/texts/in-process-dispatcher.test.ts
+++ b/apps/web/src/lib/server/texts/in-process-dispatcher.test.ts
@@ -168,7 +168,7 @@ describe('processTextNow', () => {
           is_oov: false,
           romanization: 'bolnā',
           number_forms: {
-            value: 123,
+            value: '123',
             digits_latin: '123',
             digits_deva: '१२३',
             digits_orya: '୧୨୩',
@@ -209,11 +209,11 @@ describe('processTextNow', () => {
       lemmaId: string | null;
       surface: string;
       romanization: string | null;
-      numberForms: { value: number } | null;
+      numberForms: { value: string } | null;
     }>;
     expect(firstInsert[0]!.lemmaId).toBe('lemma-bolnaa');
     expect(firstInsert[0]!.romanization).toBe('bolnā');
-    expect(firstInsert[0]!.numberForms?.value).toBe(123);
+    expect(firstInsert[0]!.numberForms?.value).toBe('123');
 
     const secondInsert = (inserts[1] as Extract<Call, { kind: 'insert' }>).values as Array<{
       lemmaId: string | null;
@@ -360,7 +360,7 @@ describe('processTextNow', () => {
           is_oov: false,
           romanization: '1,013,322',
           number_forms: {
-            value: 1_013_322,
+            value: '1013322',
             digits_latin: '1,013,322',
             digits_deva: '१,०१३,३२२',
             digits_orya: '୧,୦୧୩,୩୨୨',
@@ -385,11 +385,11 @@ describe('processTextNow', () => {
     const tokenInsert = inserts[0]!.values as Array<{
       lemmaId: string | null;
       surface: string;
-      numberForms: { value: number } | null;
+      numberForms: { value: string } | null;
     }>;
     expect(tokenInsert[0]!.lemmaId).toBeNull();
     expect(tokenInsert[0]!.surface).toBe('1,013,322');
-    expect(tokenInsert[0]!.numberForms?.value).toBe(1_013_322);
+    expect(tokenInsert[0]!.numberForms?.value).toBe('1013322');
   });
 
   it('resolves a post-#316 nukta candidate onto an existing pre-#316 lemma row (#320)', async () => {

--- a/apps/web/src/lib/server/texts/tokens.test.ts
+++ b/apps/web/src/lib/server/texts/tokens.test.ts
@@ -92,7 +92,7 @@ describe('loadChapterTokens', () => {
         surface: '123',
         lemmaId: null,
         numberForms: {
-          value: 123,
+          value: '123',
           digits_latin: '123',
           digits_deva: '१२३',
           digits_orya: '୧୨୩',
@@ -106,7 +106,7 @@ describe('loadChapterTokens', () => {
     expect(result![0]).toMatchObject({
       id: 'num-1',
       numberForms: {
-        value: 123,
+        value: '123',
         digitsLatin: '123',
         digitsDeva: '१२३',
         digitsOrya: '୧୨୩',

--- a/apps/web/src/lib/server/texts/tokens.ts
+++ b/apps/web/src/lib/server/texts/tokens.ts
@@ -48,7 +48,10 @@ export type RenderedNumberLanguageForm = {
 };
 
 export type RenderedNumberForms = {
-  value: number;
+  /** Canonical Latin-digit string form. T-2.8a widened this from
+   *  number to string so signed + decimal numerals (`"-3.14"`,
+   *  `"0.001"`) round-trip without floating-point drift. */
+  value: string;
   digitsLatin: string;
   digitsDeva: string;
   digitsOrya: string;

--- a/services/nlp/app/numbers.py
+++ b/services/nlp/app/numbers.py
@@ -9,9 +9,12 @@ romanization in each of the three MVP languages (Hindi, Marathi, Odia).
 
 Range
 =====
-Non-negative integers from 0 through 10⁷ (one crore) inclusive. Numbers
-larger than that, signed numbers, and decimals fall through (T-2.8a
-will lift those last two).
+Integer-part values from 0 through 10⁷ (one crore) inclusive — the
+sign-and-decimal extensions added in T-2.8a respect the same cap on
+the integer part but accept an arbitrarily long fractional part
+(each digit pronounced individually, English-style). Out-of-range
+integer parts and unsupported shapes (mixed scripts, multiple decimal
+points, lonely sign or decimal point) fall through.
 
 Linguistic notes
 ================
@@ -42,6 +45,7 @@ the same scheme as the rest of the popup.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Literal
 
 from app.romanize import to_roman
@@ -571,10 +575,188 @@ def to_words_or(n: int) -> str:
 
 
 # ----------------------------------------------------------------
+# T-2.8a — sign + decimal extensions
+# ----------------------------------------------------------------
+
+#: Sign component of a parsed numeric token. Always populated even
+#: for unsigned input (defaults to ``"+"``).
+Sign = Literal["+", "-"]
+
+#: Accepted minus characters: ASCII hyphen-minus and U+2212 MINUS SIGN.
+#: Plus signs are not accepted — leading ``+`` falls through.
+_NEG_SIGNS: tuple[str, ...] = ("-", "−")
+
+#: ASCII full stop is the only accepted decimal point. The Devanagari
+#: danda (U+0964) is sentence punctuation, not a decimal separator,
+#: even when surrounded by Devanagari digits.
+_DECIMAL_POINT: str = "."
+
+# Per-language "minus" prefix for negatives. Curator-confirmed before
+# T-2.8a sign-off — these are loanwords from Sanskrit ``ṛṇa`` (debt /
+# negative) common in mathematical registers; ``-3`` in Hindi reads
+# as ``ऋण तीन``.
+_HI_NEG: str = "ऋण"
+_MR_NEG: str = "उणे"
+_OR_NEG: str = "ଋଣ"
+_NEG_WORDS: dict[str, str] = {"hi": _HI_NEG, "mr": _MR_NEG, "or": _OR_NEG}
+
+# Per-language "point" word for decimals. Curator-confirmed.
+# Hindi/Marathi use Sanskrit-derived ``daśamlava`` / ``daśāṁśa``;
+# Odia uses ``daśamika``. Each is the standard mathematical register.
+_HI_POINT: str = "दशमलव"
+_MR_POINT: str = "दशांश"
+_OR_POINT: str = "ଦଶମିକ"
+_POINT_WORDS: dict[str, str] = {"hi": _HI_POINT, "mr": _MR_POINT, "or": _OR_POINT}
+
+
+def parse_number(surface: str) -> tuple[Sign, int, str | None] | None:
+    """Parse a possibly signed and/or decimal numeric surface (T-2.8a).
+
+    Returns ``(sign, integer, fractional)`` where:
+
+    * ``sign`` is ``"+"`` for unsigned input, ``"-"`` when the surface
+      begins with ASCII ``-`` or U+2212 MINUS SIGN.
+    * ``integer`` is the absolute value of the integer part, bounded
+      by :data:`MAX_VALUE`.
+    * ``fractional`` is the fractional digits as a Latin-digit string
+      (so ``"0.001"`` round-trips with the leading zeros intact), or
+      ``None`` when no decimal point was present.
+
+    Returns ``None`` for unparseable, mixed-script, or out-of-range
+    input. ``1,000``-style thousands separators are out of scope here
+    — the unsigned integer path with separators lives in
+    :func:`parse_digits`. ``number_forms`` glues the two together.
+
+    The decimal point is ASCII ``.`` only. Both the integer and
+    fractional parts must each be non-empty and from a single script,
+    and they must both be from the *same* script.
+    """
+    if not surface:
+        return None
+
+    # Sign — single optional leading minus, no leading plus, no
+    # multiple sign characters.
+    sign: Sign = "+"
+    if surface[0] in _NEG_SIGNS:
+        sign = "-"
+        surface = surface[1:]
+        if not surface:
+            return None  # lonely "-" / "−"
+    if any(c in _NEG_SIGNS for c in surface):
+        return None  # "--1", "1-2", trailing "-", etc.
+
+    # Comma-grouping is a separate path; reject here so misuse like
+    # "-1,000" doesn't silently lose the negative.
+    if "," in surface:
+        return None
+
+    # Decimal split. Decimal requires both sides to be non-empty.
+    int_part_str: str
+    frac_part_str: str | None
+    if _DECIMAL_POINT in surface:
+        if surface.count(_DECIMAL_POINT) > 1:
+            return None  # "1.2.3"
+        int_part_str, frac_part_str = surface.split(_DECIMAL_POINT)
+        if not int_part_str or not frac_part_str:
+            return None  # "1." / ".5"
+    else:
+        int_part_str = surface
+        frac_part_str = None
+
+    int_script = _classify_script(int_part_str)
+    if int_script is None:
+        return None
+    if frac_part_str is not None:
+        frac_script = _classify_script(frac_part_str)
+        if frac_script is None or frac_script != int_script:
+            return None  # mixed script across the decimal
+
+    digits = _DIGIT_SETS[int_script]
+    int_value = 0
+    for c in int_part_str:
+        int_value = int_value * 10 + digits.index(c)
+    if int_value > MAX_VALUE:
+        return None
+
+    # Normalize the fractional part to Latin digits for canonical
+    # storage, preserving any leading zeros ("0.001" -> "001").
+    frac_normalized: str | None = None
+    if frac_part_str is not None:
+        frac_normalized = "".join(str(digits.index(c)) for c in frac_part_str)
+
+    return (sign, int_value, frac_normalized)
+
+
+def format_in_script(
+    sign: Sign,
+    integer: int,
+    fractional: str | None,
+    script: DigitScript,
+) -> str:
+    """Render a (possibly signed, possibly decimal) number in the
+    target script's digits. Sign uses ASCII ``-``; decimal point uses
+    ASCII ``.``. The fractional digits are mapped one-for-one — the
+    Latin-digit canonical fractional ``"001"`` becomes ``"००१"`` in
+    Devanagari, ``"୦୦୧"`` in Odia.
+    """
+    out = digits_in_script(integer, script)
+    if fractional is not None:
+        digits = _DIGIT_SETS[script]
+        out = out + _DECIMAL_POINT + "".join(digits[int(c)] for c in fractional)
+    if sign == "-":
+        out = "-" + out
+    return out
+
+
+# ----------------------------------------------------------------
 # Public entry point
 # ----------------------------------------------------------------
 
 _LANG_TO_SCRIPT: dict[str, str] = {"hi": "Deva", "mr": "Deva", "or": "Orya"}
+
+# Per-language 0-9 spelled-out forms — used for fractional digit
+# read-out (English "three point one four" style) so we don't repeat
+# the trickier <100 forms here. Slicing the existing tables keeps the
+# 0-9 source-of-truth in one place.
+_FRAC_DIGIT_WORDS: dict[str, tuple[str, ...]] = {
+    "hi": _HI_BELOW_100[:10],
+    "mr": _MR_BELOW_100[:10],
+    "or": _OR_BELOW_100[:10],
+}
+
+_INT_TO_WORDS: dict[str, Callable[[int], str]] = {
+    "hi": to_words_hi,
+    "mr": to_words_mr,
+    "or": to_words_or,
+}
+
+
+def spell(
+    sign: Sign,
+    integer: int,
+    fractional: str | None,
+    language: str,
+) -> str:
+    """Spell out a (possibly signed, possibly decimal) number in the
+    target language (T-2.8a). Format:
+
+        [<minus-word>] <integer-words> [<point-word> <digit> ...]
+
+    Negatives prefix the language's minus word (e.g. Hindi ``ऋण``).
+    Decimals append the language's point word (e.g. Hindi ``दशमलव``)
+    followed by each fractional digit pronounced individually — so
+    ``-3.14`` in Hindi reads ``ऋण तीन दशमलव एक चार``.
+    """
+    parts: list[str] = []
+    if sign == "-":
+        parts.append(_NEG_WORDS[language])
+    parts.append(_INT_TO_WORDS[language](integer))
+    if fractional is not None:
+        parts.append(_POINT_WORDS[language])
+        digit_words = _FRAC_DIGIT_WORDS[language]
+        for c in fractional:
+            parts.append(digit_words[int(c)])
+    return " ".join(parts)
 
 
 def _romanize(spelled: str, language: str) -> str:
@@ -593,35 +775,64 @@ def _language_form(spelled: str, language: str) -> NumberLanguageForm:
     )
 
 
-def number_forms(surface: str) -> NumberForms | None:
-    """Build the per-language spelled-out + romanized struct for a
-    digit-only token, or ``None`` if the surface doesn't qualify.
+def _canonical_value(sign: Sign, integer: int, fractional: str | None) -> str:
+    """Canonical Latin-digit string for the wire ``value`` field.
+    ``"-3.14"``, ``"0.001"``, ``"123"``."""
+    base = str(integer) if fractional is None else f"{integer}.{fractional}"
+    return f"-{base}" if sign == "-" else base
 
-    Qualifying input: non-empty, all-digit, single-script (Latin /
-    Devanagari / Odia), value in ``[0, MAX_VALUE]``.
-    """
-    value = parse_digits(surface)
-    if value is None:
-        return None
+
+def _build_forms(sign: Sign, integer: int, fractional: str | None) -> NumberForms:
     return NumberForms(
-        value=value,
-        digits_latin=digits_in_script(value, "latin"),
-        digits_deva=digits_in_script(value, "deva"),
-        digits_orya=digits_in_script(value, "orya"),
-        hi=_language_form(to_words_hi(value), "hi"),
-        mr=_language_form(to_words_mr(value), "mr"),
+        value=_canonical_value(sign, integer, fractional),
+        digits_latin=format_in_script(sign, integer, fractional, "latin"),
+        digits_deva=format_in_script(sign, integer, fractional, "deva"),
+        digits_orya=format_in_script(sign, integer, fractional, "orya"),
+        hi=_language_form(spell(sign, integer, fractional, "hi"), "hi"),
+        mr=_language_form(spell(sign, integer, fractional, "mr"), "mr"),
         # Wire field is ISO 639-1 ``or``; Python attribute is ``odia``
         # (``or`` is a reserved keyword).
-        odia=_language_form(to_words_or(value), "or"),
+        odia=_language_form(spell(sign, integer, fractional, "or"), "or"),
     )
+
+
+def number_forms(surface: str) -> NumberForms | None:
+    """Build the per-language spelled-out + romanized struct for a
+    numeric token, or ``None`` if the surface doesn't qualify.
+
+    Two parsing paths feed into this:
+
+    * :func:`parse_digits` — unsigned positive integers, optionally
+      with thousands / lakh comma separators (``"1,000"``, ``"10,00,000"``).
+      This path stays for backward compatibility with the chapter-
+      processor's existing surfaces.
+    * :func:`parse_number` (T-2.8a) — signed and/or decimal forms
+      without separators (``"-12"``, ``"3.14"``, ``"-2.5"``).
+
+    The two paths are tried in order; their accepted surface sets are
+    disjoint by construction (parse_digits rejects sign / decimal,
+    parse_number rejects commas) so the dispatch order doesn't matter
+    for correctness.
+    """
+    simple_value = parse_digits(surface)
+    if simple_value is not None:
+        return _build_forms("+", simple_value, None)
+    parsed = parse_number(surface)
+    if parsed is None:
+        return None
+    return _build_forms(*parsed)
 
 
 __all__ = [
     "MAX_VALUE",
     "DigitScript",
+    "Sign",
     "digits_in_script",
+    "format_in_script",
     "number_forms",
     "parse_digits",
+    "parse_number",
+    "spell",
     "to_words_hi",
     "to_words_mr",
     "to_words_or",

--- a/services/nlp/app/schemas.py
+++ b/services/nlp/app/schemas.py
@@ -35,9 +35,14 @@ class NumberForms(BaseModel):
     MVP languages so a learner can sound out a numeral without leaving
     the page (T-2.8). ``None`` on the parent :class:`Token` for any
     token that isn't a single-script digit run in ``[0, 10_000_000]``.
+
+    ``value`` carries the canonical Latin-digit string form so signed
+    + decimal numerals round-trip losslessly (T-2.8a). ``"-3.14"``,
+    ``"0.001"``, ``"123"`` are all valid; the integer part is bounded
+    by ``10_000_000`` and the fractional part may be arbitrarily long.
     """
 
-    value: int
+    value: str
     digits_latin: str
     digits_deva: str
     digits_orya: str

--- a/services/nlp/tests/test_numbers.py
+++ b/services/nlp/tests/test_numbers.py
@@ -18,8 +18,11 @@ import pytest
 from app.numbers import (
     MAX_VALUE,
     digits_in_script,
+    format_in_script,
     number_forms,
     parse_digits,
+    parse_number,
+    spell,
     to_words_hi,
     to_words_mr,
     to_words_or,
@@ -289,7 +292,10 @@ def test_below_100_sweep_non_empty(converter) -> None:
 def test_number_forms_for_123() -> None:
     nf = number_forms("123")
     assert isinstance(nf, NumberForms)
-    assert nf.value == 123
+    # T-2.8a: ``value`` is the canonical Latin-digit string form so
+    # signed + decimal numerals can round-trip without floating-point
+    # drift. Unsigned integers serialize as plain digits, no sign.
+    assert nf.value == "123"
     assert nf.digits_latin == "123"
     assert nf.digits_deva == "१२३"
     assert nf.digits_orya == "୧୨୩"
@@ -305,21 +311,21 @@ def test_number_forms_for_123() -> None:
 def test_number_forms_devanagari_input() -> None:
     nf = number_forms("१२३")
     assert nf is not None
-    assert nf.value == 123
+    assert nf.value == "123"
     assert nf.digits_latin == "123"
 
 
 def test_number_forms_odia_input() -> None:
     nf = number_forms("୧୨୩")
     assert nf is not None
-    assert nf.value == 123
+    assert nf.value == "123"
     assert nf.digits_deva == "१२३"
 
 
 def test_number_forms_zero() -> None:
     nf = number_forms("0")
     assert nf is not None
-    assert nf.value == 0
+    assert nf.value == "0"
     assert nf.hi.spelled == "शून्य"
     assert nf.mr.spelled == "शून्य"
     assert nf.odia.spelled == "ଶୂନ୍ୟ"
@@ -328,7 +334,7 @@ def test_number_forms_zero() -> None:
 def test_number_forms_max() -> None:
     nf = number_forms("10000000")
     assert nf is not None
-    assert nf.value == 10_000_000
+    assert nf.value == "10000000"
 
 
 def test_number_forms_serializes_odia_field() -> None:
@@ -348,11 +354,241 @@ def test_number_forms_serializes_odia_field() -> None:
         "",
         "abc",
         "१23",  # mixed
-        "-1",
-        "1.5",
+        # Note: `-1` and `1.5` USED to live here when number_forms only
+        # supported the unsigned-integer path. T-2.8a routes them
+        # through parse_number, so they're accepted now — see the new
+        # decimal/negative tests below.
+        "1.",  # trailing decimal — still rejected
+        ".5",  # leading decimal — still rejected
+        "1.2.3",  # multiple decimals
+        "-",  # lonely sign
+        "−",  # lonely U+2212
         "10000001",  # out of range
         "100000000",
     ],
 )
 def test_number_forms_returns_none_for_non_qualifying(surface: str) -> None:
     assert number_forms(surface) is None
+
+
+# ----------------------------------------------------------------
+# T-2.8a: parse_number — signed / decimal extensions.
+# ----------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "surface,expected",
+    [
+        # Unsigned positive — equivalent to parse_digits (minus the
+        # comma path).
+        ("0", ("+", 0, None)),
+        ("123", ("+", 123, None)),
+        ("9999999", ("+", 9_999_999, None)),
+        ("10000000", ("+", 10_000_000, None)),
+        # Negatives — ASCII hyphen-minus.
+        ("-1", ("-", 1, None)),
+        ("-100", ("-", 100, None)),
+        ("-9999999", ("-", 9_999_999, None)),
+        # Negatives — U+2212 MINUS SIGN.
+        ("−5", ("-", 5, None)),
+        ("−99", ("-", 99, None)),
+        # Decimals — Latin digits.
+        ("0.5", ("+", 0, "5")),
+        ("3.14", ("+", 3, "14")),
+        # Leading-zero fractional preserved (so the wire ``value``
+        # round-trips ``0.001`` rather than collapsing to ``0.1``).
+        ("0.001", ("+", 0, "001")),
+        ("123.456", ("+", 123, "456")),
+        # Negative + decimal.
+        ("-2.5", ("-", 2, "5")),
+        ("−2.5", ("-", 2, "5")),
+        # Native-script digits.
+        ("१२३", ("+", 123, None)),
+        ("-१२३", ("-", 123, None)),
+        ("३.१४", ("+", 3, "14")),  # Devanagari, fractional normalized to Latin
+        ("୧୨୩", ("+", 123, None)),
+        ("-୨", ("-", 2, None)),
+        ("୦.୦୦୧", ("+", 0, "001")),
+    ],
+)
+def test_parse_number_accepts(
+    surface: str, expected: tuple[str, int, str | None]
+) -> None:
+    assert parse_number(surface) == expected
+
+
+@pytest.mark.parametrize(
+    "surface",
+    [
+        "",
+        "-",
+        "−",  # lonely U+2212
+        "--1",
+        "-−1",
+        "1-2",
+        "1.",
+        ".5",
+        "1.2.3",
+        "1,000",  # comma-grouping is the parse_digits path, not this one
+        "-1,000",
+        # Mixed-script across the decimal — Devanagari ``1.२`` mixed
+        # with Latin or different-script fractional.
+        "१.5",
+        "1.२",
+        "१.୨",
+        # Sign on a non-numeric.
+        "-abc",
+        "-",
+        # Out of range integer part.
+        "-10000001",
+        "10000001",
+    ],
+)
+def test_parse_number_rejects(surface: str) -> None:
+    assert parse_number(surface) is None
+
+
+def test_parse_number_accepts_max_integer_with_fractional() -> None:
+    """Boundary: 10⁷ is the inclusive upper bound on the integer part.
+    A decimal at that bound is fine — only the integer part is
+    capped, the fractional part is unbounded."""
+    assert parse_number("10000000.5") == ("+", 10_000_000, "5")
+    assert parse_number("-10000000.5") == ("-", 10_000_000, "5")
+
+
+# ----------------------------------------------------------------
+# T-2.8a: format_in_script — sign + decimal renderer.
+# ----------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "sign,integer,fractional,latin,deva,orya",
+    [
+        ("+", 0, None, "0", "०", "୦"),
+        ("+", 123, None, "123", "१२३", "୧୨୩"),
+        ("-", 12, None, "-12", "-१२", "-୧୨"),
+        ("+", 3, "14", "3.14", "३.१४", "୩.୧୪"),
+        ("-", 2, "5", "-2.5", "-२.५", "-୨.୫"),
+        # Leading-zero fractional preserved per script.
+        ("+", 0, "001", "0.001", "०.००१", "୦.୦୦୧"),
+    ],
+)
+def test_format_in_script(
+    sign: str,
+    integer: int,
+    fractional: str | None,
+    latin: str,
+    deva: str,
+    orya: str,
+) -> None:
+    assert format_in_script(sign, integer, fractional, "latin") == latin  # type: ignore[arg-type]
+    assert format_in_script(sign, integer, fractional, "deva") == deva  # type: ignore[arg-type]
+    assert format_in_script(sign, integer, fractional, "orya") == orya  # type: ignore[arg-type]
+
+
+# ----------------------------------------------------------------
+# T-2.8a: spell — composed sign + decimal output. Pinned reference
+# values in each language so a typo in ऋण / उणे / ଋଣ or दशमलव /
+# दशांश / ଦଶମିକ trips CI rather than ships silently.
+# ----------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "sign,integer,fractional,hi,mr,or_",
+    [
+        ("-", 1, None, "ऋण एक", "उणे एक", "ଋଣ ଏକ"),
+        ("-", 100, None, "ऋण एक सौ", "उणे एकशे", "ଋଣ ଏକ ଶହ"),
+        ("+", 0, "5", "शून्य दशमलव पाँच", "शून्य दशांश पाच", "ଶୂନ୍ୟ ଦଶମିକ ପାଞ୍ଚ"),
+        (
+            "+", 3, "14",
+            "तीन दशमलव एक चार",
+            "तीन दशांश एक चार",
+            "ତିନି ଦଶମିକ ଏକ ଚାରି",
+        ),
+        # Leading-zero fractional pronounces each digit (so 0.001 is
+        # ``... point zero zero one``).
+        (
+            "+", 0, "001",
+            "शून्य दशमलव शून्य शून्य एक",
+            "शून्य दशांश शून्य शून्य एक",
+            "ଶୂନ୍ୟ ଦଶମିକ ଶୂନ୍ୟ ଶୂନ୍ୟ ଏକ",
+        ),
+        # Negative + decimal.
+        (
+            "-", 2, "5",
+            "ऋण दो दशमलव पाँच",
+            "उणे दोन दशांश पाच",
+            "ଋଣ ଦୁଇ ଦଶମିକ ପାଞ୍ଚ",
+        ),
+    ],
+)
+def test_spell_signed_decimal(
+    sign: str,
+    integer: int,
+    fractional: str | None,
+    hi: str,
+    mr: str,
+    or_: str,
+) -> None:
+    assert spell(sign, integer, fractional, "hi") == hi  # type: ignore[arg-type]
+    assert spell(sign, integer, fractional, "mr") == mr  # type: ignore[arg-type]
+    assert spell(sign, integer, fractional, "or") == or_  # type: ignore[arg-type]
+
+
+# ----------------------------------------------------------------
+# T-2.8a: number_forms — full integration for signed / decimal.
+# ----------------------------------------------------------------
+
+
+def test_number_forms_negative() -> None:
+    nf = number_forms("-100")
+    assert nf is not None
+    assert nf.value == "-100"
+    assert nf.digits_latin == "-100"
+    assert nf.digits_deva == "-१००"
+    assert nf.digits_orya == "-୧୦୦"
+    # Spelled-out prefixes the language minus word.
+    assert nf.hi.spelled.startswith("ऋण ")
+    assert nf.mr.spelled.startswith("उणे ")
+    assert nf.odia.spelled.startswith("ଋଣ ")
+
+
+def test_number_forms_decimal() -> None:
+    nf = number_forms("3.14")
+    assert nf is not None
+    assert nf.value == "3.14"
+    assert nf.digits_latin == "3.14"
+    assert nf.digits_deva == "३.१४"
+    assert nf.digits_orya == "୩.୧୪"
+    assert "दशमलव" in nf.hi.spelled
+    assert "दशांश" in nf.mr.spelled
+    assert "ଦଶମିକ" in nf.odia.spelled
+
+
+def test_number_forms_negative_decimal() -> None:
+    nf = number_forms("-2.5")
+    assert nf is not None
+    assert nf.value == "-2.5"
+    assert nf.digits_latin == "-2.5"
+    assert nf.hi.spelled == "ऋण दो दशमलव पाँच"
+    assert nf.mr.spelled == "उणे दोन दशांश पाच"
+    assert nf.odia.spelled == "ଋଣ ଦୁଇ ଦଶମିକ ପାଞ୍ଚ"
+
+
+def test_number_forms_u2212_minus_sign() -> None:
+    """U+2212 MINUS SIGN (the typographically correct minus, often
+    produced by autoformatting word processors) is accepted alongside
+    ASCII hyphen-minus and produces the same canonical wire form."""
+    nf = number_forms("−5")
+    assert nf is not None
+    assert nf.value == "-5"
+    assert nf.digits_latin == "-5"
+
+
+def test_number_forms_decimal_preserves_leading_zeros() -> None:
+    """``0.001`` round-trips with the leading zeros intact — that's
+    why ``value`` is a string."""
+    nf = number_forms("0.001")
+    assert nf is not None
+    assert nf.value == "0.001"
+    assert nf.hi.spelled == "शून्य दशमलव शून्य शून्य एक"

--- a/services/nlp/tests/test_pipelines.py
+++ b/services/nlp/tests/test_pipelines.py
@@ -148,13 +148,55 @@ def test_pipeline_attaches_number_forms_for_digit_tokens(
     tok = _find_number_token(out.tokens, number_surface)
     assert tok is not None, f"no token with surface {number_surface!r} in {out.tokens}"
     assert tok.number_forms is not None
-    # value matches the digit run regardless of source script
-    expected_value = int(number_surface) if number_surface.isascii() else None
+    # T-2.8a widened ``value`` from int to str. For the integer-only
+    # path (no sign, no decimal) the canonical form is the Latin-digit
+    # string of the value — same regardless of source script.
+    expected_value = (
+        str(int(number_surface)) if number_surface.isascii() else None
+    )
     if expected_value is not None:
         assert tok.number_forms.value == expected_value
     # All three language renderings populated.
     assert tok.number_forms.hi.spelled
     assert tok.number_forms.hi.romanized
+    assert tok.number_forms.mr.spelled
+    assert tok.number_forms.odia.spelled
+
+
+# ----------------------------------------------------------------
+# T-2.8a: signed and decimal NUM tokens flow through the pipeline
+# with their negative / decimal payload populated end-to-end.
+# ----------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "language,text,number_surface,expected_value",
+    [
+        # Negative integer.
+        ("hi", "तापमान -12 डिग्री", "-12", "-12"),
+        # Positive decimal.
+        ("hi", "मान 3.14 है", "3.14", "3.14"),
+        # U+2212 MINUS SIGN (typographically correct minus).
+        ("mr", "−5 अंश", "−5", "-5"),
+        # Negative + decimal.
+        ("or", "ତାପମାନ -2.5 ଡିଗ୍ରି", "-2.5", "-2.5"),
+    ],
+)
+def test_pipeline_attaches_number_forms_for_signed_and_decimal_tokens(
+    language: str, text: str, number_surface: str, expected_value: str
+) -> None:
+    pipe = get_pipeline(language)
+    out = pipe.process(text)
+    tok = _find_number_token(out.tokens, number_surface)
+    assert tok is not None, f"no token with surface {number_surface!r} in {out.tokens}"
+    assert tok.number_forms is not None
+    # Canonical wire form normalizes U+2212 to ASCII "-" and preserves
+    # the decimal point.
+    assert tok.number_forms.value == expected_value
+    # All three language renderings still populated for signed / decimal
+    # tokens — the popup needs them regardless of which language the
+    # text is in.
+    assert tok.number_forms.hi.spelled
     assert tok.number_forms.mr.spelled
     assert tok.number_forms.odia.spelled
 


### PR DESCRIPTION
## Summary

- Extends `services/nlp/app/numbers.py` so signed (`-12`, `−5` with U+2212) and decimal (`3.14`, `0.001`) digit tokens spell out alongside the existing T-2.8 unsigned-integer path. Curator-confirmed minus words (Hindi `ऋण`, Marathi `उणे`, Odia `ଋଣ`) and decimal words (`दशमलव`, `दशांश`, `ଦଶମିକ`).
- `NumberForms.value` widens `int → str` so signed + decimal forms round-trip losslessly. TypeScript mirror updated in `nlp-client.ts`, `db/schema.ts` jsonb `$type`, `texts/tokens.ts`, and `components/reader/types.ts`.
- `looksLikeNumberToken` extended for signed / decimal so the dispatcher keeps skipping lemma auto-create on `-3.14`-shape surfaces.

## Test plan

- [x] `services/nlp` pytest: 453 passing, 93% coverage (numbers.py 99%).
- [x] `apps/web` vitest: 1221 passing.
- [x] `apps/web` svelte-check: 0 errors.
- [x] `test_numbers.py` parametrizes all spec cases — negatives -1/-100/-9_999_999 (ASCII + U+2212), decimals 0.5/3.14/0.001/123.456/-2.5, rejects 1./.5/-/--1/1,000/1.2.3/mixed-script, max-integer + fractional boundary.
- [x] `test_pipelines.py` adds `-12`, `3.14`, `−5`, `-2.5` flowing through Hindi / Marathi / Odia pipelines end-to-end with Latin-canonical wire form.
- [x] `WordPopup.test.ts` renders a `-3.14` token end-to-end (Latin + Devanagari signed digits in the heading; `ऋण ... दशमलव ...` in the body).
- [ ] Browser-side smoke of the popup on a real text not done in this PR.

Closes #306. Refs #14, #304.