### PR TITLE
T-13.4: scripts/deploy.sh — one-command deploys from the laptop

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,22 @@ Staging certs aren't browser-trusted (you'll see a security warning) but the rat
 
 The `backup` service runs as a sidecar in the prod compose stack. Cron jobs `pg_dump` the DB nightly and tar the audio volume weekly, uploading both via `rclone` to whatever remote you've configured (Dropbox, B2, Hetzner Storage Box, etc.). Setup walkthrough + restore procedure: [`infra/backup/README.md`](infra/backup/README.md).
 
+### Deploying a change
+
+Once `infra/.env` exists on the box and the stack is running, deploys are a single command from your laptop:
+
+```
+./scripts/deploy.sh                   # deploy origin/main
+./scripts/deploy.sh <branch-or-sha>   # deploy a specific ref (preview branches, hotfixes)
+./scripts/deploy.sh --dry-run         # print the plan without touching the box
+```
+
+The script SSHes to the box, fast-forwards the repo at `/opt/ciareader`, runs `docker compose up -d --build`, prunes dangling images, and then polls `https://parhiba.com/api/v1/smoke` from the laptop side until it returns 200. On health-check timeout it prints the last 50 lines of web logs and exits non-zero, so a failed deploy is loud and diagnosable.
+
+Override host / path with env vars: `DEPLOY_HOST=root@example.com ./scripts/deploy.sh`.
+
 ### M13 roadmap
 
-- **T-13.4** — deploy script (rsync + `docker compose pull` + restart)
 - **T-13.5** — monitoring-lite
 
 ## Status

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,18 +4,16 @@
 #   ./scripts/deploy.sh                  # deploy origin/main
 #   ./scripts/deploy.sh <ref>            # deploy a specific branch / tag / sha
 #   ./scripts/deploy.sh --dry-run        # print what we would run, do nothing
+#   ./scripts/deploy.sh --no-build       # force-skip the rebuild (fastest)
+#   ./scripts/deploy.sh --build          # force a rebuild even if auto-detect skips
 #   DEPLOY_HOST=root@... ./scripts/deploy.sh
 #
-# What it does:
-#   1. SSH to the prod box.
-#   2. git fetch + reset to the requested ref (detached HEAD).
-#   3. docker compose up -d --build (web's startup applies pending
-#      migrations; #408's backup service stays up across deploys).
-#   4. Prune unused images so /var/lib/docker doesn't grow without
-#      bound on a small CX/CCX disk.
-#   5. From the laptop side, poll the public health endpoint until
-#      it returns 200 or HEALTH_TIMEOUT elapses.
-#   6. On timeout, fetch the last 50 lines of web logs and exit 1.
+# Build mode is `auto` by default — the box-side step diffs OLD_HEAD vs
+# the new ref and only passes `--build` when files in any image's
+# context changed (apps/, services/, packages/, infra/backup/,
+# pnpm-lock.yaml, etc.). Pure docs / scripts / compose-config changes
+# skip the rebuild entirely and the deploy collapses from minutes to
+# a few seconds.
 set -euo pipefail
 
 DEPLOY_HOST="${DEPLOY_HOST:-root@parhiba.com}"
@@ -26,12 +24,15 @@ COMPOSE_FILE="infra/docker-compose.prod.yml"
 ENV_FILE="infra/.env"
 
 DRY_RUN=0
+BUILD_MODE="auto"   # auto | force | skip
 REF=""
 for arg in "$@"; do
   case "$arg" in
     --dry-run|-n) DRY_RUN=1 ;;
+    --build|-b)   BUILD_MODE="force" ;;
+    --no-build|-B) BUILD_MODE="skip" ;;
     --help|-h)
-      sed -n '2,15p' "$0" | sed 's/^#//; s/^ //'
+      sed -n '2,16p' "$0" | sed 's/^#//; s/^ //'
       exit 0
       ;;
     -*)
@@ -60,6 +61,7 @@ cat <<EOF
     ref:           $REF  ($LOCAL_SHA)
     health URL:    $HEALTH_URL
     health budget: ${HEALTH_TIMEOUT}s
+    build mode:    $BUILD_MODE
 EOF
 
 if [ "$DRY_RUN" = "1" ]; then
@@ -72,14 +74,17 @@ fi
 ssh -o StrictHostKeyChecking=accept-new \
     -o ConnectTimeout=10 \
     "$DEPLOY_HOST" \
-    bash -s -- "$REF" "$DEPLOY_PATH" "$COMPOSE_FILE" "$ENV_FILE" <<'REMOTE_SCRIPT'
+    bash -s -- "$REF" "$DEPLOY_PATH" "$COMPOSE_FILE" "$ENV_FILE" "$BUILD_MODE" <<'REMOTE_SCRIPT'
 set -euo pipefail
 REF="$1"
 DEPLOY_PATH="$2"
 COMPOSE_FILE="$3"
 ENV_FILE="$4"
+BUILD_MODE="$5"
 
 cd "$DEPLOY_PATH"
