### PR TITLE
Edit/delete personal translations + show them in the hover tooltip

### DIFF
--- a/apps/web/src/lib/components/reader/ChapterBody.svelte
+++ b/apps/web/src/lib/components/reader/ChapterBody.svelte
@@ -56,12 +56,25 @@
   // T-6.4's loader join; this state is purely for the current
   // session.
   let lemmaCorrections = $state(new Map<string, string>());
+  // Mirror of personal-translation edits made in the popup so the
+  // hover tooltip refreshes without a chapter reload. Value is the
+  // new primary personal body, or null when the viewer has just
+  // deleted their last one for this lemma. Keys with a `null` value
+  // mean "override to no personal gloss"; absent keys defer to the
+  // server-side payload.
+  let personalGlossOverrides = $state(
+    new Map<string, string | null>(),
+  );
 
   // Apply any pending optimistic status flips to the token list
   // before paragraph splitting so the .status-* classes update live.
   const tokensWithOverrides = $derived.by(() => {
     if (!chapter.tokens) return null;
-    if (statusOverrides.size === 0 && lemmaCorrections.size === 0) {
+    if (
+      statusOverrides.size === 0 &&
+      lemmaCorrections.size === 0 &&
+      personalGlossOverrides.size === 0
+    ) {
       return chapter.tokens;
     }
     return chapter.tokens.map((t) => {
@@ -93,6 +106,12 @@
       }
       if (next.lemmaId && statusOverrides.has(next.lemmaId)) {
         next = { ...next, status: statusOverrides.get(next.lemmaId)! };
+      }
+      if (next.lemmaId && personalGlossOverrides.has(next.lemmaId)) {
+        next = {
+          ...next,
+          personalGloss: personalGlossOverrides.get(next.lemmaId) ?? null,
+        };
       }
       return next;
     });
@@ -422,6 +441,15 @@
     statusOverrides = next;
   }
 
+  function onPersonalTranslationChange(
+    lemmaId: string,
+    gloss: string | null,
+  ) {
+    const next = new Map(personalGlossOverrides);
+    next.set(lemmaId, gloss);
+    personalGlossOverrides = next;
+  }
+
   // T-6.2b: after a correction commits, surface a toast offering
   // bulk-apply across the rest of the chapter / text.
   let toastTokenId = $state<string | null>(null);
@@ -523,6 +551,7 @@
   }}
   {onStatusChange}
   {onCorrectionApplied}
+  {onPersonalTranslationChange}
 />
 
 <CorrectionToast

--- a/apps/web/src/lib/components/reader/ReaderScroll.svelte
+++ b/apps/web/src/lib/components/reader/ReaderScroll.svelte
@@ -71,7 +71,11 @@
   // the rendered tokens immediately.
   const correctedTokens = $derived.by(() => {
     if (!current?.tokens) return null;
-    if (statusOverrides.size === 0 && lemmaCorrections.size === 0) {
+    if (
+      statusOverrides.size === 0 &&
+      lemmaCorrections.size === 0 &&
+      personalGlossOverrides.size === 0
+    ) {
       return current.tokens;
     }
     return current.tokens.map((t) => {
@@ -92,6 +96,12 @@
       }
       if (next.lemmaId && statusOverrides.has(next.lemmaId)) {
         next = { ...next, status: statusOverrides.get(next.lemmaId)! };
+      }
+      if (next.lemmaId && personalGlossOverrides.has(next.lemmaId)) {
+        next = {
+          ...next,
+          personalGloss: personalGlossOverrides.get(next.lemmaId) ?? null,
+        };
       }
       return next;
     });
@@ -364,6 +374,20 @@
     lemmaCorrections = next;
   }
 
+  // Live-update personal-gloss override for the hover tooltip after
+  // the popup adds / edits / deletes one of the viewer's translations.
+  let personalGlossOverrides = $state(
+    new Map<string, string | null>(),
+  );
+  function onPersonalTranslationChange(
+    lemmaId: string,
+    gloss: string | null,
+  ) {
+    const next = new Map(personalGlossOverrides);
+    next.set(lemmaId, gloss);
+    personalGlossOverrides = next;
+  }
+
   // T-5.7: ←/→ flip pages within the chapter.
   function isTypingInsideElement(target: EventTarget | null): boolean {
     if (!(target instanceof HTMLElement)) return false;
@@ -467,6 +491,7 @@
     onClose={closePopup}
     {onStatusChange}
     {onCorrectionApplied}
+    {onPersonalTranslationChange}
   />
 {/if}
 

--- a/apps/web/src/lib/components/reader/WordPopup.svelte
+++ b/apps/web/src/lib/components/reader/WordPopup.svelte
@@ -83,6 +83,7 @@
     onStatusChange,
     onCorrectionApplied,
     onPhraseCreated,
+    onPersonalTranslationChange,
   }: {
     token: ServerToken | null;
     /** T-14.3: surface the longest phrase containing the click
@@ -120,6 +121,15 @@
     /** T-14.3a: fired after a successful phrase-create POST so
      *  the parent can refetch chapter spans / close the popup. */
     onPhraseCreated?: (phraseId: string) => void;
+    /** Fired after a personal translation is added, edited, or
+     *  deleted. The parent uses it to update the chapter's hover
+     *  tooltip without a full reload. `gloss` is the new primary
+     *  personal translation body, or null when the viewer no longer
+     *  has any. */
+    onPersonalTranslationChange?: (
+      lemmaId: string,
+      gloss: string | null,
+    ) => void;
   } = $props();
 
   // T-14.3a: phrase-create state.
@@ -396,6 +406,27 @@
     }
   });
 
