### PR TITLE
T-13.1: production docker-compose stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,27 @@ make smoke
 - `make dev` / `make dev-down` — start / stop the dev stack
 - `make install-nlp` — create `.venv` for the NLP service (for running `pytest` directly)
 
+## Production deployment
+
+The production stack is a separate compose file: [`infra/docker-compose.prod.yml`](infra/docker-compose.prod.yml). It boots `web`, `nlp`, `postgres`, `redis`, and `caddy` on a single Hetzner CX/CCX box. Caddy is the only service that binds host ports (80 / 443); everything else stays on the internal docker network.
+
+On the deploy host:
+
+```
+cp infra/.env.prod.example infra/.env
+# edit infra/.env — fill POSTGRES_PASSWORD, AUTH_SECRET, SMTP_*, APP_BASE_URL
+docker compose -f infra/docker-compose.prod.yml --env-file infra/.env up -d --build
+```
+
+The web service's startup command runs `apps/web/scripts/migrate-prod.mjs` (drizzle-orm's migrator — no drizzle-kit dependency at runtime) before starting the SvelteKit server, so a fresh deploy applies any pending migrations automatically.
+
+The other M13 tickets layer on top of this:
+
+- **T-13.2** — Caddyfile + auto-TLS (replaces the HTTP-only placeholder in [`infra/Caddyfile`](infra/Caddyfile))
+- **T-13.3** — nightly backups (postgres-data + audio-data volumes)
+- **T-13.4** — deploy script (rsync + `docker compose pull` + restart)
+- **T-13.5** — monitoring-lite
+
 ## Status
 
 Early. See [GitHub Issues](https://github.com/chickendude/CIA-Reader/issues) — each milestone is an epic with child tickets.

--- a/apps/web/Dockerfile.prod
+++ b/apps/web/Dockerfile.prod
@@ -1,0 +1,74 @@
+# Production image for the SvelteKit web app.
+#
+# Two stages:
+#   1. builder — install full deps, run `pnpm --filter @ciareader/web build`.
+#      adapter-node emits a self-contained Node app at apps/web/build/.
+#   2. runtime — install prod deps in a fresh layer (avoids copying pnpm's
+#      symlinked node_modules across stages, which is fragile), copy the
+#      build output + drizzle migrations + migrate-prod.mjs, drop privs.
+#
+# Startup command runs migrations against the live DB before booting the
+# server, so a fresh deploy is a single `docker compose up -d` away.
+
+# ---- builder ----
+FROM node:20.18-slim AS builder
+
+ENV PNPM_HOME=/usr/local/pnpm \
+    PATH=/usr/local/pnpm:$PATH \
+    COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+RUN corepack enable && corepack prepare pnpm@9.12.0 --activate
+
+WORKDIR /srv/build
+
+# Copy lockfile and metadata first for a cached pnpm install on
+# subsequent rebuilds when only source changes.
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+COPY apps/web/package.json apps/web/package.json
+COPY packages/shared-types/package.json packages/shared-types/package.json
+
+RUN pnpm install --frozen-lockfile
+
+COPY apps/web apps/web
+COPY packages/shared-types packages/shared-types
+
+RUN pnpm --filter @ciareader/web build
+
+# ---- runtime ----
+FROM node:20.18-slim AS runtime
+
+ENV NODE_ENV=production \
+    PNPM_HOME=/usr/local/pnpm \
+    PATH=/usr/local/pnpm:$PATH \
+    COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+RUN corepack enable && corepack prepare pnpm@9.12.0 --activate
+
+WORKDIR /srv/app
+
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+COPY apps/web/package.json apps/web/package.json
+COPY packages/shared-types/package.json packages/shared-types/package.json
+
+# Production-only deps for the runtime — drizzle-orm/postgres-js for
+# migrate-prod.mjs, @node-rs/argon2 + jose for auth at request time, etc.
+# adapter-node's build output references these at runtime by `import`.
+RUN pnpm install --frozen-lockfile --prod
+
+# Bundled SvelteKit app from the build stage.
+COPY --from=builder /srv/build/apps/web/build apps/web/build
+# Migration assets — needed by the startup migrate step.
+COPY --from=builder /srv/build/apps/web/drizzle apps/web/drizzle
+COPY --from=builder /srv/build/apps/web/scripts/migrate-prod.mjs apps/web/scripts/migrate-prod.mjs
+# shared-types' source — adapter-node bundles direct imports, but
+# anything that re-exports types via $env or runtime requires the
+# package present on the resolution path.
+COPY --from=builder /srv/build/packages/shared-types packages/shared-types
+
+# Run as non-root.
+RUN groupadd --system --gid 10001 app && \
+    useradd  --system --uid 10001 --gid app --home-dir /srv/app --shell /sbin/nologin app && \
+    chown -R app:app /srv/app
+USER app
+
+EXPOSE 5173
+
+CMD ["sh", "-c", "node apps/web/scripts/migrate-prod.mjs && node apps/web/build/index.js"]

--- a/apps/web/scripts/migrate-prod.mjs
+++ b/apps/web/scripts/migrate-prod.mjs
@@ -1,0 +1,31 @@
+// Production migration runner. The prod web service's startup command
+// invokes this before `node build/index.js`, so a fresh deploy applies
+// any pending migrations against the live DB and then boots.
+//
+// Uses drizzle-orm's built-in migrator instead of drizzle-kit so the
+// production image doesn't need to ship dev tooling.
+//
+// DATABASE_URL is required. The migration files live in
+// apps/web/drizzle/ inside the runtime image (copied from the build
+// stage by Dockerfile.prod).
+
+import postgres from 'postgres';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { migrate } from 'drizzle-orm/postgres-js/migrator';
+
+const DATABASE_URL = process.env.DATABASE_URL;
+if (!DATABASE_URL) {
+  console.error('migrate-prod: DATABASE_URL is required');
+  process.exit(1);
+}
+
+const client = postgres(DATABASE_URL, { max: 1 });
+const db = drizzle(client);
+
+console.log('migrate-prod: applying migrations from apps/web/drizzle');
+try {
+  await migrate(db, { migrationsFolder: 'apps/web/drizzle' });
+  console.log('migrate-prod: done');
+} finally {
+  await client.end();
+}

--- a/infra/.env.prod.example
+++ b/infra/.env.prod.example
@@ -1,0 +1,40 @@
+# Production env vars consumed by docker-compose.prod.yml.
+#
+# Copy to infra/.env on the deploy host (NOT committed — gitignored
+# at the repo root), fill in real secrets, and:
+#
+#   docker compose -f infra/docker-compose.prod.yml --env-file infra/.env up -d --build
+
+# === Postgres ===
+POSTGRES_USER=ciareader
+POSTGRES_PASSWORD=                 # required — generate a long random string
+POSTGRES_DB=ciareader
+
+# === Web app secrets ===
+# Used to sign JWT access tokens and verify session cookies.
+# Generate (32 random bytes, base64url):
+#   node -e "console.log(require('crypto').randomBytes(32).toString('base64url'))"
+AUTH_SECRET=
+
+# Public URL the app is reachable at (used in magic-link emails).
+APP_BASE_URL=https://your-domain.example.com
+
+# === SMTP (real provider for magic-link emails) ===
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USER=
+SMTP_PASS=
+SMTP_FROM=no-reply@your-domain.example.com
+
+# === Audio storage ===
+# Default backend is the local filesystem mounted at /srv/audio inside
+# the web container, backed by the `audio-data` named volume. To switch
+# to Hetzner Object Storage / any S3-compatible API, uncomment and fill
+# the AUDIO_S3_* vars below — that wiring lands in a follow-up PR; for
+# now they're documented placeholders so the deploy host's secrets
+# layout is forward-compatible.
+# AUDIO_S3_ENDPOINT=https://hel1.your-objectstorage.com
+# AUDIO_S3_REGION=hel1
+# AUDIO_S3_BUCKET=ciareader-audio
+# AUDIO_S3_ACCESS_KEY=
+# AUDIO_S3_SECRET_KEY=

--- a/infra/Caddyfile
+++ b/infra/Caddyfile
@@ -1,0 +1,20 @@
+# Caddy reverse-proxy for the production stack (T-13.1 placeholder).
+#
+# This file is HTTP-only on :80 so the prod stack can boot end-to-end
+# during initial deploy. T-13.2 will replace this with auto-TLS using
+# Let's Encrypt against the real production domain.
+
+{
+	# Disable the local admin endpoint — production uses
+	# `docker compose exec caddy caddy reload` for config changes.
+	admin off
+}
+
+:80 {
+	encode gzip zstd
+
+	# All app traffic goes to the SvelteKit web service. The audio /
+	# api routes are sub-paths handled inside the same SvelteKit app,
+	# so a single proxy rule covers them.
+	reverse_proxy web:5173
+}

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -1,0 +1,198 @@
+name: ciareader-prod
+
+# Production stack. Boots on a single Hetzner CX/CCX box. Caddy is the
+# only service that binds host ports (80/443); everything else lives on
+# the internal network. Pair with infra/.env for secrets and
+# infra/Caddyfile for the reverse-proxy config.
+#
+# Operate:
+#   docker compose -f infra/docker-compose.prod.yml --env-file infra/.env up -d --build
+#   docker compose -f infra/docker-compose.prod.yml down
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    restart: always
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-ciareader}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in infra/.env}
+      POSTGRES_DB: ${POSTGRES_DB:-ciareader}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    networks:
+      - internal
+    deploy:
+      resources:
+        limits:
+          memory: 2g
+          cpus: "1.0"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-ciareader} -d ${POSTGRES_DB:-ciareader}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  redis:
+    image: redis:7-alpine
+    restart: always
+    # AOF off, RDB snapshot every 60s if ≥1 key changed. Loglevel
+    # warning to keep the journal small (BullMQ is chatty at notice).
+    command:
+      - redis-server
+      - --save
+      - "60"
+      - "1"
+      - --loglevel
+      - warning
+    volumes:
+      - redis-data:/data
+    networks:
+      - internal
+    deploy:
+      resources:
+        limits:
+          memory: 256m
+          cpus: "0.25"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 10
+
+  nlp:
+    build:
+      context: ..
+      dockerfile: services/nlp/Dockerfile
+    restart: always
+    # Override the Dockerfile's dev-style `--reload` CMD with a
+    # production worker pool. Two workers fits CX32 / CCX13 headroom
+    # and keeps Stanza models pinned per process.
+    command:
+      - uvicorn
+      - app.main:app
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8000"
+      - --workers
+      - "2"
+    networks:
+      - internal
+    environment:
+      PYTHONPATH: /opt/shared-types:/srv/nlp
+    deploy:
+      resources:
+        limits:
+          memory: 2500m
+          cpus: "1.5"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health').read()"
+      interval: 15s
+      timeout: 5s
+      retries: 10
+
+  web:
+    build:
+      context: ..
+      dockerfile: apps/web/Dockerfile.prod
+    restart: always
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      nlp:
+        condition: service_healthy
+    env_file:
+      - ./.env
+    environment:
+      # Service-network URLs — overrides anything in env_file so a
+      # forgotten dev-style entry there can't accidentally leak.
+      NLP_SERVICE_URL: http://nlp:8000
+      DATABASE_URL: postgres://${POSTGRES_USER:-ciareader}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-ciareader}
+      REDIS_URL: redis://redis:6379
+      AUDIO_LOCAL_ROOT: /srv/audio
+    volumes:
+      - audio-data:/srv/audio
+    networks:
+      - internal
+    deploy:
+      resources:
+        limits:
+          memory: 1500m
+          cpus: "1.0"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - "node -e \"require('http').get('http://localhost:5173/api/v1/smoke', (r) => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))\""
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+  caddy:
+    image: caddy:2-alpine
+    restart: always
+    ports:
+      - "80:80"
+      - "443:443"
+      - "443:443/udp" # HTTP/3
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    networks:
+      - internal
+      - public
+    depends_on:
+      web:
+        condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          memory: 256m
+          cpus: "0.25"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
+
+# Two networks so postgres / redis / nlp / web stay invisible to the
+# public side. Only caddy bridges both.
+networks:
+  internal:
+    driver: bridge
+  public:
+    driver: bridge
+
+volumes:
+  postgres-data: {}
+  redis-data: {}
+  caddy-data: {}    # ACME state (T-13.2 will rely on this surviving restarts)
+  caddy-config: {}
+  audio-data: {}    # Object storage backend lives here for the local-fs
+                    # mode. Switching to Hetzner Object Storage (S3 API)
+                    # is a follow-up — env hooks (AUDIO_S3_*) are already
+                    # documented in .env.prod.example.

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -129,6 +129,9 @@ services:
       DATABASE_URL: postgres://${POSTGRES_USER:-ciareader}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-ciareader}
       REDIS_URL: redis://redis:6379
       AUDIO_LOCAL_ROOT: /srv/audio
