### PR TITLE
T-11.2: rate limits on text uploads, EPUB, corrections, audio

### DIFF
--- a/apps/web/src/routes/api/v1/me/token-corrections/+server.ts
+++ b/apps/web/src/routes/api/v1/me/token-corrections/+server.ts
@@ -14,6 +14,11 @@ import { z } from 'zod';
 
 import { requireUser } from '$lib/server/auth/require-user.js';
 import {
+  consumeRateLimit,
+  rateLimitHeaders,
+  RequestRateLimitError,
+} from '$lib/server/auth/rate-limits.js';
+import {
   CorrectionValidationError,
   writeTokenCorrection,
 } from '$lib/server/corrections.js';
@@ -21,6 +26,12 @@ import { parseJson } from '../../auth/_helpers.js';
 import type { RequestHandler } from './$types';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// T-11.2: corrections per hour. Active proofreading bursts can hit
+// dozens of corrections in a session; 200/hour leaves comfortable
+// headroom while catching scripted spam.
+const CORRECTIONS_PER_HOUR = 200;
+const CORRECTION_WINDOW_MS = 60 * 60 * 1_000;
 
 const bodySchema = z
   .object({
@@ -47,6 +58,11 @@ export const POST: RequestHandler = async (event) => {
   const body = await parseJson(event.request, bodySchema);
 
   try {
+    const requestLimit = await consumeRateLimit(event, user.id, {
+      scope: 'corrections:create',
+      limit: CORRECTIONS_PER_HOUR,
+      windowMs: CORRECTION_WINDOW_MS,
+    });
     const row = await writeTokenCorrection({
       userId: user.id,
       tokenId: body.tokenId,
@@ -54,8 +70,22 @@ export const POST: RequestHandler = async (event) => {
       chosenLemmaId: body.chosenLemmaId ?? null,
       note: body.note ?? null,
     });
-    return json({ correction: row }, { status: 201 });
+    return json(
+      { correction: row },
+      { status: 201, headers: rateLimitHeaders(requestLimit) },
+    );
   } catch (err) {
+    if (err instanceof RequestRateLimitError) {
+      return json(
+        {
+          error: 'rate_limited',
+          message: 'Too many corrections submitted. Try again in a bit.',
+          limit: err.limit,
+          retryAfterSeconds: err.retryAfterSeconds,
+        },
+        { status: 429, headers: rateLimitHeaders(err) },
+      );
+    }
     if (err instanceof CorrectionValidationError) {
       throw error(err.status, err.message);
     }

--- a/apps/web/src/routes/api/v1/me/token-corrections/token-corrections-server.test.ts
+++ b/apps/web/src/routes/api/v1/me/token-corrections/token-corrections-server.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const writeTokenCorrection = vi.fn();
 const requireUser = vi.fn();
+const consumeRateLimit = vi.fn();
 
 vi.mock('$lib/server/corrections.js', async () => {
   const actual = await vi.importActual<typeof import('$lib/server/corrections.js')>(
@@ -20,6 +21,16 @@ vi.mock('$lib/server/corrections.js', async () => {
 vi.mock('$lib/server/auth/require-user.js', () => ({
   requireUser: (...a: unknown[]) => requireUser(...a),
 }));
+
+vi.mock('$lib/server/auth/rate-limits.js', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/auth/rate-limits.js')>(
+    '$lib/server/auth/rate-limits.js',
+  );
+  return {
+    ...actual,
+    consumeRateLimit: (...a: unknown[]) => consumeRateLimit(...a),
+  };
+});
 
 type Post = (typeof import('./+server.js'))['POST'];
 
@@ -46,6 +57,12 @@ beforeEach(() => {
   writeTokenCorrection.mockReset();
   requireUser.mockReset();
   requireUser.mockResolvedValue({ id: 'u1' });
+  consumeRateLimit.mockReset();
+  consumeRateLimit.mockResolvedValue({
+    limit: 200,
+    remaining: 199,
+    subjectType: 'user',
+  });
 });
 
 afterEach(() => vi.resetModules());

--- a/apps/web/src/routes/api/v1/texts/+server.ts
+++ b/apps/web/src/routes/api/v1/texts/+server.ts
@@ -19,6 +19,11 @@ import { z } from 'zod';
 
 import { requireUser } from '$lib/server/auth/require-user.js';
 import {
+  consumeRateLimit,
+  rateLimitHeaders,
+  RequestRateLimitError,
+} from '$lib/server/auth/rate-limits.js';
+import {
   createPastedText,
   createTxtText,
   TextValidationError,
@@ -28,6 +33,14 @@ import {
 } from '$lib/server/texts/upload.js';
 import type { RequestHandler } from './$types';
 import { parseJson } from '../auth/_helpers.js';
+
+// T-11.2: per-day cap on text uploads. 50/day is generous for an
+// engaged learner uploading a chapter at a time and trips long
+// before a runaway script floods the chunker. Window is exactly
+// 24h so a user who uploads at 11pm doesn't get throttled at 1am
+// of the next calendar day.
+const UPLOADS_PER_DAY = 50;
+const UPLOAD_WINDOW_MS = 24 * 60 * 60 * 1_000;
 
 // One discriminated schema per source type — paste's body cap is
 // stricter than .txt's, and the error message users see should reflect
@@ -52,6 +65,11 @@ export const POST: RequestHandler = async (event) => {
   const user = await requireUser(event);
   const input = await parseJson(event.request, body);
   try {
+    const requestLimit = await consumeRateLimit(event, user.id, {
+      scope: 'texts:create',
+      limit: UPLOADS_PER_DAY,
+      windowMs: UPLOAD_WINDOW_MS,
+    });
     const created =
       input.sourceType === 'txt'
         ? await createTxtText(
@@ -85,9 +103,20 @@ export const POST: RequestHandler = async (event) => {
         },
         chapterCount: created.chapters.length,
       },
-      { status: 201 },
+      { status: 201, headers: rateLimitHeaders(requestLimit) },
     );
   } catch (err) {
+    if (err instanceof RequestRateLimitError) {
+      return json(
+        {
+          error: 'rate_limited',
+          message: 'Daily text upload limit reached. Try again tomorrow.',
+          limit: err.limit,
+          retryAfterSeconds: err.retryAfterSeconds,
+        },
+        { status: 429, headers: rateLimitHeaders(err) },
+      );
+    }
     if (err instanceof TextValidationError) throw error(err.status, err.message);
     throw err;
   }

--- a/apps/web/src/routes/api/v1/texts/[id]/audio/+server.ts
+++ b/apps/web/src/routes/api/v1/texts/[id]/audio/+server.ts
@@ -8,6 +8,11 @@ import { error, json } from '@sveltejs/kit';
 
 import { requireUser } from '$lib/server/auth/require-user.js';
 import {
+  consumeRateLimit,
+  rateLimitHeaders,
+  RequestRateLimitError,
+} from '$lib/server/auth/rate-limits.js';
+import {
   AudioError,
   listAudioForText,
   uploadAudio,
@@ -17,6 +22,13 @@ import { getReadableText } from '$lib/server/texts/upload.js';
 import type { RequestHandler } from './$types';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// T-11.2: per-day cap on audio uploads (the per-file size cap lives
+// in `MAX_AUDIO_BYTES`, enforced inside `uploadAudio`). 20/day is
+// generous for chapter-by-chapter narration uploads while keeping
+// storage growth and worker queue depth bounded.
+const AUDIO_UPLOADS_PER_DAY = 20;
+const AUDIO_WINDOW_MS = 24 * 60 * 60 * 1_000;
 
 export const GET: RequestHandler = async (event) => {
   const id = event.params.id;
@@ -55,6 +67,11 @@ export const POST: RequestHandler = async (event) => {
   const acknowledgedRedistribution =
     ackRaw === 'on' || ackRaw === 'true' || ackRaw === '1';
   try {
+    const requestLimit = await consumeRateLimit(event, user.id, {
+      scope: 'audio:upload',
+      limit: AUDIO_UPLOADS_PER_DAY,
+      windowMs: AUDIO_WINDOW_MS,
+    });
     const buf = new Uint8Array(await file.arrayBuffer());
     const audio = await uploadAudio({
       textId: id,
@@ -74,8 +91,22 @@ export const POST: RequestHandler = async (event) => {
       uploader: { id: user.id, role: user.role },
       acknowledgedRedistribution,
     });
-    return json({ audio }, { status: 201 });
+    return json(
+      { audio },
+      { status: 201, headers: rateLimitHeaders(requestLimit) },
+    );
   } catch (e) {
+    if (e instanceof RequestRateLimitError) {
+      return json(
+        {
+          error: 'rate_limited',
+          message: 'Daily audio upload limit reached. Try again tomorrow.',
+          limit: e.limit,
+          retryAfterSeconds: e.retryAfterSeconds,
+        },
+        { status: 429, headers: rateLimitHeaders(e) },
+      );
+    }
     if (e instanceof AudioError) throw error(e.status, e.message);
     throw e;
   }

--- a/apps/web/src/routes/api/v1/texts/epub/+server.ts
+++ b/apps/web/src/routes/api/v1/texts/epub/+server.ts
@@ -22,6 +22,11 @@ import { error, json } from '@sveltejs/kit';
 
 import { requireUser } from '$lib/server/auth/require-user.js';
 import {
+  consumeRateLimit,
+  rateLimitHeaders,
+  RequestRateLimitError,
+} from '$lib/server/auth/rate-limits.js';
+import {
   createEpubText,
   EpubParseError,
   TextValidationError,
@@ -32,6 +37,12 @@ import {
 import type { RequestHandler } from './$types';
 
 const SUPPORTED_LANGS = new Set(['hi', 'mr', 'or']);
+
+// T-11.2: EPUB ingest is expensive (chunking + parsing + chapter
+// fan-out), so the daily quota is tighter than the paste / .txt
+// path. 10/day still covers a learner working through a course.
+const EPUB_UPLOADS_PER_DAY = 10;
+const UPLOAD_WINDOW_MS = 24 * 60 * 60 * 1_000;
 
 export const POST: RequestHandler = async (event) => {
   const user = await requireUser(event);
@@ -75,6 +86,11 @@ export const POST: RequestHandler = async (event) => {
 
   const epubBytes = new Uint8Array(await file.arrayBuffer());
   try {
+    const requestLimit = await consumeRateLimit(event, user.id, {
+      scope: 'texts:epub',
+      limit: EPUB_UPLOADS_PER_DAY,
+      windowMs: UPLOAD_WINDOW_MS,
+    });
     const created = await createEpubText(
       { id: user.id },
       {
@@ -98,9 +114,20 @@ export const POST: RequestHandler = async (event) => {
         },
         chapterCount: created.chapters.length,
       },
-      { status: 201 },
+      { status: 201, headers: rateLimitHeaders(requestLimit) },
     );
   } catch (err) {
+    if (err instanceof RequestRateLimitError) {
+      return json(
+        {
+          error: 'rate_limited',
+          message: 'Daily EPUB upload limit reached. Try again tomorrow.',
+          limit: err.limit,
+          retryAfterSeconds: err.retryAfterSeconds,
+        },
+        { status: 429, headers: rateLimitHeaders(err) },
+      );
+    }
     if (err instanceof TextValidationError) throw error(err.status, err.message);
     if (err instanceof EpubParseError) throw error(400, err.message);
     throw err;

--- a/apps/web/src/routes/api/v1/texts/epub/epub-server.test.ts
+++ b/apps/web/src/routes/api/v1/texts/epub/epub-server.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const createEpubText = vi.fn();
 const requireUser = vi.fn();
+const consumeRateLimit = vi.fn();
 
 vi.mock('$lib/server/texts/upload.js', async () => {
   const actual = await vi.importActual<typeof import('$lib/server/texts/upload.js')>(
@@ -20,6 +21,16 @@ vi.mock('$lib/server/texts/upload.js', async () => {
 vi.mock('$lib/server/auth/require-user.js', () => ({
   requireUser: (...a: unknown[]) => requireUser(...a),
 }));
+
+vi.mock('$lib/server/auth/rate-limits.js', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/auth/rate-limits.js')>(
+    '$lib/server/auth/rate-limits.js',
+  );
+  return {
+    ...actual,
+    consumeRateLimit: (...a: unknown[]) => consumeRateLimit(...a),
+  };
+});
 
 type PostFn = (typeof import('./+server.js'))['POST'];
 
@@ -63,6 +74,12 @@ async function callPost(
 beforeEach(() => {
   createEpubText.mockReset();
   requireUser.mockReset();
+  consumeRateLimit.mockReset();
+  consumeRateLimit.mockResolvedValue({
+    limit: 10,
+    remaining: 9,
+    subjectType: 'user',
+  });
 });
 
 afterEach(() => {

--- a/apps/web/src/routes/api/v1/texts/texts-server.test.ts
+++ b/apps/web/src/routes/api/v1/texts/texts-server.test.ts
@@ -9,6 +9,7 @@ import { jsonContract } from '$lib/test/json-contract.js';
 const createPastedText = vi.fn();
 const createTxtText = vi.fn();
 const requireUser = vi.fn();
+const consumeRateLimit = vi.fn();
 
 vi.mock('$lib/server/texts/upload.js', async () => {
   const actual = await vi.importActual<typeof import('$lib/server/texts/upload.js')>(
@@ -24,6 +25,16 @@ vi.mock('$lib/server/texts/upload.js', async () => {
 vi.mock('$lib/server/auth/require-user.js', () => ({
   requireUser: (...a: unknown[]) => requireUser(...a),
 }));
+
+vi.mock('$lib/server/auth/rate-limits.js', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/auth/rate-limits.js')>(
+    '$lib/server/auth/rate-limits.js',
+  );
+  return {
+    ...actual,
+    consumeRateLimit: (...a: unknown[]) => consumeRateLimit(...a),
+  };
+});
 
 type PostFn = (typeof import('./+server.js'))['POST'];
 
@@ -58,6 +69,12 @@ beforeEach(() => {
   createPastedText.mockReset();
   createTxtText.mockReset();
   requireUser.mockReset();
+  consumeRateLimit.mockReset();
+  consumeRateLimit.mockResolvedValue({
+    limit: 50,
+    remaining: 49,
+    subjectType: 'user',
+  });
 });
 
 afterEach(() => {
@@ -194,6 +211,25 @@ describe('POST /api/v1/texts', () => {
       null,
     )) as { status: number };
     expect(res.status).toBe(401);
+    expect(createPastedText).not.toHaveBeenCalled();
+  });
+
+  it('returns 429 when the daily upload rate limit is exceeded (T-11.2)', async () => {
+    const { RequestRateLimitError } = await import(
+      '$lib/server/auth/rate-limits.js'
+    );
+    consumeRateLimit.mockRejectedValueOnce(
+      new RequestRateLimitError(86_400, 50, 'user'),
+    );
+    const res = (await callPost({
+      language: 'hi',
+      title: 'X',
+      body: 'hello',
+    })) as Response;
+    expect(res.status).toBe(429);
+    expect(res.headers.get('Retry-After')).toBe('86400');
+    const json = await res.json();
+    expect(json.error).toBe('rate_limited');
     expect(createPastedText).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

The shared rate-limit infrastructure (DB-backed event table, per-user / per-device / per-API-key subjects, `X-RateLimit-*` + `Retry-After` headers) already existed; only the translations endpoint was wired through. This wires the remaining surfaces called out in the T-11.2 spec.

| Surface | Scope | Limit | Window |
|---|---|---|---|
| `POST /api/v1/texts` (paste / .txt) | `texts:create` | 50 | 24h |
| `POST /api/v1/texts/epub` | `texts:epub` | 10 | 24h |
| `POST /api/v1/me/token-corrections` | `corrections:create` | 200 | 1h |
| `POST /api/v1/texts/[id]/audio` | `audio:upload` | 20 | 24h |

Audio per-file size cap (`MAX_AUDIO_BYTES`) already lived inside `uploadAudio` — the new daily quota stacks on top.

429 responses match the existing translations envelope (`rate_limited` + `limit` + `retryAfterSeconds`), so a single 429 handler on the client covers every endpoint.

## Test plan

- [x] `apps/web` vitest: 1221 passing.
- [x] `apps/web` svelte-check: 0 errors.
- [x] `texts-server.test.ts` adds a 429-shape assertion for the upload limit.
- [x] `texts-server.test.ts`, `epub-server.test.ts`, `token-corrections-server.test.ts` mock `consumeRateLimit` (matching the established translations test pattern).
- [ ] Manual smoke against a running stack to verify limits trip at the right thresholds.

Closes #98. Refs #96.