### PR TITLE
chore: make fetch-dictionary-sources.sh idempotent + atomic

### DIFF
--- a/apps/web/scripts/fetch-dictionary-sources.sh
+++ b/apps/web/scripts/fetch-dictionary-sources.sh
@@ -4,23 +4,53 @@
 # The raw artifacts are .gitignored — re-running the appropriate
 # `pnpm dictionary:import <source>` after a fetch picks up the new file.
 #
+# Idempotent: a source whose `raw.jsonl` already exists is skipped. Pass
+# --force (or set FORCE=1) to re-download and overwrite. Downloads land
+# in `<source>/raw.jsonl.tmp` first and are atomically renamed only on
+# success, so a stalled transfer never leaves a half-file masquerading
+# as cached.
+#
 # Usage:
-#   scripts/fetch-dictionary-sources.sh           # fetch every source
-#   scripts/fetch-dictionary-sources.sh kaikki-hindi
+#   scripts/fetch-dictionary-sources.sh                    # fetch missing sources
+#   scripts/fetch-dictionary-sources.sh kaikki-hindi       # fetch one (if missing)
+#   scripts/fetch-dictionary-sources.sh --force            # re-fetch every source
+#   scripts/fetch-dictionary-sources.sh --force kaikki-hindi
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
 DATA_ROOT="data/dictionaries"
 mkdir -p "$DATA_ROOT"
 
+FORCE="${FORCE:-0}"
+ARGS=()
+for arg in "$@"; do
+  case "$arg" in
+    --force|-f) FORCE=1 ;;
+    *)          ARGS+=("$arg") ;;
+  esac
+done
+set -- "${ARGS[@]+"${ARGS[@]}"}"
+
+skip_if_cached() {
+  # $1 = label, $2 = path to raw.jsonl.
+  # Returns 0 (skip) if the final file already exists and we're not forcing.
+  if [[ -s "$2" && "$FORCE" != "1" ]]; then
+    echo "[fetch] $1  cached at $2 ($(wc -l <"$2") lines, $(du -h "$2" | cut -f1)) — skipping (--force to re-download)"
+    return 0
+  fi
+  return 1
+}
+
 fetch_kaikki() {
   local lang_slug="$1"   # kebab-case, e.g. kaikki-hindi
   local lang_name="$2"   # capitalized, e.g. Hindi (matches Kaikki's URL)
   local out="$DATA_ROOT/$lang_slug"
   mkdir -p "$out"
+  if skip_if_cached "$lang_slug" "$out/raw.jsonl"; then return; fi
   local url="https://kaikki.org/dictionary/${lang_name}/kaikki.org-dictionary-${lang_name}.jsonl"
   echo "[fetch] $lang_slug  $url -> $out/raw.jsonl"
-  curl --fail --location --output "$out/raw.jsonl" "$url"
+  curl --fail --location --output "$out/raw.jsonl.tmp" "$url"
+  mv "$out/raw.jsonl.tmp" "$out/raw.jsonl"
   echo "[fetch] $lang_slug  done ($(wc -l <"$out/raw.jsonl") lines, $(du -h "$out/raw.jsonl" | cut -f1))"
 }
 
@@ -31,16 +61,19 @@ fetch_kaikki_en_translations() {
   # (~3 GB JSONL) and kaikki.org throttles late in the transfer, so
   # we use --continue-at - to resume on retry and --speed-time /
   # --speed-limit to bail+retry when the stream stalls instead of
-  # hanging for hours.
+  # hanging for hours. The .tmp suffix lets `--continue-at -` resume
+  # an interrupted run without colliding with a previously-completed
+  # raw.jsonl.
   local out="$DATA_ROOT/kaikki-en-translations"
   mkdir -p "$out"
+  if skip_if_cached "kaikki-en-translations" "$out/raw.jsonl"; then return; fi
   local url="https://kaikki.org/dictionary/English/kaikki.org-dictionary-English.jsonl"
   echo "[fetch] kaikki-en-translations  $url -> $out/raw.jsonl"
   echo "[fetch] kaikki-en-translations  (large file; resume-safe via --continue-at -)"
   curl \
     --fail \
     --location \
-    --output "$out/raw.jsonl" \
+    --output "$out/raw.jsonl.tmp" \
     --continue-at - \
     --retry 10 \
     --retry-delay 5 \
@@ -48,6 +81,7 @@ fetch_kaikki_en_translations() {
     --speed-time 60 \
     --speed-limit 102400 \
     "$url"
+  mv "$out/raw.jsonl.tmp" "$out/raw.jsonl"
   echo "[fetch] kaikki-en-translations  done ($(wc -l <"$out/raw.jsonl") lines, $(du -h "$out/raw.jsonl" | cut -f1))"
 }
 


### PR DESCRIPTION
## Summary

Re-running [`apps/web/scripts/fetch-dictionary-sources.sh`](apps/web/scripts/fetch-dictionary-sources.sh) used to re-download every source from scratch. Fine the first time; painful with the ~3 GB English Wiktionary dump. Now the script skips any source whose `raw.jsonl` already exists; pass `--force` (or `FORCE=1`) to override.

- **Idempotency check**: `[[ -s "$path" && "$FORCE" != "1" ]]`. An empty file is treated as *not cached* so a stalled-then-deleted download re-fetches automatically.
- **Atomic completion**: downloads write to `<source>/raw.jsonl.tmp` first and `mv` to `raw.jsonl` only on success. Curl exiting non-zero (network drop, kaikki throttle) leaves the `.tmp` for the next run to resume against, but never poisons the canonical filename. The `kaikki-en-translations` resume logic (`--continue-at -`) still works because it now resumes against `.tmp`.
- **Flag parsing**: order-independent — `--force kaikki-hindi` and `kaikki-hindi --force` both work.

Motivation surfaced while planning a `docker compose down -v` + clean re-migrate to recover from a `drizzle-kit push`-driven schema drift. Re-fetching the dumps shouldn't have been the slow part.

## Test plan

- [x] `bash -n` clean.
- [x] Cached file + no `--force` → `skipping` message, zero curl invocations (verified via `bash -x` trace).
- [x] `--force` toggles FORCE=1 and proceeds to curl (verified via trace, then `kill`'d before hitting kaikki).
- [x] Empty `raw.jsonl` is not treated as cached (proceeds to curl).
- [ ] Reviewer: a real fetch of `kaikki-hindi` (smallest source) produces a `raw.jsonl` and a second invocation skips cleanly.