### PR TITLE
Streamline "add my translation" UX in word popup

### DIFF
--- a/apps/web/src/lib/components/reader/WordPopup.svelte
+++ b/apps/web/src/lib/components/reader/WordPopup.svelte
@@ -386,6 +386,15 @@
   let newTranslationBody = $state('');
   let savingTranslation = $state(false);
   let addError = $state<string | null>(null);
+  let addTextareaEl = $state<HTMLTextAreaElement | null>(null);
+
+  // Focus the textarea as soon as the form mounts so the user can
+  // start typing immediately after clicking "+ Add my translation".
+  $effect(() => {
+    if (showAddForm && addTextareaEl) {
+      addTextareaEl.focus();
+    }
+  });
 
   // ---- Customize-official flow (T-3.11) ---------------------------
   // Which official translation (id) is currently being forked, if any,
@@ -554,6 +563,19 @@
       newTranslationBody = '';
       addError = null;
     }
+  }
+
+  // The form has no explicit Save/Cancel buttons — losing focus is
+  // the natural "I'm done" signal. Empty content silently closes the
+  // form; non-empty content commits exactly like Enter would.
+  function onAddFormBlur() {
+    if (savingTranslation) return;
+    if (newTranslationBody.trim().length === 0) {
+      showAddForm = false;
+      addError = null;
+      return;
+    }
+    void submitNewTranslation();
   }
 
   // Mirror onAddFormKeydown so Enter/Esc on the customize textarea
@@ -1112,33 +1134,18 @@
             }}
           >
             <textarea
+              bind:this={addTextareaEl}
               bind:value={newTranslationBody}
               placeholder="Your translation (Enter to save, Shift+Enter for a newline, Esc to cancel)"
               rows="2"
               maxlength="500"
               disabled={savingTranslation}
               onkeydown={onAddFormKeydown}
+              onblur={onAddFormBlur}
             ></textarea>
             {#if addError}
               <p class="err small">{addError}</p>
             {/if}
-            <div class="add-row">
-              <button type="submit" disabled={savingTranslation}>
-                {savingTranslation ? 'Saving…' : 'Save'}
-              </button>
-              <button
-                type="button"
-                class="ghost"
-                disabled={savingTranslation}
-                onclick={() => {
-                  showAddForm = false;
-                  newTranslationBody = '';
-                  addError = null;
-                }}
-              >
-                Cancel
-              </button>
-            </div>
           </form>
         {:else}
           <button

--- a/apps/web/src/lib/components/reader/WordPopup.test.ts
+++ b/apps/web/src/lib/components/reader/WordPopup.test.ts
@@ -283,3 +283,161 @@ describe('WordPopup — translation reporting (T-11.1)', () => {
     ).toBeNull();
   });
 });
