### PR TITLE
T-8.4: finish collection sharing — visibility + email-grant + manage UI

### DIFF
--- a/apps/web/src/lib/server/collections.test.ts
+++ b/apps/web/src/lib/server/collections.test.ts
@@ -784,3 +784,17 @@ describe('viewerHasCollectionShareForText', () => {
     expect(await viewerHasCollectionShareForText('viewer', 't-orphan')).toBe(false);
   });
 });
+
+describe('viewerHasCollectionShare (T-8.4)', () => {
+  it('returns true when the viewer has a share row for the collection', async () => {
+    const { viewerHasCollectionShare } = await import('./collections.js');
+    queue.push([{ collectionId: 'col-1' }]);
+    expect(await viewerHasCollectionShare('viewer-1', 'col-1')).toBe(true);
+  });
+
+  it('returns false when no share row exists', async () => {
+    const { viewerHasCollectionShare } = await import('./collections.js');
+    queue.push([]);
+    expect(await viewerHasCollectionShare('viewer-2', 'col-1')).toBe(false);
+  });
+});

--- a/apps/web/src/lib/server/collections.ts
+++ b/apps/web/src/lib/server/collections.ts
@@ -8,7 +8,7 @@
  * Pure DB-side service — UI lives in routes/collections, /library,
  * and the reader's prev/next-text strip (T-8.3).
  */
-import { and, asc, desc, eq, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, inArray, sql } from 'drizzle-orm';
 
 import { db, schema } from './db/index.js';
 import type {
@@ -460,6 +460,71 @@ export async function listCollectionShares(
     .where(
       eq(schema.collectionShares.collectionId, collectionId),
     )) as CollectionShare[];
+}
+
+/**
+ * T-8.4 — share row decorated with the recipient's email + display
+ * name. The bare `CollectionShare` only carries `sharedWithUserId`
+ * which isn't human-readable; the manage-shares UI (and the GET
+ * /shares JSON endpoint) call this so the owner sees who actually
+ * has access. Recipients that have since been deleted come through
+ * with `recipient: null`.
+ */
+export type CollectionShareWithRecipient = CollectionShare & {
+  recipient: {
+    id: string;
+    email: string;
+    displayName: string | null;
+  } | null;
+};
+
+export async function listCollectionSharesWithRecipients(
+  collectionId: string,
+  actor: Pick<User, 'id' | 'role'>,
+): Promise<CollectionShareWithRecipient[]> {
+  const shares = await listCollectionShares(collectionId, actor);
+  if (shares.length === 0) return [];
+  const ids = shares.map((s) => s.sharedWithUserId);
+  const recipients = (await db
+    .select({
+      id: schema.users.id,
+      email: schema.users.email,
+      displayName: schema.users.displayName,
+    })
+    .from(schema.users)
+    .where(inArray(schema.users.id, ids))) as Array<{
+    id: string;
+    email: string;
+    displayName: string | null;
+  }>;
+  const byId = new Map(recipients.map((r) => [r.id, r]));
+  return shares.map((s) => ({
+    ...s,
+    recipient: byId.get(s.sharedWithUserId) ?? null,
+  }));
+}
+
+/**
+ * T-8.4 — does this viewer have a share row for this collection?
+ * Used by the collection detail page (`/collections/:id`) to grant
+ * non-owners view access. Cheap lookup against the
+ * `(collectionId, sharedWithUserId)` unique index.
+ */
+export async function viewerHasCollectionShare(
+  viewerId: string,
+  collectionId: string,
+): Promise<boolean> {
+  const [row] = (await db
+    .select({ collectionId: schema.collectionShares.collectionId })
+    .from(schema.collectionShares)
+    .where(
+      and(
+        eq(schema.collectionShares.collectionId, collectionId),
+        eq(schema.collectionShares.sharedWithUserId, viewerId),
+      ),
+    )
+    .limit(1)) as Array<{ collectionId: string }>;
+  return Boolean(row);
 }
 
 /**

--- a/apps/web/src/routes/api/v1/collections/[id]/shares/+server.ts
+++ b/apps/web/src/routes/api/v1/collections/[id]/shares/+server.ts
@@ -1,30 +1,40 @@
 /**
  * GET + POST /api/v1/collections/:id/shares (T-8.4).
+ *
+ * The POST endpoint accepts EITHER `recipientUserId` (UUID) OR
+ * `recipientEmail`. The email path is what the inline manage-shares
+ * UI uses — it's the only piece of identifying information the owner
+ * actually knows about a recipient. The UUID path stays available
+ * for tooling / future API consumers that already have a user id.
  */
 import { error, json } from '@sveltejs/kit';