+  // ---- Edit / delete personal translation -------------------------
+  // The viewer can revise or remove their own translations inline.
+  // The edit textarea reuses the same Enter-to-save / Esc-to-cancel
+  // ergonomics as the add form. Delete is a single click guarded by
+  // the browser's confirm dialog — translations are short, but
+  // they're still real authored content, so a typo'd click shouldn't
+  // wipe one silently.
+  let editingId = $state<string | null>(null);
+  let editBody = $state('');
+  let savingEdit = $state(false);
+  let editError = $state<string | null>(null);
+  let editTextareaEl = $state<HTMLTextAreaElement | null>(null);
+  let deletingId = $state<string | null>(null);
+  let deleteError = $state<string | null>(null);
+
+  $effect(() => {
+    if (editingId !== null && editTextareaEl) {
+      editTextareaEl.focus();
+    }
+  });
+
   // ---- Customize-official flow (T-3.11) ---------------------------
   // Which official translation (id) is currently being forked, if any,
   // plus the body of the in-progress fork. The eligibility set itself
@@ -525,6 +556,16 @@
     }
   }
 
+  // The hover tooltip caches the chapter payload, so adding /
+  // editing / deleting a personal translation needs to push the new
+  // primary body up to the parent. The "primary" matches the loader's
+  // pick: the oldest personal row (which the popup also lists first).
+  function notifyPersonalChange() {
+    if (!token?.lemmaId) return;
+    const next = payload?.translations.personal[0]?.body ?? null;
+    onPersonalTranslationChange?.(token.lemmaId, next);
+  }
+
   async function submitNewTranslation() {
     if (!token || !token.lemmaId) return;
     const trimmed = newTranslationBody.trim();
@@ -540,6 +581,7 @@
       await refetchPayload(lemmaId);
       newTranslationBody = '';
       showAddForm = false;
+      notifyPersonalChange();
     } catch (e) {
       addError = (e as PostError).message ?? (e as Error).message;
     } finally {
@@ -608,10 +650,107 @@
       await refetchPayload(lemmaId);
       customizingId = null;
       customizeBody = '';
+      notifyPersonalChange();
     } catch (e) {
       customizeError = (e as PostError).message ?? (e as Error).message;
     } finally {
       savingCustomize = false;
+    }
+  }
+
+  function startEditPersonal(t: PublicTranslation) {
+    editingId = t.id;
+    editBody = t.body;
+    editError = null;
+  }
+
+  function cancelEditPersonal() {
+    editingId = null;
+    editBody = '';
+    editError = null;
+  }
+
+  async function submitEditPersonal() {
+    if (!editingId || !token?.lemmaId) return;
+    const trimmed = editBody.trim();
+    if (trimmed.length === 0) {
+      editError = 'Translation cannot be empty.';
+      return;
+    }
+    const lemmaId = token.lemmaId;
+    const id = editingId;
+    savingEdit = true;
+    editError = null;
+    try {
+      const res = await fetch(`/api/v1/translations/${id}`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ body: trimmed }),
+      });
+      if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        editError = text || `Could not save (${res.status})`;
+        return;
+      }
+      await refetchPayload(lemmaId);
+      editingId = null;
+      editBody = '';
+      notifyPersonalChange();
+    } catch (e) {
+      editError = `Network error: ${(e as Error).message}`;
+    } finally {
+      savingEdit = false;
+    }
+  }
+
+  function onEditPersonalKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      void submitEditPersonal();
+      return;
+    }
+    if (e.key === 'Escape') {
+      e.stopPropagation();
+      e.preventDefault();
+      cancelEditPersonal();
+    }
+  }
+
+  function onEditPersonalBlur() {
+    if (savingEdit) return;
+    if (editBody.trim().length === 0) {
+      cancelEditPersonal();
+      return;
+    }
+    void submitEditPersonal();
+  }
+
+  async function deletePersonal(t: PublicTranslation) {
+    if (!token?.lemmaId) return;
+    if (
+      typeof window !== 'undefined' &&
+      !window.confirm('Delete this translation?')
+    ) {
+      return;
+    }
+    const lemmaId = token.lemmaId;
+    deletingId = t.id;
+    deleteError = null;
+    try {
+      const res = await fetch(`/api/v1/translations/${t.id}`, {
+        method: 'DELETE',
+      });
+      if (!res.ok && res.status !== 204) {
+        const text = await res.text().catch(() => '');
+        deleteError = text || `Could not delete (${res.status})`;
+        return;
+      }
+      await refetchPayload(lemmaId);
+      notifyPersonalChange();
+    } catch (e) {
+      deleteError = `Network error: ${(e as Error).message}`;
+    } finally {
+      deletingId = null;
     }
   }
 
