### PR TITLE
Page-mode reader: show start–end progress range

### DIFF
--- a/apps/web/src/lib/components/reader/ReaderPage.svelte
+++ b/apps/web/src/lib/components/reader/ReaderPage.svelte
@@ -27,6 +27,7 @@
     computePctRead,
     findFirstWordInColumn,
     findTokenElementAtOrAfter,
+    pageBoundaryAnchor,
   } from './reader-progress.js';
   import { classifySwipe } from './touch-gestures.js';
   import type { ChapterView } from './types.js';
@@ -92,7 +93,9 @@
     initialTokenApplied = false;
     restorePaintReady = initialTokenIdx <= 0;
     lastReportedKey = '';
-    displayPct = computePctRead(chapters, chapterIdx, initialTokenIdx);
+    const seed = computePctRead(chapters, chapterIdx, initialTokenIdx);
+    startPct = seed;
+    endPct = seed;
   });
 
   // Keep pageInChapter in range when pageCount shrinks (e.g. window
@@ -108,10 +111,14 @@
 
   // Overall progress — fraction of the whole text in *words*, not pages.
   // A page with 10 words must advance the bar less than a page with 500.
-  // Driven by `reportProgress`, which derives the anchor from the first
-  // visible word and runs it through `computePctRead`. Mirrored here so
-  // the footer always matches what we persist to the server.
-  let displayPct = $state(0);
+  // We track two values: `startPct` is the position of the first
+  // visible word on the page (= where you'd resume), `endPct` is the
+  // position of the first word on the *next* page (= what you've read
+  // up through). Footer shows the range. The bar fill follows endPct
+  // and the value persisted to the server is endPct, so the library
+  // card and reader footer always agree.
+  let startPct = $state(0);
+  let endPct = $state(0);
 
   function go(nextIdx: number, opts: { lastPage?: boolean } = {}) {
     void goto(`/reader/${textId}?mode=page&chapter=${nextIdx}`, {
@@ -279,14 +286,37 @@
       fallbackChapterIdx: chapterIdx,
     });
     if (!anchor) return;
+    const nextPageAnchor =
+      pageInChapter < pageCount - 1
+        ? findFirstWordInColumn(contentEl, {
+            contentEl,
+            pageWidth: pageW,
+            pageIdx: pageInChapter + 1,
+            fallbackChapterIdx: chapterIdx,
+          })
+        : null;
+    const boundary = pageBoundaryAnchor({
+      chapters,
+      chapterIdx,
+      pageInChapter,
+      pageCount,
+      currentAnchor: anchor,
+      nextAnchor: nextPageAnchor,
+    });
+    const startPctNext = computePctRead(chapters, anchor.chapterIdx, anchor.tokenIdx);
+    const endPctNext = computePctRead(chapters, boundary.chapterIdx, boundary.tokenIdx, {
+      completedText: boundary.completed,
+    });
+    startPct = startPctNext;
+    endPct = endPctNext;
+    if (!onProgress) return;
+    // Resume position is the first word on this page; pctRead reports
+    // how far the user has READ — i.e. the end-of-page boundary —
+    // so the library card matches the reader footer.
     const next: ProgressAnchor = {
       ...anchor,
-      pctRead: computePctRead(chapters, anchor.chapterIdx, anchor.tokenIdx, {
-        completedText: anchor.chapterIdx >= chapters.length - 1 && pageInChapter >= pageCount - 1,
-      }),
+      pctRead: endPctNext,
     };
-    displayPct = next.pctRead;
-    if (!onProgress) return;
     const key = `${next.chapterIdx}:${next.tokenIdx}:${next.pctRead}`;
     if (key === lastReportedKey) return;
     lastReportedKey = key;
@@ -385,9 +415,15 @@
       Page {pageInChapter + 1} of {pageCount}
       <span class="muted">· Ch. {chapterIdx + 1} / {chapters.length}</span>
     </span>
-    <span class="muted">{displayPct}% through text</span>
+    <span class="muted">
+      {#if startPct === endPct}
+        {endPct}% through text
+      {:else}
+        {startPct}–{endPct}% through text
+      {/if}
+    </span>
   </div>
-  <div class="reader-foot-bar"><i style="width: {displayPct}%"></i></div>
+  <div class="reader-foot-bar"><i style="width: {endPct}%"></i></div>
 </footer>
 
 <style>

--- a/apps/web/src/lib/components/reader/reader-progress.test.ts
+++ b/apps/web/src/lib/components/reader/reader-progress.test.ts
@@ -7,6 +7,7 @@ import {
   findFirstWordInColumn,
   findTokenElementAtOrAfter,
   firstTokenPage,
+  pageBoundaryAnchor,
 } from './reader-progress.js';
 import type { ChapterView } from './types.js';
 
@@ -221,5 +222,83 @@ describe('reader progress helpers', () => {
     const root = document.createElement('article');
     root.append(word(3, rect(0, 0, 1, 1)), word(7, rect(0, 0, 1, 1)));
     expect(findTokenElementAtOrAfter(root, 99)).toBeNull();
+  });
+
+  describe('pageBoundaryAnchor', () => {
+    const chapters = [{ tokenCount: 100 }, { tokenCount: 200 }];
+
+    it('uses the next page anchor for mid-chapter pages', () => {
+      const r = pageBoundaryAnchor({
+        chapters,
+        chapterIdx: 0,
+        pageInChapter: 1,
+        pageCount: 5,
+        currentAnchor: { chapterIdx: 0, tokenIdx: 20 },
+        nextAnchor: { chapterIdx: 0, tokenIdx: 60 },
+      });
+      expect(r).toEqual({ chapterIdx: 0, tokenIdx: 60, completed: false });
+    });
+
+    it('rolls over to the next chapter on the last page of a non-last chapter', () => {
+      const r = pageBoundaryAnchor({
+        chapters,
+        chapterIdx: 0,
+        pageInChapter: 4,
+        pageCount: 5,
+        currentAnchor: { chapterIdx: 0, tokenIdx: 80 },
+        nextAnchor: null,
+      });
+      expect(r).toEqual({ chapterIdx: 1, tokenIdx: 0, completed: false });
+    });
+
+    it('marks completed on the last page of the last chapter', () => {
+      const r = pageBoundaryAnchor({
+        chapters,
+        chapterIdx: 1,
+        pageInChapter: 9,
+        pageCount: 10,
+        currentAnchor: { chapterIdx: 1, tokenIdx: 180 },
+        nextAnchor: null,
+      });
+      expect(r.completed).toBe(true);
+    });
+
+    it('falls back to the current anchor when the next-page anchor is unavailable mid-chapter', () => {
+      const r = pageBoundaryAnchor({
+        chapters,
+        chapterIdx: 0,
+        pageInChapter: 1,
+        pageCount: 5,
+        currentAnchor: { chapterIdx: 0, tokenIdx: 20 },
+        nextAnchor: null,
+      });
+      expect(r).toEqual({ chapterIdx: 0, tokenIdx: 20, completed: false });
+    });
+
+    it('produces an end-pct that exceeds the start-pct by the page word count', () => {
+      // Start of page 2 is token 30; start of page 3 is token 230 — end-pct
+      // should reflect having consumed all 200 words on page 2.
+      const start = computePctRead(
+        chapters as ChapterView[],
+        0,
+        30,
+      );
+      const boundary = pageBoundaryAnchor({
+        chapters,
+        chapterIdx: 0,
+        pageInChapter: 1,
+        pageCount: 5,
+        currentAnchor: { chapterIdx: 0, tokenIdx: 30 },
+        nextAnchor: { chapterIdx: 0, tokenIdx: 230 },
+      });
+      // 230 clamped to currentCount-1 = 99 inside chapter 0 of size 100.
+      const end = computePctRead(
+        chapters as ChapterView[],
+        boundary.chapterIdx,
+        boundary.tokenIdx,
+        { completedText: boundary.completed },
+      );
+      expect(end).toBeGreaterThan(start);
+    });
   });
 });

