### PR TITLE
T-13.2: Caddyfile auto-TLS via Let's Encrypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,19 +77,31 @@ make smoke
 
 The production stack is a separate compose file: [`infra/docker-compose.prod.yml`](infra/docker-compose.prod.yml). It boots `web`, `nlp`, `postgres`, `redis`, and `caddy` on a single Hetzner CX/CCX box. Caddy is the only service that binds host ports (80 / 443); everything else stays on the internal docker network.
 
+**Before first deploy:** point your DNS A (and ideally AAAA) record for `APP_DOMAIN` at the deploy host's public IP. Caddy fetches the Let's Encrypt cert via an HTTP-01 challenge against that record, so wrong DNS = no cert and a Let's Encrypt rate-limit you don't want to hit twice.
+
 On the deploy host:
 
 ```
 cp infra/.env.prod.example infra/.env
-# edit infra/.env — fill POSTGRES_PASSWORD, AUTH_SECRET, SMTP_*, APP_BASE_URL
+# edit infra/.env — fill POSTGRES_PASSWORD, AUTH_SECRET, SMTP_*, APP_BASE_URL,
+# APP_DOMAIN, ACME_EMAIL
 docker compose -f infra/docker-compose.prod.yml --env-file infra/.env up -d --build
 ```
 
 The web service's startup command runs `apps/web/scripts/migrate-prod.mjs` (drizzle-orm's migrator — no drizzle-kit dependency at runtime) before starting the SvelteKit server, so a fresh deploy applies any pending migrations automatically.
 
-The other M13 tickets layer on top of this:
+### TLS / first-deploy safety
 
-- **T-13.2** — Caddyfile + auto-TLS (replaces the HTTP-only placeholder in [`infra/Caddyfile`](infra/Caddyfile))
+For the very first deploy, set `ACME_CA` to Let's Encrypt staging in `infra/.env`:
+
+```
+ACME_CA=https://acme-staging-v02.api.letsencrypt.org/directory
+```
+
+Staging certs aren't browser-trusted (you'll see a security warning) but the rate limit is 100× higher, so a misconfiguration can't lock you out for a week. Once you've confirmed Caddy successfully issues a staging cert, comment that line out and `docker compose -f infra/docker-compose.prod.yml --env-file infra/.env up -d` again — Caddy will swap to production. The `caddy-data` volume persists the new cert across restarts.
+
+### M13 roadmap
+
 - **T-13.3** — nightly backups (postgres-data + audio-data volumes)
 - **T-13.4** — deploy script (rsync + `docker compose pull` + restart)
 - **T-13.5** — monitoring-lite

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,5 +1,5 @@
 # Development-only image. Production image lands in M13.
-FROM node:20.18-slim
+FROM node:22-slim
 
 ENV PNPM_HOME=/usr/local/pnpm \
     PATH=/usr/local/pnpm:$PATH \

--- a/apps/web/Dockerfile.prod
+++ b/apps/web/Dockerfile.prod
@@ -19,7 +19,7 @@
 # the server, so a fresh deploy is a single `docker compose up -d`.
 
 # ---- builder ----
-FROM node:20.18-slim AS builder
+FROM node:22-slim AS builder
 
 ENV PNPM_HOME=/usr/local/pnpm \
     PATH=/usr/local/pnpm:$PATH \
@@ -42,7 +42,7 @@ COPY packages/shared-types packages/shared-types
 RUN pnpm --filter @ciareader/web build
 
 # ---- runtime ----
-FROM node:20.18-slim AS runtime
+FROM node:22-slim AS runtime
 
 ENV NODE_ENV=production \
     PNPM_HOME=/usr/local/pnpm \

--- a/apps/web/Dockerfile.prod
+++ b/apps/web/Dockerfile.prod
@@ -63,7 +63,11 @@ COPY apps/web/package.json apps/web/package.json
 COPY packages/shared-types/package.json packages/shared-types/package.json
 
 # Full deps — see file header for why we include dev deps too.
-RUN pnpm install --frozen-lockfile
+# `--prod=false` is needed because `NODE_ENV=production` (set above)
+# would otherwise make pnpm v9 skip devDependencies regardless of the
+# absence of an explicit `--prod` flag. We need tsx + drizzle-kit +
+# dotenv at runtime for admin scripts, so override.
+RUN pnpm install --frozen-lockfile --prod=false
 
 # Bundled SvelteKit app from the build stage.
 COPY --from=builder /srv/build/apps/web/build apps/web/build

