### PR TITLE
Adaptive progress precision + column-index cache for page reader

### DIFF
--- a/apps/web/src/lib/components/reader/ReaderPage.svelte
+++ b/apps/web/src/lib/components/reader/ReaderPage.svelte
@@ -23,11 +23,15 @@
   import type { ProgressAnchor } from './progress-client.js';
   import {
     WORD_SELECTOR,
+    buildPageWordIndex,
     columnIndexForElement,
     computePctRead,
-    findFirstWordInColumn,
     findTokenElementAtOrAfter,
+    firstWordInColumnFromIndex,
+    formatPctRange,
     pageBoundaryAnchor,
+    pctPrecisionFor,
+    type PageWordIndex,
   } from './reader-progress.js';
   import { classifySwipe } from './touch-gestures.js';
   import type { ChapterView } from './types.js';
@@ -93,6 +97,7 @@
     initialTokenApplied = false;
     restorePaintReady = initialTokenIdx <= 0;
     lastReportedKey = '';
+    columnIndexCache = null;
     const seed = computePctRead(chapters, chapterIdx, initialTokenIdx);
     startPct = seed;
     endPct = seed;
@@ -119,6 +124,16 @@
   // card and reader footer always agree.
   let startPct = $state(0);
   let endPct = $state(0);
+
+  const totalTokens = $derived(chapters.reduce((sum, c) => sum + Math.max(0, c.tokenCount), 0));
+  const pctPrecision = $derived(pctPrecisionFor(totalTokens));
+
+  // Per-measure cache of word→column mapping. `findFirstWordInColumn`
+  // forces a layout flush per token; building once per measure and
+  // serving both the current-page and next-page anchors from the same
+  // index drops the page-flip cost in half (and keeps it constant
+  // regardless of how many additional anchors we ever query).
+  let columnIndexCache: PageWordIndex | null = null;
 
   function go(nextIdx: number, opts: { lastPage?: boolean } = {}) {
     void goto(`/reader/${textId}?mode=page&chapter=${nextIdx}`, {
@@ -221,6 +236,7 @@
     const total = contentEl.scrollWidth;
     pageW = w;
     contentW = total;
+    columnIndexCache = null;
   }
 
   onMount(() => {
@@ -272,6 +288,25 @@
     });
   }
 
+  function ensureColumnIndex(): PageWordIndex | null {
+    if (!contentEl) return null;
+    if (
+      !columnIndexCache ||
+      columnIndexCache.pageWidth !== pageW ||
+      columnIndexCache.contentWidth !== contentW ||
+      columnIndexCache.fallbackChapterIdx !== chapterIdx
+    ) {
+      columnIndexCache = buildPageWordIndex({
+        root: contentEl,
+        contentEl,
+        pageWidth: pageW,
+        contentWidth: contentW,
+        fallbackChapterIdx: chapterIdx,
+      });
+    }
+    return columnIndexCache;
+  }
+
   function reportProgress() {
     if (!contentEl) return;
     // Don't fire while the viewport mask is up — the writer would
@@ -279,21 +314,13 @@
     // applyInitialTokenPage jumps to the saved column, and on a
     // chapter change we'd briefly mirror tokenIdx=0 to the URL.
     if (isRestoringInitialToken) return;
-    const anchor = findFirstWordInColumn(contentEl, {
-      contentEl,
-      pageWidth: pageW,
-      pageIdx: pageInChapter,
-      fallbackChapterIdx: chapterIdx,
-    });
+    const index = ensureColumnIndex();
+    if (!index) return;
+    const anchor = firstWordInColumnFromIndex(index, pageInChapter);
     if (!anchor) return;
     const nextPageAnchor =
       pageInChapter < pageCount - 1
-        ? findFirstWordInColumn(contentEl, {
-            contentEl,
-            pageWidth: pageW,
-            pageIdx: pageInChapter + 1,
-            fallbackChapterIdx: chapterIdx,
-          })
+        ? firstWordInColumnFromIndex(index, pageInChapter + 1)
         : null;
     const boundary = pageBoundaryAnchor({
       chapters,
@@ -415,13 +442,7 @@
       Page {pageInChapter + 1} of {pageCount}
       <span class="muted">· Ch. {chapterIdx + 1} / {chapters.length}</span>
     </span>
-    <span class="muted">
-      {#if startPct === endPct}
-        {endPct}%
-      {:else}
-        {startPct}–{endPct}%
-      {/if}
-    </span>
+    <span class="muted">{formatPctRange(startPct, endPct, pctPrecision)}</span>
   </div>
   <div class="reader-foot-bar">
     <i class="read" style="width: {startPct}%"></i>

--- a/apps/web/src/lib/components/reader/ReaderPage.svelte
+++ b/apps/web/src/lib/components/reader/ReaderPage.svelte
@@ -417,13 +417,19 @@
     </span>
     <span class="muted">
       {#if startPct === endPct}
-        {endPct}% through text
+        {endPct}%
       {:else}
-        {startPct}–{endPct}% through text
+        {startPct}–{endPct}%
       {/if}
     </span>
   </div>
-  <div class="reader-foot-bar"><i style="width: {endPct}%"></i></div>
+  <div class="reader-foot-bar">
+    <i class="read" style="width: {startPct}%"></i>
+    <i
+      class="current"
+      style="left: {startPct}%; width: {Math.max(0, endPct - startPct)}%"
+    ></i>
+  </div>
 </footer>
 
 <style>
@@ -625,10 +631,23 @@
   }
   .reader-foot-bar > i {
     position: absolute;
-    inset: 0 auto 0 0;
-    background: var(--accent, var(--color-accent));
+    top: 0;
+    bottom: 0;
     border-radius: 2px;
-    transition: width 250ms ease;
+    transition:
+      width 250ms ease,
+      left 250ms ease;
+  }
+  /* Words read before the current page — muted accent so the eye
+     reads it as "behind me" rather than "active". */
+  .reader-foot-bar > i.read {
+    left: 0;
+    background: color-mix(in oklch, var(--accent, var(--color-accent)) 45%, transparent);
+  }
+  /* Words on the current page — full-strength accent so the active
+     range stands out as the "you are here" segment. */
+  .reader-foot-bar > i.current {
+    background: var(--accent, var(--color-accent));
   }
 
   /* Respect reduced-motion: skip the page-flip slide. */

--- a/apps/web/src/lib/components/reader/reader-progress.test.ts
+++ b/apps/web/src/lib/components/reader/reader-progress.test.ts
@@ -1,13 +1,18 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  buildPageWordIndex,
   columnIndexForElement,
   computePctRead,
   findFirstVisibleWordAnchor,
   findFirstWordInColumn,
   findTokenElementAtOrAfter,
   firstTokenPage,
+  firstWordInColumnFromIndex,
+  formatPct,
+  formatPctRange,
   pageBoundaryAnchor,
+  pctPrecisionFor,
 } from './reader-progress.js';
 import type { ChapterView } from './types.js';
 
@@ -299,6 +304,128 @@ describe('reader progress helpers', () => {
         { completedText: boundary.completed },
       );
       expect(end).toBeGreaterThan(start);
+    });
+  });
+
+  describe('pctPrecisionFor', () => {
+    it('uses integers for short texts', () => {
+      expect(pctPrecisionFor(0)).toBe(0);
+      expect(pctPrecisionFor(1_000)).toBe(0);
+      expect(pctPrecisionFor(4_999)).toBe(0);
+    });
+
+    it('uses one decimal for medium-length texts', () => {
+      expect(pctPrecisionFor(5_000)).toBe(1);
+      expect(pctPrecisionFor(20_000)).toBe(1);
+      expect(pctPrecisionFor(49_999)).toBe(1);
+    });
+
+    it('uses two decimals for long texts', () => {
+      expect(pctPrecisionFor(50_000)).toBe(2);
+      expect(pctPrecisionFor(500_000)).toBe(2);
+    });
+  });
+
+  describe('formatPct', () => {
+    it('formats with the requested precision', () => {
+      expect(formatPct(12.3456, 0)).toBe('12%');
+      expect(formatPct(12.3456, 1)).toBe('12.3%');
+      expect(formatPct(12.3456, 2)).toBe('12.35%');
+    });
+
+    it('clamps out-of-range values', () => {
+      expect(formatPct(-5, 0)).toBe('0%');
+      expect(formatPct(150, 1)).toBe('100.0%');
+      expect(formatPct(Number.NaN, 1)).toBe('0.0%');
+    });
+  });
+
+  describe('formatPctRange', () => {
+    it('shows a single value when start and end round to the same string', () => {
+      // Both 12.3% at precision=1.
+      expect(formatPctRange(12.31, 12.34, 1)).toBe('12.3%');
+    });
+
+    it('shows a dashed range when start and end differ at the chosen precision', () => {
+      expect(formatPctRange(1, 12, 0)).toBe('1–12%');
+      expect(formatPctRange(1.2, 11.7, 1)).toBe('1.2–11.7%');
+    });
+
+    it('collapses a true zero range to a single value', () => {
+      expect(formatPctRange(0, 0, 0)).toBe('0%');
+    });
+  });
+
+  describe('buildPageWordIndex / firstWordInColumnFromIndex', () => {
+    function setupContent(words: Array<{ idx: number; left: number }>) {
+      const content = document.createElement('div');
+      content.getBoundingClientRect = () => rect(0, 0, 100, 0);
+      for (const w of words) {
+        const el = word(w.idx, rect(0, w.left, 20, w.left + 18));
+        el.getClientRects = () =>
+          ({
+            0: rect(0, w.left, 20, w.left + 18),
+            length: 1,
+            item: (i: number) => (i === 0 ? rect(0, w.left, 20, w.left + 18) : null),
+            [Symbol.iterator]: function* () {
+              yield rect(0, w.left, 20, w.left + 18);
+            },
+          }) as DOMRectList;
+        content.append(el);
+      }
+      return content;
+    }
+
+    it('builds a per-token column map using one DOM pass', () => {
+      // pageWidth=50: x∈[0,50)→col0, x∈[50,100)→col1, x∈[100,150)→col2.
+      const content = setupContent([
+        { idx: 0, left: 0 },
+        { idx: 1, left: 25 },
+        { idx: 2, left: 60 },
+        { idx: 3, left: 110 },
+      ]);
+      const index = buildPageWordIndex({
+        root: content,
+        contentEl: content,
+        pageWidth: 50,
+        contentWidth: 150,
+        fallbackChapterIdx: 4,
+      });
+      expect(index.entries.map((e) => e.columnIndex)).toEqual([0, 0, 1, 2]);
+      expect(index.entries.every((e) => e.chapterIdx === 4)).toBe(true);
+    });
+
+    it('returns the first word in the requested column', () => {
+      const content = setupContent([
+        { idx: 0, left: 0 },
+        { idx: 1, left: 25 },
+        { idx: 2, left: 60 },
+        { idx: 3, left: 110 },
+      ]);
+      const index = buildPageWordIndex({
+        root: content,
+        contentEl: content,
+        pageWidth: 50,
+        contentWidth: 150,
+        fallbackChapterIdx: 0,
+      });
+      expect(firstWordInColumnFromIndex(index, 0)).toEqual({ chapterIdx: 0, tokenIdx: 0 });
+      expect(firstWordInColumnFromIndex(index, 1)).toEqual({ chapterIdx: 0, tokenIdx: 2 });
+      expect(firstWordInColumnFromIndex(index, 2)).toEqual({ chapterIdx: 0, tokenIdx: 3 });
+      expect(firstWordInColumnFromIndex(index, 5)).toBeNull();
+    });
+
+    it('returns an empty index when pageWidth is zero (pre-measure)', () => {
+      const content = setupContent([{ idx: 0, left: 0 }]);
+      const index = buildPageWordIndex({
+        root: content,
+        contentEl: content,
+        pageWidth: 0,
+        contentWidth: 0,
+        fallbackChapterIdx: 0,
+      });
+      expect(index.entries).toHaveLength(0);
+      expect(firstWordInColumnFromIndex(index, 0)).toBeNull();
     });
   });
 });

