### PR TITLE
Move primary translation to top of popup + POS pill with hover name

### DIFF
--- a/apps/web/src/lib/components/reader/PosPill.svelte
+++ b/apps/web/src/lib/components/reader/PosPill.svelte
@@ -1,0 +1,111 @@
+<!--
+  Compact part-of-speech badge with a hover/focus popover that
+  expands the abbreviation into a full Universal-Dependencies name.
+  Replaces the plain "Part of speech: NOUN" line in the WordPopup
+  header and the inline POS tag in the alt-candidate list, where the
+  raw UD tag spelt out long was visually heavy.
+-->
+<script lang="ts">
+  import { posAbbr, posFullName } from './pos-labels.js';
+
+  interface Props {
+    pos: string;
+    /** Optional class hook so callers can place the pill in flex
+     *  rows without piling extra spans on top of it. */
+    class?: string;
+  }
+
+  let { pos, class: extraClass = '' }: Props = $props();
+
+  const abbr = $derived(posAbbr(pos));
+  const fullName = $derived(posFullName(pos));
+</script>
+
+<!-- A non-interactive POS chip that still surfaces a tooltip on
+     focus + hover. role="button" is overkill (it doesn't trigger
+     anything), but tabindex on a bare span trips an a11y warning
+     unless we mark it as something the keyboard can land on. -->
+<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+<span
+  class="pos-pill {extraClass}"
+  data-pos={pos}
+  data-testid="pos-pill"
+  tabindex="0"
+  aria-label={fullName}
+>
+  <span class="pos-abbr">{abbr}</span>
+  <span class="pos-pop" role="tooltip">{fullName}</span>
+</span>
+
+<style>
+  .pos-pill {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.6rem;
+    height: 1.25rem;
+    padding: 0 0.45rem;
+    background: color-mix(
+      in oklch,
+      var(--ink, var(--color-fg)) 6%,
+      transparent
+    );
+    color: var(--ink-2, var(--color-fg));
+    border: 1px solid var(--rule, var(--color-border));
+    border-radius: 999px;
+    font-family: var(--font-mono-display, var(--font-mono, monospace));
+    font-size: 0.7rem;
+    line-height: 1;
+    text-transform: lowercase;
+    letter-spacing: 0.02em;
+    cursor: help;
+  }
+  .pos-pill:focus-visible {
+    outline: 2px solid var(--accent, var(--color-accent));
+    outline-offset: 2px;
+  }
+  .pos-abbr {
+    font-weight: 600;
+  }
+  .pos-pop {
+    position: absolute;
+    bottom: calc(100% + 6px);
+    left: 50%;
+    transform: translateX(-50%);
+    padding: 0.3rem 0.55rem;
+    background: var(--ink, #1f1a14);
+    color: var(--paper, #fdfaf3);
+    border-radius: 6px;
+    font-family: var(--font-sans, system-ui, sans-serif);
+    font-size: 0.7rem;
+    line-height: 1.2;
+    white-space: nowrap;
+    text-transform: none;
+    letter-spacing: 0;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.18);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 100ms ease-out;
+    z-index: 60;
+  }
+  .pos-pop::after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border: 4px solid transparent;
+    border-top-color: var(--ink, #1f1a14);
+  }
+  .pos-pill:hover .pos-pop,
+  .pos-pill:focus-visible .pos-pop,
+  .pos-pill:focus .pos-pop {
+    opacity: 1;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .pos-pop {
+      transition: none;
+    }
+  }
+</style>

--- a/apps/web/src/lib/components/reader/PosPill.test.ts
+++ b/apps/web/src/lib/components/reader/PosPill.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render } from '@testing-library/svelte';
+
+import PosPill from './PosPill.svelte';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('PosPill', () => {
+  it('renders the abbreviated form for a known UD tag', () => {
+    const { container } = render(PosPill, { pos: 'NOUN' });
+    const pill = container.querySelector('[data-testid="pos-pill"]');
+    expect(pill).not.toBeNull();
+    expect(pill!.querySelector('.pos-abbr')?.textContent).toBe('n');
+  });
+
+  it('renders the full name inside the tooltip popover', () => {
+    const { container } = render(PosPill, { pos: 'PROPN' });
+    const pop = container.querySelector('.pos-pop');
+    expect(pop?.textContent?.trim()).toBe('proper noun');
+  });
+
+  it('exposes the full name via aria-label so screen readers read it instead of the abbr', () => {
+    const { container } = render(PosPill, { pos: 'ADV' });
+    const pill = container.querySelector<HTMLElement>(
+      '[data-testid="pos-pill"]',
+    );
+    expect(pill?.getAttribute('aria-label')).toBe('adverb');
+  });
+
+  it('falls back to a lowercased copy for unknown tags', () => {
+    const { container } = render(PosPill, { pos: 'WEIRD' });
+    const pill = container.querySelector('[data-testid="pos-pill"]');
+    expect(pill!.querySelector('.pos-abbr')?.textContent).toBe('weird');
+    expect(pill!.querySelector('.pos-pop')?.textContent?.trim()).toBe('weird');
+  });
+
+  it('forwards the optional class hook so callers can position the pill', () => {
+    const { container } = render(PosPill, { pos: 'NOUN', class: 'extra-hook' });
+    const pill = container.querySelector('[data-testid="pos-pill"]');
+    expect(pill?.classList.contains('extra-hook')).toBe(true);
+    expect(pill?.classList.contains('pos-pill')).toBe(true);
+  });
+});

