### PR TITLE
chore: add seed-admin script for dev user provisioning

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,7 +18,8 @@
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
     "dictionary:import": "tsx scripts/import-dictionary.ts",
-    "aggregate-corrections": "tsx scripts/aggregate-corrections.ts"
+    "aggregate-corrections": "tsx scripts/aggregate-corrections.ts",
+    "seed-admin": "tsx scripts/seed-admin.ts"
   },
   "dependencies": {
     "@ciareader/shared-types": "workspace:*",

--- a/apps/web/scripts/seed-admin.ts
+++ b/apps/web/scripts/seed-admin.ts
@@ -1,0 +1,116 @@
+/**
+ * Dev-only seeder for an admin (or other-role) user. Idempotent — if the
+ * email already exists, password_hash + role are updated; otherwise a new
+ * row is inserted with email_verified_at=NOW so login works immediately.
+ *
+ *   pnpm seed-admin user@example.com plainpassword
+ *   pnpm seed-admin user@example.com plainpassword --role curator --name "Foo Bar"
+ *
+ * Reads DATABASE_URL from apps/web/.env (auto-loaded via the same
+ * dotenv pattern used by import-dictionary).
+ */
+import { config as loadEnv } from 'dotenv';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import { drizzle } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+
+import * as schema from '../src/lib/server/db/schema.js';
+import { hashPassword } from '../src/lib/server/auth/password.js';
+
+loadEnv({ path: resolve(dirname(fileURLToPath(import.meta.url)), '..', '.env') });
+
+const DATABASE_URL =
+  process.env.DATABASE_URL ??
+  'postgres://ciareader:ciareader@localhost:5432/ciareader';
+
+const VALID_ROLES = ['user', 'curator', 'admin'] as const;
+type Role = (typeof VALID_ROLES)[number];
+
+function parseArgs(argv: string[]): {
+  email: string;
+  password: string;
+  role: Role;
+  displayName: string | null;
+} {
+  const positional: string[] = [];
+  const flags: Record<string, string> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg.startsWith('--')) {
+      const key = arg.slice(2);
+      const val = argv[i + 1];
+      if (val === undefined || val.startsWith('--')) {
+        throw new Error(`flag --${key} needs a value`);
+      }
+      flags[key] = val;
+      i++;
+    } else {
+      positional.push(arg);
+    }
+  }
+  if (positional.length < 2) {
+    throw new Error(
+      'usage: pnpm seed-admin <email> <password> [--role user|curator|admin] [--name "Display Name"]',
+    );
+  }
+  const role = (flags.role ?? 'admin') as Role;
+  if (!(VALID_ROLES as readonly string[]).includes(role)) {
+    throw new Error(`invalid --role "${role}"; must be one of ${VALID_ROLES.join(', ')}`);
+  }
+  return {
+    email: positional[0],
+    password: positional[1],
+    role,
+    displayName: flags.name ?? null,
+  };
+}
+
+let parsed: ReturnType<typeof parseArgs>;
+try {
+  parsed = parseArgs(process.argv.slice(2));
+} catch (e) {
+  console.error((e as Error).message);
+  process.exit(1);
+}
+
+const { email, password, role, displayName } = parsed;
+
+const client = postgres(DATABASE_URL, { max: 1, idle_timeout: 5 });
+const db = drizzle(client, { schema });
+
+const passwordHash = await hashPassword(password);
+const now = new Date();
+
+const [row] = await db
+  .insert(schema.users)
+  .values({
+    email,
+    passwordHash,
+    role,
+    displayName,
+    emailVerifiedAt: now,
+  })
+  .onConflictDoUpdate({
+    target: schema.users.email,
+    set: {
+      passwordHash,
+      role,
+      updatedAt: now,
+      // Preserve existing display_name when --name isn't supplied, so re-running
+      // the script to rotate a password doesn't wipe the on-record name.
+      ...(displayName !== null && { displayName }),
+    },
+  })
+  .returning({
+    id: schema.users.id,
+    email: schema.users.email,
+    role: schema.users.role,
+    displayName: schema.users.displayName,
+    emailVerifiedAt: schema.users.emailVerifiedAt,
+  });
+
+console.log('seeded user:', row);
+
+await client.end();


### PR DESCRIPTION
## Summary

Codifies the dev-user-provisioning ritual (manual `node -e <hash>` + `psql INSERT`) into a repeatable, idempotent CLI. Mirrors the shape of the existing standalone scripts under `apps/web/scripts/`: tsx-executed, postgres-js + drizzle, dotenv-loaded `apps/web/.env`.

```
pnpm seed-admin user@example.com plainpassword
pnpm seed-admin user@example.com plainpassword --role curator --name "Foo Bar"
```

- **Idempotent** on email — re-running rotates `password_hash` and (optionally) `role` / `display_name`. Re-running *without* `--name` preserves the existing `display_name` so a password rotation doesn't wipe it.
- **Validates** `--role` against the `user_role` enum (`user|curator|admin`).
- **Defaults** `--role` to `admin` since "admin user provisioning" is the primary use case the script is named for.
- Sets `email_verified_at=NOW` on insert so the seeded user can log in immediately, bypassing the magic-link verification flow.
- Reuses `hashPassword` from `$lib/server/auth/password` so the argon2 parameters stay in lock-step with the production login path — if the cost params get bumped, this script picks it up automatically.

## Test plan

Smoke-tested against a local DB (test rows cleaned up after each run):

- [x] No args → prints usage to stderr, exits 1.
- [x] `--role banana` → rejects with "must be one of user, curator, admin", exits 1.
- [x] Fresh insert with `--name "Original Name"` → row created, `role=admin`, `display_name=Original Name`, `email_verified_at` populated.
- [x] Re-run without `--name`, with `--role curator` → same UUID, role updated to `curator`, **`display_name` preserved as "Original Name"**.
- [x] Re-run with `--name "Updated Name"` → same UUID, `display_name` updated.
- [x] `pnpm typecheck` clean.
- [x] `pnpm lint scripts/seed-admin.ts` clean.

## Out of scope

- Test file: this is a dev-only utility, follows the same no-test pattern as `seed-form-overrides.mjs` and `reprocess-text.mjs`. The interesting logic (`hashPassword`, the `users` schema) is already covered by existing tests.
- Bulk seed / fixtures: this script does one user per invocation. If we ever want to seed a fixture set, that's a separate "fixtures" script that calls the same upsert helper.