### PR TITLE
chore: include scripts + dev tooling in prod web image

### DIFF
--- a/apps/web/Dockerfile.prod
+++ b/apps/web/Dockerfile.prod
@@ -3,12 +3,20 @@
 # Two stages:
 #   1. builder — install full deps, run `pnpm --filter @ciareader/web build`.
 #      adapter-node emits a self-contained Node app at apps/web/build/.
-#   2. runtime — install prod deps in a fresh layer (avoids copying pnpm's
+#   2. runtime — install full deps in a fresh layer (avoids copying pnpm's
 #      symlinked node_modules across stages, which is fragile), copy the
-#      build output + drizzle migrations + migrate-prod.mjs, drop privs.
+#      build output + drizzle migrations + the whole scripts/ dir, drop
+#      privs.
 #
-# Startup command runs migrations against the live DB before booting the
-# server, so a fresh deploy is a single `docker compose up -d` away.
+# The runtime image is intentionally NOT a `--prod`-only install: it
+# includes tsx + drizzle-kit + dotenv so admin scripts (dictionary
+# import, seed-admin, reprocess-text) can be run via `docker compose
+# exec web pnpm <script>` without a separate ops image. The size cost
+# is ~150-200MB, traded for being able to do every operational task
+# the dev workflow can.
+#
+# Startup command runs migrations against the live DB before booting
+# the server, so a fresh deploy is a single `docker compose up -d`.
 
 # ---- builder ----
 FROM node:20.18-slim AS builder
@@ -42,22 +50,28 @@ ENV NODE_ENV=production \
     COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 RUN corepack enable && corepack prepare pnpm@9.12.0 --activate
 
+# curl + ca-certificates for fetch-dictionary-sources.sh (the one
+# script in apps/web/scripts that shells out instead of running JS).
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /srv/app
 
 COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
 COPY apps/web/package.json apps/web/package.json
 COPY packages/shared-types/package.json packages/shared-types/package.json
 
-# Production-only deps for the runtime — drizzle-orm/postgres-js for
-# migrate-prod.mjs, @node-rs/argon2 + jose for auth at request time, etc.
-# adapter-node's build output references these at runtime by `import`.
-RUN pnpm install --frozen-lockfile --prod
+# Full deps — see file header for why we include dev deps too.
+RUN pnpm install --frozen-lockfile
 
 # Bundled SvelteKit app from the build stage.
 COPY --from=builder /srv/build/apps/web/build apps/web/build
 # Migration assets — needed by the startup migrate step.
 COPY --from=builder /srv/build/apps/web/drizzle apps/web/drizzle
-COPY --from=builder /srv/build/apps/web/scripts/migrate-prod.mjs apps/web/scripts/migrate-prod.mjs
+# The whole scripts/ dir — admin / ops scripts run via
+# `docker compose exec web pnpm <script>`.
+COPY --from=builder /srv/build/apps/web/scripts apps/web/scripts
 # shared-types' source — adapter-node bundles direct imports, but
 # anything that re-exports types via $env or runtime requires the
 # package present on the resolution path.


### PR DESCRIPTION
## Summary

Follow-up to #405. The runtime stage of `Dockerfile.prod` was too aggressive about slimness — only `migrate-prod.mjs` made it into the image, and `pnpm install --prod` excluded `tsx` + `drizzle-kit` + `dotenv`. Result: a fresh prod deploy can't run admin scripts; `docker compose exec web pnpm dictionary:import` fails with "fetch-dictionary-sources.sh: not found." Surfaced when seeding the first prod box.

## What changes

| Change | Why |
|---|---|
| Copy `apps/web/scripts/` (whole dir) in runtime stage | Was previously only `migrate-prod.mjs`; now all admin scripts ship. |
| Drop `--prod` from runtime `pnpm install` | Pulls in `tsx`, `drizzle-kit`, `dotenv`. ~150-200 MB image cost; in exchange any project script is `docker compose exec web pnpm <script>`-able. |
| `apt-get install curl ca-certificates` in runtime stage | `fetch-dictionary-sources.sh` shells out to `curl`. Slim base doesn't include it. |

## Operator UX after this lands

```bash
# Seed the dictionary on a fresh prod box:
docker compose -f infra/docker-compose.prod.yml --env-file infra/.env \
  exec -T web sh -c '
    apps/web/scripts/fetch-dictionary-sources.sh kaikki-hindi &&
    pnpm --filter @ciareader/web dictionary:import kaikki-hindi
  '

# Create an admin user:
docker compose -f infra/docker-compose.prod.yml --env-file infra/.env \
  exec web pnpm seed-admin admin@parhiba.com 'long-random-password'

# Reprocess a stuck text:
docker compose -f infra/docker-compose.prod.yml --env-file infra/.env \
  exec web node apps/web/scripts/reprocess-text.mjs <text-id>
```

## Trade-off considered

The alternative would be a separate "ops" image based on the dev Dockerfile, kept off the running stack and spun up only for admin tasks. That keeps the runtime image lean but adds a build step + a separate image to maintain. For a single-host single-developer project this PR's "fat image" approach is simpler and the size cost is one-time at pull, paid once per deploy.

## Test plan

- [x] `docker compose config` exits 0 against the updated compose.
- [ ] Reviewer: `docker compose -f infra/docker-compose.prod.yml --env-file infra/.env up -d --build web` rebuilds the web image. After it's up, `docker compose ... exec -T web sh -c 'apps/web/scripts/fetch-dictionary-sources.sh kaikki-hindi && pnpm --filter @ciareader/web dictionary:import kaikki-hindi'` succeeds and the dictionary lemma count climbs.
- [ ] Reviewer: web container still boots cleanly from a fresh DB (the `migrate-prod.mjs` startup path is unchanged).