### PR TITLE
T-11.3: owner retry on failed text + audio load-error retry

### DIFF
--- a/apps/web/src/lib/components/reader/AudioPlayer.svelte
+++ b/apps/web/src/lib/components/reader/AudioPlayer.svelte
@@ -43,6 +43,10 @@
   let pendingListeningMs = 0;
   let pendingListeningAudioId: string | null = null;
   let lastMediaSec: number | null = null;
+  // T-11.3: surface a load failure so a flaky network or a 404 on
+  // the storage backend doesn't leave the player silently stuck.
+  // The retry button calls `audioEl.load()` again.
+  let loadError = $state<string | null>(null);
 
   const SPEEDS = [0.5, 0.75, 1, 1.25, 1.5, 1.75, 2];
   const LISTENING_FLUSH_MS = 10_000;
@@ -98,9 +102,28 @@
   }
   function onLoadedMetadata() {
     if (!audioEl) return;
+    loadError = null;
     if (Number.isFinite(audioEl.duration) && audioEl.duration > 0) {
       durationSec = audioEl.duration;
     }
+  }
+
+  function onAudioError() {
+    // The HTMLMediaElement spec assigns numeric error codes; map
+    // the common ones to friendlier wording. Anything else falls
+    // through as a generic failure.
+    const code = audioEl?.error?.code;
+    if (code === 2) loadError = 'Network error while loading audio.';
+    else if (code === 3) loadError = 'Audio file could not be decoded.';
+    else if (code === 4) loadError = 'Audio source not supported.';
+    else loadError = 'Audio failed to load.';
+    isPlaying = false;
+  }
+
+  function retryLoad() {
+    if (!audioEl) return;
+    loadError = null;
+    audioEl.load();
   }
   function onPlay() {
     isPlaying = true;
@@ -203,9 +226,22 @@
     preload="metadata"
     ontimeupdate={onTimeUpdate}
     onloadedmetadata={onLoadedMetadata}
+    onerror={onAudioError}
     onplay={onPlay}
     onpause={onPause}
   ></audio>
+
+  {#if loadError}
+    <!-- T-11.3: load-failure banner with a retry button. Keyboard
+         users can tab to the retry button; screen readers get the
+         message via role="alert". -->
+    <p class="ap-err" role="alert" data-testid="audio-load-error">
+      <span>{loadError}</span>
+      <button type="button" onclick={retryLoad} data-testid="audio-retry">
+        Retry
+      </button>
+    </p>
+  {/if}
 
   <button
     type="button"
@@ -319,6 +355,28 @@
     gap: 0.45rem;
     justify-content: center;
     flex-wrap: wrap;
+  }
+  .ap-err {
+    grid-column: 1 / -1;
+    margin: 0;
+    padding: 0.4rem 0.7rem;
+    border-radius: 6px;
+    background: color-mix(in oklch, var(--err, #b94545) 10%, transparent);
+    color: var(--err, #b94545);
+    font-size: 0.82rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.6rem;
+  }
+  .ap-err button {
+    background: var(--err, #b94545);
+    color: var(--paper, var(--color-bg));
+    border: 0;
+    border-radius: 4px;
+    padding: 0.2rem 0.6rem;
+    font: inherit;
+    cursor: pointer;
   }
   .ap-license {
     background: color-mix(in oklch, var(--ink, var(--color-fg)) 6%, transparent);

--- a/apps/web/src/routes/api/v1/admin/texts/[id]/reprocess/+server.ts
+++ b/apps/web/src/routes/api/v1/admin/texts/[id]/reprocess/+server.ts
@@ -8,22 +8,45 @@
  * re-processing after dictionary / override updates.
  *
  * Synchronous (awaits the full process), so the caller can tell
- * whether the run succeeded. Admin-only.
+ * whether the run succeeded.
+ *
+ * Authorization (T-11.3): admin OR text owner. Owners need a retry
+ * affordance when their own upload lands in `failed` — gating it
+ * behind admin meant a learner whose text bombed had no recourse
+ * but to delete + re-upload. Non-owners (even with read access via
+ * a share) are still rejected because re-running the pipeline is
+ * an active operation, not a read.
  */
+import { eq } from 'drizzle-orm';
 import { error, json } from '@sveltejs/kit';
 
 import { requireUser } from '$lib/server/auth/require-user.js';
+import { db, schema } from '$lib/server/db/index.js';
 import { isAdmin } from '$lib/server/dictionary/permissions.js';
 import { processTextNow } from '$lib/server/texts/in-process-dispatcher.js';
+import type { Text } from '$lib/server/db/schema.js';
 import type { RequestHandler } from './$types';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export const POST: RequestHandler = async (event) => {
   const user = await requireUser(event);
-  if (!isAdmin({ role: user.role })) throw error(403, 'Admin role required');
   const id = event.params.id;
   if (!id || !UUID_RE.test(id)) throw error(400, 'Invalid text id');
+
+  if (!isAdmin({ role: user.role })) {
+    // Non-admin path: must own the text. Flat 404 if missing or
+    // owned by someone else, matching the rest of the texts API.
+    const [row] = (await db
+      .select()
+      .from(schema.texts)
+      .where(eq(schema.texts.id, id))
+      .limit(1)) as [Text | undefined];
+    if (!row || row.ownerId !== user.id) {
+      throw error(404, 'Text not found');
+    }
+  }
+
   const total = await processTextNow(id);
   return json({ ok: true, tokensWritten: total });
 };

--- a/apps/web/src/routes/api/v1/admin/texts/[id]/reprocess/reprocess-server.test.ts
+++ b/apps/web/src/routes/api/v1/admin/texts/[id]/reprocess/reprocess-server.test.ts
@@ -4,6 +4,32 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const processTextNow = vi.fn();
 const requireUser = vi.fn();
 
+// Stage rows for the ownership-check db lookup in the non-admin path.
+const staged: Array<unknown[]> = [];
+function stage(rows: unknown[]) {
+  staged.push(rows);
+}
+
+function makeSelectChain() {
+  const chain: Record<string, unknown> = {};
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.limit = vi.fn(() => chain);
+  chain.then = (resolve: (v: unknown) => unknown) => {
+    const v = staged.shift();
+    if (!v) throw new Error('Test bug: no staged db result');
+    return resolve(v);
+  };
+  return chain;
+}
+
+vi.mock('$lib/server/db/index.js', () => ({
+  db: { select: () => makeSelectChain() },
+  schema: {
+    texts: { id: 'texts.id', ownerId: 'texts.ownerId' },
+  },
+}));
+
 vi.mock('$lib/server/texts/in-process-dispatcher.js', async () => {
   const actual = await vi.importActual<
     typeof import('$lib/server/texts/in-process-dispatcher.js')
@@ -44,6 +70,7 @@ async function callPost(id = VALID_ID, user: typeof ADMIN | typeof USER | null =
 beforeEach(() => {
   processTextNow.mockReset();
   requireUser.mockReset();
+  staged.length = 0;
 });
 
 afterEach(() => {
@@ -51,7 +78,7 @@ afterEach(() => {
 });
 
 describe('POST /api/v1/admin/texts/:id/reprocess', () => {
-  it('runs the dispatcher and returns the token count', async () => {
+  it('runs the dispatcher and returns the token count for an admin', async () => {
     processTextNow.mockResolvedValueOnce(1234);
     const res = (await callPost()) as Response;
     expect(res.status).toBe(200);
@@ -60,9 +87,29 @@ describe('POST /api/v1/admin/texts/:id/reprocess', () => {
     expect(processTextNow).toHaveBeenCalledWith(VALID_ID);
   });
 
-  it('rejects non-admins with 403', async () => {
+  // T-11.3: owners can retry their own failed text. Non-owners
+  // (even authenticated readers) get a flat 404, matching the rest
+  // of the texts API — we don't leak text existence.
+  it('lets the text owner trigger a reprocess (T-11.3)', async () => {
+    stage([{ id: VALID_ID, ownerId: USER.id }]);
+    processTextNow.mockResolvedValueOnce(99);
+    const res = (await callPost(VALID_ID, USER)) as Response;
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.tokensWritten).toBe(99);
+  });
+
+  it('returns 404 when a non-admin non-owner asks (T-11.3)', async () => {
+    stage([{ id: VALID_ID, ownerId: 'someone-else' }]);
     const res = (await callPost(VALID_ID, USER)) as { status: number };
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(404);
+    expect(processTextNow).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the text does not exist for a non-admin', async () => {
+    stage([]);
+    const res = (await callPost(VALID_ID, USER)) as { status: number };
+    expect(res.status).toBe(404);
     expect(processTextNow).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/routes/reader/[textId]/+page.svelte
+++ b/apps/web/src/routes/reader/[textId]/+page.svelte
@@ -426,16 +426,28 @@
         Aa
       </button>
 
-      {#if data.isAdmin}
+      {#if data.isAdmin || (data.isOwner && liveStatus === 'failed')}
+        <!-- T-11.3: owners get a Retry button when their own text
+             is in the failed state, so a botched upload isn't a
+             dead end. Admins keep the always-on Reprocess affordance
+             for diagnostics + dictionary-update reprocessing. -->
         <button
           type="button"
           class="reprocess-toggle"
           onclick={reprocessText}
           disabled={reprocessing}
-          title="Re-run the NLP pipeline on this text (admin only)"
-          data-testid="admin-reprocess"
+          title={data.isAdmin
+            ? 'Re-run the NLP pipeline on this text (admin)'
+            : 'Retry processing this text'}
+          data-testid={data.isAdmin ? 'admin-reprocess' : 'owner-retry'}
         >
-          {reprocessing ? 'Reprocessing…' : 'Reprocess'}
+          {reprocessing
+            ? data.isAdmin
+              ? 'Reprocessing…'
+              : 'Retrying…'
+            : data.isAdmin
+              ? 'Reprocess'
+              : 'Retry'}
         </button>
       {/if}
 


### PR DESCRIPTION
## Summary

Two retry surfaces called out in T-11.3 spec ("'NLP job failed' / 'audio failed to load' surfaced with retry buttons").

**NLP failure.** The reader page already showed a Processing-failed alert but the only retry affordance was admin-only — non-admin owners whose own upload landed in failed had no recourse.

- `POST /api/v1/admin/texts/[id]/reprocess` now allows admin OR text owner; non-owner non-admins get a flat 404 (matching the rest of the texts API to avoid leaking text existence).
- Reader page shows a Retry button when `isOwner && liveStatus === 'failed'`; admins keep the always-on Reprocess affordance.

**Audio load failure.** The `<audio>` element had no `onerror` wiring — a flaky network or 404 on the storage backend silently left the player stuck.

- `AudioPlayer.svelte` adds an `onAudioError` handler that maps `HTMLMediaError.code` to a friendly string (network / decode / unsupported / generic) and surfaces a `role="alert"` banner with a Retry button calling `audioEl.load()`.

## Test plan

- [x] `apps/web` vitest: 1223 passing.
- [x] `apps/web` svelte-check: 0 errors.
- [x] `reprocess-server.test.ts` rewritten for the new dual-mode auth — 5 cases (admin happy path, owner happy path, non-owner 404, missing-text 404, invalid-uuid 400).
- [ ] Browser-side smoke of the retry surfaces (force a failed text + an audio 404) not done in this PR.

T-11.4's audio-player keyboard shortcuts ship in a follow-up PR stacked on this branch.

Closes #99. Refs #96.