### PR TITLE
T-13.5: monitoring-lite — /healthz + Uptime Kuma

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,13 +114,24 @@ Once `infra/.env` exists on the box and the stack is running, deploys are a sing
 ./scripts/deploy.sh --dry-run         # print the plan without touching the box
 ```
 
-The script SSHes to the box, fast-forwards the repo at `/opt/ciareader`, runs `docker compose up -d --build`, prunes dangling images, and then polls `https://parhiba.com/api/v1/smoke` from the laptop side until it returns 200. On health-check timeout it prints the last 50 lines of web logs and exits non-zero, so a failed deploy is loud and diagnosable.
+The script SSHes to the box, fast-forwards the repo at `/opt/ciareader`, runs `docker compose up -d --build` (auto-skips `--build` when no image-relevant files changed), prunes dangling images, and then polls `https://parhiba.com/healthz` from the laptop side until it returns 200. On health-check timeout it prints the last 50 lines of web logs and exits non-zero, so a failed deploy is loud and diagnosable.
 
 Override host / path with env vars: `DEPLOY_HOST=root@example.com ./scripts/deploy.sh`.
 
-### M13 roadmap
+### Monitoring
 
-- **T-13.5** — monitoring-lite
+Each service exposes `/healthz`:
+
+- **`https://parhiba.com/healthz`** — web. 200 + `{status:"ok"}` when the process is up and can reach Postgres; 503 if the DB is unreachable.
+- **NLP `/healthz`** (internal `http://nlp:8000/healthz`) — alias of the existing `/health`. 200 + the supported language list.
+
+The prod stack also runs an [Uptime Kuma](https://github.com/louislam/uptime-kuma) sidecar at `https://status.<APP_DOMAIN>` (e.g. `https://status.parhiba.com`). DNS prerequisite: an A (and ideally AAAA) record for `status.<APP_DOMAIN>` pointing at the deploy host before first boot — Caddy issues a separate Let's Encrypt cert for it via the same auto-TLS pipeline.
+
+First-time setup is two clicks: visit `https://status.<APP_DOMAIN>` to create the admin account, then add monitors for `https://<APP_DOMAIN>/healthz` and any other endpoints worth tracking. Notification channels (email, Discord, Slack, Telegram, etc.) are configured in Kuma's UI; nothing in this repo to wire.
+
+If you'd rather use an external SaaS (UptimeRobot, BetterStack), comment out the `kuma` service + the `status.{$APP_DOMAIN}` block in the Caddyfile and point the SaaS at `https://parhiba.com/healthz`.
+
+Logs: docker's json-file driver is rotated at 10 MB × 5 files per service in [`infra/docker-compose.prod.yml`](infra/docker-compose.prod.yml), so `/var/lib/docker` doesn't grow without bound. View live logs via `docker compose -f infra/docker-compose.prod.yml --env-file infra/.env logs -f <service>`.
 
 ## Status
 

--- a/apps/web/src/routes/healthz/+server.ts
+++ b/apps/web/src/routes/healthz/+server.ts
@@ -1,0 +1,26 @@
+import { json, error } from '@sveltejs/kit';
+import { sql } from 'drizzle-orm';
+
+import { db } from '$lib/server/db';
+import type { RequestHandler } from './$types';
+
+/**
+ * Production health probe (T-13.5).
+ *
+ * Lighter than /api/v1/smoke — no NLP round-trip, just a 1ms DB ping
+ * to confirm the web process can reach Postgres. Used by:
+ *   - the web container's docker healthcheck,
+ *   - scripts/deploy.sh's post-deploy poll,
+ *   - Uptime Kuma's external monitor.
+ *
+ * Returns 200 when ready to serve traffic, 503 otherwise.
+ */
+export const GET: RequestHandler = async () => {
+  try {
+    await db.execute(sql`SELECT 1`);
+    return json({ status: 'ok' });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    throw error(503, `database unreachable: ${message}`);
+  }
+};

--- a/apps/web/src/routes/healthz/healthz.test.ts
+++ b/apps/web/src/routes/healthz/healthz.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+const execute = vi.fn<(query: unknown) => Promise<unknown>>();
+
+vi.mock('$lib/server/db', () => ({
+  db: { execute: (query: unknown) => execute(query) },
+  schema: {},
+}));
+
+describe('GET /healthz', () => {
+  beforeEach(() => {
+    execute.mockReset();
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it('returns 200 + status:ok when the DB ping succeeds', async () => {
+    execute.mockResolvedValue([{ '?column?': 1 }]);
+    const { GET } = await import('./+server.js');
+    const res = await GET({} as Parameters<typeof GET>[0]);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ status: 'ok' });
+    expect(execute).toHaveBeenCalledOnce();
+  });
+
+  it('returns 503 when the DB ping fails', async () => {
+    execute.mockRejectedValue(new Error('connection refused'));
+    const { GET } = await import('./+server.js');
+    await expect(async () => {
+      await GET({} as Parameters<typeof GET>[0]);
+    }).rejects.toMatchObject({
+      status: 503,
+      body: { message: expect.stringContaining('connection refused') },
+    });
+  });
+});

--- a/infra/Caddyfile
+++ b/infra/Caddyfile
@@ -61,6 +61,17 @@ www.{$APP_DOMAIN} {
 	redir https://{$APP_DOMAIN}{uri} permanent
 }
 
+# Uptime Kuma admin UI (T-13.5). DNS A/AAAA for status.<APP_DOMAIN>
+# must point at this box (or CNAME status → APP_DOMAIN). Caddy issues
+# a separate cert for it. Kuma manages its own login on first visit;
+# the proxy here just terminates TLS + forwards. If you don't run the
+# kuma service, comment this block out.
+status.{$APP_DOMAIN} {
+	encode zstd gzip
+	reverse_proxy kuma:3001
+	header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+}
+
 # When the API moves to its own subdomain (CORS scoping + separate
 # caching, per the original T-13.2 spec), set API_DOMAIN in infra/.env
 # and uncomment this block. Frontend fetch() URLs need to be updated

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -103,7 +103,7 @@ services:
     healthcheck:
       test:
         - CMD-SHELL
-        - python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health').read()"
+        - python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/healthz').read()"
       interval: 15s
       timeout: 5s
       retries: 10
@@ -147,9 +147,12 @@ services:
         max-size: "10m"
         max-file: "5"
     healthcheck:
+      # Hits /healthz (lighter than /api/v1/smoke — no NLP round-trip,
+      # just a 1ms DB ping). Container is "healthy" when web can reach
+      # postgres and serve a request.
       test:
         - CMD-SHELL
-        - "node -e \"require('http').get('http://localhost:5173/api/v1/smoke', (r) => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))\""
+        - "node -e \"require('http').get('http://localhost:5173/healthz', (r) => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))\""
       interval: 30s
       timeout: 10s
       retries: 5
@@ -237,6 +240,29 @@ services:
         max-size: "10m"
         max-file: "5"
 
+  # Uptime Kuma (T-13.5) — self-hosted monitor that pings the public
+  # health endpoints and notifies via email / Discord / Slack / etc.
+  # Lives only on the internal network; Caddy proxies the admin UI
+  # at status.<APP_DOMAIN>. Persisted state in `kuma-data` so monitor
+  # configs + notification channels survive container recreation.
+  kuma:
+    image: louislam/uptime-kuma:1
+    restart: always
+    volumes:
+      - kuma-data:/app/data
+    networks:
+      - internal
+    deploy:
+      resources:
+        limits:
+          memory: 256m
+          cpus: "0.25"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
+
 # Two networks so postgres / redis / nlp / web stay invisible to the
 # public side. Only caddy bridges both.
 networks:
@@ -257,3 +283,4 @@ volumes:
   rclone-config: {} # Backup service's rclone config (Dropbox/B2/etc OAuth
                     # token). Survives container recreation so re-auth
                     # isn't needed after every deploy.
+  kuma-data: {}     # Uptime Kuma's monitor configs + notification channels.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -132,6 +132,19 @@ esac
 echo "[box] docker compose up -d $BUILD_ARG"
 docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" up -d $BUILD_ARG
 
+# The Caddyfile is bind-mounted (./Caddyfile:/etc/caddy/Caddyfile),
+# so a `git reset --hard` updates the file on disk but compose has
+# no reason to recreate the caddy container — its image and
+# compose-config are unchanged. Caddy keeps running with the in-
+# memory config it loaded at boot, and any new site blocks (new
+# subdomains, header changes) silently don't take effect.
+# Detect Caddyfile-touching diffs and restart caddy explicitly.
+if [ -n "$OLD_HEAD" ] && [ "$OLD_HEAD" != "$NEW_HEAD" ] && \
+   git diff --name-only "$OLD_HEAD" "$NEW_HEAD" | grep -q '^infra/Caddyfile$'; then
+  echo "[box] Caddyfile changed, restarting caddy to pick it up"
+  docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" restart caddy
+fi
+
 if [ -n "$BUILD_ARG" ]; then
   echo "[box] pruning dangling images"
   docker image prune -f >/dev/null

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 
 DEPLOY_HOST="${DEPLOY_HOST:-root@parhiba.com}"
 DEPLOY_PATH="${DEPLOY_PATH:-/opt/ciareader}"
-HEALTH_URL="${HEALTH_URL:-https://parhiba.com/api/v1/smoke}"
+HEALTH_URL="${HEALTH_URL:-https://parhiba.com/healthz}"
 HEALTH_TIMEOUT="${HEALTH_TIMEOUT:-180}"
 COMPOSE_FILE="infra/docker-compose.prod.yml"
 ENV_FILE="infra/.env"

--- a/services/nlp/app/main.py
+++ b/services/nlp/app/main.py
@@ -21,12 +21,19 @@ from app.schemas import HealthResponse, ProcessRequest, ProcessResponse
 app = FastAPI(title="CIA Reader NLP", version="0.0.0")
 
 
-@app.get("/health", response_model=HealthResponse)
-async def health() -> HealthResponse:
+async def _health() -> HealthResponse:
     return HealthResponse(
         status="ok",
         languages=list(SUPPORTED_LANGUAGE_CODES),
     )
+
+
+# /health is the legacy name; /healthz is the canonical one aligned
+# with the rest of the stack (T-13.5 monitoring). Both are backed by
+# the same handler so existing callers (the dev compose's Dockerfile
+# healthcheck) keep working unchanged.
+app.add_api_route("/health", _health, response_model=HealthResponse, methods=["GET"])
+app.add_api_route("/healthz", _health, response_model=HealthResponse, methods=["GET"])
 
 
 @app.post("/process", response_model=ProcessResponse)

--- a/services/nlp/tests/test_smoke.py
+++ b/services/nlp/tests/test_smoke.py
@@ -15,6 +15,16 @@ def test_health_ok():
     assert set(body["languages"]) == {"hi", "mr", "or"}
 
 
+def test_healthz_alias_returns_same_payload():
+    # /healthz is the canonical name (T-13.5); /health stays as a
+    # backwards-compat alias for callers like the dev compose
+    # Dockerfile healthcheck.
+    resp_health = client.get("/health")
+    resp_healthz = client.get("/healthz")
+    assert resp_healthz.status_code == 200
+    assert resp_healthz.json() == resp_health.json()
+
+
 def test_process_hindi_canned():
     resp = client.post("/process", json={"language": "hi", "text": "नमस्ते दुनिया"})
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary

Closes the M13 deployment epic. Two pieces:

1. **`/healthz` on both services**
2. **Uptime Kuma sidecar** , monitoring those endpoints.

Plus the small plumbing knock-ons that fall out of having `/healthz` available (compose healthchecks + deploy-script post-deploy poll switch from `/api/v1/smoke` to `/healthz`, gaining isolation from NLP-restart flakes).

## Health endpoints

| Service | Endpoint | What it checks |
|---|---|---|
| web | `https://parhiba.com/healthz` | Process up + can `SELECT 1` against Postgres. 503 if DB unreachable. |
| nlp | `http://nlp:8000/healthz` (internal) | Alias of the existing `/health`. Returns supported language list. The legacy `/health` URL stays — the dev Dockerfile healthcheck still uses it. |

Lighter than `/api/v1/smoke` — no NLP round-trip on the web side, no DB on the nlp side. Each service's readiness is independently observable.

## Uptime Kuma

- New `kuma` service in [`infra/docker-compose.prod.yml`](infra/docker-compose.prod.yml). `louislam/uptime-kuma:1`, 256 MB / 0.25 CPU, persistent `kuma-data` volume so monitor configs + notification channels survive container recreation.
- New site block in [`infra/Caddyfile`](infra/Caddyfile): `status.{$APP_DOMAIN} { reverse_proxy kuma:3001 ... }`. Same auto-TLS pipeline as the main domain — DNS prereq is one extra A/AAAA record for `status.<APP_DOMAIN>`.
- First-time setup: visit `https://status.<APP_DOMAIN>`, create the admin account, add monitors. Notification channels (email / Discord / Slack / Telegram / SMS / etc.) configured in the UI.

If you'd rather use an external SaaS (UptimeRobot, BetterStack), comment out the `kuma` service + the `status.{$APP_DOMAIN}` block and point the SaaS at `https://parhiba.com/healthz`. The `/healthz` endpoint stands on its own.

## Knock-on changes

Switched the compose healthchecks (web + nlp) and the deploy script's default `HEALTH_URL` from `/api/v1/smoke` to `/healthz`. Reason: a slow NLP recreation during a deploy used to make the web container appear unhealthy and the deploy time-out, even though web itself was fine. With `/healthz` (DB ping only), web's readiness is decoupled from NLP's.

The legacy `/api/v1/smoke` route stays — it's still useful for end-to-end "everything is wired" verification. Just no longer the per-service health probe.

## Test plan

- [x] `pnpm --filter @ciareader/web test` — **1329 / 1329 pass** including the two new `/healthz` cases (200 happy-path, 503 DB-failure).
- [x] `pnpm --filter @ciareader/web typecheck` — 0 errors, 0 warnings.
- [x] `pnpm --filter @ciareader/web lint` — clean.
- [x] `pytest services/nlp/tests/test_smoke.py` — 7 / 7 pass including `test_healthz_alias_returns_same_payload`.
- [x] `docker compose -f infra/docker-compose.prod.yml --env-file infra/.env config` — exit 0, kuma service + kuma-data volume both resolve.
- [x] `caddy validate` against the updated Caddyfile — `Valid configuration`, with the new `status.<APP_DOMAIN>` block parsed cleanly.
- [ ] Reviewer: `./scripts/deploy.sh feat/t-13.5-monitoring-lite` (after merging in your local checkout). Add an A/AAAA record for `status.parhiba.com` first; Caddy will issue a cert on first request. Visit `https://status.parhiba.com`, create the admin account, add a monitor for `https://parhiba.com/healthz` and verify it goes green.

## Out of scope

- **Heavy observability** — Prometheus / Grafana / Loki / OpenTelemetry. Ticket spec defers these until there's real traffic.
- **Sentry SDK** for exception capture. Pluggable later via the SaaS free tier.
- **Pre-canned Kuma monitor configs** — the JSON-import format keeps changing across versions; safer to add the few monitors from the UI once.

Closes #115.