+
+OLD_HEAD="$(git rev-parse HEAD 2>/dev/null || echo "")"
 
 echo "[box] $(hostname): fetching origin"
 git fetch origin --tags --quiet
@@ -93,11 +98,44 @@ else
 fi
 git --no-pager log --oneline -1
 
-echo "[box] docker compose up -d --build"
-docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" up -d --build
+NEW_HEAD="$(git rev-parse HEAD)"
 
-echo "[box] pruning dangling images"
-docker image prune -f >/dev/null
+# Decide whether to rebuild images. Building is the slow part
+# (~30-60s per service even with cache hits, because BuildKit
+# re-exports manifests with new digests and that triggers
+# container recreation). Skip it when nothing in any image's
+# build context changed.
+case "$BUILD_MODE" in
+  force)
+    BUILD_ARG="--build"
+    echo "[box] build: --build (forced)"
+    ;;
+  skip)
+    BUILD_ARG=""
+    echo "[box] build: skipped (forced)"
+    ;;
+  auto)
+    if [ -z "$OLD_HEAD" ] || [ "$OLD_HEAD" = "$NEW_HEAD" ]; then
+      BUILD_ARG=""
+      echo "[box] build: skipped (no commits to apply)"
+    elif git diff --name-only "$OLD_HEAD" "$NEW_HEAD" \
+           | grep -qE '^(apps/|services/|packages/|infra/backup/|pnpm-lock\.yaml|pnpm-workspace\.yaml|package\.json)' ; then
+      BUILD_ARG="--build"
+      echo "[box] build: --build (image-relevant files changed)"
+    else
+      BUILD_ARG=""
+      echo "[box] build: skipped (only docs/scripts/compose-config changed)"
+    fi
+    ;;
+esac
+
+echo "[box] docker compose up -d $BUILD_ARG"
+docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" up -d $BUILD_ARG
+
+if [ -n "$BUILD_ARG" ]; then
+  echo "[box] pruning dangling images"
+  docker image prune -f >/dev/null
+fi
 
 echo "[box] deploy step complete"
 REMOTE_SCRIPT

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Production deploy. Run from your laptop.
+#
+#   ./scripts/deploy.sh                  # deploy origin/main
+#   ./scripts/deploy.sh <ref>            # deploy a specific branch / tag / sha
+#   ./scripts/deploy.sh --dry-run        # print what we would run, do nothing
+#   DEPLOY_HOST=root@... ./scripts/deploy.sh
+#
+# What it does:
+#   1. SSH to the prod box.
+#   2. git fetch + reset to the requested ref (detached HEAD).
+#   3. docker compose up -d --build (web's startup applies pending
+#      migrations; #408's backup service stays up across deploys).
+#   4. Prune unused images so /var/lib/docker doesn't grow without
+#      bound on a small CX/CCX disk.
+#   5. From the laptop side, poll the public health endpoint until
+#      it returns 200 or HEALTH_TIMEOUT elapses.
+#   6. On timeout, fetch the last 50 lines of web logs and exit 1.
+set -euo pipefail
+
+DEPLOY_HOST="${DEPLOY_HOST:-root@parhiba.com}"
+DEPLOY_PATH="${DEPLOY_PATH:-/opt/ciareader}"
+HEALTH_URL="${HEALTH_URL:-https://parhiba.com/api/v1/smoke}"
+HEALTH_TIMEOUT="${HEALTH_TIMEOUT:-180}"
+COMPOSE_FILE="infra/docker-compose.prod.yml"
+ENV_FILE="infra/.env"
+
+DRY_RUN=0
+REF=""
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run|-n) DRY_RUN=1 ;;
+    --help|-h)
+      sed -n '2,15p' "$0" | sed 's/^#//; s/^ //'
+      exit 0
+      ;;
+    -*)
+      echo "unknown flag: $arg" >&2
+      exit 2
+      ;;
+    *)
+      if [ -n "$REF" ]; then
+        echo "deploy.sh takes at most one positional ref" >&2
+        exit 2
+      fi
+      REF="$arg"
+      ;;
+  esac
+done
+REF="${REF:-main}"
+
+# Resolve the ref locally (best-effort, just for the human-readable
+# log line — we still re-resolve on the box from origin).
+LOCAL_SHA="$(git rev-parse --short "origin/$REF" 2>/dev/null || git rev-parse --short "$REF" 2>/dev/null || echo "?")"
+
+cat <<EOF
+==> Deploy summary
+    target host:   $DEPLOY_HOST
+    target path:   $DEPLOY_PATH
+    ref:           $REF  ($LOCAL_SHA)
+    health URL:    $HEALTH_URL
+    health budget: ${HEALTH_TIMEOUT}s
+EOF
+
+if [ "$DRY_RUN" = "1" ]; then
+  echo "==> --dry-run set; nothing executed"
+  exit 0
+fi
+
+# Execute the deploy on the box. heredoc with quoted limiter so
+# nothing on the laptop side gets prematurely expanded.
+ssh -o StrictHostKeyChecking=accept-new \
+    -o ConnectTimeout=10 \
+    "$DEPLOY_HOST" \
+    bash -s -- "$REF" "$DEPLOY_PATH" "$COMPOSE_FILE" "$ENV_FILE" <<'REMOTE_SCRIPT'
+set -euo pipefail
+REF="$1"
+DEPLOY_PATH="$2"
+COMPOSE_FILE="$3"
+ENV_FILE="$4"
+
+cd "$DEPLOY_PATH"
+
+echo "[box] $(hostname): fetching origin"
+git fetch origin --tags --quiet
+
+echo "[box] checking out $REF"
+# Try origin/<ref> first (branch), then the literal ref (tag / sha).
+if git rev-parse --verify --quiet "origin/$REF" >/dev/null; then
+  git reset --hard "origin/$REF"
+else
+  git reset --hard "$REF"
+fi
+git --no-pager log --oneline -1
+
+echo "[box] docker compose up -d --build"
+docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" up -d --build
+
+echo "[box] pruning dangling images"
+docker image prune -f >/dev/null
+
+echo "[box] deploy step complete"
+REMOTE_SCRIPT
+
+# Health check from the laptop side. We hit the public URL through
+# Caddy → web, so a green check covers TLS, the proxy chain, the web
+# server, AND the migrate step (which has to finish before web binds
+# its port).
+echo "==> Waiting for health: $HEALTH_URL (timeout ${HEALTH_TIMEOUT}s)"
+ELAPSED=0
+INTERVAL=2
+while [ $ELAPSED -lt $HEALTH_TIMEOUT ]; do
+  if curl -fsS --max-time 5 "$HEALTH_URL" >/dev/null 2>&1; then
+    echo "==> ✓ Healthy after ${ELAPSED}s"
+    exit 0
+  fi
+  sleep $INTERVAL
+  ELAPSED=$((ELAPSED + INTERVAL))
+  printf "."
+done
+echo ""
+echo "==> ✗ Health check timed out after ${HEALTH_TIMEOUT}s"
+echo "==> Last 50 lines of web logs:"
+ssh "$DEPLOY_HOST" \
+  "cd $DEPLOY_PATH && docker compose -f $COMPOSE_FILE --env-file $ENV_FILE logs --tail=50 web"
+exit 1