--- a/apps/web/src/lib/components/reader/reader-progress.ts
+++ b/apps/web/src/lib/components/reader/reader-progress.ts
@@ -169,6 +169,44 @@ export function computePctRead(
   return Math.max(0, Math.min(100, Math.round(((before + inChapter) / total) * 100)));
 }
 
+// Resolve the anchor that represents the *end* of the user's reading
+// position on the current page — i.e. the first token they have NOT
+// yet read. Used to drive the displayed progress percentage so a page
+// densely packed with 500 words advances the bar by 500/total, while
+// a sparse page contributes proportionally less. Without this, a page
+// reader anchored to the *first visible word* shows progress that
+// reflects everything before the page but nothing within it, so
+// dense pages register as a single tick the moment you flip past them.
+//
+// `currentAnchor` is the first visible word on the current page (kept
+// for the resume position); `nextAnchor` is the first visible word on
+// the page after, supplied by the caller from a second DOM scan. When
+// the current page is the last in its chapter we roll over to the
+// next chapter's first token; on the very last page of the very last
+// chapter we mark the text completed.
+export function pageBoundaryAnchor(args: {
+  chapters: { tokenCount: number }[];
+  chapterIdx: number;
+  pageInChapter: number;
+  pageCount: number;
+  currentAnchor: { chapterIdx: number; tokenIdx: number };
+  nextAnchor: { chapterIdx: number; tokenIdx: number } | null;
+}): { chapterIdx: number; tokenIdx: number; completed: boolean } {
+  const { chapters, chapterIdx, pageInChapter, pageCount, currentAnchor, nextAnchor } = args;
+  const isLastPage = pageInChapter >= Math.max(0, pageCount - 1);
+  const isLastChapter = chapterIdx >= chapters.length - 1;
+  if (isLastPage && isLastChapter) {
+    return { chapterIdx: currentAnchor.chapterIdx, tokenIdx: currentAnchor.tokenIdx, completed: true };
+  }
+  if (isLastPage) {
+    return { chapterIdx: chapterIdx + 1, tokenIdx: 0, completed: false };
+  }
+  if (nextAnchor) {
+    return { chapterIdx: nextAnchor.chapterIdx, tokenIdx: nextAnchor.tokenIdx, completed: false };
+  }
+  return { chapterIdx: currentAnchor.chapterIdx, tokenIdx: currentAnchor.tokenIdx, completed: false };
+}
+
 export function firstTokenPage<T extends { idx: number; isWord: boolean }>(
   pages: T[][][] | null,
   tokenIdx: number,


### PR DESCRIPTION
## Summary
Follow-up to [#390](https://github.com/chickendude/CIA-Reader/pull/390). After that fix, the footer percentage was the *first visible word* on the current page — so a page packed with 500 words still registered as a tiny tick because the user hadn't yet "moved past" it. The intuitive expectation is that sitting on a page means you've read everything *up through* it.

- Switch the displayed pct (and the value persisted to the server) to the **end-of-page boundary** — the first word on the next page, or chapter rollover at chapter end, or 100% on the final page.
- Show **both** numbers in the footer: `X–Y% through text`, where X is the position of the first visible word and Y is the boundary. The bar fill follows Y so library card and reader footer agree.
- Extracted `pageBoundaryAnchor` as a pure helper covering the mid-page, last-page-of-chapter, last-page-of-text, and still-laying-out branches.

## Test plan
- [x] `pnpm check` clean (0 errors)
- [x] `reader-progress` tests pass (16/16, including 5 new `pageBoundaryAnchor` cases)
- [ ] Manual: open the Hindi article from #390, confirm the footer reads e.g. `0–1%` on a near-empty first page, `1–12%` on a dense second page, and `12–23%` on a similar third page (rather than the prior 0% / 1% / 12% jumps)
- [ ] Manual: navigate to the last page of the last chapter — boundary should round to 100%
- [ ] Manual: refresh mid-text — bar fill matches what the library card shows