--- a/apps/web/src/lib/components/reader/reader-progress.ts
+++ b/apps/web/src/lib/components/reader/reader-progress.ts
@@ -110,6 +110,74 @@ export function columnIndexForElement(el: Element, contentEl: Element, pageWidth
   return Math.max(0, Math.floor((x + 1) / pageWidth));
 }
 
+// Map of word elements to their column index, built once per measure
+// cycle. Each `columnIndexForElement` call forces a layout flush via
+// `getClientRects()`; on a chapter with thousands of word spans this
+// dominates page-flip cost. `findFirstWordInColumn` recomputes the
+// mapping for every call, so a single page flip used to flush layout
+// O(n_tokens) times — twice, once for the current page and once for
+// the next-page boundary. Build it once, reuse for both queries.
+export interface PageWordIndex {
+  pageWidth: number;
+  contentWidth: number;
+  fallbackChapterIdx: number;
+  // Document-order entries — column index is monotonically
+  // non-decreasing in left-to-right column flow, so consumers can
+  // short-circuit once they pass the target column.
+  entries: ReadonlyArray<{ chapterIdx: number; tokenIdx: number; columnIndex: number }>;
+}
+
+export function buildPageWordIndex(args: {
+  root: ParentNode;
+  contentEl: Element;
+  pageWidth: number;
+  contentWidth: number;
+  fallbackChapterIdx: number;
+}): PageWordIndex {
+  const empty: PageWordIndex = {
+    pageWidth: args.pageWidth,
+    contentWidth: args.contentWidth,
+    fallbackChapterIdx: args.fallbackChapterIdx,
+    entries: [],
+  };
+  if (args.pageWidth <= 0) return empty;
+
+  const contentRect = args.contentEl.getBoundingClientRect();
+  const entries: Array<{ chapterIdx: number; tokenIdx: number; columnIndex: number }> = [];
+  for (const el of Array.from(args.root.querySelectorAll<HTMLElement>(WORD_SELECTOR))) {
+    const rawTokenIdx = el.dataset.tokenIdx;
+    if (rawTokenIdx == null) continue;
+    const tokenIdx = Number.parseInt(rawTokenIdx, 10);
+    if (!Number.isFinite(tokenIdx)) continue;
+    const rawChapterIdx = el.closest<HTMLElement>('[data-chapter-idx]')?.dataset.chapterIdx;
+    const chapterIdx =
+      rawChapterIdx == null ? args.fallbackChapterIdx : Number.parseInt(rawChapterIdx, 10);
+    if (!Number.isFinite(chapterIdx)) continue;
+    const firstRect = el.getClientRects()[0] ?? el.getBoundingClientRect();
+    const x = Math.max(0, firstRect.left - contentRect.left);
+    const columnIndex = Math.max(0, Math.floor((x + 1) / args.pageWidth));
+    entries.push({ chapterIdx, tokenIdx, columnIndex });
+  }
+  return {
+    pageWidth: args.pageWidth,
+    contentWidth: args.contentWidth,
+    fallbackChapterIdx: args.fallbackChapterIdx,
+    entries,
+  };
+}
+
+export function firstWordInColumnFromIndex(
+  index: PageWordIndex,
+  pageIdx: number,
+): Pick<ProgressAnchor, 'chapterIdx' | 'tokenIdx'> | null {
+  for (const e of index.entries) {
+    if (e.columnIndex < pageIdx) continue;
+    if (e.columnIndex > pageIdx) return null;
+    return { chapterIdx: e.chapterIdx, tokenIdx: e.tokenIdx };
+  }
+  return null;
+}
+
 export function findFirstWordInColumn(
   root: ParentNode,
   args: {
@@ -152,6 +220,10 @@ export function findFirstWordInColumn(
   return best ? { chapterIdx: best.chapterIdx, tokenIdx: best.tokenIdx } : null;
 }
 
+// Returns a float 0..100 with no rounding. Display sites should pass
+// the result through `formatPct` / `formatPctRange` with a precision
+// derived from `pctPrecisionFor(totalTokens)`. Persisted progress
+// (`pct_read` column, `real`) keeps the full-precision value.
 export function computePctRead(
   chapters: ChapterView[],
   chapterIdx: number,
@@ -166,7 +238,30 @@ export function computePctRead(
     .reduce((sum, c) => sum + Math.max(0, c.tokenCount), 0);
   const currentCount = Math.max(0, chapters[chapterIdx]?.tokenCount ?? 0);
   const inChapter = Math.max(0, Math.min(tokenIdx, Math.max(0, currentCount - 1)));
-  return Math.max(0, Math.min(100, Math.round(((before + inChapter) / total) * 100)));
+  return Math.max(0, Math.min(100, ((before + inChapter) / total) * 100));
+}
+
+// Choose decimal precision for the progress display so flipping one
+// page advances the number by ~1 unit. With ~200 words/page typical:
+// short texts (< 5k tokens) get clean integers, mid-length (5k–50k)
+// get one decimal, and long texts (50k+) get two so the bar isn't
+// "stuck" at 4% for twenty page-flips.
+export function pctPrecisionFor(totalTokens: number): 0 | 1 | 2 {
+  const n = Math.max(0, Math.floor(totalTokens));
+  if (n < 5_000) return 0;
+  if (n < 50_000) return 1;
+  return 2;
+}
+
+export function formatPct(pct: number, precision: 0 | 1 | 2): string {
+  const clamped = Math.max(0, Math.min(100, Number.isFinite(pct) ? pct : 0));
+  return `${clamped.toFixed(precision)}%`;
+}
+
+export function formatPctRange(startPct: number, endPct: number, precision: 0 | 1 | 2): string {
+  const startStr = formatPct(startPct, precision);
+  const endStr = formatPct(endPct, precision);
+  return startStr === endStr ? endStr : `${startStr.replace(/%$/, '')}–${endStr}`;
 }
 
 // Resolve the anchor that represents the *end* of the user's reading


### PR DESCRIPTION
## Summary
Two related changes to the page-mode reader's progress display, following [#395](https://github.com/chickendude/CIA-Reader/pull/395).

### 1. Adaptive precision
`computePctRead` now returns a float; the footer formats with precision chosen so flipping one page advances the displayed number by ~1 unit (assuming ~200 words/page):

| Total tokens | Precision | Example |
|---|---|---|
| < 5,000 | integer | `12%` |
| 5,000–49,999 | 1 decimal | `12.3%` |
| 50,000+ | 2 decimals | `12.34%` |

Short texts stay clean; long texts stop sitting at the same integer for twenty page-flips. The `pct_read` column is already `real` ([schema.ts:1383](apps/web/src/lib/server/db/schema.ts:1383)) so persisted progress keeps full precision; we only round at display time.

### 2. Column-index cache
`findFirstWordInColumn` iterates every word span and forces a layout flush via `getClientRects()` per token. Since [#392](https://github.com/chickendude/CIA-Reader/pull/392) introduced the end-of-page boundary, `reportProgress` runs it **twice** per page flip — on a 50k-token chapter that's ~100k layout-thrashing reads per flip.

Extracted:
- `buildPageWordIndex` — single DOM pass that materializes a `tokenIdx → columnIndex` map.
- `firstWordInColumnFromIndex` — pure JS lookup that short-circuits on monotonic column flow.

`ReaderPage` caches the index keyed by `pageWidth × contentWidth × chapterIdx` and invalidates inside `measure()` and on chapter change. Effectively halves the layout-flush count on each page flip and makes any future per-flip anchor query free.

## Test plan
- [x] `pnpm check` clean (0 errors)
- [x] All 17 reader test files green: 190/190 tests pass; 27/27 in `reader-progress.test.ts` (11 new — precision boundaries, formatter rounding, range collapsing, index build, short-circuit lookup)
- [ ] Manual: short text (~2k tokens) shows clean `0%`, `4%`, `8%`...
- [ ] Manual: medium text (~20k tokens) shows `0.4%`, `0.8%`...; long text (>50k) shows two-decimal precision
- [ ] Manual: spot-check page-flip latency on a long chapter — should feel snappier than before