### PR TITLE
Re-enable arrow-key page nav while a word is selected; fix anchor outline clip

### DIFF
--- a/apps/web/src/lib/components/reader/ReaderPage.svelte
+++ b/apps/web/src/lib/components/reader/ReaderPage.svelte
@@ -183,7 +183,6 @@
   function onKeydown(e: KeyboardEvent) {
     if (e.metaKey || e.ctrlKey || e.altKey) return;
     if (isTypingInsideElement(e.target)) return;
-    if (document.querySelector('[data-testid="word-popup"]')) return;
     if (e.key === 'ArrowLeft' && hasPrev) {
       e.preventDefault();
       prevPage();

--- a/apps/web/src/lib/components/reader/ReaderScroll.svelte
+++ b/apps/web/src/lib/components/reader/ReaderScroll.svelte
@@ -400,7 +400,6 @@
   function onKeydown(e: KeyboardEvent) {
     if (e.metaKey || e.ctrlKey || e.altKey) return;
     if (isTypingInsideElement(e.target)) return;
-    if (document.querySelector('[data-testid="word-popup"]')) return;
     if (e.key === 'ArrowLeft' && hasPrev) {
       e.preventDefault();
       prev();

--- a/apps/web/src/lib/components/reader/TokenSpan.svelte
+++ b/apps/web/src/lib/components/reader/TokenSpan.svelte
@@ -110,10 +110,13 @@
   }
   /* Anchor: the word currently locked in the side panel. Outline
      instead of fill so the user can still see the underlying status
-     tint underneath. */
+     tint underneath. Negative offset tucks the outline against the
+     border-edge so it can't bleed past column edges (where
+     overflow:hidden would clip an outline on the leftmost word in
+     a page). */
   .word.anchor {
     outline: 2px solid var(--accent, var(--color-accent));
-    outline-offset: 1px;
+    outline-offset: -2px;
     border-radius: 3px;
   }
 </style>


### PR DESCRIPTION
## Summary

Two small reader-side fixes surfaced while reading on desktop after clicking a word.

### 1. ←/→ stopped flipping pages once a word was selected

`ReaderPage.svelte` and `ReaderScroll.svelte` had this guard in the keydown handler:

```ts
if (document.querySelector('[data-testid="word-popup"]')) return;
```

`WordPopup` is mounted unconditionally in `ChapterBody.svelte` and the desktop side-panel is permanent (>=960px), so as soon as `activeToken` was set the guard tripped and never reset until the user clicked the X. That made the keyboard arrows feel broken: open a word, try to flip the page, nothing happens.

The `isTypingInsideElement(e.target)` check just above already covers the only legitimate case (typing arrow keys inside the add-translation textarea), so the popup-existence check is redundant — and harmful since the panel can stay open indefinitely on desktop. Drop it from both reader modes.

### 2. Anchor outline clipped on the leftmost word in a page

When a word is the locked anchor, `.word.anchor` in `TokenSpan.svelte` painted a 2px outline with `outline-offset: 1px`, putting its outermost edge ~3px past the border-edge. On the first word of a page that strip is clipped by `.reader-page-window`'s `overflow: hidden`, so the outline visibly cuts off on the left.

`box-shadow` would conflict with the status indicator from `tokens.css` ([line 330](apps/web/src/lib/styles/tokens.css:330)), which already uses inset shadows on `.word[data-s=N]` at higher specificity. Easiest fix is to keep the outline (different property, no conflict) but flip the offset to `-2px`. With outline-width: 2px that draws the outline from 2px inside the border-edge out to exactly the border-edge — fully visible at column edges, identical look elsewhere.

## Test plan

- [x] `pnpm test` — 1326/1326 pass
- [x] `pnpm check` — 0 errors
- [x] `pnpm lint` clean
- [ ] Manual: click a word, press ←/→, page flips and the side panel updates to the new first-visible word's lemma
- [ ] Manual: click the first word in a paragraph at the top of a page, confirm the anchor outline is fully visible on its left side
- [ ] Manual: confirm the anchor outline still reads clearly against background-tint, underline, and colored-text status modes (CSS hl variants)