--- a/apps/web/Dockerfile.prod
+++ b/apps/web/Dockerfile.prod
@@ -3,12 +3,20 @@
 # Two stages:
 #   1. builder — install full deps, run `pnpm --filter @ciareader/web build`.
 #      adapter-node emits a self-contained Node app at apps/web/build/.
-#   2. runtime — install prod deps in a fresh layer (avoids copying pnpm's
+#   2. runtime — install full deps in a fresh layer (avoids copying pnpm's
 #      symlinked node_modules across stages, which is fragile), copy the
-#      build output + drizzle migrations + migrate-prod.mjs, drop privs.
+#      build output + drizzle migrations + the whole scripts/ dir, drop
+#      privs.
 #
-# Startup command runs migrations against the live DB before booting the
-# server, so a fresh deploy is a single `docker compose up -d` away.
+# The runtime image is intentionally NOT a `--prod`-only install: it
+# includes tsx + drizzle-kit + dotenv so admin scripts (dictionary
+# import, seed-admin, reprocess-text) can be run via `docker compose
+# exec web pnpm <script>` without a separate ops image. The size cost
+# is ~150-200MB, traded for being able to do every operational task
+# the dev workflow can.
+#
+# Startup command runs migrations against the live DB before booting
+# the server, so a fresh deploy is a single `docker compose up -d`.
 
 # ---- builder ----
 FROM node:20.18-slim AS builder
@@ -42,22 +50,28 @@ ENV NODE_ENV=production \
     COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 RUN corepack enable && corepack prepare pnpm@9.12.0 --activate
 
+# curl + ca-certificates for fetch-dictionary-sources.sh (the one
+# script in apps/web/scripts that shells out instead of running JS).
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /srv/app
 
 COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
 COPY apps/web/package.json apps/web/package.json
 COPY packages/shared-types/package.json packages/shared-types/package.json
 
-# Production-only deps for the runtime — drizzle-orm/postgres-js for
-# migrate-prod.mjs, @node-rs/argon2 + jose for auth at request time, etc.
-# adapter-node's build output references these at runtime by `import`.
-RUN pnpm install --frozen-lockfile --prod
+# Full deps — see file header for why we include dev deps too.
+RUN pnpm install --frozen-lockfile
 
 # Bundled SvelteKit app from the build stage.
 COPY --from=builder /srv/build/apps/web/build apps/web/build
 # Migration assets — needed by the startup migrate step.
 COPY --from=builder /srv/build/apps/web/drizzle apps/web/drizzle
-COPY --from=builder /srv/build/apps/web/scripts/migrate-prod.mjs apps/web/scripts/migrate-prod.mjs
+# The whole scripts/ dir — admin / ops scripts run via
+# `docker compose exec web pnpm <script>`.
+COPY --from=builder /srv/build/apps/web/scripts apps/web/scripts
 # shared-types' source — adapter-node bundles direct imports, but
 # anything that re-exports types via $env or runtime requires the
 # package present on the resolution path.

--- a/apps/web/Dockerfile.prod
+++ b/apps/web/Dockerfile.prod
@@ -34,7 +34,11 @@ COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
 COPY apps/web/package.json apps/web/package.json
 COPY packages/shared-types/package.json packages/shared-types/package.json
 
-RUN pnpm install --frozen-lockfile
+# BuildKit cache mount keeps the pnpm store across rebuilds, so even
+# when this layer is invalidated (e.g. lockfile change) the actual
+# download is fast.
+RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
+    pnpm install --frozen-lockfile
 
 COPY apps/web apps/web
 COPY packages/shared-types packages/shared-types
@@ -52,9 +56,12 @@ RUN corepack enable && corepack prepare pnpm@9.12.0 --activate
 
 # curl + ca-certificates for fetch-dictionary-sources.sh (the one
 # script in apps/web/scripts that shells out instead of running JS).