--- a/apps/web/src/lib/components/reader/WordPopup.svelte
+++ b/apps/web/src/lib/components/reader/WordPopup.svelte
@@ -21,6 +21,7 @@
   import { untrack } from 'svelte';
   import Sheet from '../overlay/Sheet.svelte';
   import CorrectionModal from './CorrectionModal.svelte';
+  import PosPill from './PosPill.svelte';
   import ReportTranslationModal from './ReportTranslationModal.svelte';
   import { customizableOfficialIds } from './customize-eligibility.js';
   import type { LanguageCode } from '@ciareader/shared-types';
@@ -406,6 +407,25 @@
     }
   });
 
+  // ---- Primary-translation editor ---------------------------------
+  // The viewer's "selected" translation lives at the top of the
+  // popup, above the learning-status buttons. It mirrors the hover
+  // tooltip's pick (oldest personal row), and clicking it opens an
+  // inline editor — PATCH if a personal row already exists, POST a
+  // new one if not. Multiple personal rows still render in the
+  // translations list below; this is just the prominent "yours" slot.
+  let editingPrimary = $state(false);
+  let primaryBody = $state('');
+  let savingPrimary = $state(false);
+  let primaryError = $state<string | null>(null);
+  let primaryTextareaEl = $state<HTMLTextAreaElement | null>(null);
+
+  $effect(() => {
+    if (editingPrimary && primaryTextareaEl) {
+      primaryTextareaEl.focus();
+    }
+  });
+
   // ---- Edit / delete personal translation -------------------------
   // The viewer can revise or remove their own translations inline.
   // The edit textarea reuses the same Enter-to-save / Esc-to-cancel
@@ -564,6 +584,78 @@
     if (!token?.lemmaId) return;
     const next = payload?.translations.personal[0]?.body ?? null;
     onPersonalTranslationChange?.(token.lemmaId, next);
