### PR TITLE
Simplify translation textarea placeholder

### DIFF
--- a/apps/web/src/lib/components/reader/WordPopup.svelte
+++ b/apps/web/src/lib/components/reader/WordPopup.svelte
@@ -1204,7 +1204,7 @@
               maxlength="500"
               disabled={savingPrimary}
               aria-label="Your translation"
-              placeholder="Your translation (Enter to save, Shift+Enter for a newline, Esc to cancel)"
+              placeholder="Type your translation"
               onkeydown={onPrimaryKeydown}
               onblur={onPrimaryBlur}
             ></textarea>
@@ -1460,7 +1460,7 @@
             <textarea
               bind:this={addTextareaEl}
               bind:value={newTranslationBody}
-              placeholder="Your translation (Enter to save, Shift+Enter for a newline, Esc to cancel)"
+              placeholder="Type your translation"
               rows="2"
               maxlength="500"
               disabled={savingTranslation}


### PR DESCRIPTION
## Summary
- Replace the verbose translation textarea placeholder (`Your translation (Enter to save, Shift+Enter for a newline, Esc to cancel)`) with `Type your translation` in both the primary-translation editor and the add-translation form in `WordPopup.svelte`.

## Test plan
- [ ] Open a word popup, click "+ Add your translation", confirm the textarea shows the new placeholder.
- [ ] Open a word popup with an existing primary translation, enter edit mode, confirm the primary-translation textarea shows the new placeholder when empty.