### PR TITLE
T-13.3: nightly backups via rclone sidecar

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,12 @@ ACME_CA=https://acme-staging-v02.api.letsencrypt.org/directory
 
 Staging certs aren't browser-trusted (you'll see a security warning) but the rate limit is 100× higher, so a misconfiguration can't lock you out for a week. Once you've confirmed Caddy successfully issues a staging cert, comment that line out and `docker compose -f infra/docker-compose.prod.yml --env-file infra/.env up -d` again — Caddy will swap to production. The `caddy-data` volume persists the new cert across restarts.
 
+### Backups
+
+The `backup` service runs as a sidecar in the prod compose stack. Cron jobs `pg_dump` the DB nightly and tar the audio volume weekly, uploading both via `rclone` to whatever remote you've configured (Dropbox, B2, Hetzner Storage Box, etc.). Setup walkthrough + restore procedure: [`infra/backup/README.md`](infra/backup/README.md).
+
 ### M13 roadmap
 
-- **T-13.3** — nightly backups (postgres-data + audio-data volumes)
 - **T-13.4** — deploy script (rsync + `docker compose pull` + restart)
 - **T-13.5** — monitoring-lite
 

--- a/infra/.env.prod.example
+++ b/infra/.env.prod.example
@@ -48,6 +48,24 @@ SMTP_USER=
 SMTP_PASS=
 SMTP_FROM=no-reply@your-domain.example.com
 
+# === Backups (T-13.3) ===
+# rclone remote spec — what `rclone config` produced for you, plus a
+# path prefix. Examples by provider:
+#   dropbox:ciareader-backups
+#   b2:my-bucket-name
+#   hetzner-storage-box:backups/ciareader
+# First-time setup walkthrough lives in infra/backup/README.md.
+RCLONE_REMOTE=
+
+# How many days of dumps to keep on the remote. The backup service
+# prunes anything older after each run.
+BACKUP_RETENTION_DAYS=14
+
+# Optional: separate retention for audio tarballs (weekly cadence,
+# longer retention by default since they're less frequently
+# regenerated). Leave blank to default to 4 * BACKUP_RETENTION_DAYS.
+AUDIO_RETENTION_DAYS=
+
 # === Audio storage ===
 # Default backend is the local filesystem mounted at /srv/audio inside
 # the web container, backed by the `audio-data` named volume. To switch