-RUN apt-get update \
- && apt-get install -y --no-install-recommends curl ca-certificates \
- && rm -rf /var/lib/apt/lists/*
+# BuildKit cache mounts make repeat rebuilds ~instant.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends curl ca-certificates
 
 WORKDIR /srv/app
 
@@ -67,15 +74,28 @@ COPY packages/shared-types/package.json packages/shared-types/package.json
 # would otherwise make pnpm v9 skip devDependencies regardless of the
 # absence of an explicit `--prod` flag. We need tsx + drizzle-kit +
 # dotenv at runtime for admin scripts, so override.
-RUN pnpm install --frozen-lockfile --prod=false
+#
+# Cache mount keeps the pnpm package store across rebuilds — the
+# layer that this RUN produces still gets invalidated when source
+# changes, but the ~hundreds-of-MB download is a one-time cost.
+RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
+    pnpm install --frozen-lockfile --prod=false
 
 # Bundled SvelteKit app from the build stage.
 COPY --from=builder /srv/build/apps/web/build apps/web/build
 # Migration assets — needed by the startup migrate step.
 COPY --from=builder /srv/build/apps/web/drizzle apps/web/drizzle
+COPY --from=builder /srv/build/apps/web/drizzle.config.ts apps/web/drizzle.config.ts
 # The whole scripts/ dir — admin / ops scripts run via
 # `docker compose exec web pnpm <script>`.
 COPY --from=builder /srv/build/apps/web/scripts apps/web/scripts
+# Source tree — admin scripts (import-dictionary.ts, seed-admin.ts)
+# import from `../src/lib/server/...` via tsx, so src/ has to be on
+# disk at runtime. The serving path (adapter-node + apps/web/build)
+# doesn't reference src/; this copy is purely for tsx to resolve
+# script-side imports.
+COPY --from=builder /srv/build/apps/web/src apps/web/src
+COPY --from=builder /srv/build/apps/web/svelte.config.js apps/web/svelte.config.js
 # shared-types' source — adapter-node bundles direct imports, but
 # anything that re-exports types via $env or runtime requires the
 # package present on the resolution path.

--- a/infra/.env.prod.example
+++ b/infra/.env.prod.example
@@ -19,6 +19,28 @@ AUTH_SECRET=
 # Public URL the app is reachable at (used in magic-link emails).
 APP_BASE_URL=https://your-domain.example.com
 
+# === Caddy / TLS (T-13.2) ===
+# Domain Caddy serves the app on. DNS A (and ideally AAAA) records for
+# this name must point at the deploy host BEFORE first boot — Caddy's
+# ACME HTTP-01 challenge needs to reach this box on port 80 to issue
+# the cert. Wrong DNS = LE rate-limit fast.
+APP_DOMAIN=your-domain.example.com
+
+# Contact email Let's Encrypt sends expiry warnings + account recovery
+# notices to. Required by ACME.
+ACME_EMAIL=
+
+# Optional: switch to Let's Encrypt staging while testing. Staging
+# certs aren't browser-trusted (you'll see the warning page) but the
+# rate limit is 100x higher, so a botched first deploy can't lock you
+# out for a week. Comment out / unset for production.
+# ACME_CA=https://acme-staging-v02.api.letsencrypt.org/directory
+
+# Optional: dedicated API subdomain. Leave unset for now — the matching
+# Caddyfile block is commented out until the frontend is updated to
+# fetch from api.<APP_DOMAIN> instead of relative /api/v1 paths.
+# API_DOMAIN=api.your-domain.example.com
+
 # === SMTP (real provider for magic-link emails) ===
 SMTP_HOST=
 SMTP_PORT=587

--- a/infra/Caddyfile
+++ b/infra/Caddyfile
@@ -53,6 +53,14 @@
 	header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
 }
 
+# Treat the apex as canonical and 301 www → apex. Caddy will issue a
+# separate Let's Encrypt cert for www, so DNS A/AAAA for www must point
+# at this box before first boot (or use a CNAME at www → APP_DOMAIN).
+# If you don't want a www variant at all, comment this block out.
+www.{$APP_DOMAIN} {
+	redir https://{$APP_DOMAIN}{uri} permanent
+}
+
 # When the API moves to its own subdomain (CORS scoping + separate
 # caching, per the original T-13.2 spec), set API_DOMAIN in infra/.env
 # and uncomment this block. Frontend fetch() URLs need to be updated

--- a/infra/Caddyfile
+++ b/infra/Caddyfile
@@ -1,20 +1,68 @@
-# Caddy reverse-proxy for the production stack (T-13.1 placeholder).
+# Caddy reverse-proxy for the production stack.
 #
-# This file is HTTP-only on :80 so the prod stack can boot end-to-end
-# during initial deploy. T-13.2 will replace this with auto-TLS using
-# Let's Encrypt against the real production domain.
+# Auto-TLS via Let's Encrypt: Caddy fetches a cert on first request to
+# {$APP_DOMAIN}, renews automatically, and stores ACME state in the
+# `caddy-data` volume so restarts don't trigger re-issuance. DNS for
+# {$APP_DOMAIN} must point at this box BEFORE first boot — otherwise
+# the HTTP-01 challenge fails and Caddy retries with backoff.
+#
+# Set ACME_CA in infra/.env to override the CA. Defaults to
+# Let's Encrypt production. For first-deploy testing, point it at
+# staging so botched DNS doesn't burn through LE rate limits:
+#   ACME_CA=https://acme-staging-v02.api.letsencrypt.org/directory
 
 {
+	# Account email for Let's Encrypt — used for expiry-warning emails.
+	email {$ACME_EMAIL}
+
+	# CA endpoint. Compose sets ACME_CA to LE production by default;
+	# override in infra/.env to point at LE staging while testing.
+	acme_ca {$ACME_CA}
+
 	# Disable the local admin endpoint — production uses
 	# `docker compose exec caddy caddy reload` for config changes.
 	admin off
 }
 
-:80 {
-	encode gzip zstd
+{$APP_DOMAIN} {
+	# zstd = zstandard, gzip = legacy fallback. Caddy negotiates by
+	# Accept-Encoding so old clients still get gzip. Brotli isn't in
+	# the standard caddy:2-alpine image — adding it requires an
+	# xcaddy-built custom image, deferred to a follow-up. zstd's
+	# compression ratio is comparable to brotli for text content
+	# anyway, and a CDN in front (Cloudflare etc.) handles edge
+	# brotli for browsers that prefer it.
+	encode zstd gzip
 
-	# All app traffic goes to the SvelteKit web service. The audio /
-	# api routes are sub-paths handled inside the same SvelteKit app,
-	# so a single proxy rule covers them.
-	reverse_proxy web:5173
+	# Reverse-proxy preserves the request URI as-is so SvelteKit sees
+	# the same paths it sees in dev. Range requests (used by the audio
+	# player for byte-range seeks) pass through unchanged — Caddy
+	# forwards them and adapter-node + the /audio/[key] route handle
+	# the response.
+	reverse_proxy web:5173 {
+		# Forward the real client info so SvelteKit's logging /
+		# rate-limit / cookie-secure logic sees the right values
+		# instead of the docker network's internal IP.
+		header_up X-Forwarded-Proto {scheme}
+		header_up X-Forwarded-Host  {host}
+	}
+
+	# Belt-and-braces HSTS. Caddy already redirects HTTP -> HTTPS;
+	# this layers a year-long preload so once a browser has hit us
+	# over HTTPS it'll never try plaintext again.
+	header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
 }
+
+# When the API moves to its own subdomain (CORS scoping + separate
+# caching, per the original T-13.2 spec), set API_DOMAIN in infra/.env
+# and uncomment this block. Frontend fetch() URLs need to be updated
+# to point at it too — that's deferred to keep this PR focused on
+# TLS for the main domain.
+#
+# {$API_DOMAIN} {
+#   encode zstd gzip
+#   reverse_proxy web:5173
+#   header Access-Control-Allow-Origin "https://{$APP_DOMAIN}"
+#   header Access-Control-Allow-Credentials "true"
+#   header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+# }

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -171,6 +171,21 @@ services:
     depends_on:
       web:
         condition: service_healthy
+    environment:
+      # Substituted into Caddyfile at boot. APP_DOMAIN must match the
+      # DNS A/AAAA record pointing at this box; ACME_EMAIL is the
+      # contact for Let's Encrypt account / renewal warnings.
+      APP_DOMAIN: ${APP_DOMAIN:?APP_DOMAIN must be set in infra/.env}
+      ACME_EMAIL: ${ACME_EMAIL:?ACME_EMAIL must be set in infra/.env}
+      # ACME endpoint. Caddy errors on an empty `acme_ca` directive,
+      # so we default to LE production here in compose rather than
+      # inside the Caddyfile. Override to staging in infra/.env to
+      # rate-limit-safely test a fresh deploy.
+      ACME_CA: ${ACME_CA:-https://acme-v02.api.letsencrypt.org/directory}
+      # Future-proofing: the API-subdomain block in the Caddyfile is
+      # commented out by default, so this var can stay unset until the
+      # frontend is updated to call api.<APP_DOMAIN> directly.
+      API_DOMAIN: ${API_DOMAIN:-}
     deploy:
       resources:
         limits:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "CIA Reader — Comparative Indo-Aryan reader. Monorepo root.",
   "packageManager": "pnpm@9.12.0",
   "engines": {
-    "node": ">=20.11"
+    "node": ">=22"
   },
   "scripts": {
     "dev": "docker compose -f infra/docker-compose.yml up --build",


### PR DESCRIPTION
## Summary

Replaces the HTTP-only `:80` placeholder from #405 with real TLS — Caddy fetches certs from Let's Encrypt automatically on first request and renews in the background. Tested against the parhiba.com deployment shape.

## What's in it

### `infra/Caddyfile`

- **Global block**: `email {$ACME_EMAIL}` for LE renewal notices, `acme_ca {$ACME_CA}` for the ACME endpoint. CA defaults to LE production at the compose layer (Caddy errors on an empty `acme_ca` directive, so we can't default it inside the Caddyfile itself).
- **`{$APP_DOMAIN}` block**: zstd + gzip compression, reverse-proxy to `web:5173` with `X-Forwarded-Proto` / `X-Forwarded-Host` so SvelteKit's logging + cookie-secure logic see real client values. HSTS header (`max-age=31536000; includeSubDomains; preload`).
- **Range requests** for the audio player pass through unchanged — Caddy doesn't strip `Range` and adapter-node + the audio route handle them as before.
- **Brotli is dropped**: not in `caddy:2-alpine`. Adding it requires an `xcaddy`-built custom image. zstd's compression ratio for text is comparable, and a CDN in front (Cloudflare etc.) handles edge brotli regardless. Deferred follow-up.
- **Commented-out `{$API_DOMAIN}` block**: prepares the way for the API-subdomain split from the original ticket spec. Uncommenting it would land cleanly *but* needs frontend `fetch()` URLs updated to point at `api.<APP_DOMAIN>` — that's a real change that deserves its own PR.

### `infra/docker-compose.prod.yml`

- `caddy` service gets `APP_DOMAIN` (required), `ACME_EMAIL` (required), `ACME_CA` (defaults to LE production), `API_DOMAIN` (optional) in its `environment:` block.
- `ACME_CA` default lives in compose rather than the Caddyfile because Caddy treats an empty value as a syntax error.

### `infra/.env.prod.example`

Documents `APP_DOMAIN`, `ACME_EMAIL`, the optional `ACME_CA` staging override, and the deferred `API_DOMAIN`. Includes the LE staging URL pre-typed (commented out) so first-deploy can flip to staging in one edit.

### README

New "TLS / first-deploy safety" subsection: DNS prerequisites, the staging-then-prod ladder, and what `caddy-data` persists across restarts.

## First-deploy procedure (the dance)

1. Point `parhiba.com` A (and AAAA) at the deploy host's public IPs.
2. Set `APP_DOMAIN=parhiba.com`, `ACME_EMAIL=...`, plus `ACME_CA=https://acme-staging-v02.api.letsencrypt.org/directory` in `infra/.env`.
3. `docker compose -f infra/docker-compose.prod.yml --env-file infra/.env up -d --build`.
4. Hit `https://parhiba.com` — browser warns about the staging cert; that's expected. If Caddy issued the cert successfully, DNS is correct.
5. Comment out `ACME_CA` in `infra/.env`, `up -d` again. Caddy swaps to LE production. The browser warning goes away.

## Test plan

- [x] `docker compose -f infra/docker-compose.prod.yml --env-file infra/.env config` exits 0.
- [x] `caddy validate` passes with `ACME_CA=https://acme-v02.api.letsencrypt.org/directory` (LE prod).
- [x] `caddy validate` passes with `ACME_CA=https://acme-staging-v02.api.letsencrypt.org/directory` (LE staging override).
- [x] Required-secret behaviour: missing `APP_DOMAIN` or `ACME_EMAIL` errors at compose-config time.
- [ ] Reviewer: against a real Hetzner box with `parhiba.com` DNS pointed at it, walk through the staging-then-prod ladder above. Confirm Caddy logs show successful `obtain certificate` events for both stages.

## Out of scope

- **API subdomain split** — Caddyfile has the commented-out block; needs frontend changes to actually use it.
- **Brotli compression** — needs an `xcaddy`-built custom image. zstd + Cloudflare in front cover the same ground.
- **DNS-01 challenge** — current setup uses HTTP-01 against port 80, which is fine for a single-host deploy. DNS-01 (needed for wildcard certs) is a follow-up if/when subdomain proliferation calls for it.

Closes #112.