### PR TITLE
Move translation editor keyboard hints into hover tooltip

### DIFF
--- a/apps/web/src/lib/components/reader/WordPopup.svelte
+++ b/apps/web/src/lib/components/reader/WordPopup.svelte
@@ -1205,6 +1205,7 @@
               disabled={savingPrimary}
               aria-label="Your translation"
               placeholder="Type your translation"
+              title={'Enter to save\nShift+Enter for a newline\nEsc to cancel'}
               onkeydown={onPrimaryKeydown}
               onblur={onPrimaryBlur}
             ></textarea>
@@ -1461,6 +1462,7 @@
               bind:this={addTextareaEl}
               bind:value={newTranslationBody}
               placeholder="Type your translation"
+              title={'Enter to save\nShift+Enter for a newline\nEsc to cancel'}
               rows="2"
               maxlength="500"
               disabled={savingTranslation}


### PR DESCRIPTION
## Summary
- Add a `title` attribute to the primary-translation and add-translation textareas in `WordPopup.svelte` so the keyboard shortcuts (`Enter` to save, `Shift+Enter` for newline, `Esc` to cancel) surface on hover instead of cluttering the placeholder.

## Test plan
- [ ] Open a word popup, click "+ Add your translation", hover the textarea, confirm the tooltip lists the three shortcuts on separate lines.
- [ ] Open a word popup with an existing primary translation, enter edit mode, hover the textarea, confirm the tooltip appears.
- [ ] Confirm the placeholder still reads `Type your translation`.