### PR TITLE
Show keyboard hints on the primary-translation button hover

### DIFF
--- a/apps/web/src/lib/components/reader/WordPopup.svelte
+++ b/apps/web/src/lib/components/reader/WordPopup.svelte
@@ -1219,9 +1219,7 @@
             class="sp-primary-display"
             data-testid="primary-translation-edit"
             data-empty={payload.translations.personal[0] ? '0' : '1'}
-            title={payload.translations.personal[0]
-              ? 'Edit your translation'
-              : 'Add your translation'}
+            title={'Enter to save\nShift+Enter for a newline\nEsc to cancel'}
             onclick={startEditPrimary}
           >
             {#if payload.translations.personal[0]}


### PR DESCRIPTION
## Summary
- Replace the redundant `Edit your translation` / `Add your translation` `title` on the primary-translation button in `WordPopup.svelte` with the same keyboard-hint tooltip used on the editor textarea, so hovering the empty "+ Add your translation" button (or an existing translation) previews the `Enter` / `Shift+Enter` / `Esc` shortcuts that apply once you click in.

## Test plan
- [ ] Open a word popup with no primary translation, hover "+ Add your translation", confirm the tooltip lists the three shortcuts on separate lines.
- [ ] Open a word popup with an existing primary translation, hover the displayed translation, confirm the same tooltip appears.