@@ -996,9 +1135,63 @@
 
       <ul class="translations">
         {#each payload.translations.personal as t (t.id)}
-          <li>
-            <span class="badge tone-personal">yours</span>
-            {t.body}
+          <li class="personal-row" data-testid="personal-row">
+            {#if editingId === t.id}
+              <form
+                class="add-form"
+                data-testid="edit-personal-form"
+                onsubmit={(e) => {
+                  e.preventDefault();
+                  void submitEditPersonal();
+                }}
+              >
+                <textarea
+                  bind:this={editTextareaEl}
+                  bind:value={editBody}
+                  rows="2"
+                  maxlength="500"
+                  disabled={savingEdit}
+                  aria-label="Edit your translation"
+                  onkeydown={onEditPersonalKeydown}
+                  onblur={onEditPersonalBlur}
+                ></textarea>
+                {#if editError}
+                  <p class="err small">{editError}</p>
+                {/if}
+              </form>
+            {:else}
+              <div class="personal-body">
+                <span class="badge tone-personal">yours</span>
+                <span class="personal-text">{t.body}</span>
+                {#if isOwner}
+                  <div class="personal-actions">
+                    <button
+                      type="button"
+                      class="row-action"
+                      data-testid="edit-personal"
+                      title="Edit this translation"
+                      disabled={editingId !== null || deletingId !== null}
+                      onclick={() => startEditPersonal(t)}
+                    >
+                      Edit
+                    </button>
+                    <button
+                      type="button"
+                      class="row-action danger"
+                      data-testid="delete-personal"
+                      title="Delete this translation"
+                      disabled={deletingId !== null || editingId !== null}
+                      onclick={() => void deletePersonal(t)}
+                    >
+                      {deletingId === t.id ? 'Deleting…' : 'Delete'}
+                    </button>
+                  </div>
+                {/if}
+              </div>
+              {#if deleteError && deletingId === null}
+                <p class="err small">{deleteError}</p>
+              {/if}
+            {/if}
           </li>
         {/each}
         {#each payload.translations.official as t (t.id)}
@@ -1639,6 +1832,52 @@
       transparent
     );
     color: var(--accent-ink, var(--color-accent));
+  }
+  .personal-row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+  .personal-body {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.3rem;
+  }
+  .personal-text {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+  .personal-actions {
+    margin-left: auto;
+    display: inline-flex;
+    gap: 0.3rem;
+  }
+  .row-action {
+    padding: 0.1rem 0.55rem;
+    background: transparent;
+    border: 1px solid var(--rule, var(--color-border));
+    border-radius: 999px;
+    font: inherit;
+    font-size: 0.7rem;
+    color: var(--ink-3, var(--color-fg-muted));
+    cursor: pointer;
+  }
+  .row-action:hover:not([disabled]) {
+    color: var(--ink, var(--color-fg));
+    border-color: color-mix(
+      in oklch,
+      var(--ink, var(--color-fg)) 22%,
+      var(--rule, var(--color-border))
+    );
+  }
+  .row-action.danger:hover:not([disabled]) {
+    color: #b91c1c;
+    border-color: #fecaca;
+  }
+  .row-action[disabled] {
+    opacity: 0.5;
+    cursor: not-allowed;
   }
   .tone-curator {
     border-color: color-mix(

--- a/apps/web/src/lib/components/reader/WordPopup.test.ts
+++ b/apps/web/src/lib/components/reader/WordPopup.test.ts
@@ -60,6 +60,7 @@ function makeToken(overrides: Partial<ServerToken> = {}): ServerToken {
     lemmaId: null,
     romanization: null,
     glossDefault: null,
+    personalGloss: null,
     candidates: [],
     numberForms: null,
     status: 'unknown',
@@ -438,6 +439,274 @@ describe('WordPopup — add-translation form (no buttons, focus, refetch)', () =
       expect(list?.textContent ?? '').toContain('water');
       expect(document.body.querySelector('.add-form')).toBeNull();
       expect(document.body.querySelector('.add-toggle')).not.toBeNull();
+    });
+  });
+});
+
+describe('WordPopup — edit + delete personal translations', () => {
+  function personalRow(id: string, body: string) {
+    return {
+      id,
+      source: 'user' as const,
+      submittedBy: 'me',
+      body,
+      targetLanguage: 'en',
+      sourceAttribution: null,
+      parentTranslationId: null,
+      provenance: { kind: 'personal' as const, attribution: null },
+      voteScore: 0,
+      viewerVote: null,
+    };
+  }
+
+  function payloadOf(personal: { id: string; body: string }[]) {
+    return {
+      lemma: { id: 'lem-1', headword: 'पानी', pos: 'NOUN', glossDefault: null },
+      translations: {
+        personal: personal.map((p) => personalRow(p.id, p.body)),
+        official: [],
+        community: [],
+      },
+    };
+  }
+
+  function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('renders Edit + Delete buttons on each personal row when isOwner=true', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        jsonResponse(payloadOf([{ id: 'tr-1', body: 'water' }])),
+      ),
+    );
+    render(WordPopup, {
+      token: makeToken({ surface: 'पानी', lemmaId: 'lem-1' }),
+      language: 'hi',
+      isOwner: true,
+      onClose: vi.fn(),
+    });
+    await waitFor(() => {
+      expect(
+        document.body.querySelector('[data-testid="edit-personal"]'),
+      ).not.toBeNull();
+      expect(
+        document.body.querySelector('[data-testid="delete-personal"]'),
+      ).not.toBeNull();
+    });
+  });
+
+  it('hides Edit + Delete buttons when isOwner=false', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        jsonResponse(payloadOf([{ id: 'tr-1', body: 'water' }])),
+      ),
+    );
+    render(WordPopup, {
+      token: makeToken({ surface: 'पानी', lemmaId: 'lem-1' }),
+      language: 'hi',
+      isOwner: false,
+      onClose: vi.fn(),
+    });
+    await waitFor(() => {
+      expect(document.body.querySelector('[data-testid="personal-row"]')).not.toBeNull();
+    });
+    expect(document.body.querySelector('[data-testid="edit-personal"]')).toBeNull();
+    expect(document.body.querySelector('[data-testid="delete-personal"]')).toBeNull();
+  });
+
+  it('Edit swaps the row for a focused textarea and PATCHes the body on Enter', async () => {
+    const fetchMock = vi
+      .fn()
+      // initial GET
+      .mockResolvedValueOnce(jsonResponse(payloadOf([{ id: 'tr-1', body: 'water' }])))
+      // PATCH
+      .mockResolvedValueOnce(
+        jsonResponse({ translation: personalRow('tr-1', 'fresh water') }),
+      )
+      // refetch GET
+      .mockResolvedValueOnce(jsonResponse(payloadOf([{ id: 'tr-1', body: 'fresh water' }])));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const onPersonalTranslationChange = vi.fn();
+    render(WordPopup, {
+      token: makeToken({ surface: 'पानी', lemmaId: 'lem-1' }),
+      language: 'hi',
+      isOwner: true,
+      onClose: vi.fn(),
+      onPersonalTranslationChange,
+    });
+
+    const editBtn = await waitFor(() => {
+      const el = document.body.querySelector<HTMLButtonElement>(
+        '[data-testid="edit-personal"]',
+      );
+      if (!el) throw new Error('edit-personal missing');
+      return el;
+    });
+    editBtn.click();
+
+    const textarea = await waitFor(() => {
+      const el = document.body.querySelector<HTMLTextAreaElement>(
+        '[data-testid="edit-personal-form"] textarea',
+      );
+      if (!el) throw new Error('edit textarea missing');
+      return el;
+    });
+    expect(document.activeElement).toBe(textarea);
+    expect(textarea.value).toBe('water');
+
+    textarea.value = 'fresh water';
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    textarea.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
+    );
+
+    await waitFor(() => {
+      // Form gone, list shows the new body, parent was notified.
+      expect(
+        document.body.querySelector('[data-testid="edit-personal-form"]'),
+      ).toBeNull();
+      const list = document.body.querySelector('.translations');
+      expect(list?.textContent ?? '').toContain('fresh water');
+      expect(onPersonalTranslationChange).toHaveBeenCalledWith(
+        'lem-1',
+        'fresh water',
+      );
+    });
+
+    // PATCH happened against /api/v1/translations/tr-1.
+    const patchCall = fetchMock.mock.calls.find(
+      ([url, init]) =>
+        typeof url === 'string' &&
+        url.endsWith('/api/v1/translations/tr-1') &&
+        (init as RequestInit | undefined)?.method === 'PATCH',
+    );
+    expect(patchCall).toBeDefined();
+  });
+
+  it('Delete confirms, sends DELETE, and notifies parent that the personal gloss is gone', async () => {
+    const fetchMock = vi
+      .fn()
+      // initial GET
+      .mockResolvedValueOnce(jsonResponse(payloadOf([{ id: 'tr-1', body: 'water' }])))
+      // DELETE — 204 No Content
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+      // refetch GET — empty personal bucket now
+      .mockResolvedValueOnce(jsonResponse(payloadOf([])));
+    vi.stubGlobal('fetch', fetchMock);
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    const onPersonalTranslationChange = vi.fn();
+    render(WordPopup, {
+      token: makeToken({ surface: 'पानी', lemmaId: 'lem-1' }),
+      language: 'hi',
+      isOwner: true,
+      onClose: vi.fn(),
+      onPersonalTranslationChange,
+    });
+
+    const delBtn = await waitFor(() => {
+      const el = document.body.querySelector<HTMLButtonElement>(
+        '[data-testid="delete-personal"]',
+      );
+      if (!el) throw new Error('delete-personal missing');
+      return el;
+    });
+    delBtn.click();
+
+    await waitFor(() => {
+      expect(document.body.querySelector('[data-testid="personal-row"]')).toBeNull();
+      expect(onPersonalTranslationChange).toHaveBeenCalledWith('lem-1', null);
+    });
+
+    const deleteCall = fetchMock.mock.calls.find(
+      ([url, init]) =>
+        typeof url === 'string' &&
+        url.endsWith('/api/v1/translations/tr-1') &&
+        (init as RequestInit | undefined)?.method === 'DELETE',
+    );
+    expect(deleteCall).toBeDefined();
+  });
+
+  it('Delete is a no-op when window.confirm is dismissed', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(payloadOf([{ id: 'tr-1', body: 'water' }])));
+    vi.stubGlobal('fetch', fetchMock);
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+
+    render(WordPopup, {
+      token: makeToken({ surface: 'पानी', lemmaId: 'lem-1' }),
+      language: 'hi',
+      isOwner: true,
+      onClose: vi.fn(),
+    });
+
+    const delBtn = await waitFor(() => {
+      const el = document.body.querySelector<HTMLButtonElement>(
+        '[data-testid="delete-personal"]',
+      );
+      if (!el) throw new Error('delete-personal missing');
+      return el;
+    });
+    delBtn.click();
+
+    // Only the initial GET should have fired — no DELETE.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(
+      document.body.querySelector('[data-testid="personal-row"]'),
+    ).not.toBeNull();
+  });
+
+  it('fires onPersonalTranslationChange after a successful add', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(payloadOf([])))
+      .mockResolvedValueOnce(jsonResponse({ translation: personalRow('tr-1', 'water') }))
+      .mockResolvedValueOnce(jsonResponse(payloadOf([{ id: 'tr-1', body: 'water' }])));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const onPersonalTranslationChange = vi.fn();
+    render(WordPopup, {
+      token: makeToken({ surface: 'पानी', lemmaId: 'lem-1' }),
+      language: 'hi',
+      isOwner: true,
+      onClose: vi.fn(),
+      onPersonalTranslationChange,
+    });
+
+    const toggle = await waitFor(() => {
+      const el = document.body.querySelector<HTMLButtonElement>('.add-toggle');
+      if (!el) throw new Error('add-toggle missing');
+      return el;
+    });
+    toggle.click();
+    const textarea = await waitFor(() => {
+      const el = document.body.querySelector<HTMLTextAreaElement>(
+        '.add-form textarea',
+      );
+      if (!el) throw new Error('add textarea missing');
+      return el;
+    });
+    textarea.value = 'water';
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    textarea.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
+    );
+
+    await waitFor(() => {
+      expect(onPersonalTranslationChange).toHaveBeenCalledWith('lem-1', 'water');
     });
   });
 });