+      # adapter-node defaults to PORT=3000; we standardize on 5173
+      # across dev + prod so EXPOSE / healthcheck / Caddy all line up.
+      PORT: "5173"
     volumes:
       - audio-data:/srv/audio
     networks:

--- a/services/nlp/Dockerfile
+++ b/services/nlp/Dockerfile
@@ -7,8 +7,17 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /srv/nlp
 
+# unicodedata2 (transitive via indic-nlp-library) has no prebuilt wheel
+# for aarch64-linux, so pip compiles it from C source. The slim base
+# image doesn't ship a compiler — install gcc + headers, do the install,
+# then purge in the same RUN so the final layer doesn't carry them.
 COPY services/nlp/pyproject.toml /srv/nlp/pyproject.toml
-RUN pip install -U pip && pip install -e '.[dev,models]'
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends gcc libc6-dev \
+ && pip install -U pip \
+ && pip install -e '.[dev,models]' \
+ && apt-get purge -y --auto-remove gcc libc6-dev \
+ && rm -rf /var/lib/apt/lists/*
 
 COPY services/nlp/app /srv/nlp/app
 COPY services/nlp/tests /srv/nlp/tests


### PR DESCRIPTION
## Summary

Foundation for the M13 deployment milestone. Adds a production `docker-compose.prod.yml` that boots `web`, `nlp`, `postgres`, `redis`, and `caddy` on a single Hetzner CX/CCX box, with the supporting prod web Dockerfile and migration runner needed to make `docker compose up -d` actually work end-to-end.

## What's in the PR

| File | Purpose |
|---|---|
| [infra/docker-compose.prod.yml](infra/docker-compose.prod.yml) | Five-service stack, restart=always, json-file log rotation, `deploy.resources.limits` sized for CX32 with headroom, two networks (`internal` / `public`), no host port mappings except caddy. |
| [infra/Caddyfile](infra/Caddyfile) | HTTP-only placeholder so the stack boots end-to-end. **T-13.2 replaces this with auto-TLS** — the `caddy-data` volume already persists ACME state. |
| [infra/.env.prod.example](infra/.env.prod.example) | Full required-var inventory: `POSTGRES_*`, `AUTH_SECRET`, `APP_BASE_URL`, `SMTP_*`, plus commented `AUDIO_S3_*` for the future Hetzner Object Storage backend. |
| [apps/web/Dockerfile.prod](apps/web/Dockerfile.prod) | Multi-stage. Builder runs `pnpm --filter @ciareader/web build`; runtime does a fresh `pnpm install --prod`, copies the adapter-node output + drizzle migrations + migrate runner, drops privs to a non-root `app` user. |
| [apps/web/scripts/migrate-prod.mjs](apps/web/scripts/migrate-prod.mjs) | Production migration runner using `drizzle-orm/postgres-js/migrator`. Lets the runtime image skip `drizzle-kit` entirely. |
| [README.md](README.md) | New "Production deployment" section + M13 roadmap. |

## Operating shape

```bash
cp infra/.env.prod.example infra/.env
# fill POSTGRES_PASSWORD, AUTH_SECRET, SMTP_*, APP_BASE_URL
docker compose -f infra/docker-compose.prod.yml --env-file infra/.env up -d --build
```

Web container's startup runs `migrate-prod.mjs` against the live DB **before** booting `node build/index.js`, so fresh deploys apply pending migrations automatically.

## Resource sizing (CX32 = 4 vCPU / 8 GB)

| Service | mem_limit | cpus |
|---|---|---|
| postgres | 2 GB | 1.0 |
| redis | 256 MB | 0.25 |
| nlp | 2.5 GB | 1.5 |
| web | 1.5 GB | 1.0 |
| caddy | 256 MB | 0.25 |
| **Total** | **~6.5 GB / 4 cpu** | leaves ~1.5 GB OS headroom |

Tunable via `infra/.env` if a smaller / larger Hetzner instance is targeted.

## Test plan

- [x] `docker compose -f infra/docker-compose.prod.yml --env-file infra/.env config` exits 0 and resolves all five services, both networks, and all five volumes (`postgres-data`, `redis-data`, `caddy-data`, `caddy-config`, `audio-data`).
- [x] Web healthcheck JS quoting validated through compose config (single quotes round-trip cleanly).
- [x] Compose `${POSTGRES_PASSWORD:?…}` correctly errors on missing secret.
- [ ] Reviewer: build the web prod image (`docker build -f apps/web/Dockerfile.prod .`) — slow but should succeed end-to-end.
- [ ] Reviewer: full `up -d` against a throwaway Hetzner box; verify Caddy on `:80` proxies to web, web's startup logs show "migrate-prod: done", `/api/v1/smoke` returns 200.

## Out of scope (other M13 tickets)

- **#112 T-13.2** — Caddyfile + auto-TLS replaces the placeholder.
- **#113 T-13.3** — nightly backups of `postgres-data` + `audio-data`.
- **#114 T-13.4** — deploy script (rsync, pull, compose up).
- **#115 T-13.5** — monitoring-lite.
- **Audio S3 backend** — env-var hooks (`AUDIO_S3_*`) are documented; the actual `S3Storage` implementation in [apps/web/src/lib/server/audio/storage.ts](apps/web/src/lib/server/audio/storage.ts) is a follow-up. Until then, prod uses the local-fs backend backed by the `audio-data` named volume.

Closes #111.