+  }
+
+  function startEditPrimary() {
+    primaryBody = payload?.translations.personal[0]?.body ?? '';
+    primaryError = null;
+    editingPrimary = true;
+  }
+
+  function cancelEditPrimary() {
+    editingPrimary = false;
+    primaryBody = '';
+    primaryError = null;
+  }
+
+  async function submitPrimary() {
+    if (!token?.lemmaId) return;
+    const trimmed = primaryBody.trim();
+    if (trimmed.length === 0) {
+      cancelEditPrimary();
+      return;
+    }
+    const lemmaId = token.lemmaId;
+    const existing = payload?.translations.personal[0] ?? null;
+    savingPrimary = true;
+    primaryError = null;
+    try {
+      if (existing) {
+        const res = await fetch(`/api/v1/translations/${existing.id}`, {
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ body: trimmed }),
+        });
+        if (!res.ok) {
+          const text = await res.text().catch(() => '');
+          primaryError = text || `Could not save (${res.status})`;
+          return;
+        }
+      } else {
+        await postTranslation(trimmed, null);
+      }
+      await refetchPayload(lemmaId);
+      editingPrimary = false;
+      primaryBody = '';
+      notifyPersonalChange();
+    } catch (e) {
+      const err = e as Partial<PostError> & Error;
+      primaryError = err.message ?? `Network error: ${(e as Error).message}`;
+    } finally {
+      savingPrimary = false;
+    }
+  }
+
+  function onPrimaryKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      void submitPrimary();
+      return;
+    }
+    if (e.key === 'Escape') {
+      e.stopPropagation();
+      e.preventDefault();
+      cancelEditPrimary();
+    }
+  }
+
+  function onPrimaryBlur() {
+    if (savingPrimary) return;
+    if (primaryBody.trim().length === 0) {
+      cancelEditPrimary();
+      return;
+    }
+    void submitPrimary();
   }
 
   async function submitNewTranslation() {
@@ -1079,11 +1171,10 @@
         {#if payload}
           <p class="sp-row">
             <span class="k">Lemma</span>
-            <span class="v">{payload.lemma.headword}</span>
-          </p>
-          <p class="sp-row">
-            <span class="k">Part of speech</span>
-            <span class="v">{payload.lemma.pos}</span>
+            <span class="v sp-headword">
+              <span>{payload.lemma.headword}</span>
+              <PosPill pos={payload.lemma.pos} class="sp-pos-pill" />
+            </span>
           </p>
         {:else if token.isOov}
           <p class="muted">No dictionary match</p>
@@ -1096,6 +1187,53 @@
     </header>
 
     {#if !isNumberToken}
+    {#if isOwner && token.lemmaId && payload}
+      <section class="sp-primary" data-testid="primary-translation">
+        {#if editingPrimary}
+          <form
+            class="sp-primary-form"
+            onsubmit={(e) => {
+              e.preventDefault();
+              void submitPrimary();
+            }}
+          >
+            <textarea
+              bind:this={primaryTextareaEl}
+              bind:value={primaryBody}
+              rows="2"
+              maxlength="500"
+              disabled={savingPrimary}
+              aria-label="Your translation"
+              placeholder="Your translation (Enter to save, Shift+Enter for a newline, Esc to cancel)"
+              onkeydown={onPrimaryKeydown}
+              onblur={onPrimaryBlur}
+            ></textarea>
+            {#if primaryError}
+              <p class="err small">{primaryError}</p>
+            {/if}
+          </form>
+        {:else}
+          <button
+            type="button"
+            class="sp-primary-display"
+            data-testid="primary-translation-edit"
+            data-empty={payload.translations.personal[0] ? '0' : '1'}
+            title={payload.translations.personal[0]
+              ? 'Edit your translation'
+              : 'Add your translation'}
+            onclick={startEditPrimary}
+          >
+            {#if payload.translations.personal[0]}
+              <span class="sp-primary-body">
+                {payload.translations.personal[0].body}
+              </span>
+            {:else}
+              <span class="sp-primary-empty">+ Add your translation</span>
+            {/if}
+          </button>
+        {/if}
+      </section>
+    {/if}
     {#if isOwner && token.lemmaId}
       <div class="sp-status" role="group" aria-label="Mark status">
         <button
@@ -1132,7 +1270,7 @@
       </h3>
 
       <ul class="translations">
-        {#each payload.translations.personal as t (t.id)}
+        {#each payload.translations.personal.slice(1) as t (t.id)}
           <li class="personal-row" data-testid="personal-row">
             {#if editingId === t.id}
               <form
@@ -1377,7 +1515,7 @@
             <li class="alt" data-lemma-id={cand.lemmaId}>
               <div class="alt-head">
                 <span class="alt-h">{cand.headword}</span>
-                <span class="alt-pos">{cand.pos}</span>
+                <PosPill pos={cand.pos} class="alt-pos-pill" />
               </div>
               {#if cand.glossDefault}
                 <p class="alt-gloss">{cand.glossDefault}</p>
@@ -1647,6 +1785,81 @@
     flex: 1;
     color: var(--ink, var(--color-fg));
     font-size: 0.85rem;
+  }
+  .sp-headword {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    flex-wrap: wrap;
+  }
+  :global(.sp-pos-pill) {
+    flex-shrink: 0;
+  }
+
+  .sp-primary {
+    margin: 0.75rem 0 0.6rem;
+  }
+  .sp-primary-display {
+    width: 100%;
+    text-align: left;
+    padding: 0.6rem 0.75rem;
+    background: color-mix(
+      in oklch,
+      var(--accent, var(--color-accent)) 8%,
+      var(--card, var(--color-bg))
+    );
+    border: 1px solid color-mix(
+      in oklch,
+      var(--accent, var(--color-accent)) 22%,
+      var(--rule, var(--color-border))
+    );
+    border-radius: 8px;
+    color: var(--ink, var(--color-fg));
+    font: inherit;
+    font-size: 0.95rem;
+    line-height: 1.35;
+    cursor: text;
+  }
+  .sp-primary-display:hover {
+    border-color: color-mix(
+      in oklch,
+      var(--accent, var(--color-accent)) 50%,
+      var(--rule, var(--color-border))
+    );
+  }
+  .sp-primary-display:focus-visible {
+    outline: 2px solid var(--accent, var(--color-accent));
+    outline-offset: 1px;
+  }
+  .sp-primary-display[data-empty='1'] {
+    background: transparent;
+    border-style: dashed;
+    color: var(--ink-3, var(--color-fg-muted));
+    font-size: 0.82rem;
+    text-align: center;
+  }
+  .sp-primary-empty {
+    display: inline-block;
+  }
+  .sp-primary-form textarea {
+    width: 100%;
+    padding: 0.6rem 0.75rem;
+    font: inherit;
+    font-size: 0.95rem;
+    line-height: 1.35;
+    border: 1px solid color-mix(
+      in oklch,
+      var(--accent, var(--color-accent)) 35%,
+      var(--rule, var(--color-border))
+    );
+    border-radius: 8px;
+    background: var(--card, var(--color-bg));
+    color: var(--ink, var(--color-fg));
+    resize: vertical;
+  }
+  .sp-primary-form textarea:focus-visible {
+    outline: 2px solid var(--accent, var(--color-accent));
+    outline-offset: 1px;
   }
 
   .sp-status {
@@ -2033,11 +2246,8 @@
     font-size: 1.05rem;
     color: var(--ink, var(--color-fg));
   }
-  .alt-pos {
-    font-size: 0.66rem;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-    color: var(--ink-3, var(--color-fg-muted));
+  :global(.alt-pos-pill) {
+    flex-shrink: 0;
   }
   .alt-gloss {
     margin: 0 0 0.45rem;

--- a/apps/web/src/lib/components/reader/WordPopup.test.ts
+++ b/apps/web/src/lib/components/reader/WordPopup.test.ts
@@ -432,11 +432,14 @@ describe('WordPopup — add-translation form (no buttons, focus, refetch)', () =
       new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
     );
 
-    // The translations list refreshes and the form collapses back to
-    // the toggle so the user immediately sees what they added.
+    // The user sees the new translation immediately — added rows
+    // become the new primary slot at the top of the popup. The
+    // bottom add form collapses back to the toggle button.
     await waitFor(() => {
-      const list = document.body.querySelector('.translations');
-      expect(list?.textContent ?? '').toContain('water');
+      const primary = document.body.querySelector(
+        '[data-testid="primary-translation-edit"]',
+      );
+      expect(primary?.textContent ?? '').toContain('water');
       expect(document.body.querySelector('.add-form')).toBeNull();
       expect(document.body.querySelector('.add-toggle')).not.toBeNull();
     });
@@ -482,12 +485,19 @@ describe('WordPopup — edit + delete personal translations', () => {
     vi.restoreAllMocks();
   });
 
-  it('renders Edit + Delete buttons on each personal row when isOwner=true', async () => {
+  // The list-row Edit + Delete buttons cover the secondary personal
+  // translations only — the primary (oldest) one moved out into its
+  // own slot at the top of the popup, so payloads need at least two
+  // personal rows to surface a list-row to act on.
+  const TWO_PERSONAL = [
+    { id: 'tr-1', body: 'water' },
+    { id: 'tr-2', body: 'lake' },
+  ];
+
+  it('renders Edit + Delete buttons on each non-primary personal row when isOwner=true', async () => {
     vi.stubGlobal(
       'fetch',
-      vi.fn().mockResolvedValue(
-        jsonResponse(payloadOf([{ id: 'tr-1', body: 'water' }])),
-      ),
+      vi.fn().mockResolvedValue(jsonResponse(payloadOf(TWO_PERSONAL))),
     );
     render(WordPopup, {
       token: makeToken({ surface: 'पानी', lemmaId: 'lem-1' }),
@@ -505,12 +515,10 @@ describe('WordPopup — edit + delete personal translations', () => {
     });
   });
 
-  it('hides Edit + Delete buttons when isOwner=false', async () => {
+  it('hides Edit + Delete buttons on non-primary personal rows when isOwner=false', async () => {
     vi.stubGlobal(
       'fetch',
-      vi.fn().mockResolvedValue(
-        jsonResponse(payloadOf([{ id: 'tr-1', body: 'water' }])),
-      ),
+      vi.fn().mockResolvedValue(jsonResponse(payloadOf(TWO_PERSONAL))),
     );
     render(WordPopup, {
       token: makeToken({ surface: 'पानी', lemmaId: 'lem-1' }),
@@ -525,17 +533,24 @@ describe('WordPopup — edit + delete personal translations', () => {
     expect(document.body.querySelector('[data-testid="delete-personal"]')).toBeNull();
   });
 
-  it('Edit swaps the row for a focused textarea and PATCHes the body on Enter', async () => {
+  it('Edit swaps the secondary row for a focused textarea and PATCHes the body on Enter', async () => {
     const fetchMock = vi
       .fn()
       // initial GET
-      .mockResolvedValueOnce(jsonResponse(payloadOf([{ id: 'tr-1', body: 'water' }])))
+      .mockResolvedValueOnce(jsonResponse(payloadOf(TWO_PERSONAL)))
       // PATCH
       .mockResolvedValueOnce(
-        jsonResponse({ translation: personalRow('tr-1', 'fresh water') }),
+        jsonResponse({ translation: personalRow('tr-2', 'pond') }),
       )
       // refetch GET
-      .mockResolvedValueOnce(jsonResponse(payloadOf([{ id: 'tr-1', body: 'fresh water' }])));
+      .mockResolvedValueOnce(
+        jsonResponse(
+          payloadOf([
+            { id: 'tr-1', body: 'water' },
+            { id: 'tr-2', body: 'pond' },
+          ]),
+        ),
+      );
     vi.stubGlobal('fetch', fetchMock);
 
     const onPersonalTranslationChange = vi.fn();
@@ -564,56 +579,54 @@ describe('WordPopup — edit + delete personal translations', () => {
       return el;
     });
     expect(document.activeElement).toBe(textarea);
-    expect(textarea.value).toBe('water');
+    expect(textarea.value).toBe('lake');
 
-    textarea.value = 'fresh water';
+    textarea.value = 'pond';
     textarea.dispatchEvent(new Event('input', { bubbles: true }));
     textarea.dispatchEvent(
       new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
     );
 
     await waitFor(() => {
-      // Form gone, list shows the new body, parent was notified.
       expect(
         document.body.querySelector('[data-testid="edit-personal-form"]'),
       ).toBeNull();
       const list = document.body.querySelector('.translations');
-      expect(list?.textContent ?? '').toContain('fresh water');
+      expect(list?.textContent ?? '').toContain('pond');
+      // The primary row didn't change, so the parent gets the
+      // unchanged primary body (the live-update channel only carries
+      // the primary).
       expect(onPersonalTranslationChange).toHaveBeenCalledWith(
         'lem-1',
-        'fresh water',
+        'water',
       );
     });
 
-    // PATCH happened against /api/v1/translations/tr-1.
     const patchCall = fetchMock.mock.calls.find(
       ([url, init]) =>
         typeof url === 'string' &&
-        url.endsWith('/api/v1/translations/tr-1') &&
+        url.endsWith('/api/v1/translations/tr-2') &&
         (init as RequestInit | undefined)?.method === 'PATCH',
     );
     expect(patchCall).toBeDefined();
   });
 
-  it('Delete confirms, sends DELETE, and notifies parent that the personal gloss is gone', async () => {
+  it('Delete on a secondary row confirms, sends DELETE, and refetches', async () => {
     const fetchMock = vi
       .fn()
-      // initial GET
-      .mockResolvedValueOnce(jsonResponse(payloadOf([{ id: 'tr-1', body: 'water' }])))
-      // DELETE — 204 No Content
+      .mockResolvedValueOnce(jsonResponse(payloadOf(TWO_PERSONAL)))
       .mockResolvedValueOnce(new Response(null, { status: 204 }))
-      // refetch GET — empty personal bucket now
-      .mockResolvedValueOnce(jsonResponse(payloadOf([])));
+      .mockResolvedValueOnce(
+        jsonResponse(payloadOf([{ id: 'tr-1', body: 'water' }])),
+      );
     vi.stubGlobal('fetch', fetchMock);
     vi.spyOn(window, 'confirm').mockReturnValue(true);
 
-    const onPersonalTranslationChange = vi.fn();
     render(WordPopup, {
       token: makeToken({ surface: 'पानी', lemmaId: 'lem-1' }),
       language: 'hi',
       isOwner: true,
       onClose: vi.fn(),
-      onPersonalTranslationChange,
     });
 
     const delBtn = await waitFor(() => {
@@ -626,14 +639,15 @@ describe('WordPopup — edit + delete personal translations', () => {
     delBtn.click();
 
     await waitFor(() => {
-      expect(document.body.querySelector('[data-testid="personal-row"]')).toBeNull();
-      expect(onPersonalTranslationChange).toHaveBeenCalledWith('lem-1', null);
+      expect(
+        document.body.querySelector('[data-testid="personal-row"]'),
+      ).toBeNull();
     });
 
     const deleteCall = fetchMock.mock.calls.find(
       ([url, init]) =>
         typeof url === 'string' &&
-        url.endsWith('/api/v1/translations/tr-1') &&
+        url.endsWith('/api/v1/translations/tr-2') &&
         (init as RequestInit | undefined)?.method === 'DELETE',
     );
     expect(deleteCall).toBeDefined();
@@ -642,7 +656,7 @@ describe('WordPopup — edit + delete personal translations', () => {
   it('Delete is a no-op when window.confirm is dismissed', async () => {
     const fetchMock = vi
       .fn()
-      .mockResolvedValueOnce(jsonResponse(payloadOf([{ id: 'tr-1', body: 'water' }])));
+      .mockResolvedValueOnce(jsonResponse(payloadOf(TWO_PERSONAL)));
     vi.stubGlobal('fetch', fetchMock);
     vi.spyOn(window, 'confirm').mockReturnValue(false);
 
@@ -662,7 +676,6 @@ describe('WordPopup — edit + delete personal translations', () => {
     });
     delBtn.click();
 
-    // Only the initial GET should have fired — no DELETE.
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(
       document.body.querySelector('[data-testid="personal-row"]'),
@@ -707,6 +720,319 @@ describe('WordPopup — edit + delete personal translations', () => {
 
     await waitFor(() => {
       expect(onPersonalTranslationChange).toHaveBeenCalledWith('lem-1', 'water');
+    });
+  });
+});
+
+describe('WordPopup — primary translation editor (above status buttons)', () => {
+  function personalRow(id: string, body: string) {
+    return {
+      id,
+      source: 'user' as const,
+      submittedBy: 'me',
+      body,
+      targetLanguage: 'en',
+      sourceAttribution: null,
+      parentTranslationId: null,
+      provenance: { kind: 'personal' as const, attribution: null },
+      voteScore: 0,
+      viewerVote: null,
+    };
+  }
+
+  function payloadOf(personal: { id: string; body: string }[]) {
+    return {
+      lemma: { id: 'lem-1', headword: 'पानी', pos: 'NOUN', glossDefault: null },
+      translations: {
+        personal: personal.map((p) => personalRow(p.id, p.body)),
+        official: [],
+        community: [],
+      },
+    };
+  }
+
+  function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  async function awaitElement<T extends Element>(selector: string): Promise<T> {
+    return waitFor(() => {
+      const el = document.body.querySelector<T>(selector);
+      if (!el) throw new Error(`missing ${selector}`);
+      return el;
+    });
+  }
+
+  it('renders an empty primary slot when the viewer has no personal translation', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(jsonResponse(payloadOf([]))),
+    );
+    render(WordPopup, {
+      token: makeToken({ surface: 'पानी', lemmaId: 'lem-1' }),
+      language: 'hi',
+      isOwner: true,
+      onClose: vi.fn(),
+    });
+    const slot = await awaitElement<HTMLElement>(
+      '[data-testid="primary-translation-edit"]',
+    );
+    expect(slot.dataset.empty).toBe('1');
+    expect(slot.textContent ?? '').toContain('+ Add your translation');
+  });
+
+  it('shows the existing personal body in the primary slot above the status buttons', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        jsonResponse(payloadOf([{ id: 'tr-1', body: 'water' }])),
+      ),
+    );
+    render(WordPopup, {
+      token: makeToken({ surface: 'पानी', lemmaId: 'lem-1' }),
+      language: 'hi',
+      isOwner: true,
+      onClose: vi.fn(),
+    });
+    const slot = await awaitElement<HTMLElement>(
+      '[data-testid="primary-translation-edit"]',
+    );
+    expect(slot.dataset.empty).toBe('0');
+    expect(slot.textContent ?? '').toContain('water');
+
+    // Slot must come before the status buttons in document order.
+    const status = document.body.querySelector('.sp-status');
+    expect(status).not.toBeNull();
+    const cmp = slot.compareDocumentPosition(status!);
+    expect(cmp & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
+    // The primary row is hidden from the translations list to avoid
+    // duplicating itself.
+    const personalRows = document.body.querySelectorAll(
+      '[data-testid="personal-row"]',
+    );
+    expect(personalRows.length).toBe(0);
+  });
+
+  it('clicking the empty slot opens an autofocused textarea and POSTs a new personal translation', async () => {
+    const fetchMock = vi
+      .fn()
+      // initial GET — no personal yet
+      .mockResolvedValueOnce(jsonResponse(payloadOf([])))
+      // POST /api/v1/translations
+      .mockResolvedValueOnce(
+        jsonResponse({ translation: personalRow('tr-1', 'water') }),
+      )
+      // refetch
+      .mockResolvedValueOnce(
+        jsonResponse(payloadOf([{ id: 'tr-1', body: 'water' }])),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const onPersonalTranslationChange = vi.fn();
+    render(WordPopup, {
+      token: makeToken({ surface: 'पानी', lemmaId: 'lem-1' }),
+      language: 'hi',
+      isOwner: true,
+      onClose: vi.fn(),
+      onPersonalTranslationChange,
+    });
+
+    const slot = await awaitElement<HTMLButtonElement>(
+      '[data-testid="primary-translation-edit"]',
+    );
+    slot.click();
+
+    const textarea = await awaitElement<HTMLTextAreaElement>(
+      '.sp-primary-form textarea',
+    );
+    expect(document.activeElement).toBe(textarea);
+
+    textarea.value = 'water';
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    textarea.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
+    );
+
+    await waitFor(() => {
+      const display = document.body.querySelector<HTMLElement>(
+        '[data-testid="primary-translation-edit"]',
+      );
+      expect(display).not.toBeNull();
+      expect(display!.textContent ?? '').toContain('water');
+      expect(display!.dataset.empty).toBe('0');
+    });
+
+    const postCall = fetchMock.mock.calls.find(
+      ([url, init]) =>
+        typeof url === 'string' &&
+        url.endsWith('/api/v1/translations') &&
+        (init as RequestInit | undefined)?.method === 'POST',
+    );
+    expect(postCall).toBeDefined();
+    expect(onPersonalTranslationChange).toHaveBeenCalledWith('lem-1', 'water');
+  });
+
+  it('clicking an existing primary opens the editor pre-filled and PATCHes on Enter', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse(payloadOf([{ id: 'tr-1', body: 'water' }])),
+      )
+      // PATCH
+      .mockResolvedValueOnce(
+        jsonResponse({ translation: personalRow('tr-1', 'fresh water') }),
+      )
+      // refetch
+      .mockResolvedValueOnce(
+        jsonResponse(payloadOf([{ id: 'tr-1', body: 'fresh water' }])),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const onPersonalTranslationChange = vi.fn();
+    render(WordPopup, {
+      token: makeToken({ surface: 'पानी', lemmaId: 'lem-1' }),
+      language: 'hi',
+      isOwner: true,
+      onClose: vi.fn(),
+      onPersonalTranslationChange,
+    });
+
+    const slot = await awaitElement<HTMLButtonElement>(
+      '[data-testid="primary-translation-edit"]',
+    );
+    slot.click();
+    const textarea = await awaitElement<HTMLTextAreaElement>(
+      '.sp-primary-form textarea',
+    );
+    expect(textarea.value).toBe('water');
+    expect(document.activeElement).toBe(textarea);
+
+    textarea.value = 'fresh water';
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    textarea.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
+    );
+
+    await waitFor(() => {
+      const display = document.body.querySelector<HTMLElement>(
+        '[data-testid="primary-translation-edit"]',
+      );
+      expect(display?.textContent ?? '').toContain('fresh water');
+    });
+
+    const patchCall = fetchMock.mock.calls.find(
+      ([url, init]) =>
+        typeof url === 'string' &&
+        url.endsWith('/api/v1/translations/tr-1') &&
+        (init as RequestInit | undefined)?.method === 'PATCH',
+    );
+    expect(patchCall).toBeDefined();
+    expect(onPersonalTranslationChange).toHaveBeenCalledWith(
+      'lem-1',
+      'fresh water',
+    );
+  });
+
+  it('Esc cancels the primary edit and leaves the existing body in place', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        jsonResponse(payloadOf([{ id: 'tr-1', body: 'water' }])),
+      ),
+    );
+    render(WordPopup, {
+      token: makeToken({ surface: 'पानी', lemmaId: 'lem-1' }),
+      language: 'hi',
+      isOwner: true,
+      onClose: vi.fn(),
+    });
+
+    const slot = await awaitElement<HTMLButtonElement>(
+      '[data-testid="primary-translation-edit"]',
+    );
+    slot.click();
+    const textarea = await awaitElement<HTMLTextAreaElement>(
+      '.sp-primary-form textarea',
+    );
+    textarea.value = 'about to be discarded';
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    textarea.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+    );
+
+    await waitFor(() => {
+      const display = document.body.querySelector<HTMLElement>(
+        '[data-testid="primary-translation-edit"]',
+      );
+      expect(display?.textContent ?? '').toContain('water');
+      expect(document.body.querySelector('.sp-primary-form')).toBeNull();
+    });
+  });
+
+  it('does not render the primary slot for non-owner viewers', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(jsonResponse(payloadOf([]))),
+    );
+    render(WordPopup, {
+      token: makeToken({ surface: 'पानी', lemmaId: 'lem-1' }),
+      language: 'hi',
+      isOwner: false,
+      onClose: vi.fn(),
+    });
+    await awaitElement('[data-testid="word-popup"]');
+    expect(
+      document.body.querySelector('[data-testid="primary-translation"]'),
+    ).toBeNull();
+  });
+});
+
+describe('WordPopup — POS pill in header', () => {
+  function payloadOf(pos: string) {
+    return {
+      lemma: { id: 'lem-1', headword: 'पानी', pos, glossDefault: null },
+      translations: { personal: [], official: [], community: [] },
+    };
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('renders an abbreviated POS pill next to the headword and exposes the full name via aria-label', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify(payloadOf('NOUN')), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      ),
+    );
+    render(WordPopup, {
+      token: makeToken({ surface: 'पानी', lemmaId: 'lem-1' }),
+      language: 'hi',
+      isOwner: true,
+      onClose: vi.fn(),
+    });
+    await waitFor(() => {
+      const pill = document.body.querySelector<HTMLElement>(
+        '.sp-headword [data-testid="pos-pill"]',
+      );
+      if (!pill) throw new Error('missing pos-pill in header');
+      expect(pill.querySelector('.pos-abbr')?.textContent).toBe('n');
+      expect(pill.getAttribute('aria-label')).toBe('noun');
+      // The expanded name lives in the popover so it can show on hover/focus.
+      expect(pill.querySelector('.pos-pop')?.textContent?.trim()).toBe('noun');
     });
   });
 });

--- a/apps/web/src/lib/components/reader/pos-labels.test.ts
+++ b/apps/web/src/lib/components/reader/pos-labels.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { posAbbr, posFullName } from './pos-labels.js';
+
+describe('pos-labels', () => {
+  it.each([
+    ['NOUN', 'n', 'noun'],
+    ['VERB', 'v', 'verb'],
+    ['ADJ', 'adj', 'adjective'],
+    ['ADV', 'adv', 'adverb'],
+    ['PROPN', 'prop', 'proper noun'],
+    ['PRON', 'pron', 'pronoun'],
+    ['ADP', 'adp', 'adposition'],
+    ['AUX', 'aux', 'auxiliary'],
+    ['CCONJ', 'conj', 'coordinating conjunction'],
+    ['SCONJ', 'sconj', 'subordinating conjunction'],
+    ['DET', 'det', 'determiner'],
+    ['INTJ', 'intj', 'interjection'],
+    ['NUM', 'num', 'numeral'],
+    ['PART', 'part', 'particle'],
+  ] as const)('maps %s to abbr=%s and fullName=%s', (pos, abbr, full) => {
+    expect(posAbbr(pos)).toBe(abbr);
+    expect(posFullName(pos)).toBe(full);
+  });
+
+  it('uppercases lookup keys so lowercase inputs still resolve', () => {
+    expect(posAbbr('noun')).toBe('n');
+    expect(posFullName('verb')).toBe('verb');
+  });
+
+  it('falls back to a lowercased copy when the tag is unknown', () => {
+    expect(posAbbr('NEW_TAG')).toBe('new_tag');
+    expect(posFullName('NEW_TAG')).toBe('new_tag');
+  });
+
+  it('returns empty string when called with empty input', () => {
+    expect(posAbbr('')).toBe('');
+    expect(posFullName('')).toBe('');
+  });
+});

--- a/apps/web/src/lib/components/reader/pos-labels.ts
+++ b/apps/web/src/lib/components/reader/pos-labels.ts
@@ -1,0 +1,51 @@
+/**
+ * Universal-Dependencies part-of-speech abbreviations + full names.
+ *
+ * The NLP pipeline tags every lemma with a UD POS string like
+ * `NOUN` / `VERB` / `PROPN`. The reader's PosPill renders a short
+ * form (e.g. "n", "v", "prop") with the full name in a hover
+ * tooltip; the table below is the single source of truth for that
+ * mapping so the abbreviation stays consistent everywhere.
+ *
+ * Unknown tags fall through to a lowercased copy of the tag itself
+ * — better to render a non-noisy "x" than crash on a value the
+ * worker added but we haven't registered yet.
+ */
+export type PosLabel = {
+  abbr: string;
+  fullName: string;
+};
+
+const POS_LABELS: Readonly<Record<string, PosLabel>> = Object.freeze({
+  NOUN: { abbr: 'n', fullName: 'noun' },
+  VERB: { abbr: 'v', fullName: 'verb' },
+  ADJ: { abbr: 'adj', fullName: 'adjective' },
+  ADV: { abbr: 'adv', fullName: 'adverb' },
+  PRON: { abbr: 'pron', fullName: 'pronoun' },
+  PROPN: { abbr: 'prop', fullName: 'proper noun' },
+  ADP: { abbr: 'adp', fullName: 'adposition' },
+  AUX: { abbr: 'aux', fullName: 'auxiliary' },
+  CCONJ: { abbr: 'conj', fullName: 'coordinating conjunction' },
+  SCONJ: { abbr: 'sconj', fullName: 'subordinating conjunction' },
+  DET: { abbr: 'det', fullName: 'determiner' },
+  INTJ: { abbr: 'intj', fullName: 'interjection' },
+  NUM: { abbr: 'num', fullName: 'numeral' },
+  PART: { abbr: 'part', fullName: 'particle' },
+  SYM: { abbr: 'sym', fullName: 'symbol' },
+  PUNCT: { abbr: 'punct', fullName: 'punctuation' },
+  X: { abbr: 'x', fullName: 'other' },
+});
+
+function lookup(pos: string): PosLabel | null {
+  if (!pos) return null;
+  const key = pos.toUpperCase();
+  return POS_LABELS[key] ?? null;
+}
+
+export function posAbbr(pos: string): string {
+  return lookup(pos)?.abbr ?? pos.toLowerCase();
+}
+
+export function posFullName(pos: string): string {
+  return lookup(pos)?.fullName ?? pos.toLowerCase();
+}


### PR DESCRIPTION
## Summary

Two changes to `WordPopup` so the bits a learner cares about read first.

### 1. Primary translation moves to the top

The viewer's primary personal translation now sits in its own slot **above** the Learning / Known / Ignored buttons instead of being mixed into the translations list. The slot is editable in place:

- **Has a personal translation already.** Click → autofocused textarea pre-filled with the existing body. Enter saves (PATCH). Esc cancels. Blur with content saves.
- **No personal translation yet.** Click → empty textarea. Enter saves (POST a new personal). Same Esc/blur ergonomics.

Either path calls `notifyPersonalChange()` on success so the hover tooltip in the chapter view refreshes without a reload (re-using the live-update channel from the earlier PR). Secondary personal translations still render in the list with the existing Edit / Delete actions.

### 2. POS pill with full-name on hover

The Universal-Dependencies POS tag becomes a compact pill (`n`, `v`, `adj`, `prop`, …) rendered inline next to the headword in the popup header and on each alt-candidate row. Hovering or focusing the pill pops up a small bubble with the full name (`noun`, `proper noun`, `coordinating conjunction`, …). The full name also lives on `aria-label` so screen readers read the long form.

The abbreviation table lives in `pos-labels.ts` so any future surface that wants the same shortening shares one source of truth. Unknown tags fall through to a lowercased copy rather than crashing.

## Test plan

- [x] `pnpm test` (web) — full suite (1315) passes; new specs cover the abbreviation table, the pill component, the primary-translation flow (empty, prefilled, Esc cancel, owner gating), and the existing edit/delete tests now use a 2-personal-row fixture so the secondary-row buttons still surface.
- [x] `pnpm typecheck` clean.
- [x] `pnpm lint` clean.
- [ ] Manual: open a popup with no personal translation — click \"+ Add your translation\" at the top, type, press Enter, see the slot fill and the hover tooltip update.
- [ ] Manual: open a popup that already has a personal translation — click it, edit, press Enter, slot updates.
- [ ] Manual: hover the POS pill — see the full name in the bubble.
- [ ] Manual: keyboard-tab to the POS pill — same bubble appears via :focus-visible.