+
+describe('WordPopup — add-translation form (no buttons, focus, refetch)', () => {
+  function emptyPayload() {
+    return {
+      lemma: { id: 'lem-1', headword: 'पानी', pos: 'NOUN', glossDefault: null },
+      translations: { personal: [], official: [], community: [] },
+    };
+  }
+
+  function payloadWith(personal: { id: string; body: string }[]) {
+    return {
+      lemma: { id: 'lem-1', headword: 'पानी', pos: 'NOUN', glossDefault: null },
+      translations: {
+        personal: personal.map((p) => ({
+          id: p.id,
+          source: 'user',
+          submittedBy: 'me',
+          body: p.body,
+          targetLanguage: 'en',
+          sourceAttribution: null,
+          parentTranslationId: null,
+          provenance: { kind: 'personal', attribution: null },
+          voteScore: 0,
+          viewerVote: null,
+        })),
+        official: [],
+        community: [],
+      },
+    };
+  }
+
+  function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('focuses the textarea as soon as "+ Add my translation" is clicked', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(jsonResponse(emptyPayload())),
+    );
+    render(WordPopup, {
+      token: makeToken({ surface: 'पानी', lemmaId: 'lem-1' }),
+      language: 'hi',
+      isOwner: true,
+      onClose: vi.fn(),
+    });
+    const toggle = await waitFor(() => {
+      const el = document.body.querySelector<HTMLButtonElement>('.add-toggle');
+      if (!el) throw new Error('add-toggle missing');
+      return el;
+    });
+    toggle.click();
+    await waitFor(() => {
+      const textarea = document.body.querySelector<HTMLTextAreaElement>(
+        '.add-form textarea',
+      );
+      expect(textarea).not.toBeNull();
+      expect(document.activeElement).toBe(textarea);
+    });
+  });
+
+  it('does not render any Save/Cancel buttons inside the add-translation form', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(jsonResponse(emptyPayload())),
+    );
+    render(WordPopup, {
+      token: makeToken({ surface: 'पानी', lemmaId: 'lem-1' }),
+      language: 'hi',
+      isOwner: true,
+      onClose: vi.fn(),
+    });
+    const toggle = await waitFor(() => {
+      const el = document.body.querySelector<HTMLButtonElement>('.add-toggle');
+      if (!el) throw new Error('add-toggle missing');
+      return el;
+    });
+    toggle.click();
+    const form = await waitFor(() => {
+      const el = document.body.querySelector<HTMLFormElement>('.add-form');
+      if (!el) throw new Error('add-form missing');
+      return el;
+    });
+    expect(form.querySelector('button')).toBeNull();
+  });
+
+  it('shows the newly-added translation in the popup after Enter submits', async () => {
+    const fetchMock = vi
+      .fn()
+      // initial GET — empty payload
+      .mockResolvedValueOnce(jsonResponse(emptyPayload()))
+      // POST /api/v1/translations — server echoes the row back
+      .mockResolvedValueOnce(
+        jsonResponse({
+          translation: {
+            id: 'tr-mine',
+            source: 'user',
+            submittedBy: 'me',
+            body: 'water',
+            targetLanguage: 'en',
+            sourceAttribution: null,
+            parentTranslationId: null,
+            provenance: { kind: 'personal', attribution: null },
+            voteScore: 0,
+            viewerVote: null,
+          },
+        }),
+      )
+      // refetch GET — payload now contains the personal row
+      .mockResolvedValueOnce(
+        jsonResponse(payloadWith([{ id: 'tr-mine', body: 'water' }])),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(WordPopup, {
+      token: makeToken({ surface: 'पानी', lemmaId: 'lem-1' }),
+      language: 'hi',
+      isOwner: true,
+      onClose: vi.fn(),
+    });
+    const toggle = await waitFor(() => {
+      const el = document.body.querySelector<HTMLButtonElement>('.add-toggle');
+      if (!el) throw new Error('add-toggle missing');
+      return el;
+    });
+    toggle.click();
+    const textarea = await waitFor(() => {
+      const el = document.body.querySelector<HTMLTextAreaElement>(
+        '.add-form textarea',
+      );
+      if (!el) throw new Error('textarea missing');
+      return el;
+    });
+
+    // Type via the same mechanism Svelte's bind:value listens for.
+    textarea.value = 'water';
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    textarea.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
+    );
+
+    // The translations list refreshes and the form collapses back to
+    // the toggle so the user immediately sees what they added.
+    await waitFor(() => {
+      const list = document.body.querySelector('.translations');
+      expect(list?.textContent ?? '').toContain('water');
+      expect(document.body.querySelector('.add-form')).toBeNull();
+      expect(document.body.querySelector('.add-toggle')).not.toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Three small fixes to the personal-translation form inside `WordPopup.svelte`:

- **Type-immediately**: the textarea autofocuses as soon as the form mounts, so a single click on **+ Add my translation** lets the user start typing right away (no extra click into the field).
- **No Save / Cancel buttons**: the form is now textarea-only. **Enter** saves, **Esc** cancels, and blurring an empty textarea silently closes the form. This matches the inline-editor feel the user asked for and removes redundant chrome.
- **Shows up in the popup**: on success, the form refetches the lemma payload and collapses, so the new translation lands in the "yours" list inside the same panel without a reload.

The customize-fork form (a different surface for editing official translations) is unchanged.

## Test plan

- [x] `pnpm test` (web) — 1271 tests pass; three new specs cover autofocus, button removal, and post-save rendering.
- [x] `pnpm typecheck` clean.
- [x] `pnpm lint` clean.
- [ ] Manual: click a known word, hit **+ Add my translation**, type "water", press Enter — translation appears in the popup as a "yours" row, form closes.
- [ ] Manual: open the form, hit Esc — form closes, no save.
- [ ] Manual: open the form, click outside without typing — form closes silently.