--- a/apps/web/src/lib/components/reader/WordTooltip.svelte
+++ b/apps/web/src/lib/components/reader/WordTooltip.svelte
@@ -133,14 +133,21 @@
     </div>
   {:else if isLegacyNumber}
     <div class="tip-def empty" data-testid="legacy-number">Number</div>
-  {:else if token.isOov}
+  {:else if token.isOov && !token.personalGloss}
     <!-- T-5.20: surface the top translation when we have one, fall
          back to an italic "No translations" otherwise so the user
          always knows whether the lookup is empty or just absent. The
          tooltip stays no-fetch — it reads `glossDefault` off the token
          row, which the side-panel still backs up with the full
-         hierarchy on click. -->
+         hierarchy on click. A user-supplied translation overrides the
+         OOV copy so words the reader has chosen to translate read in
+         their own words even when the dictionary missed them. -->
     <div class="tip-def empty">No dictionary match</div>
+  {:else if token.personalGloss}
+    <div class="tip-def" data-testid="tip-personal">
+      <span class="tip-mine">yours</span>
+      {token.personalGloss}
+    </div>
   {:else if token.glossDefault}
     <div class="tip-def">{token.glossDefault}</div>
   {:else}
@@ -206,6 +213,21 @@
   .tip-def.empty {
     color: color-mix(in oklch, var(--paper, #fdfaf3) 65%, transparent);
     font-style: italic;
+  }
+  /* Tiny inline badge that flags the gloss as the viewer's own
+     translation rather than the dictionary one. Keeps the bookkeeping
+     visible without making the tooltip noisy. */
+  .tip-mine {
+    display: inline-block;
+    margin-right: 0.35rem;
+    padding: 0 0.35rem;
+    border-radius: 999px;
+    background: color-mix(in oklch, var(--paper, #fdfaf3) 22%, transparent);
+    color: var(--paper, #fdfaf3);
+    font-size: 0.6rem;
+    font-style: normal;
+    text-transform: lowercase;
+    letter-spacing: 0.02em;
   }
   @keyframes fade-in {
     from {

--- a/apps/web/src/lib/components/reader/WordTooltip.test.ts
+++ b/apps/web/src/lib/components/reader/WordTooltip.test.ts
@@ -25,6 +25,7 @@ function makeToken(overrides: Partial<ServerToken> = {}): ServerToken {
     lemmaId: 'lem-1',
     romanization: 'prabhāt',
     glossDefault: null,
+    personalGloss: null,
     candidates: [],
     numberForms: null,
     status: 'unknown',
@@ -76,6 +77,38 @@ describe('WordTooltip — gloss display (T-5.18)', () => {
     const def = document.body.querySelector('.tip-def');
     expect(def?.textContent).toBe('No dictionary match');
     expect(def?.classList.contains('empty')).toBe(true);
+  });
+
+  it('prefers the viewer’s own personalGloss over glossDefault', () => {
+    render(WordTooltip, {
+      token: makeToken({
+        glossDefault: 'morning, dawn',
+        personalGloss: 'sunrise (mine)',
+      }),
+      anchorRect: ANCHOR,
+    });
+    const def = document.body.querySelector(
+      '[data-testid="tip-personal"]',
+    );
+    expect(def?.textContent).toContain('sunrise (mine)');
+    expect(def?.textContent).toContain('yours');
+    // The dictionary gloss is suppressed when the viewer has their own.
+    expect(document.body.textContent).not.toContain('morning, dawn');
+  });
+
+  it('shows the personalGloss even on OOV tokens (the user has translated it themselves)', () => {
+    render(WordTooltip, {
+      token: makeToken({
+        isOov: true,
+        glossDefault: null,
+        personalGloss: 'my coinage',
+      }),
+      anchorRect: ANCHOR,
+    });
+    expect(
+      document.body.querySelector('[data-testid="tip-personal"]')?.textContent,
+    ).toContain('my coinage');
+    expect(document.body.textContent).not.toContain('No dictionary match');
   });
 
   it("treats no-lemma tokens like an empty-translation lemma — italic 'No translations' (T-5.20)", () => {

--- a/apps/web/src/lib/components/reader/lazy-tokens.test.ts
+++ b/apps/web/src/lib/components/reader/lazy-tokens.test.ts
@@ -18,6 +18,7 @@ function fakeTokens(n: number): ServerToken[] {
     lemmaId: `lem-${i}`,
     romanization: null,
     glossDefault: null,
+    personalGloss: null,
     candidates: [],
     numberForms: null,
     status: 'unknown',

--- a/apps/web/src/lib/components/reader/phrase-selection.test.ts
+++ b/apps/web/src/lib/components/reader/phrase-selection.test.ts
@@ -30,6 +30,7 @@ function tok(
     lemmaId: null,
     romanization: null,
     glossDefault: null,
+    personalGloss: null,
     candidates: [],
     numberForms: null,
     status: 'unknown',

--- a/apps/web/src/lib/components/reader/segment-phrases.test.ts
+++ b/apps/web/src/lib/components/reader/segment-phrases.test.ts
@@ -30,6 +30,7 @@ function tok(idx: number, surface: string): ServerToken {
     lemmaId: null,
     romanization: null,
     glossDefault: null,
+    personalGloss: null,
     candidates: [],
     numberForms: null,
     status: 'unknown',

--- a/apps/web/src/lib/components/reader/types.ts
+++ b/apps/web/src/lib/components/reader/types.ts
@@ -113,6 +113,11 @@ export type ServerToken = {
   /** Canonical short gloss for the lemma — surfaced in the hover
    *  tooltip (T-5.18). Null when there's no lemma or no gloss yet. */
   glossDefault: string | null;
+  /** The viewer's own translation for this lemma, if any. The hover
+   *  tooltip prefers this over `glossDefault` so a reader sees their
+   *  own words for lemmas they've translated. Null when anonymous
+   *  or when the viewer hasn't added a personal translation. */
+  personalGloss: string | null;
   /** T-6.1: alternate-meaning candidates for is_ambiguous tokens.
    *  Empty array when the worker scored only one viable candidate
    *  or hasn't run yet. */

--- a/apps/web/src/lib/server/texts/tokens.test.ts
+++ b/apps/web/src/lib/server/texts/tokens.test.ts
@@ -44,6 +44,14 @@ vi.mock('../db/index.js', () => ({
       id: 'lemmas.id',
       glossDefault: 'lemmas.gloss_default',
     },
+    translations: {
+      targetType: 'translations.target_type',
+      targetId: 'translations.target_id',
+      source: 'translations.source',
+      submittedBy: 'translations.submitted_by',
+      body: 'translations.body',
+      createdAt: 'translations.created_at',
+    },
   },
 }));
 
@@ -120,6 +128,7 @@ describe('loadChapterTokens', () => {
     stage([]); // token_corrections (T-6.4) — none
     stage([]); // user_known_lemmas → empty
     stage([]); // lemmas (gloss lookup) → empty
+    stage([]); // personal translations → empty
     const result = await loadChapterTokens('chap-1', 'user-1');
     expect(result).not.toBeNull();
     expect(result!.every((t) => t.status === 'unknown')).toBe(true);
@@ -137,6 +146,7 @@ describe('loadChapterTokens', () => {
       { userId: 'user-1', lemmaId: 'lem-learning', status: 'learning' },
     ]);
     stage([]); // lemmas (gloss lookup) — none on file for these lemmas
+    stage([]); // personal translations
     const result = await loadChapterTokens('chap-1', 'user-1');
     expect(result).toEqual([
       expect.objectContaining({ id: 't1', status: 'known' }),
@@ -157,6 +167,7 @@ describe('loadChapterTokens', () => {
       { id: 'lem-a', language: 'hi', headword: 'सुबह', glossDefault: 'morning' },
       { id: 'lem-b', language: 'hi', headword: 'rare', glossDefault: null },
     ]);
+    stage([]); // personal translations
     // T-3.14 sibling fallback: lem-b had no gloss, so the loader runs
     // a sibling lookup. No sibling exists for "rare", so an empty
     // result keeps the null gloss as-is.
@@ -179,6 +190,7 @@ describe('loadChapterTokens', () => {
     stage([
       { id: 'lem-propn', language: 'hi', headword: 'पार्क', glossDefault: null },
     ]);
+    stage([]); // personal translations
     stage([
       { language: 'hi', headword: 'पार्क', glossDefault: 'park' },
     ]);
@@ -191,11 +203,13 @@ describe('loadChapterTokens', () => {
     stage([]); // token_corrections (T-6.4)
     stage([]); // user_known_lemmas
     stage([{ id: 'lem-a', language: 'hi', headword: 'पानी', glossDefault: 'water' }]);
-    // No 5th stage — fallback query must not fire.
+    stage([]); // personal translations
+    // No further stage — fallback query must not fire.
     await loadChapterTokens('chap-1', 'user-1');
     // 1 (tokens) + 1 (token_corrections) + 1 (user_known_lemmas) +
-    // 1 (gloss lookup) = 4, no sibling fallback.
-    expect(selectFn).toHaveBeenCalledTimes(4);
+    // 1 (gloss lookup) + 1 (personal translations) = 5, no sibling
+    // fallback.
+    expect(selectFn).toHaveBeenCalledTimes(5);
   });
 
   it('populates token.candidates with metadata pulled from the lemmas table (T-6.1)', async () => {
@@ -231,6 +245,7 @@ describe('loadChapterTokens', () => {
         glossDefault: 'to read',
       },
     ]);
+    stage([]); // personal translations
     const result = await loadChapterTokens('chap-1', 'user-1');
     expect(result![0]).toMatchObject({
       id: 't1',
@@ -291,6 +306,7 @@ describe('loadChapterTokens', () => {
         glossDefault: 'corrected',
       },
     ]);
+    stage([]); // personal translations
     const result = await loadChapterTokens('chap-1', 'user-1');
     expect(result![0]).toMatchObject({
       id: 't1',
@@ -327,6 +343,7 @@ describe('loadChapterTokens', () => {
         glossDefault: 'placeholder',
       },
     ]);
+    stage([]); // personal translations
     const result = await loadChapterTokens('chap-1', 'user-1');
     expect(result![0]).toMatchObject({
       id: 't1',
@@ -335,6 +352,60 @@ describe('loadChapterTokens', () => {
       isWord: false,
       isOov: false,
     });
+  });
+
+  it("attaches the viewer's own translation as personalGloss for the hover tooltip", async () => {
+    stage([
+      tokenRow({ id: 't1', idx: 0, lemmaId: 'lem-a' }),
+      tokenRow({ id: 't2', idx: 1, lemmaId: 'lem-b' }),
+    ]);
+    stage([]); // token_corrections
+    stage([]); // user_known_lemmas
+    stage([
+      { id: 'lem-a', language: 'hi', headword: 'पानी', glossDefault: 'water' },
+      { id: 'lem-b', language: 'hi', headword: 'सुबह', glossDefault: 'morning' },
+    ]);
+    // The viewer has translated lem-a but not lem-b. Two rows for
+    // lem-a — the loader should pick the OLDER one to stay in sync
+    // with the popup's oldest-first personal ordering.
+    stage([
+      {
+        targetId: 'lem-a',
+        body: 'newer mine',
+        createdAt: new Date('2026-04-30T12:00:00Z'),
+      },
+      {
+        targetId: 'lem-a',
+        body: 'older mine',
+        createdAt: new Date('2026-04-01T12:00:00Z'),
+      },
+    ]);
+    const result = await loadChapterTokens('chap-1', 'user-1');
+    expect(result![0]).toMatchObject({
+      id: 't1',
+      glossDefault: 'water',
+      personalGloss: 'older mine',
+    });
+    expect(result![1]).toMatchObject({
+      id: 't2',
+      glossDefault: 'morning',
+      personalGloss: null,
+    });
+  });
+
+  it('skips the personal-translations SELECT for anonymous viewers', async () => {
+    stage([tokenRow({ id: 't1', idx: 0, lemmaId: 'lem-a' })]);
+    stage([
+      { id: 'lem-a', language: 'hi', headword: 'पानी', glossDefault: 'water' },
+    ]);
+    const result = await loadChapterTokens('chap-1', null);
+    expect(result![0]).toMatchObject({
+      id: 't1',
+      personalGloss: null,
+    });
+    // tokens (1) + lemmas (1) = 2. Personal-translations SELECT does
+    // not fire when there's no viewer.
+    expect(selectFn).toHaveBeenCalledTimes(2);
   });
 
   it('handles anonymous viewers (no user_known_lemmas SELECT, every status=unknown)', async () => {

--- a/apps/web/src/lib/server/texts/tokens.ts
+++ b/apps/web/src/lib/server/texts/tokens.ts
@@ -77,6 +77,13 @@ export type RenderedToken = {
    *  locking the side panel. Null when the lemma has no glossDefault
    *  on file, or when the token has no lemma id (whitespace, OOV). */
   glossDefault: string | null;
+  /** The viewer's own translation for this lemma, if any. Pulled
+   *  from `translations` where `source = 'user'` and
+   *  `submitted_by = viewerId`. Surfaced in the hover tooltip ahead
+   *  of `glossDefault` so words the user has personally translated
+   *  read in their own words on hover. Null for anonymous viewers
+   *  and for lemmas the viewer hasn't translated. */
+  personalGloss: string | null;
   /** T-6.1: alternate lemma candidates the worker scored. Empty
    *  array when the token has no candidates beyond the top pick
    *  (or when the worker hasn't run). The popup hides the
@@ -236,6 +243,38 @@ export async function loadChapterTokens(
     }
   }
 
+  // The viewer's own personal translations for these lemmas, so the
+  // hover tooltip can show "their" gloss instead of (or alongside)
+  // the dictionary one. We only need the oldest body per lemma —
+  // the popup orders the personal bucket oldest-first, so picking
+  // the same row here keeps the two surfaces in sync. Anonymous
+  // viewers and lemmas without a personal row simply leave
+  // `personalGloss` null below.
+  const personalGlossByLemma = new Map<string, string>();
+  if (viewerId && lemmaIds.length > 0) {
+    const personalRows = (await db
+      .select({
+        targetId: schema.translations.targetId,
+        body: schema.translations.body,
+        createdAt: schema.translations.createdAt,
+      })
+      .from(schema.translations)
+      .where(
+        and(
+          eq(schema.translations.targetType, 'lemma'),
+          eq(schema.translations.source, 'user'),
+          eq(schema.translations.submittedBy, viewerId),
+          inArray(schema.translations.targetId, lemmaIds),
+        ),
+      )) as Array<{ targetId: string; body: string; createdAt: Date }>;
+    personalRows.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+    for (const r of personalRows) {
+      if (!personalGlossByLemma.has(r.targetId)) {
+        personalGlossByLemma.set(r.targetId, r.body);
+      }
+    }
+  }
+
   // Sibling-fallback pass: for any chapter lemma whose own gloss is
   // null, find another lemma with the same (language, headword) that
   // has a non-null gloss and use it. We bucket by (language,
@@ -379,6 +418,9 @@ export async function loadChapterTokens(
       romanization: t.romanization,
       glossDefault: effectiveLemmaId
         ? glossByLemma.get(effectiveLemmaId) ?? null
+        : null,
+      personalGloss: effectiveLemmaId
+        ? personalGlossByLemma.get(effectiveLemmaId) ?? null
         : null,
       candidates,
       numberForms: renderedNumberForms,


### PR DESCRIPTION
## Summary

Three connected changes so the viewer's own translations feel like first-class data instead of write-only state.

- **Edit / Delete on personal rows.** Each \"yours\" entry in `WordPopup` now has Edit + Delete buttons. Edit swaps the row for an autofocused textarea (Enter saves, Esc cancels, blur-with-content saves) and PATCHes `/api/v1/translations/:id`; Delete confirms via `window.confirm` and DELETEs. Both endpoints already existed under T-3.5; this just wires up the UI.
- **Personal translations on hover.** `loadChapterTokens` now joins the viewer's user-source translations for every chapter lemma and exposes the oldest one (matching the popup's oldest-first personal ordering) as a new `personalGloss` field on `RenderedToken`. Anonymous viewers and lemmas without a personal row stay null, so dictionary-only readers see no change.
- **Tooltip prefers \"yours\".** `WordTooltip` shows `personalGloss` ahead of `glossDefault`, behind a small \"yours\" badge. A personal translation also wins over the OOV \"No dictionary match\" copy — if the viewer chose to translate it, they should see what they wrote.

To keep the hover tooltip in sync without a chapter reload, the popup fires `onPersonalTranslationChange(lemmaId, gloss)` after every add / edit / delete. `ChapterBody` and `ReaderScroll` thread it through a per-lemma override map applied in the same `\$derived` chain as the existing status / lemma-correction overrides.

## Test plan

- [x] `pnpm test` (web) — 1281 tests pass; new specs cover the edit/delete paths in `WordPopup.test.ts`, the new tooltip branch in `WordTooltip.test.ts`, and the `personalGloss` join in `tokens.test.ts` (including the anonymous-viewer skip).
- [x] `pnpm typecheck` clean.
- [x] `pnpm lint` clean.
- [ ] Manual: add a translation on a word — hover the same word, see your gloss with the \"yours\" badge.
- [ ] Manual: click the word, hit Edit, change the body, press Enter — popup updates and the tooltip on next hover shows the new body.
- [ ] Manual: click Delete, confirm — row disappears, tooltip falls back to `glossDefault` on the next hover.