+import { eq } from 'drizzle-orm';
 import { z } from 'zod';
 
 import { requireUser } from '$lib/server/auth/require-user.js';
 import {
   CollectionError,
   grantCollectionShare,
-  listCollectionShares,
+  listCollectionSharesWithRecipients,
 } from '$lib/server/collections.js';
-import { parseJson } from '../../../auth/_helpers.js';
+import { db, schema } from '$lib/server/db/index.js';
+import { emailSchema, parseJson } from '../../../auth/_helpers.js';
 import type { RequestHandler } from './$types';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 const postSchema = z
-  .object({ recipientUserId: z.string().regex(UUID_RE) })
-  .strict();
+  .union([
+    z.object({ recipientUserId: z.string().regex(UUID_RE) }).strict(),
+    z.object({ recipientEmail: emailSchema }).strict(),
+  ]);
 
 export const GET: RequestHandler = async (event) => {
   const user = await requireUser(event);
   const id = event.params.id;
   if (!id || !UUID_RE.test(id)) throw error(400, 'Invalid collection id');
   try {
-    const shares = await listCollectionShares(id, {
+    const shares = await listCollectionSharesWithRecipients(id, {
       id: user.id,
       role: user.role,
     });
@@ -40,10 +50,25 @@ export const POST: RequestHandler = async (event) => {
   const id = event.params.id;
   if (!id || !UUID_RE.test(id)) throw error(400, 'Invalid collection id');
   const body = await parseJson(event.request, postSchema);
+
+  // Resolve the recipient — either passed by UUID or by email.
+  let recipientUserId: string;
+  if ('recipientUserId' in body) {
+    recipientUserId = body.recipientUserId;
+  } else {
+    const [row] = (await db
+      .select({ id: schema.users.id })
+      .from(schema.users)
+      .where(eq(schema.users.email, body.recipientEmail))
+      .limit(1)) as Array<{ id: string }>;
+    if (!row) throw error(404, 'No user with that email');
+    recipientUserId = row.id;
+  }
+
   try {
     const share = await grantCollectionShare({
       collectionId: id,
-      recipientUserId: body.recipientUserId,
+      recipientUserId,
       actor: { id: user.id, role: user.role },
     });
     return json({ share }, { status: 201 });

--- a/apps/web/src/routes/collections/[id]/+page.server.ts
+++ b/apps/web/src/routes/collections/[id]/+page.server.ts
@@ -1,20 +1,33 @@
 /**
- * Collection detail page (T-8.2).
+ * Collection detail page (T-8.2 + T-8.4).
  *
  * Loads the collection + ordered member texts. Visible to:
  *   - Owner (always).
+ *   - Admin (always).
  *   - Anyone, when visibility='official'.
- *   - Members of share grants (T-8.4 — no-op for now since the
- *     M7 sharing layer isn't merged into main yet).
+ *   - Members of share grants (T-8.4): when the viewer has a row in
+ *     `collection_shares` for this collection, they can view the
+ *     detail page and read every member text. The reader-side
+ *     `canReadText` already grants per-text access via the same
+ *     share row (see `viewerHasCollectionShareForText`); this gate
+ *     mirrors that policy at the collection level.
  *
  * Aggregated progress is computed in the loader so the UI stays
  * static — the backend has the user's user_text_progress rows for
  * every member text already.
+ *
+ * When the viewer is the owner we also load the existing share rows
+ * so the inline "Manage sharing" form can render without an extra
+ * round-trip.
  */
 import { error } from '@sveltejs/kit';
 import { and, eq, inArray } from 'drizzle-orm';
 
-import { loadCollectionDetail } from '$lib/server/collections.js';
+import {
+  listCollectionSharesWithRecipients,
+  loadCollectionDetail,
+  viewerHasCollectionShare,
+} from '$lib/server/collections.js';
 import { db, schema } from '$lib/server/db/index.js';
 import type { UserTextProgress } from '$lib/server/db/schema.js';
 import type { PageServerLoad } from './$types';
@@ -28,18 +41,26 @@ export const load: PageServerLoad = async ({ params, locals }) => {
   const detail = await loadCollectionDetail(params.id);
   if (!detail) throw error(404, 'Collection not found');
 
-  // Visibility gate. Mirrors the policy in T-8.4:
-  //   - official: anyone.
-  //   - private: owner-only.
-  //   - shared: owner + anyone with a share row (M7-dependent).
   const isOwner = Boolean(
     locals.user && detail.collection.ownerId === locals.user.id,
   );
   const isAdmin = locals.user?.role === 'admin';
+  // T-8.4: a non-owner non-admin viewer with a share row passes too.
+  // The per-text canReadText gate also honours these rows, so a
+  // viewer who lands on the detail page can click into any member
+  // text without a second permission denial.
+  const hasShare =
+    !isOwner &&
+    !isAdmin &&
+    locals.user != null &&
+    detail.collection.visibility !== 'official' &&
+    (await viewerHasCollectionShare(locals.user.id, detail.collection.id));
+
   if (
     detail.collection.visibility !== 'official' &&
     !isOwner &&
-    !isAdmin
+    !isAdmin &&
+    !hasShare
   ) {
     throw error(404, 'Collection not found');
   }
@@ -89,5 +110,15 @@ export const load: PageServerLoad = async ({ params, locals }) => {
       (i) => (progressByTextId[i.text.id]?.pctRead ?? 0) >= 100,
     ).length,
     isOwner,
+    // T-8.4: existing share grants for the inline manage-sharing
+    // form. Loaded only for the owner so non-owners never see who
+    // else has access. Each share is decorated with the recipient's
+    // email + display name (or null when the user was deleted).
+    shares: isOwner
+      ? await listCollectionSharesWithRecipients(detail.collection.id, {
+          id: locals.user!.id,
+          role: locals.user!.role,
+        })
+      : [],
   };
 };

--- a/apps/web/src/routes/collections/[id]/+page.svelte
+++ b/apps/web/src/routes/collections/[id]/+page.svelte
@@ -91,6 +91,48 @@
     );
     if (res.ok) await invalidateAll();
   }
+
+  // T-8.4 — manage sharing. Owner enters a recipient email; the API
+  // looks up the user and inserts a row in `collection_shares`. The
+  // grant also flips visibility from 'private' to 'shared' so the
+  // canReadText fallback path picks it up.
+  let shareEmail = $state('');
+  let sharing = $state(false);
+  let shareError = $state<string | null>(null);
+  async function grantShare(e: Event) {
+    e.preventDefault();
+    const email = shareEmail.trim();
+    if (!email) return;
+    sharing = true;
+    shareError = null;
+    try {
+      const res = await fetch(
+        `/api/v1/collections/${data.collection.id}/shares`,
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ recipientEmail: email }),
+        },
+      );
+      if (!res.ok) {
+        shareError = (await res.text().catch(() => '')) || `HTTP ${res.status}`;
+        return;
+      }
+      shareEmail = '';
+      await invalidateAll();
+    } finally {
+      sharing = false;
+    }
+  }
+
+  async function revokeShare(userId: string) {
+    if (!window.confirm('Revoke this share?')) return;
+    const res = await fetch(
+      `/api/v1/collections/${data.collection.id}/shares/${userId}`,
+      { method: 'DELETE' },
+    );
+    if (res.ok) await invalidateAll();
+  }
 </script>
 
 <svelte:head>
