### PR TITLE
chore: add max-age + If-Modified-Since to dictionary fetch script

### DIFF
--- a/apps/web/scripts/fetch-dictionary-sources.sh
+++ b/apps/web/scripts/fetch-dictionary-sources.sh
@@ -4,17 +4,23 @@
 # The raw artifacts are .gitignored — re-running the appropriate
 # `pnpm dictionary:import <source>` after a fetch picks up the new file.
 #
-# Idempotent: a source whose `raw.jsonl` already exists is skipped. Pass
-# --force (or set FORCE=1) to re-download and overwrite. Downloads land
-# in `<source>/raw.jsonl.tmp` first and are atomically renamed only on
-# success, so a stalled transfer never leaves a half-file masquerading
-# as cached.
+# Cache freshness rules (per source):
+#   1. No `raw.jsonl`        → fetch.
+#   2. mtime < MAX_AGE_DAYS  → skip (offline-friendly fast path; no network).
+#   3. mtime ≥ MAX_AGE_DAYS  → ask upstream with `If-Modified-Since`:
+#                                 304 → touch local mtime, skip.
+#                                 200 → re-download, atomic-rename .tmp → raw.jsonl.
+#   --force / FORCE=1        → always download, ignore freshness.
+#
+# Downloads write to `<source>/raw.jsonl.tmp` first and rename only on
+# success, so a stalled transfer never poisons the canonical filename.
 #
 # Usage:
-#   scripts/fetch-dictionary-sources.sh                    # fetch missing sources
-#   scripts/fetch-dictionary-sources.sh kaikki-hindi       # fetch one (if missing)
-#   scripts/fetch-dictionary-sources.sh --force            # re-fetch every source
-#   scripts/fetch-dictionary-sources.sh --force kaikki-hindi
+#   scripts/fetch-dictionary-sources.sh                    # fetch missing or stale (>7d)
+#   scripts/fetch-dictionary-sources.sh kaikki-hindi       # one source
+#   scripts/fetch-dictionary-sources.sh --force            # always download
+#   scripts/fetch-dictionary-sources.sh --max-age 30       # only refresh after 30 days
+#   MAX_AGE_DAYS=0 scripts/...                             # always check upstream
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
@@ -22,23 +28,89 @@ DATA_ROOT="data/dictionaries"
 mkdir -p "$DATA_ROOT"
 
 FORCE="${FORCE:-0}"
+MAX_AGE_DAYS="${MAX_AGE_DAYS:-7}"
 ARGS=()
-for arg in "$@"; do
+i=0
+while (( i < $# )); do
+  i=$((i + 1))
+  arg="${!i}"
   case "$arg" in
-    --force|-f) FORCE=1 ;;
-    *)          ARGS+=("$arg") ;;
+    --force|-f)
+      FORCE=1
+      ;;
+    --max-age)
+      i=$((i + 1))
+      MAX_AGE_DAYS="${!i:?--max-age needs a number of days}"
+      ;;
+    --max-age=*)
+      MAX_AGE_DAYS="${arg#--max-age=}"
+      ;;
+    *)
+      ARGS+=("$arg")
+      ;;
   esac
 done
 set -- "${ARGS[@]+"${ARGS[@]}"}"
 