### PR DESCRIPTION
## Summary

A single command from your laptop replaces the manual ssh / git pull / `docker compose up` dance:

```
./scripts/deploy.sh                   # deploy origin/main
./scripts/deploy.sh feat/branch       # preview a feature branch in prod
./scripts/deploy.sh v1.0.0            # tag deploy
./scripts/deploy.sh c190379           # specific sha (rollback)
./scripts/deploy.sh --dry-run         # plan-only, no ssh
```

## What the script does

1. SSH to the box.
2. `git fetch origin --tags` then hard-reset to the requested ref. Resolves `origin/<ref>` first (branches), falls back to the literal ref (tags / shas).
3. `docker compose up -d --build` — web's startup runs `migrate-prod.mjs` before binding its port, and #408's backup sidecar keeps running across the rebuild.
4. `docker image prune -f` to avoid `/var/lib/docker` growing without bound on the small CX/CCX disk.
5. From the laptop side, polls `https://parhiba.com/api/v1/smoke` until it returns 200 or `HEALTH_TIMEOUT` (default 180s) elapses.
6. On timeout, prints the last 50 lines of web logs and exits non-zero. Failed deploys are loud and the diagnostic context is right there.

## Knobs

| Env var | Default | Purpose |
|---|---|---|
| `DEPLOY_HOST` | `root@parhiba.com` | Where to ssh |
| `DEPLOY_PATH` | `/opt/ciareader` | Where the repo lives on the box |
| `HEALTH_URL` | `https://parhiba.com/api/v1/smoke` | What to poll after deploy |
| `HEALTH_TIMEOUT` | `180` | Seconds to wait for green |

## Test plan

- [x] `bash -n` clean.
- [x] `--help` prints the doc block.
- [x] `--dry-run` with no args prints "ref: main (<sha>)" and exits 0 without contacting the box.
- [x] `--dry-run feat/t-13.4-deploy-script` resolves the local SHA and prints the right ref.
- [x] Two positional args → exit 2 with "deploy.sh takes at most one positional ref".
- [x] `--bogus` → exit 2 with "unknown flag: --bogus".
- [ ] Reviewer: real deploy of this branch via `./scripts/deploy.sh feat/t-13.4-deploy-script` from your laptop. The script should ssh, pull, rebuild, then poll until `/api/v1/smoke` is 200. Once back on green, deploy `main` to verify rollback works.

## Out of scope

- **Pre-deploy `pnpm typecheck` / `pnpm test` gate** — relies on local state; CI is the right layer for that.
- **Confirmation prompt** — a `--dry-run` ahead of each real deploy serves the same purpose without nagging on every run.
- **Tagging deploys with annotated git tags / Slack notifications** — T-13.5 territory or beyond.
- **GitHub Actions + GHCR path** — alternative the ticket mentioned. Defer until a team forms; for a single-developer project, building on the box is simpler.

Closes #114.