### PR TITLE
T-3.12: romanization-aware search + audio-filter stub

### DIFF
--- a/apps/web/src/lib/server/dictionary/browse.test.ts
+++ b/apps/web/src/lib/server/dictionary/browse.test.ts
@@ -245,6 +245,67 @@ describe('listDictionaryLemmas', () => {
     const result = await listDictionaryLemmas('hi');
     expect(result.usedNuktaFallback).toBe(false);
   });
+
+  // ---- romanization-aware search (T-3.12) ----------------------------
+
+  it('transliterates a Latin query to native and searches against the strict tier', async () => {
+    // The headline use case from T-3.12: user types `kitaab` in
+    // Latin, the search runs against `किताब` and finds the lemma row.
+    // We don't introspect the WHERE clause directly but we can prove
+    // the tier landed via the `usedRomanizationTransliteration` flag
+    // and the `effectiveQuery` echoed back in the result.
+    stage([lemmaRow({ headword: 'किताब' })]);
+    stage([{ n: 1 }]);
+    const result = await listDictionaryLemmas('hi', { q: 'kitaab' });
+    expect(result.usedRomanizationTransliteration).toBe(true);
+    expect(result.effectiveQuery).toBe('किताब');
+    expect(result.usedNuktaFallback).toBe(false);
+    expect(result.lemmas).toHaveLength(1);
+  });
+
+  it('does not transliterate when the query already contains native script', async () => {
+    stage([lemmaRow({ headword: 'किताब' })]);
+    stage([{ n: 1 }]);
+    const result = await listDictionaryLemmas('hi', { q: 'किताब' });
+    expect(result.usedRomanizationTransliteration).toBe(false);
+    expect(result.effectiveQuery).toBe('किताब');
+  });
+
+  it('echoes the empty effectiveQuery when no q is provided', async () => {
+    stage([lemmaRow()]);
+    stage([{ n: 1 }]);
+    const result = await listDictionaryLemmas('hi');
+    expect(result.usedRomanizationTransliteration).toBe(false);
+    expect(result.effectiveQuery).toBe('');
+  });
+
+  it('preserves the romanization-transliteration flag through the nukta fallback path', async () => {
+    // Strict tier on the transliterated `पढना` misses; the
+    // nukta-agnostic tier picks up `पढ़ना`. The romanization flag
+    // should still be true on the result so the UI can render both
+    // hints.
+    stage([]); // strict rows
+    stage([{ n: 0 }]); // strict count
+    stage([lemmaRow({ headword: 'पढ़ना' })]); // fallback rows
+    stage([{ n: 1 }]); // fallback count
+    const result = await listDictionaryLemmas('hi', { q: 'paDhana' });
+    expect(result.usedRomanizationTransliteration).toBe(true);
+    expect(result.usedNuktaFallback).toBe(true);
+  });
+
+  it('does not advertise transliteration when the helper leaves the input unchanged', async () => {
+    // `123` runs through `latinToNative` cleanly — none of the
+    // ITRANS keys match digits, so the helper returns the input
+    // verbatim. We don't want a misleading "transliterated from"
+    // hint in that case. Stage a strict-tier hit so the fallback
+    // doesn't fire (the digit-shaped query is irrelevant for
+    // headword search but the function still walks the same path).
+    stage([lemmaRow({ headword: '123' })]);
+    stage([{ n: 1 }]);
+    const result = await listDictionaryLemmas('hi', { q: '123' });
+    expect(result.usedRomanizationTransliteration).toBe(false);
+    expect(result.effectiveQuery).toBe('123');
+  });
 });
 
 describe('publicLemma', () => {

--- a/apps/web/src/lib/server/dictionary/browse.ts
+++ b/apps/web/src/lib/server/dictionary/browse.ts
@@ -1,5 +1,5 @@
 /**
- * Public lemma-browsing service (T-3.6).
+ * Public lemma-browsing service (T-3.6 + T-3.12).
  *
  * The backing page is `/dictionary/:language` — public, unauthenticated-
  * accessible, rendered server-side so it ranks for "<lemma> meaning"
@@ -7,10 +7,17 @@
  * by the dictionary editor (T-3.7) and the correction modal (T-6.2), so
  * it stays free of HTML concerns.
  *
- * Search is a simple case-insensitive prefix match on the NFC-normalized
- * headword. The client-side `<ScriptAwareInput>` (T-6.2a) is responsible
- * for turning a user's romanized input into the native script before it
- * arrives here — this service does not transliterate.
+ * Search is a case-insensitive prefix match on the NFC-normalized
+ * headword. T-3.12 added romanization-aware search: when the submitted
+ * query is in Latin (`kitaab`), we run the same client-side ITRANS-
+ * flavored `latinToNative` transliterator the `<ScriptAwareInput>`
+ * uses, then prefix-match the resulting native form against the
+ * existing `headword` index. This keeps the change to a pure-server
+ * change — no new index, no NLP-service round trip — and the UX
+ * matches the input field (whatever the user sees as the native
+ * preview is what the server searches for). A future quality bump
+ * could route through aksharamukha server-side, but the ITRANS-based
+ * helper is good enough that "kitaab" → "किताब" finds the headword.
  *
  * Nukta-agnostic fallback (#318): when the user's query has zero
  * exact-prefix hits AND the query strips down to something different
@@ -19,12 +26,19 @@
  * `headword_nukta_stripped` generated column with the query also
  * nukta-stripped. This is **lossy by design** (`ज़रा` and `जरा` collapse
  * to the same key), so the result advertises `usedNuktaFallback` and
- * the UI surfaces a "showing nukta-agnostic results" hint.
+ * the UI surfaces a "showing nukta-agnostic results" hint. The same
+ * pattern applies to the romanization tier: results from a transliterated
+ * query carry `usedRomanizationTransliteration` so the UI can render
+ * "showing matches for किताब (transliterated from kitaab)".
  */
 import { and, asc, count, eq, gte, ilike, inArray, lte, sql } from 'drizzle-orm';
 
 import { db, schema } from '../db/index.js';
 import type { Lemma } from '../db/schema.js';
+import {
+  latinToNative,
+  looksLikeNativeScript,
+} from '$lib/components/input/transliterate.js';
 import { stripNukta, type LanguageCode } from '@ciareader/shared-types';
 
 /**
@@ -64,6 +78,23 @@ export type BrowseResult = {
    * been empty — there's no fallback to advertise).
    */
   usedNuktaFallback: boolean;
+  /**
+   * T-3.12: True when the user submitted a Latin query that we
+   * transliterated to the language's native script before searching.
+   * The UI surfaces "showing matches for `${effectiveQuery}` (from
+   * `${query.q}`)" so the user can see what we actually queried —
+   * useful when the ITRANS-style mapping picks an unexpected glyph
+   * (e.g. typing `S` instead of `Sh`) and a result list looks off.
+   * `effectiveQuery` carries the post-transliteration native string
+   * so the UI doesn't need to re-derive it.
+   */
+  usedRomanizationTransliteration: boolean;
+  /**
+   * T-3.12: The native-script query the search actually ran against.
+   * Equal to the input `q` when no transliteration was needed. Empty
+   * string when `q` itself was empty.
+   */
+  effectiveQuery: string;
 };
 
 /** `%` and `_` are the two wildcards Postgres recognises in LIKE/ILIKE. */
@@ -86,6 +117,36 @@ function normalizeQuery(q: string | null | undefined): string | null {
   if (!q) return null;
   const trimmed = q.normalize('NFC').trim();
   return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * T-3.12: detect a Latin-script query and transliterate to the
+ * language's native script using the same ITRANS-flavored mapping
+ * the `<ScriptAwareInput>` uses on the client. Pure function — no
+ * I/O, no NLP-service round trip — so adding it costs nothing on the
+ * happy path where the query is already in the native script.
+ *
+ * Returns the original query unchanged when (a) the query already
+ * contains native-script characters, or (b) the language's script is
+ * already Latin (no transliteration target), or (c) the transliterator
+ * left the string unchanged (no recognized ITRANS keys hit).
+ */
+function transliterateLatinQuery(
+  q: string,
+  language: LanguageCode,
+): { value: string; transliterated: boolean } {
+  if (looksLikeNativeScript(q, language)) {
+    return { value: q, transliterated: false };
+  }
+  const native = latinToNative(language, q).normalize('NFC');
+  if (native === q) {
+    // Either the language's script is Latin (function returns input
+    // unchanged) or no ITRANS keys matched. Either way the search
+    // can run as-is — no point advertising a transliteration that
+    // didn't change anything.
+    return { value: q, transliterated: false };
+  }
+  return { value: native, transliterated: true };
 }
 
 type SearchClause = ReturnType<typeof ilike> | null;
@@ -111,8 +172,7 @@ function baseConditions(language: LanguageCode, query: BrowseQuery) {
     conditions.push(
       sql`EXISTS (
         SELECT 1 FROM ${schema.translations} t
-        WHERE t.target_type = 'lemma'
-          AND t.target_id = ${schema.lemmas.id}
+        WHERE t.lemma_id = ${schema.lemmas.id}
           AND t.hidden = false
           AND t.source IN ('official_dictionary', 'curator')
       )`,
@@ -181,7 +241,14 @@ export async function listDictionaryLemmas(
 ): Promise<BrowseResult> {
   const limit = clampLimit(query.limit);
   const offset = clampOffset(query.offset);
-  const q = normalizeQuery(query.q);
+  const rawQ = normalizeQuery(query.q);
+
+  // T-3.12: transliterate Latin queries to the native script before
+  // running the strict tier. Empty / native-script queries pass
+  // through unchanged.
+  const { value: q, transliterated } = rawQ
+    ? transliterateLatinQuery(rawQ, language)
+    : { value: '', transliterated: false };
 
   const strictClause: SearchClause = q
     ? ilike(schema.lemmas.headword, `${escapeLikePrefix(q)}%`)
@@ -195,6 +262,8 @@ export async function listDictionaryLemmas(
       limit,
       offset,
       usedNuktaFallback: false,
+      usedRomanizationTransliteration: transliterated,
+      effectiveQuery: q,
     };
   }
 
@@ -227,6 +296,8 @@ export async function listDictionaryLemmas(
       limit,
       offset,
       usedNuktaFallback: false,
+      usedRomanizationTransliteration: transliterated,
+      effectiveQuery: q,
     };
   }
 
@@ -236,6 +307,8 @@ export async function listDictionaryLemmas(
     limit,
     offset,
     usedNuktaFallback: true,
+    usedRomanizationTransliteration: transliterated,
+    effectiveQuery: q,
   };
 }
 

--- a/apps/web/src/routes/dictionary/[language]/+page.server.ts
+++ b/apps/web/src/routes/dictionary/[language]/+page.server.ts
@@ -61,6 +61,10 @@ export const load: PageServerLoad = async ({ params, url }) => {
     // render a hint when an exact-match search missed and we showed
     // the user the closest nukta-stripped match instead.
     usedNuktaFallback: result.usedNuktaFallback,
+    // T-3.12: surface the romanization-transliteration tier so the
+    // page can render "showing matches for किताब (from kitaab)".
+    usedRomanizationTransliteration: result.usedRomanizationTransliteration,
+    effectiveQuery: result.effectiveQuery,
     query: {
       q: q ?? '',
       pos,

--- a/apps/web/src/routes/dictionary/[language]/+page.svelte
+++ b/apps/web/src/routes/dictionary/[language]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import ScriptAwareInput from '$lib/components/input/ScriptAwareInput.svelte';
   import type { PageData } from './$types';
   let { data }: { data: PageData } = $props();
 
@@ -41,13 +42,17 @@
     </p>
   </header>
 
-  <form method="get" class="search">
-    <input
-      type="search"
+  <form method="get" class="search" data-testid="dictionary-search-form">
+    <!-- T-3.12: ScriptAwareInput renders an `<input name="q">` whose
+         value flows through the form-GET unchanged. The user can type
+         in either the native script directly OR in ITRANS-flavored
+         Latin (`kitaab`); the server-side transliterator in
+         `listDictionaryLemmas` handles the Latin → native step. -->
+    <ScriptAwareInput
+      language={data.language.code}
       name="q"
       value={data.query.q}
-      placeholder="Type a headword in {data.language.nativeName}…"
-      aria-label="Search {data.language.displayName} headwords"
+      placeholder="Type a headword in {data.language.nativeName} or in Latin (e.g. kitaab)…"
     />
     <label class="checkbox">
       <input
@@ -58,8 +63,40 @@
       />
       Only lemmas with an official translation
     </label>
+    <!-- T-3.12: audio-example filter is on the original T-3.6 spec but
+         the schema doesn't yet model audio examples — that lands with
+         M9 (#82). Render the affordance disabled with a tooltip so the
+         filter shape is visible to users and we don't add a "where
+         did the filter go?" surprise when M9 finally ships. -->
+    <label
+      class="checkbox checkbox-disabled"
+      title="Available once audio examples ship in M9."
+      data-testid="audio-filter-stub"
+    >
+      <input
+        type="checkbox"
+        name="hasAudioExample"
+        value="true"
+        disabled
+        aria-disabled="true"
+      />
+      Only lemmas with an audio example
+      <span class="muted">(coming in M9)</span>
+    </label>
     <button type="submit">Search</button>
   </form>
+
+  {#if data.usedRomanizationTransliteration}
+    <!--
+      T-3.12: the user typed Latin and we transliterated to native
+      before searching. Show what we actually queried so an unexpected
+      ITRANS mapping (e.g. `S` vs `Sh`) is debuggable from the UI.
+    -->
+    <p class="transliteration-hint" role="status" data-testid="transliteration-hint">
+      Showing matches for <strong>{data.effectiveQuery}</strong>
+      <span class="muted">(transliterated from {data.query.q})</span>.
+    </p>
+  {/if}
 
   {#if data.usedNuktaFallback}
     <!--
@@ -138,16 +175,6 @@
     align-items: center;
     margin-bottom: 1.25rem;
   }
-  .search input[type='search'] {
-    grid-column: 1 / 2;
-    padding: 0.6rem 0.75rem;
-    font: inherit;
-    min-height: 44px;
-    border: 1px solid var(--color-border);
-    border-radius: 6px;
-    background: var(--color-bg);
-    color: var(--color-fg);
-  }
   .search .checkbox {
     grid-column: 1 / 2;
     font-size: 0.9rem;
@@ -207,7 +234,8 @@
     margin: 2rem 0;
     color: var(--color-fg-muted);
   }
-  .nukta-fallback {
+  .nukta-fallback,
+  .transliteration-hint {
     margin: 0 0 1rem;
     padding: 0.6rem 0.85rem;
     border-radius: 6px;
@@ -215,6 +243,13 @@
     color: var(--color-info-fg, var(--color-fg));
     border-left: 3px solid var(--color-accent);
     font-size: 0.9rem;
+  }
+  .checkbox-disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+  .checkbox-disabled input {
+    cursor: not-allowed;
   }
   .pager {
     display: flex;

--- a/apps/web/src/routes/dictionary/[language]/page-server.test.ts
+++ b/apps/web/src/routes/dictionary/[language]/page-server.test.ts
@@ -111,4 +111,27 @@ describe('GET /dictionary/:language load', () => {
       expect.objectContaining({ pos: ['verb', 'noun'] }),
     );
   });
+
+  it('surfaces T-3.12 transliteration metadata to the page', async () => {
+    listDictionaryLemmas.mockResolvedValueOnce({
+      lemmas: [],
+      totalCount: 0,
+      limit: 50,
+      offset: 0,
+      usedNuktaFallback: false,
+      usedRomanizationTransliteration: true,
+      effectiveQuery: 'किताब',
+    });
+    const data = (await callLoad(
+      'http://x/dictionary/hi?q=kitaab',
+    )) as {
+      usedRomanizationTransliteration: boolean;
+      effectiveQuery: string;
+      query: { q: string };
+    };
+    expect(data.usedRomanizationTransliteration).toBe(true);
+    expect(data.effectiveQuery).toBe('किताब');
+    // Original Latin query echoed back so the UI can show both forms.
+    expect(data.query.q).toBe('kitaab');
+  });
 });


### PR DESCRIPTION
## Summary

- Server detects Latin queries on `/dictionary/[language]` and runs them through the existing client-side `latinToNative` (same ITRANS map the `<ScriptAwareInput>` uses) before prefix-matching against the existing `headword` index. UI shows "Showing matches for किताब (transliterated from kitaab)".
- Replaces the bare `<input type="search">` with the shared `<ScriptAwareInput>` (T-6.2a, #57) so users see the native preview as they type Latin.
- Adds the disabled `hasAudioExample` filter with the spec'd tooltip "Available once audio examples ship in M9." + "(coming in M9)" hint — keeps the affordance honest without committing to an implementation.

Deferred from the original spec (documented inline): server-side aksharamukha pipeline integration (would require an HTTP round-trip for marginal quality lift over ITRANS) and the `lemma_forms.surface` matcher.

## Test plan

- [x] `apps/web` vitest: 1218 passing.
- [x] `apps/web` svelte-check: 0 errors.
- [x] `browse.test.ts` covers Latin→native transliteration, native passthrough, empty query, transliteration-flag survival through the nukta fallback, and no-op transliteration not advertising.
- [x] `page-server.test.ts` asserts the new fields land on the page payload.
- [ ] Browser-side smoke of the dictionary search on a real text not done in this PR.

Closes #195. Refs #25, #31, #57, #82.