--- a/infra/backup/Dockerfile
+++ b/infra/backup/Dockerfile
@@ -1,0 +1,32 @@
+# Backup sidecar for the production stack (T-13.3).
+#
+# Runs crond in foreground; cron jobs `pg_dump` the live DB and tar
+# the audio-data volume, then upload via rclone to whatever remote
+# the operator has configured (Dropbox, B2, Hetzner Storage Box,
+# anything rclone supports).
+#
+# Container is intentionally minimal — alpine + the four binaries we
+# need + the scripts. Stays under ~50 MB.
+FROM alpine:3.20
+
+RUN apk add --no-cache \
+      bash \
+      dcron \
+      gzip \
+      postgresql16-client \
+      rclone \
+      tar \
+      tzdata
+
+COPY entrypoint.sh    /usr/local/bin/entrypoint.sh
+COPY backup-db.sh     /usr/local/bin/backup-db.sh
+COPY backup-audio.sh  /usr/local/bin/backup-audio.sh
+COPY restore-db.sh    /usr/local/bin/restore-db.sh
+COPY crontab          /etc/crontabs/root
+RUN chmod +x /usr/local/bin/*.sh
+
+# UTC for predictable cron schedules — operators reading the crontab
+# don't have to convert timezones to figure out when a job fires.
+ENV TZ=UTC
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/infra/backup/README.md
+++ b/infra/backup/README.md
@@ -1,0 +1,138 @@
+# Backups (T-13.3)
+
+A `backup` sidecar service runs alongside the prod stack, executing two cron jobs:
+
+| Job | Schedule (UTC) | What it does |
+|---|---|---|
+| `backup-db.sh` | `5 3 * * *` (nightly, 03:05) | `pg_dump` → gzip → upload via rclone to `${RCLONE_REMOTE}/db/<timestamp>.sql.gz`. Prunes remote dumps older than `BACKUP_RETENTION_DAYS` (default 14). |
+| `backup-audio.sh` | `5 4 * * 0` (weekly, Sun 04:05) | `tar.gz` of the `audio-data` volume → upload to `${RCLONE_REMOTE}/audio/<timestamp>.tar.gz`. Prunes older than `AUDIO_RETENTION_DAYS` (default `4 * BACKUP_RETENTION_DAYS`). |
+
+Output goes to `docker compose logs backup`.
+
+## One-time rclone setup
+
+The backup container needs an authenticated rclone remote. Two paths.
+
+### Path 1 — set up rclone on the deploy host
+
+Run rclone interactively against the named volume the backup container reads from:
+
+```bash
+docker compose -f infra/docker-compose.prod.yml --env-file infra/.env \
+  run --rm -it backup rclone config --config /config/rclone/rclone.conf
+```
+
+Walk the prompts — pick a name (e.g. `dropbox`), choose your provider, **say "n" to "Use auto config?"** (the deploy host has no browser). rclone prints a URL; open it on your laptop, log into Dropbox/B2/whatever, paste the resulting auth code back into the server terminal. The token is saved into the `rclone-config` named volume and survives container recreation.
+
+After the wizard exits, set the remote spec in `infra/.env`:
+
+```
+RCLONE_REMOTE=dropbox:ciareader-backups
+```
+
+The path after the colon (`ciareader-backups` here) is the folder rclone will create on the remote. Pick anything you like.
+
+### Path 2 — set up rclone on your laptop, copy the config
+
+If you'd rather use a browser for the OAuth flow:
+
+```bash
+# On your laptop (install rclone first):
+rclone config
+# Walk the wizard with auto-config = yes (opens browser).
+
+# Then copy the resulting config to the deploy host:
+scp ~/.config/rclone/rclone.conf root@parhiba.com:/tmp/rclone.conf
+ssh root@parhiba.com 'docker run --rm \
+  -v ciareader-prod_rclone-config:/dst \
+  -v /tmp/rclone.conf:/src/rclone.conf:ro \
+  alpine sh -c "mkdir -p /dst && cp /src/rclone.conf /dst/rclone.conf && chmod 600 /dst/rclone.conf"'
+ssh root@parhiba.com 'rm /tmp/rclone.conf'
+```
+
+## Verify backups are working
+
+After setting `RCLONE_REMOTE` and bouncing the stack:
+
+```bash
+# Trigger a one-shot dump immediately, instead of waiting until 03:05 UTC.
+docker compose -f infra/docker-compose.prod.yml --env-file infra/.env \
+  exec backup /bin/bash -c '. /etc/backup-env && /usr/local/bin/backup-db.sh'
+
+# List remote dumps to confirm:
+docker compose -f infra/docker-compose.prod.yml --env-file infra/.env \
+  exec backup rclone --config /config/rclone/rclone.conf \
+    lsl "${RCLONE_REMOTE}/db/"
+```
+
+After waiting through one Sunday, the same trick on `backup-audio.sh` confirms the weekly job works.
+
+## Restore from a backup
+
+The included `restore-db.sh` pulls a dump from the remote and pipes it back into Postgres. **Destructive** — the dumps are taken with `--clean --if-exists`, so restoring drops every table in `${POSTGRES_DB}` first. Take a fresh backup before you run it against a DB you care about.
+
+```bash
+# List what's available:
+docker compose -f infra/docker-compose.prod.yml --env-file infra/.env \
+  exec backup rclone --config /config/rclone/rclone.conf \
+    lsf "${RCLONE_REMOTE}/db/"
+
+# Restore the latest dump:
+docker compose -f infra/docker-compose.prod.yml --env-file infra/.env \
+  exec backup restore-db.sh latest
+
+# Or a specific timestamp:
+docker compose -f infra/docker-compose.prod.yml --env-file infra/.env \
+  exec backup restore-db.sh 20260507T030500Z
+```
+
+For audio:
+
+```bash
+# Pull the tarball locally and extract into the volume in one shot.
+docker compose -f infra/docker-compose.prod.yml --env-file infra/.env \
+  exec backup sh -c '
+    rclone --config /config/rclone/rclone.conf \
+      copyto "${RCLONE_REMOTE}/audio/<timestamp>.tar.gz" /tmp/restore.tar.gz &&
+    tar xzf /tmp/restore.tar.gz -C /var/audio &&
+    rm /tmp/restore.tar.gz
+  '
+```
+
+…except `/var/audio` is mounted read-only inside the backup container by design, so audio restores actually need a one-off container with the volume in read-write mode:
+
+```bash
+docker run --rm \
+  -v ciareader-prod_audio-data:/dst \
+  -v ciareader-prod_rclone-config:/config/rclone:ro \
+  alpine sh -c '
+    apk add --no-cache rclone tar &&
+    rclone --config /config/rclone/rclone.conf \
+      copyto "<remote>:<bucket>/audio/<timestamp>.tar.gz" /tmp/audio.tar.gz &&
+    tar xzf /tmp/audio.tar.gz -C /dst
+  '
+```
+
+## Test-restore-once checklist
+
+Per the T-13.3 ticket spec — verify a restore actually works once, before betting real data on it.
+
+1. Trigger a one-shot DB dump (see "Verify backups").
+2. `docker compose -f infra/docker-compose.prod.yml --env-file infra/.env exec postgres psql -U ciareader -d ciareader -c "SELECT count(*) FROM lemmas;"` — note the count.
+3. Spin up a throwaway postgres and restore into it (don't restore over prod):
+   ```bash
+   docker run --rm -d --name pgtest -e POSTGRES_PASSWORD=test -p 25432:5432 postgres:16-alpine
+   sleep 5
+   docker run --rm \
+     --network ciareader-prod_internal \
+     -v ciareader-prod_rclone-config:/config/rclone:ro \
+     ciareader-prod-backup sh -c '
+       rclone --config /config/rclone/rclone.conf \
+         copyto "${RCLONE_REMOTE}/db/<timestamp>.sql.gz" /tmp/d.sql.gz &&
+       gunzip -c /tmp/d.sql.gz |
+       PGPASSWORD=test psql -h host.docker.internal -p 25432 -U postgres -d postgres
+     '
+   PGPASSWORD=test psql -h localhost -p 25432 -U postgres -d postgres -c "SELECT count(*) FROM lemmas;"
+   docker stop pgtest
+   ```
+4. The two counts should match. If they do, the backup pipeline is sound.

--- a/infra/backup/backup-audio.sh
+++ b/infra/backup/backup-audio.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Weekly tar.gz of the audio-data volume → rclone upload, then prune.
+# Sourced env: RCLONE_REMOTE, AUDIO_RETENTION_DAYS, BACKUP_RETENTION_DAYS
+set -euo pipefail
+
+# Defensive defaults so the script also works when invoked outside the
+# entrypoint (e.g. ad-hoc one-shot run via `docker compose exec`).
+: "${BACKUP_RETENTION_DAYS:=14}"
+: "${AUDIO_RETENTION_DAYS:=$((BACKUP_RETENTION_DAYS * 4))}"
+
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+PFX="[backup-audio $TS]"
+TMP="/tmp/audio-${TS}.tar.gz"
+REMOTE="${RCLONE_REMOTE}/audio/${TS}.tar.gz"
+RCLONE_CONF=/config/rclone/rclone.conf
+
+trap 'rm -f "$TMP"' EXIT
+
+echo "$PFX starting"
+
+# Empty volume => nothing to back up. Skip rather than upload an
+# 0-byte tarball that costs API calls + hides a real "lost data"
+# signal in the next run.
+if [ -z "$(ls -A /var/audio 2>/dev/null)" ]; then
+  echo "$PFX /var/audio is empty; nothing to back up"
+  exit 0
+fi
+
+# tar from inside the dir (-C) so the archive is rooted at . and
+# extracts cleanly into a freshly-mounted volume on restore.
+tar czf "$TMP" -C /var/audio .
+
+SIZE=$(stat -c %s "$TMP")
+echo "$PFX tarball ${SIZE} bytes -> $REMOTE"
+
+rclone copyto "$TMP" "$REMOTE" \
+  --config "$RCLONE_CONF" \
+  --stats-one-line --stats=10s
+
+echo "$PFX pruning > ${AUDIO_RETENTION_DAYS}d from ${RCLONE_REMOTE}/audio/"
+rclone delete \
+  --config "$RCLONE_CONF" \
+  --min-age "${AUDIO_RETENTION_DAYS}d" \
+  "${RCLONE_REMOTE}/audio/" || true
+
+echo "$PFX done"

--- a/infra/backup/backup-db.sh
+++ b/infra/backup/backup-db.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Nightly pg_dump → gzip → rclone upload, then prune old remote dumps.
+# Sourced env vars: POSTGRES_USER POSTGRES_PASSWORD POSTGRES_DB
+#                   RCLONE_REMOTE BACKUP_RETENTION_DAYS
+set -euo pipefail
+
+# Defensive default so the script also works when invoked outside the
+# entrypoint (e.g. ad-hoc one-shot run via `docker compose exec`).
+: "${BACKUP_RETENTION_DAYS:=14}"
+
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+PFX="[backup-db $TS]"
+TMP="/tmp/db-${TS}.sql.gz"
+REMOTE="${RCLONE_REMOTE}/db/${TS}.sql.gz"
+RCLONE_CONF=/config/rclone/rclone.conf
+
+trap 'rm -f "$TMP"' EXIT
+
+echo "$PFX starting"
+
+# --clean --if-exists makes the dump self-restoring (drops existing
+# tables before recreating). --no-owner / --no-privileges so a
+# restore into a freshly-migrated DB doesn't fight ownership /
+# GRANT statements.
+PGPASSWORD="$POSTGRES_PASSWORD" pg_dump \
+  --host=postgres \
+  --port=5432 \
+  --username="$POSTGRES_USER" \
+  --dbname="$POSTGRES_DB" \
+  --no-owner \
+  --no-privileges \
+  --clean \
+  --if-exists \
+  | gzip --best > "$TMP"
+
+SIZE=$(stat -c %s "$TMP")
+echo "$PFX dump ${SIZE} bytes -> $REMOTE"
+
+rclone copyto "$TMP" "$REMOTE" \
+  --config "$RCLONE_CONF" \
+  --stats-one-line --stats=10s
+
+echo "$PFX pruning > ${BACKUP_RETENTION_DAYS}d from ${RCLONE_REMOTE}/db/"
+rclone delete \
+  --config "$RCLONE_CONF" \
+  --min-age "${BACKUP_RETENTION_DAYS}d" \
+  "${RCLONE_REMOTE}/db/" || true
+
+echo "$PFX done"

--- a/infra/backup/crontab
+++ b/infra/backup/crontab
@@ -1,0 +1,12 @@
+# Backup schedule. Times are UTC (TZ pinned in the Dockerfile).
+#
+# Each line sources /etc/backup-env (written by the entrypoint) so
+# the script sees POSTGRES_*, RCLONE_REMOTE, *_RETENTION_DAYS — cron
+# starts children with a near-empty env. Output is redirected to
+# crond's stdout/stderr (PID 1) so it lands in `docker compose logs`.
+
+# Postgres dump nightly at 03:05 UTC.
+5 3 * * * /bin/bash -c '. /etc/backup-env && /usr/local/bin/backup-db.sh' > /proc/1/fd/1 2> /proc/1/fd/2
+
+# Audio tarball every Sunday at 04:05 UTC.
+5 4 * * 0 /bin/bash -c '. /etc/backup-env && /usr/local/bin/backup-audio.sh' > /proc/1/fd/1 2> /proc/1/fd/2

--- a/infra/backup/entrypoint.sh
+++ b/infra/backup/entrypoint.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Validates required env, persists it for cron children (cron's own
+# shell starts with a near-empty env), then exec crond in foreground.
+set -euo pipefail
+
+require() {
+  # Prints the *name* if missing — never the value.
+  local name="$1"
+  if [ -z "${!name:-}" ]; then
+    echo "[backup] env var $name is required" >&2
+    exit 1
+  fi
+}
+
+require POSTGRES_USER
+require POSTGRES_PASSWORD
+require POSTGRES_DB
+require RCLONE_REMOTE
+: "${BACKUP_RETENTION_DAYS:=14}"
+: "${AUDIO_RETENTION_DAYS:=$((BACKUP_RETENTION_DAYS * 4))}"
+
+if [ ! -f /config/rclone/rclone.conf ]; then
+  echo "[backup] rclone config missing at /config/rclone/rclone.conf." >&2
+  echo "[backup] One-time setup: docker compose -f infra/docker-compose.prod.yml \\" >&2
+  echo "          --env-file infra/.env run --rm -it backup \\" >&2
+  echo "          rclone config --config /config/rclone/rclone.conf" >&2
+  echo "[backup] See infra/backup/README.md for the full procedure." >&2
+  exit 1
+fi
+
+# cron starts each job with a near-empty env. Persist what the
+# scripts need so they don't have to read it from /proc or args.
+# 0600 because the password is in here.
+umask 077
+{
+  printf 'POSTGRES_USER=%s\n'         "$POSTGRES_USER"
+  printf 'POSTGRES_PASSWORD=%s\n'     "$POSTGRES_PASSWORD"
+  printf 'POSTGRES_DB=%s\n'           "$POSTGRES_DB"
+  printf 'RCLONE_REMOTE=%s\n'         "$RCLONE_REMOTE"
+  printf 'BACKUP_RETENTION_DAYS=%s\n' "$BACKUP_RETENTION_DAYS"
+  printf 'AUDIO_RETENTION_DAYS=%s\n'  "$AUDIO_RETENTION_DAYS"
+} > /etc/backup-env
+umask 022
+
+echo "[backup] startup ok. cron schedule:"
+sed 's/^/  /' /etc/crontabs/root
+echo "[backup] retention: db=${BACKUP_RETENTION_DAYS}d audio=${AUDIO_RETENTION_DAYS}d"
+echo "[backup] remote: ${RCLONE_REMOTE}"
+echo ""
+
+# crond -f keeps it in the foreground so docker logging captures it.
+# -l 8 = info-level cron-daemon logging; -L /dev/stdout = its own log
+# (job stdout/stderr is redirected per-line via /proc/1/fd/* so it
+# always lands in docker logs regardless of cron's mailto behavior).
+exec crond -f -l 8 -L /dev/stdout

--- a/infra/backup/entrypoint.sh
+++ b/infra/backup/entrypoint.sh
@@ -1,7 +1,18 @@
 #!/bin/bash
 # Validates required env, persists it for cron children (cron's own
 # shell starts with a near-empty env), then exec crond in foreground.
+#
+# If args are passed (e.g. `docker compose run --rm -it backup
+# rclone config`), exec them directly without the validation/cron
+# path. This is the standard "ENTRYPOINT pass-through" pattern —
+# lets operators run one-off commands like the rclone OAuth setup
+# without the entrypoint blocking on the very config it's about to
+# create.
 set -euo pipefail
+
+if [ "$#" -gt 0 ]; then
+  exec "$@"
+fi
 
 require() {
   # Prints the *name* if missing — never the value.

--- a/infra/backup/restore-db.sh
+++ b/infra/backup/restore-db.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Helper: pull a dump from the remote and pipe it back into Postgres.
+# Run from the backup container — it has rclone + postgres-client
+# already, and is on the same network as the postgres service.
+#
+# Usage:
+#   docker compose -f infra/docker-compose.prod.yml --env-file infra/.env \
+#     exec backup restore-db.sh <timestamp>
+#   # or 'latest' to pick the most recent dump
+#
+# WARNING: the dump was taken with --clean --if-exists, so applying
+# it drops every table in $POSTGRES_DB before recreating. Take a
+# fresh backup *now* before running restore against a DB you care
+# about.
+set -euo pipefail
+
+# shellcheck disable=SC1091
+. /etc/backup-env
+
+ARG="${1:-}"
+RCLONE_CONF=/config/rclone/rclone.conf
+
+if [ -z "$ARG" ]; then
+  echo "usage: restore-db.sh <YYYYMMDDTHHMMSSZ | latest>" >&2
+  echo "" >&2
+  echo "available remote dumps:" >&2
+  rclone lsf --config "$RCLONE_CONF" "${RCLONE_REMOTE}/db/" >&2 || true
+  exit 1
+fi
+
+if [ "$ARG" = "latest" ]; then
+  ARG=$(rclone lsf --config "$RCLONE_CONF" "${RCLONE_REMOTE}/db/" | sort | tail -n1)
+  if [ -z "$ARG" ]; then
+    echo "no dumps found at ${RCLONE_REMOTE}/db/" >&2
+    exit 1
+  fi
+  echo "[restore] using latest: $ARG"
+fi
+
+# Add .sql.gz suffix if user passed only the timestamp.
+case "$ARG" in
+  *.sql.gz) FILE="$ARG" ;;
+  *)        FILE="${ARG}.sql.gz" ;;
+esac
+
+REMOTE="${RCLONE_REMOTE}/db/${FILE}"
+TMP="/tmp/restore-${FILE}"
+trap 'rm -f "$TMP"' EXIT
+
+echo "[restore] downloading $REMOTE"
+rclone copyto --config "$RCLONE_CONF" "$REMOTE" "$TMP"
+
+echo "[restore] applying to ${POSTGRES_DB} on postgres:5432"
+PGPASSWORD="$POSTGRES_PASSWORD" gunzip -c "$TMP" | \
+  psql --host=postgres --port=5432 \
+       --username="$POSTGRES_USER" \
+       --dbname="$POSTGRES_DB" \
+       --single-transaction \
+       --set=ON_ERROR_STOP=on \
+       --quiet
+
+echo "[restore] done. verify rows in postgres."

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -197,6 +197,41 @@ services:
         max-size: "10m"
         max-file: "5"
 
+  backup:
+    build:
+      context: ./backup
+      dockerfile: Dockerfile
+    restart: always
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - internal
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-ciareader}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in infra/.env}
+      POSTGRES_DB: ${POSTGRES_DB:-ciareader}
+      RCLONE_REMOTE: ${RCLONE_REMOTE:?RCLONE_REMOTE must be set in infra/.env, e.g. dropbox:ciareader-backups}
+      BACKUP_RETENTION_DAYS: ${BACKUP_RETENTION_DAYS:-14}
+      AUDIO_RETENTION_DAYS: ${AUDIO_RETENTION_DAYS:-}
+    volumes:
+      # Read-only mount of the audio volume so the weekly tar can
+      # see uploads without touching them.
+      - audio-data:/var/audio:ro
+      # Persists the rclone OAuth token across container recreation.
+      # First-time setup: see infra/backup/README.md.
+      - rclone-config:/config/rclone
+    deploy:
+      resources:
+        limits:
+          memory: 256m
+          cpus: "0.25"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
+
 # Two networks so postgres / redis / nlp / web stay invisible to the
 # public side. Only caddy bridges both.
 networks:
@@ -208,9 +243,12 @@ networks:
 volumes:
   postgres-data: {}
   redis-data: {}
-  caddy-data: {}    # ACME state (T-13.2 will rely on this surviving restarts)
+  caddy-data: {}    # ACME state — survives restarts so cert renewal is seamless.
   caddy-config: {}
   audio-data: {}    # Object storage backend lives here for the local-fs
                     # mode. Switching to Hetzner Object Storage (S3 API)
                     # is a follow-up — env hooks (AUDIO_S3_*) are already
                     # documented in .env.prod.example.
+  rclone-config: {} # Backup service's rclone config (Dropbox/B2/etc OAuth
+                    # token). Survives container recreation so re-auth
+                    # isn't needed after every deploy.

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -202,6 +202,11 @@ services:
       context: ./backup
       dockerfile: Dockerfile
     restart: always
+    # Run tini as PID 1 so dcron (which runs as crond's child) can
+    # successfully setpgid. Without this, busybox dcron exits at
+    # startup with `setpgid: Operation not permitted` (kernel rule:
+    # PID 1 cannot change its process group).
+    init: true
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary

Adds a `backup` sidecar service to the prod compose stack. Cron jobs run nightly + weekly, push artifacts to whatever cloud remote the operator has configured via `rclone` (Dropbox / B2 / Hetzner Storage Box — anything rclone supports). Old artifacts are pruned by age.

## What's in it

```
infra/backup/
├── Dockerfile         alpine + rclone + pg_dump + dcron + bash + tar + gzip
├── entrypoint.sh      env validation, persists vars for cron, exec crond -f
├── crontab            5 3 * * *  → backup-db.sh
│                      5 4 * * 0  → backup-audio.sh
├── backup-db.sh       pg_dump → gzip → rclone copyto → rclone delete --min-age
├── backup-audio.sh    tar.gz of /var/audio → rclone copyto → prune
├── restore-db.sh      rclone copyto from remote → gunzip | psql
└── README.md          rclone OAuth setup walkthrough + restore procedure
```

Compose changes:
- New `backup` service. Read-only mount of `audio-data`, named volume `rclone-config` (persists OAuth state across container recreation), `depends_on: postgres healthy`.
- New env vars: `RCLONE_REMOTE` (required, e.g. `dropbox:ciareader-backups`), `BACKUP_RETENTION_DAYS` (default 14), `AUDIO_RETENTION_DAYS` (default = `4 * BACKUP_RETENTION_DAYS`).

`.env.prod.example`: documents the new vars with provider examples.

Root README: short pointer to `infra/backup/README.md`.

## Why a sidecar (not host cron)

- Self-contained: no host-side `rclone` / `pg_dump` install to maintain.
- Same compose, same `up -d` operating model — nothing new to learn.
- Internal-network access to postgres: backup never traverses the public side.
- Logs land in `docker compose logs backup` like every other service.

## First-time setup (operator)

After merging + pulling on the box:

```bash
# 1. Set RCLONE_REMOTE in infra/.env (full options in .env.prod.example).

# 2. Walk the OAuth handshake once. Run interactively:
docker compose -f infra/docker-compose.prod.yml --env-file infra/.env \
  run --rm -it backup rclone config --config /config/rclone/rclone.conf

# 3. Bring it up.
docker compose -f infra/docker-compose.prod.yml --env-file infra/.env up -d backup

# 4. Trigger a one-shot run to verify:
docker compose -f infra/docker-compose.prod.yml --env-file infra/.env \
  exec backup /bin/bash -c '. /etc/backup-env && /usr/local/bin/backup-db.sh'
```

Detailed walkthrough — including the headless-OAuth flow and the laptop-side alternative — is in [`infra/backup/README.md`](infra/backup/README.md).

## Test plan

Validated end-to-end **locally before pushing** (no more rebuild-on-prod-and-find-out):

- [x] `docker compose -f infra/docker-compose.prod.yml --env-file infra/.env config` exits 0.
- [x] `docker build` of the backup image succeeds; resulting image has all required tools (rclone v1.66, `pg_dump` 16.13, `gzip`, `tar`, `crond`, `bash`) and all four scripts.
- [x] Missing `POSTGRES_PASSWORD` fails fast with the var **name** in the message — no value ever leaks into stderr.
- [x] Missing `/config/rclone/rclone.conf` fails with a pointer to the README.
- [x] Full DB-backup roundtrip: real postgres → `backup-db.sh` → fake `[local]` rclone backend → 554-byte dump → restore-into-a-fresh-postgres → rows match original. (Trick: `[local] type = local` rclone config + a host bind-mount serves as a stand-in for Dropbox without needing OAuth.)
- [x] Audio backup with content: tars + uploads.
- [x] Audio backup with an empty volume: skips cleanly without uploading 0-byte tarballs.
- [x] Defensive defaults (`BACKUP_RETENTION_DAYS=14`, `AUDIO_RETENTION_DAYS=$((BACKUP_RETENTION_DAYS * 4))`) make scripts work both inside the cron-driven flow AND in ad-hoc one-shot invocations.
- [ ] Reviewer: real Dropbox OAuth + a 24h cycle to confirm cron actually fires. Hard to test without burning a day; the structural pieces above cover everything except the schedule itself, which is plain dcron.
- [ ] Reviewer: run the "Test-restore-once" checklist from `infra/backup/README.md` once your remote is configured.

## What this unblocks

Now that backups exist, the prod box at parhiba.com can in good conscience accept signups, audio uploads, etc. Before T-13.3, any data on it was implicitly disposable. After it's running, it isn't.

Closes #113.