@@ -190,6 +232,51 @@
           onclick={() => goto('/library')}
         >Browse library</button>
       </p>
+    </section>
+
+    <section class="cd-share" data-testid="manage-shares">
+      <h2>Sharing</h2>
+      <p class="cd-muted">
+        Grant another reader access to this collection by email.
+        Sharing also unlocks every member text for that reader.
+      </p>
+      <form onsubmit={grantShare} class="cd-add-form">
+        <input
+          type="email"
+          placeholder="reader@example.com"
+          bind:value={shareEmail}
+          autocomplete="off"
+          data-testid="share-email-input"
+        />
+        <button type="submit" disabled={sharing || !shareEmail.trim()}>
+          {sharing ? 'Sharing…' : 'Grant access'}
+        </button>
+      </form>
+      {#if shareError}
+        <p class="cd-err" role="alert">{shareError}</p>
+      {/if}
+      {#if data.shares.length === 0}
+        <p class="cd-muted">No one else has access yet.</p>
+      {:else}
+        <ul class="cd-share-list">
+          {#each data.shares as s (s.sharedWithUserId)}
+            <li>
+              <span>
+                {s.recipient?.displayName ?? s.recipient?.email ?? s.sharedWithUserId}
+                {#if s.recipient?.displayName}
+                  <span class="cd-muted">· {s.recipient.email}</span>
+                {/if}
+              </span>
+              <button
+                type="button"
+                class="cd-remove"
+                aria-label="Revoke share"
+                onclick={() => revokeShare(s.sharedWithUserId)}
+              >Revoke</button>
+            </li>
+          {/each}
+        </ul>
+      {/if}
     </section>
   {/if}
 </div>
@@ -386,5 +473,39 @@
     cursor: pointer;
     font: inherit;
     text-decoration: underline;
+  }
+  .cd-share {
+    margin-top: 1.5rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--rule, var(--color-border));
+  }
+  .cd-share h2 {
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--ink-3, var(--color-fg-muted));
+    margin: 0 0 0.6rem;
+  }
+  .cd-share-list {
+    list-style: none;
+    margin: 0.6rem 0 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+  }
+  .cd-share-list li {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.6rem;
+    padding: 0.4rem 0.6rem;
+    border: 1px solid var(--rule, var(--color-border));
+    border-radius: 6px;
+    font-size: 0.85rem;
+  }
+  .cd-share-list .cd-remove {
+    color: var(--err, #b94545);
+    font-size: 0.78rem;
   }
 </style>


### PR DESCRIPTION
## Summary

The `collection_shares` schema and share-grant API existed but the detail page's visibility check was stubbed ("no-op for now since the M7 sharing layer isn't merged") and there was no manage UI. Closes the last open T-8.4 sub-item under the M8 epic.

- `viewerHasCollectionShare(viewerId, collectionId)` + `listCollectionSharesWithRecipients` in `apps/web/src/lib/server/collections.ts`. The decorated helper returns the recipient's email + display name so the UI shows something readable, not just a UUID.
- Detail page (`/collections/[id]/+page.server.ts`): visibility gate now lets share recipients view (mirrors the per-text `canReadText` policy that already honored share rows). Loads decorated shares for the owner.
- POST `/api/v1/collections/[id]/shares`: accepts `recipientEmail` in addition to `recipientUserId` — owners only know emails, not UUIDs. GET decorates rows with recipient info via the new helper.
- Inline manage-shares form on the detail page (owner only): email input + grant button + list of current shares with revoke buttons.

## Test plan

- [x] `apps/web` vitest: 1220 passing.
- [x] `apps/web` svelte-check: 0 errors.
- [x] `collections.test.ts` adds 2 cases for `viewerHasCollectionShare`; existing share / grant / revoke / list tests still green.
- [ ] Browser-side smoke of the share form (grant by email, revoke, recipient detail-page access) not done in this PR.

Refs #75.