-skip_if_cached() {
-  # $1 = label, $2 = path to raw.jsonl.
-  # Returns 0 (skip) if the final file already exists and we're not forcing.
-  if [[ -s "$2" && "$FORCE" != "1" ]]; then
-    echo "[fetch] $1  cached at $2 ($(wc -l <"$2") lines, $(du -h "$2" | cut -f1)) — skipping (--force to re-download)"
+# Returns 0 (true) if the file is stale (older than MAX_AGE_DAYS) or missing.
+# `find -mtime +N` is portable across BSD (macOS) and GNU find.
+is_stale() {
+  local path="$1"
+  if [[ ! -s "$path" ]]; then return 0; fi
+  if (( MAX_AGE_DAYS == 0 )); then return 0; fi
+  if [[ -n "$(find "$path" -mtime "+$((MAX_AGE_DAYS - 1))" 2>/dev/null)" ]]; then
     return 0
   fi
   return 1
+}
+
+# Download with `--time-cond` so the server can answer 304 Not Modified.
+# Curl behaviour with `--time-cond <file>`:
+#   - 304 → curl exits 0 and does NOT write to --output.
+#   - 200 → curl writes the new body to --output (overwriting any prior .tmp).
+# So checking whether .tmp ends up non-empty tells us which path we took.
+# Extra curl args (e.g. resume / retry knobs) come in via $3.
+download_with_conditional() {
+  local label="$1"
+  local url="$2"
+  local out="$3"
+  shift 3
+  local extra_args=("$@")
+
+  local time_cond_args=()
+  if [[ -s "$out/raw.jsonl" && "$FORCE" != "1" ]]; then
+    time_cond_args=(--time-cond "$out/raw.jsonl")
+    echo "[fetch] $label  cached but stale, asking upstream If-Modified-Since"
+  else
+    echo "[fetch] $label  $url -> $out/raw.jsonl"
+  fi
+
+  curl --fail --location \
+    "${time_cond_args[@]+"${time_cond_args[@]}"}" \
+    --output "$out/raw.jsonl.tmp" \
+    "${extra_args[@]+"${extra_args[@]}"}" \
+    "$url"
+
+  if [[ -s "$out/raw.jsonl.tmp" ]]; then
+    mv "$out/raw.jsonl.tmp" "$out/raw.jsonl"
+    echo "[fetch] $label  downloaded ($(wc -l <"$out/raw.jsonl") lines, $(du -h "$out/raw.jsonl" | cut -f1))"
+  else
+    rm -f "$out/raw.jsonl.tmp"
+    touch "$out/raw.jsonl"
+    echo "[fetch] $label  upstream not modified — refreshed mtime, kept cache"
+  fi
+}
+
+skip_if_fresh() {
+  # $1 = label, $2 = path to raw.jsonl.
+  # Returns 0 (skip) only when the file is present AND younger than MAX_AGE_DAYS
+  # AND --force was not set. Stale-but-present cache falls through to the
+  # conditional-GET path so we can let the server tell us if it's still good.
+  if [[ "$FORCE" == "1" ]]; then return 1; fi
+  if [[ ! -s "$2" ]]; then return 1; fi
+  if is_stale "$2"; then return 1; fi
+  echo "[fetch] $1  cached at $2 ($(wc -l <"$2") lines, $(du -h "$2" | cut -f1)) — fresh (<${MAX_AGE_DAYS}d), skipping"
+  return 0
 }
 
 fetch_kaikki() {
@@ -46,43 +118,37 @@ fetch_kaikki() {
   local lang_name="$2"   # capitalized, e.g. Hindi (matches Kaikki's URL)
   local out="$DATA_ROOT/$lang_slug"
   mkdir -p "$out"
-  if skip_if_cached "$lang_slug" "$out/raw.jsonl"; then return; fi
+  if skip_if_fresh "$lang_slug" "$out/raw.jsonl"; then return; fi
   local url="https://kaikki.org/dictionary/${lang_name}/kaikki.org-dictionary-${lang_name}.jsonl"
-  echo "[fetch] $lang_slug  $url -> $out/raw.jsonl"
-  curl --fail --location --output "$out/raw.jsonl.tmp" "$url"
-  mv "$out/raw.jsonl.tmp" "$out/raw.jsonl"
-  echo "[fetch] $lang_slug  done ($(wc -l <"$out/raw.jsonl") lines, $(du -h "$out/raw.jsonl" | cut -f1))"
+  download_with_conditional "$lang_slug" "$url" "$out"
 }
 
 fetch_kaikki_en_translations() {
   # The English Wiktionary dump is shared by all three
   # kaikki-en-translations-* importers (HI / MR / OR) — they each
   # filter the same upstream file by lang_code. Big download
-  # (~3 GB JSONL) and kaikki.org throttles late in the transfer, so
-  # we use --continue-at - to resume on retry and --speed-time /
-  # --speed-limit to bail+retry when the stream stalls instead of
-  # hanging for hours. The .tmp suffix lets `--continue-at -` resume
-  # an interrupted run without colliding with a previously-completed
-  # raw.jsonl.
+  # (~3 GB JSONL) and kaikki.org throttles late in the transfer.
+  #
+  # Resume isn't safe to combine with `--time-cond` here: if the upstream
+  # changed between runs, `--continue-at -` would append to a stale .tmp
+  # whose first bytes are from a different version. So for this source we
+  # let the conditional-GET decide:
+  #   - 304 → keep cached file, skip.
+  #   - 200 → fresh download to .tmp (no resume); --speed-time / --speed-limit
+  #           keep curl bailing out of stalled transfers so it retries
+  #           cleanly via --retry rather than hanging.
   local out="$DATA_ROOT/kaikki-en-translations"
   mkdir -p "$out"
-  if skip_if_cached "kaikki-en-translations" "$out/raw.jsonl"; then return; fi
+  if skip_if_fresh "kaikki-en-translations" "$out/raw.jsonl"; then return; fi
   local url="https://kaikki.org/dictionary/English/kaikki.org-dictionary-English.jsonl"
-  echo "[fetch] kaikki-en-translations  $url -> $out/raw.jsonl"
-  echo "[fetch] kaikki-en-translations  (large file; resume-safe via --continue-at -)"
-  curl \
-    --fail \
-    --location \
-    --output "$out/raw.jsonl.tmp" \
-    --continue-at - \
+  echo "[fetch] kaikki-en-translations  (large file; --retry handles stalled transfers)"
+  download_with_conditional \
+    "kaikki-en-translations" "$url" "$out" \
     --retry 10 \
     --retry-delay 5 \
     --retry-all-errors \
     --speed-time 60 \
-    --speed-limit 102400 \
-    "$url"
-  mv "$out/raw.jsonl.tmp" "$out/raw.jsonl"
-  echo "[fetch] kaikki-en-translations  done ($(wc -l <"$out/raw.jsonl") lines, $(du -h "$out/raw.jsonl" | cut -f1))"
+    --speed-limit 102400
 }
 
 case "${1-all}" in


### PR DESCRIPTION
## Summary

Follow-up to #373. Pure file-existence idempotency meant the cache was *never* auto-refreshed — you had to remember `--force` every few weeks. Now the script combines a cheap local `mtime` check with a conditional `GET` so:

- **Fresh runs are zero-network** — same offline-friendly behaviour as #373 when the cache is recent.
- **Stale runs ask upstream** *whether* anything changed before re-downloading 3 GB.

## Cache freshness rules per source

| Local state | Behaviour |
|---|---|
| No `raw.jsonl` | fetch |
| `mtime < MAX_AGE_DAYS` (default **7**) | skip, no network |
| `mtime ≥ MAX_AGE_DAYS` | `curl --time-cond raw.jsonl`:<br>· 304 → `touch` mtime, skip download<br>· 200 → atomic `.tmp` rename |
| `--force` / `FORCE=1` | always download, ignore freshness |

`curl --time-cond <file>` uses the file's mtime as the `If-Modified-Since` header and writes to `--output` only on 200, so detecting which path we took is a single `[[ -s .tmp ]]` check after the call — no header parsing.

## Why drop `--continue-at -` from kaikki-en-translations

Resume + conditional-GET don't compose safely. A stale `.tmp` resumed against a *changed* upstream would silently produce a hybrid file: first N bytes from old version, rest from new. Since this PR's whole point is to detect upstream changes, we have to drop the resume to keep the result coherent.

Stalls are still handled — `--retry 10`, `--speed-time 60`, `--speed-limit 102400` all stay. They now retry **from scratch** instead of resuming. Trade-off: a stalled 3 GB download has to restart. Mitigation: the big download is exactly the source that most benefits from the freshness check, so in practice you'll skip it most of the time and only re-download when kaikki actually publishes a new dump.

## New flags / env

- `--max-age <days>` or `--max-age=<days>` — override the freshness window for one run.
- `MAX_AGE_DAYS=<days>` — same, via env.
- `MAX_AGE_DAYS=0` — never fast-skip; always do a conditional check (useful for cron).

## Test plan

Logic-routing tests against a mock cached file (no live kaikki traffic):

- [x] Fresh file (default 7d), no flags → "fresh, skipping" message, **no curl invocation**.
- [x] `--max-age 0` on a fresh file → routes to `"cached but stale, asking upstream If-Modified-Since"` (curl gets called with `--time-cond`).
- [x] `--force` → routes to fresh download URL message (no `--time-cond` arg).
- [x] Backdated 10-day-old file with default max-age 7 → conditional-GET path.
- [x] Backdated 10-day-old file with `--max-age 30` → fresh skip.
- [x] Empty `raw.jsonl` (e.g. truncated by accident) → not treated as fresh, conditional-GET path.
- [x] `--max-age=14` and `--max-age 14` both parse correctly.
- [x] `bash -n` clean.
- [ ] Reviewer: a real `kaikki-hindi` fetch on a freshly-touched `raw.jsonl` should print `"upstream not modified — refreshed mtime, kept cache"` and not re-download. (Skipped here to keep CI/PR-prep traffic off kaikki.)