### PR TITLE
Drop the yours / community badges from translations

### DIFF
--- a/apps/web/src/lib/components/reader/WordPopup.svelte
+++ b/apps/web/src/lib/components/reader/WordPopup.svelte
@@ -1159,7 +1159,6 @@
               </form>
             {:else}
               <div class="personal-body">
-                <span class="badge tone-personal">yours</span>
                 <span class="personal-text">{t.body}</span>
                 {#if isOwner}
                   <div class="personal-actions">
@@ -1249,7 +1248,6 @@
         {#each payload.translations.community as t (t.id)}
           <li class="community-row">
             <div class="community-body">
-              <span class="badge tone-community">community</span>
               {t.body}
               {#if isOwner}
                 {#if reportedIds.has(t.id)}
@@ -1799,24 +1797,6 @@
     font-size: 0.76rem;
     color: var(--ink-2, var(--color-fg));
   }
-  .badge {
-    display: inline-block;
-    padding: 0.1rem 0.5rem;
-    margin-right: 0.4rem;
-    font-size: 0.66rem;
-    border-radius: 999px;
-    border: 1px solid var(--rule, var(--color-border));
-    color: var(--ink-3, var(--color-fg-muted));
-    background: var(--card, var(--color-bg));
-  }
-  .tone-personal {
-    border-color: color-mix(
-      in oklch,
-      var(--accent, var(--color-accent)) 60%,
-      transparent
-    );
-    color: var(--accent-ink, var(--color-accent));
-  }
   .personal-row {
     display: flex;
     flex-direction: column;
@@ -1862,14 +1842,6 @@
   .row-action[disabled] {
     opacity: 0.5;
     cursor: not-allowed;
-  }
-  .tone-community {
-    border-color: color-mix(
-      in oklch,
-      var(--accent, var(--color-accent)) 40%,
-      transparent
-    );
-    color: var(--ink-3, var(--color-fg-muted));
   }
 
   .muted {

--- a/apps/web/src/lib/components/reader/WordTooltip.svelte
+++ b/apps/web/src/lib/components/reader/WordTooltip.svelte
@@ -145,7 +145,6 @@
     <div class="tip-def empty">No dictionary match</div>
   {:else if token.personalGloss}
     <div class="tip-def" data-testid="tip-personal">
-      <span class="tip-mine">yours</span>
       {token.personalGloss}
     </div>
   {:else if token.glossDefault}
@@ -213,21 +212,6 @@
   .tip-def.empty {
     color: color-mix(in oklch, var(--paper, #fdfaf3) 65%, transparent);
     font-style: italic;
-  }
-  /* Tiny inline badge that flags the gloss as the viewer's own
-     translation rather than the dictionary one. Keeps the bookkeeping
-     visible without making the tooltip noisy. */
-  .tip-mine {
-    display: inline-block;
-    margin-right: 0.35rem;
-    padding: 0 0.35rem;
-    border-radius: 999px;
-    background: color-mix(in oklch, var(--paper, #fdfaf3) 22%, transparent);
-    color: var(--paper, #fdfaf3);
-    font-size: 0.6rem;
-    font-style: normal;
-    text-transform: lowercase;
-    letter-spacing: 0.02em;
   }
   @keyframes fade-in {
     from {

--- a/apps/web/src/lib/components/reader/WordTooltip.test.ts
+++ b/apps/web/src/lib/components/reader/WordTooltip.test.ts
@@ -91,7 +91,6 @@ describe('WordTooltip — gloss display (T-5.18)', () => {
       '[data-testid="tip-personal"]',
     );
     expect(def?.textContent).toContain('sunrise (mine)');
-    expect(def?.textContent).toContain('yours');
     // The dictionary gloss is suppressed when the viewer has their own.
     expect(document.body.textContent).not.toContain('morning, dawn');
   });


### PR DESCRIPTION
## Summary

Follow-on to #391: same reasoning, but for the remaining row badges. The popup is for reading, not for cataloging where each translation came from. The translation body is the content; the badge is noise.

- Remove the **\"yours\"** badge on personal rows in `WordPopup` and the matching one in `WordTooltip`.
- Remove the **\"community\"** badge on community rows in `WordPopup`.
- Drop the now-dead `.badge`, `.tone-personal`, `.tone-community`, and `.tip-mine` styles.

The Customize button on official rows and the Edit / Delete actions on personal rows still distinguish row kinds visually. The dictionary's `ProvenanceBadge` component is unaffected — that surface is for curators and still wants the provenance metadata.

## Test plan

- [x] `pnpm test` (web) — full suite (1281) passes; tooltip test no longer asserts the \"yours\" string.
- [x] `pnpm typecheck` clean.
- [x] `pnpm lint` clean.
- [ ] Manual: open a popup with a personal translation — body shows alone, no \"yours\" pill.
- [ ] Manual: open a popup with a community translation — body shows alone, no \"community\" pill.
- [ ] Manual: hover a word you've personally translated — tooltip shows your translation without the \"yours\" pill.