### PR TITLE
Match primary-translation editor size to its empty placeholder

### DIFF
--- a/apps/web/src/lib/components/reader/WordPopup.svelte
+++ b/apps/web/src/lib/components/reader/WordPopup.svelte
@@ -1200,7 +1200,7 @@
             <textarea
               bind:this={primaryTextareaEl}
               bind:value={primaryBody}
-              rows="2"
+              rows="1"
               maxlength="500"
               disabled={savingPrimary}
               aria-label="Your translation"
@@ -1800,6 +1800,8 @@
     margin: 0.75rem 0 0.6rem;
   }
   .sp-primary-display {
+    box-sizing: border-box;
+    display: block;
     width: 100%;
     text-align: left;
     padding: 0.6rem 0.75rem;
@@ -1842,10 +1844,17 @@
     display: inline-block;
   }
   .sp-primary-form textarea {
+    /* Match the dashed empty-state button's footprint exactly so
+     * clicking "+ Add your translation" swaps the placeholder for
+     * an editor of the same size — no jump in height or font.
+     * The user can still drag the resize handle if they need more
+     * room for a long body. */
+    box-sizing: border-box;
+    display: block;
     width: 100%;
     padding: 0.6rem 0.75rem;
     font: inherit;
-    font-size: 0.95rem;
+    font-size: 0.82rem;
     line-height: 1.35;
     border: 1px solid color-mix(
       in oklch,

--- a/apps/web/src/lib/components/reader/WordPopup.test.ts
+++ b/apps/web/src/lib/components/reader/WordPopup.test.ts
@@ -822,6 +822,30 @@ describe('WordPopup — primary translation editor (above status buttons)', () =
     expect(personalRows.length).toBe(0);
   });
 
+  it('opens the editor at the same single-row size as the empty placeholder (no growth on click)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(jsonResponse(payloadOf([]))),
+    );
+    render(WordPopup, {
+      token: makeToken({ surface: 'पानी', lemmaId: 'lem-1' }),
+      language: 'hi',
+      isOwner: true,
+      onClose: vi.fn(),
+    });
+    const slot = await awaitElement<HTMLButtonElement>(
+      '[data-testid="primary-translation-edit"]',
+    );
+    slot.click();
+    const textarea = await awaitElement<HTMLTextAreaElement>(
+      '.sp-primary-form textarea',
+    );
+    // rows=1 keeps the textarea the same height as the dashed
+    // placeholder it replaced; the user can drag-resize if they
+    // need more vertical room.
+    expect(textarea.rows).toBe(1);
+  });
+
   it('clicking the empty slot opens an autofocused textarea and POSTs a new personal translation', async () => {
     const fetchMock = vi
       .fn()


### PR DESCRIPTION
## Summary

Follow-up to #394. The \"+ Add your translation\" placeholder was a single-line dashed chip at `0.82rem`, but clicking it swapped in a textarea at `rows=\"2\"` + `0.95rem` — visibly tripling the height of the slot. The textarea now matches the placeholder it replaces:

- `rows=\"1\"` so the initial height is one line.
- `font-size: 0.82rem` to match the empty button's font.
- Explicit `box-sizing: border-box` + `display: block` on both the display button and the textarea, so widths are identical regardless of parent container padding.

The textarea keeps `resize: vertical`, so users can still drag it larger when a long body needs the room.

## Test plan

- [x] `pnpm test` — full suite (1327) passes; new regression test asserts the textarea opens at `rows === 1`.
- [x] `pnpm typecheck` clean.
- [x] `pnpm lint` clean.
- [ ] Manual: click \"+ Add your translation\" — the editor opens at the same height/width as the dashed placeholder, no jump.
- [ ] Manual: drag the textarea's resize handle — still works.
- [ ] Manual: click an existing primary translation — same compact editor opens (slightly smaller than the read-mode display, which is acceptable since the user is now in edit mode).