### PR TITLE
T-11.4: J/K/L keyboard shortcuts for the audio player

### DIFF
--- a/apps/web/src/lib/components/reader/AudioPlayer.svelte
+++ b/apps/web/src/lib/components/reader/AudioPlayer.svelte
@@ -181,10 +181,42 @@
     });
   }
 
+  // T-11.4: YouTube-style keyboard shortcuts (J/K/L) for the audio
+  // player. Picked these letters specifically because they don't
+  // conflict with browser defaults (Space scrolls the page; arrows
+  // navigate the page) and they're already familiar to users from
+  // video players. K toggles play/pause, J seeks back 5s, L seeks
+  // forward 5s. Intentionally NO-OP when the user is typing in an
+  // input / textarea / contenteditable so reader search and
+  // translation forms stay usable.
+  const SEEK_SECONDS = 5;
+  function isTypingTarget(t: EventTarget | null): boolean {
+    if (!(t instanceof HTMLElement)) return false;
+    const tag = t.tagName;
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+    return t.isContentEditable;
+  }
+  function onPlayerKeydown(e: KeyboardEvent) {
+    if (e.altKey || e.ctrlKey || e.metaKey) return;
+    if (isTypingTarget(e.target)) return;
+    const key = e.key.toLowerCase();
+    if (key === 'k') {
+      e.preventDefault();
+      toggle();
+    } else if (key === 'j') {
+      e.preventDefault();
+      seekToSec(currentSec - SEEK_SECONDS);
+    } else if (key === 'l') {
+      e.preventDefault();
+      seekToSec(currentSec + SEEK_SECONDS);
+    }
+  }
+
   onMount(() => {
     setAudioState({ audioFileId: audio.id, isPlaying: false, currentTimeMs: 0 });
     window.addEventListener('pagehide', flushListeningOnPageHide);
     window.addEventListener('beforeunload', flushListeningOnPageHide);
+    window.addEventListener('keydown', onPlayerKeydown);
     const controller: AudioController = {
       seekMs: (ms) => seekToSec(ms / 1000),
       play,
@@ -195,6 +227,7 @@
       flushListeningOnPageHide();
       window.removeEventListener('pagehide', flushListeningOnPageHide);
       window.removeEventListener('beforeunload', flushListeningOnPageHide);
+      window.removeEventListener('keydown', onPlayerKeydown);
       setAudioController(null);
       setAudioState({ audioFileId: null, isPlaying: false, currentTimeMs: 0 });
     };
@@ -248,6 +281,8 @@
     class="ap-toggle"
     onclick={toggle}
     aria-label={isPlaying ? 'Pause' : 'Play'}
+    aria-keyshortcuts="K"
+    title={isPlaying ? 'Pause (K)' : 'Play (K)'}
   >
     {isPlaying ? '⏸' : '▶'}
   </button>


### PR DESCRIPTION
## Summary

YouTube-style keyboard shortcuts on the audio player: **K** toggles play/pause, **J** seeks back 5s, **L** seeks forward 5s. Picked these letters because they don't conflict with browser defaults (Space scrolls the page; arrows navigate the page) and they're already familiar to users from video players.

The handler is intentionally NO-OP when the focused element is an input / textarea / select / contenteditable so reader search and translation forms stay usable. Modifier-key chords (Ctrl/Cmd/Alt + K/J/L) pass through so platform shortcuts keep working.

Discoverability: `aria-keyshortcuts="K"` + a "(K)" hint in the play button's `title` attribute.

**Other a11y verified during the T-11.4 audit (already shipped):** Sheet carries `role="dialog"` + `aria-modal="true"` + `aria-labelledby`; WordPopup handles Escape; audio scrubber is a native range input with aria-label; audio toggle + speed select use native button / select semantics; audio load-error banner from T-11.3 ships with `role="alert"`.

**Out of scope (needs real-device QA from T-11.5, #101):** color-contrast measurement on highlight modes, full screen-reader smoke pass.

## Stacks on #377

This PR's diff is tiny but the file (`AudioPlayer.svelte`) is also touched by T-11.3's audio load-error work. Base branch is `feat/t-11.3-error-states` so the diff shows only the J/K/L additions. When #377 merges, GitHub will retarget this PR to `main`.

## Test plan

- [x] `apps/web` vitest: 1223 passing.
- [x] `apps/web` svelte-check: 0 errors.
- [ ] Browser-side smoke of the shortcuts (J/K/L vs typing in popup form vs typing in dictionary search) not done in this PR.

Closes #100. Refs #96.