### PR TITLE
Highlight current page on the reader progress bar

### DIFF
--- a/apps/web/src/lib/components/reader/ReaderPage.svelte
+++ b/apps/web/src/lib/components/reader/ReaderPage.svelte
@@ -417,13 +417,19 @@
     </span>
     <span class="muted">
       {#if startPct === endPct}
-        {endPct}% through text
+        {endPct}%
       {:else}
-        {startPct}–{endPct}% through text
+        {startPct}–{endPct}%
       {/if}
     </span>
   </div>
-  <div class="reader-foot-bar"><i style="width: {endPct}%"></i></div>
+  <div class="reader-foot-bar">
+    <i class="read" style="width: {startPct}%"></i>
+    <i
+      class="current"
+      style="left: {startPct}%; width: {Math.max(0, endPct - startPct)}%"
+    ></i>
+  </div>
 </footer>
 
 <style>
@@ -625,10 +631,23 @@
   }
   .reader-foot-bar > i {
     position: absolute;
-    inset: 0 auto 0 0;
-    background: var(--accent, var(--color-accent));
+    top: 0;
+    bottom: 0;
     border-radius: 2px;
-    transition: width 250ms ease;
+    transition:
+      width 250ms ease,
+      left 250ms ease;
+  }
+  /* Words read before the current page — muted accent so the eye
+     reads it as "behind me" rather than "active". */
+  .reader-foot-bar > i.read {
+    left: 0;
+    background: color-mix(in oklch, var(--accent, var(--color-accent)) 45%, transparent);
+  }
+  /* Words on the current page — full-strength accent so the active
+     range stands out as the "you are here" segment. */
+  .reader-foot-bar > i.current {
+    background: var(--accent, var(--color-accent));
   }
 
   /* Respect reduced-motion: skip the page-flip slide. */


### PR DESCRIPTION
## Summary
Follow-up to [#392](https://github.com/chickendude/CIA-Reader/pull/392). The progress bar previously filled a single accent stripe up to the end-of-page percentage, so the "current page" range wasn't visually distinguishable from "everything read so far."

- Split the fill into two segments: a muted accent stripe for `0..startPct` (already read) and full-strength accent for `startPct..endPct` (the current page).
- Drop the "through text" suffix from the label — the bar makes the meaning obvious and the chapter/page counter sits right next to it. Just show `X%` or `X–Y%`.

## Test plan
- [x] `pnpm check` clean (0 errors)
- [x] reader-progress unit tests pass (16/16)
- [ ] Manual: open a Hindi text in page mode, confirm the bar shows two distinct shades for the read portion vs the current page, and the label reads `1–12%` (no trailing "through text")
- [ ] Manual: confirm both segments transition smoothly when flipping pages
- [ ] Manual: spot-check in light + dark themes — `color-mix(... 45%, transparent)` should give a usable muted shade in both