### PR TITLE
T-3.14: admin UI for dictionary cache + imports

### DIFF
--- a/apps/web/drizzle/0034_smiling_mockingbird.sql
+++ b/apps/web/drizzle/0034_smiling_mockingbird.sql
@@ -1,0 +1,10 @@
+ALTER TABLE "dictionary_imports" ADD COLUMN "triggered_by_user_id" uuid;--> statement-breakpoint
+ALTER TABLE "dictionary_imports" ADD COLUMN "status" text DEFAULT 'succeeded' NOT NULL;--> statement-breakpoint
+ALTER TABLE "dictionary_imports" ADD COLUMN "error_message" text;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "dictionary_imports" ADD CONSTRAINT "dictionary_imports_triggered_by_user_id_users_id_fk" FOREIGN KEY ("triggered_by_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "dictionary_imports_source_latest_idx" ON "dictionary_imports" USING btree ("source_name","run_at");

--- a/apps/web/drizzle/meta/0034_snapshot.json
+++ b/apps/web/drizzle/meta/0034_snapshot.json
@@ -1,0 +1,5354 @@
+{
+  "id": "e98af320-0fb0-4c0a-b41c-e9694d10c55b",
+  "prevId": "2f2efabf-a926-4b56-a98d-008943af438e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_rate_limit_events": {
+      "name": "api_rate_limit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_hash": {
+          "name": "subject_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_rate_limit_events_subject_window_idx": {
+          "name": "api_rate_limit_events_subject_window_idx",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_rate_limit_events_user_idx": {
+          "name": "api_rate_limit_events_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_rate_limit_events_user_id_users_id_fk": {
+          "name": "api_rate_limit_events_user_id_users_id_fk",
+          "tableFrom": "api_rate_limit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.audio_alignments": {
+      "name": "audio_alignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "audio_file_id": {
+          "name": "audio_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_ms": {
+          "name": "start_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_ms": {
+          "name": "end_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "alignment_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audio_alignments_timeline_idx": {
+          "name": "audio_alignments_timeline_idx",
+          "columns": [
+            {
+              "expression": "audio_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audio_alignments_audio_file_id_audio_files_id_fk": {
+          "name": "audio_alignments_audio_file_id_audio_files_id_fk",
+          "tableFrom": "audio_alignments",
+          "tableTo": "audio_files",
+          "columnsFrom": [
+            "audio_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audio_alignments_token_id_text_tokens_id_fk": {
+          "name": "audio_alignments_token_id_text_tokens_id_fk",
+          "tableFrom": "audio_alignments",
+          "tableTo": "text_tokens",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "audio_alignments_audio_file_id_token_id_uq": {
+          "name": "audio_alignments_audio_file_id_token_id_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "audio_file_id",
+            "token_id"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.audio_files": {
+      "name": "audio_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime": {
+          "name": "mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license": {
+          "name": "license",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by_id": {
+          "name": "uploaded_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audio_files_text_idx": {
+          "name": "audio_files_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audio_files_chapter_idx": {
+          "name": "audio_files_chapter_idx",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audio_files_text_id_texts_id_fk": {
+          "name": "audio_files_text_id_texts_id_fk",
+          "tableFrom": "audio_files",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audio_files_chapter_id_text_chapters_id_fk": {
+          "name": "audio_files_chapter_id_text_chapters_id_fk",
+          "tableFrom": "audio_files",
+          "tableTo": "text_chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audio_files_uploaded_by_id_users_id_fk": {
+          "name": "audio_files_uploaded_by_id_users_id_fk",
+          "tableFrom": "audio_files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.collection_items": {
+      "name": "collection_items",
+      "schema": "",
+      "columns": {
+        "collection_id": {
+          "name": "collection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collection_items_order_idx": {
+          "name": "collection_items_order_idx",
+          "columns": [
+            {
+              "expression": "collection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collection_items_collection_id_collections_id_fk": {
+          "name": "collection_items_collection_id_collections_id_fk",
+          "tableFrom": "collection_items",
+          "tableTo": "collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collection_items_text_id_texts_id_fk": {
+          "name": "collection_items_text_id_texts_id_fk",
+          "tableFrom": "collection_items",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "collection_items_collection_id_text_id_pk": {
+          "name": "collection_items_collection_id_text_id_pk",
+          "columns": [
+            "collection_id",
+            "text_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.collection_shares": {
+      "name": "collection_shares",
+      "schema": "",
+      "columns": {
+        "collection_id": {
+          "name": "collection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shared_with_user_id": {
+          "name": "shared_with_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by_id": {
+          "name": "granted_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collection_shares_recipient_idx": {
+          "name": "collection_shares_recipient_idx",
+          "columns": [
+            {
+              "expression": "shared_with_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collection_shares_collection_id_collections_id_fk": {
+          "name": "collection_shares_collection_id_collections_id_fk",
+          "tableFrom": "collection_shares",
+          "tableTo": "collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collection_shares_shared_with_user_id_users_id_fk": {
+          "name": "collection_shares_shared_with_user_id_users_id_fk",
+          "tableFrom": "collection_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "shared_with_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collection_shares_granted_by_id_users_id_fk": {
+          "name": "collection_shares_granted_by_id_users_id_fk",
+          "tableFrom": "collection_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "collection_shares_collection_id_shared_with_user_id_pk": {
+          "name": "collection_shares_collection_id_shared_with_user_id_pk",
+          "columns": [
+            "collection_id",
+            "shared_with_user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.collections": {
+      "name": "collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "collection_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'chapter_book'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "collection_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collections_owner_idx": {
+          "name": "collections_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collections_visibility_idx": {
+          "name": "collections_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collections_owner_id_users_id_fk": {
+          "name": "collections_owner_id_users_id_fk",
+          "tableFrom": "collections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.curator_languages": {
+      "name": "curator_languages",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "curator_languages_user_idx": {
+          "name": "curator_languages_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "curator_languages_user_id_users_id_fk": {
+          "name": "curator_languages_user_id_users_id_fk",
+          "tableFrom": "curator_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "curator_languages_granted_by_users_id_fk": {
+          "name": "curator_languages_granted_by_users_id_fk",
+          "tableFrom": "curator_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "curator_languages_user_id_language_pk": {
+          "name": "curator_languages_user_id_language_pk",
+          "columns": [
+            "user_id",
+            "language"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.dictionary_imports": {
+      "name": "dictionary_imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_name": {
+          "name": "source_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_at": {
+          "name": "run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lemmas_created": {
+          "name": "lemmas_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lemmas_updated": {
+          "name": "lemmas_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lemmas_skipped_curator_locked": {
+          "name": "lemmas_skipped_curator_locked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "translations_created": {
+          "name": "translations_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "translations_updated": {
+          "name": "translations_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by_user_id": {
+          "name": "triggered_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'succeeded'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "dictionary_imports_language_idx": {
+          "name": "dictionary_imports_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dictionary_imports_source_latest_idx": {
+          "name": "dictionary_imports_source_latest_idx",
+          "columns": [
+            {
+              "expression": "source_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dictionary_imports_triggered_by_user_id_users_id_fk": {
+          "name": "dictionary_imports_triggered_by_user_id_users_id_fk",
+          "tableFrom": "dictionary_imports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triggered_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.form_lemma_overrides": {
+      "name": "form_lemma_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_nfc": {
+          "name": "surface_nfc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_signature": {
+          "name": "context_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "chosen_lemma_id": {
+          "name": "chosen_lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "promoted_at": {
+          "name": "promoted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "promoted_by": {
+          "name": "promoted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "form_lemma_overrides_lookup_idx": {
+          "name": "form_lemma_overrides_lookup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface_nfc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "form_lemma_overrides_chosen_lemma_id_lemmas_id_fk": {
+          "name": "form_lemma_overrides_chosen_lemma_id_lemmas_id_fk",
+          "tableFrom": "form_lemma_overrides",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "chosen_lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_lemma_overrides_promoted_by_users_id_fk": {
+          "name": "form_lemma_overrides_promoted_by_users_id_fk",
+          "tableFrom": "form_lemma_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "promoted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "form_lemma_overrides_lang_surface_ctx_uq": {
+          "name": "form_lemma_overrides_lang_surface_ctx_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "language",
+            "surface_nfc",
+            "context_signature"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.group_memberships": {
+      "name": "group_memberships",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by_id": {
+          "name": "added_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_memberships_user_idx": {
+          "name": "group_memberships_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_memberships_group_id_groups_id_fk": {
+          "name": "group_memberships_group_id_groups_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_memberships_user_id_users_id_fk": {
+          "name": "group_memberships_user_id_users_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_memberships_added_by_id_users_id_fk": {
+          "name": "group_memberships_added_by_id_users_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "added_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "group_memberships_group_id_user_id_pk": {
+          "name": "group_memberships_group_id_user_id_pk",
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "groups_owner_idx": {
+          "name": "groups_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_owner_id_users_id_fk": {
+          "name": "groups_owner_id_users_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemma_edit_history": {
+      "name": "lemma_edit_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phrase_id": {
+          "name": "phrase_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "editor_id": {
+          "name": "editor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "lemma_edit_change_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change": {
+          "name": "change",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_edit_history_lemma_idx": {
+          "name": "lemma_edit_history_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_edit_history_phrase_idx": {
+          "name": "lemma_edit_history_phrase_idx",
+          "columns": [
+            {
+              "expression": "phrase_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_edit_history_editor_idx": {
+          "name": "lemma_edit_history_editor_idx",
+          "columns": [
+            {
+              "expression": "editor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_edit_history_lemma_id_lemmas_id_fk": {
+          "name": "lemma_edit_history_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_edit_history",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lemma_edit_history_phrase_id_phrases_id_fk": {
+          "name": "lemma_edit_history_phrase_id_phrases_id_fk",
+          "tableFrom": "lemma_edit_history",
+          "tableTo": "phrases",
+          "columnsFrom": [
+            "phrase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lemma_edit_history_editor_id_users_id_fk": {
+          "name": "lemma_edit_history_editor_id_users_id_fk",
+          "tableFrom": "lemma_edit_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "editor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemma_forms": {
+      "name": "lemma_forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "romanization": {
+          "name": "romanization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_forms_lemma_idx": {
+          "name": "lemma_forms_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_forms_surface_idx": {
+          "name": "lemma_forms_surface_idx",
+          "columns": [
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_forms_lemma_id_lemmas_id_fk": {
+          "name": "lemma_forms_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_forms",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemma_proposals": {
+      "name": "lemma_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "proposer_id": {
+          "name": "proposer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headword": {
+          "name": "headword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos": {
+          "name": "pos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gloss_default": {
+          "name": "gloss_default",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "lemma_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "promoted_lemma_id": {
+          "name": "promoted_lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_id": {
+          "name": "reviewer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_note": {
+          "name": "reviewer_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_proposals_lang_status_idx": {
+          "name": "lemma_proposals_lang_status_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_proposals_headword_idx": {
+          "name": "lemma_proposals_headword_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "headword",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pos",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_proposals_proposer_id_users_id_fk": {
+          "name": "lemma_proposals_proposer_id_users_id_fk",
+          "tableFrom": "lemma_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "proposer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "lemma_proposals_promoted_lemma_id_lemmas_id_fk": {
+          "name": "lemma_proposals_promoted_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_proposals",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "promoted_lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "lemma_proposals_reviewer_id_users_id_fk": {
+          "name": "lemma_proposals_reviewer_id_users_id_fk",
+          "tableFrom": "lemma_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemmas": {
+      "name": "lemmas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headword": {
+          "name": "headword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos": {
+          "name": "pos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script": {
+          "name": "script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gloss_default": {
+          "name": "gloss_default",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_rank": {
+          "name": "frequency_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "translation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "curator_locked": {
+          "name": "curator_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "headword_nukta_stripped": {
+          "name": "headword_nukta_stripped",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "translate(normalize(\"headword\", NFD), '़', '')",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "lemmas_language_headword_pos_idx": {
+          "name": "lemmas_language_headword_pos_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "headword",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pos",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_language_idx": {
+          "name": "lemmas_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_language_frequency_idx": {
+          "name": "lemmas_language_frequency_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "frequency_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_source_lookup_idx": {
+          "name": "lemmas_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_language_headword_stripped_idx": {
+          "name": "lemmas_language_headword_stripped_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "headword_nukta_stripped",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.magic_links": {
+      "name": "magic_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "magic_links_user_idx": {
+          "name": "magic_links_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "magic_links_expires_idx": {
+          "name": "magic_links_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "magic_links_user_id_users_id_fk": {
+          "name": "magic_links_user_id_users_id_fk",
+          "tableFrom": "magic_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.nlp_jobs": {
+      "name": "nlp_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "nlp_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nlp_jobs_text_idx": {
+          "name": "nlp_jobs_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nlp_jobs_status_idx": {
+          "name": "nlp_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nlp_jobs_text_id_texts_id_fk": {
+          "name": "nlp_jobs_text_id_texts_id_fk",
+          "tableFrom": "nlp_jobs",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.parse_reports": {
+      "name": "parse_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_nfc": {
+          "name": "surface_nfc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_signature": {
+          "name": "context_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "original_candidates": {
+          "name": "original_candidates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "corrected_lemma_id": {
+          "name": "corrected_lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "correction_type": {
+          "name": "correction_type",
+          "type": "token_correction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "parse_report_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "assigned_reviewer_id": {
+          "name": "assigned_reviewer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_note": {
+          "name": "resolution_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duplicate_count": {
+          "name": "duplicate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parse_reports_lang_status_idx": {
+          "name": "parse_reports_lang_status_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parse_reports_dedup_idx": {
+          "name": "parse_reports_dedup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface_nfc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_signature",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "corrected_lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parse_reports_token_id_text_tokens_id_fk": {
+          "name": "parse_reports_token_id_text_tokens_id_fk",
+          "tableFrom": "parse_reports",
+          "tableTo": "text_tokens",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "parse_reports_corrected_lemma_id_lemmas_id_fk": {
+          "name": "parse_reports_corrected_lemma_id_lemmas_id_fk",
+          "tableFrom": "parse_reports",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "corrected_lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "parse_reports_reporter_id_users_id_fk": {
+          "name": "parse_reports_reporter_id_users_id_fk",
+          "tableFrom": "parse_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "parse_reports_assigned_reviewer_id_users_id_fk": {
+          "name": "parse_reports_assigned_reviewer_id_users_id_fk",
+          "tableFrom": "parse_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_reviewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.personal_api_keys": {
+      "name": "personal_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "personal_api_keys_user_idx": {
+          "name": "personal_api_keys_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "personal_api_keys_active_user_idx": {
+          "name": "personal_api_keys_active_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personal_api_keys_user_id_users_id_fk": {
+          "name": "personal_api_keys_user_id_users_id_fk",
+          "tableFrom": "personal_api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "personal_api_keys_hash_unique": {
+          "name": "personal_api_keys_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.phrase_chapter_spans": {
+      "name": "phrase_chapter_spans",
+      "schema": "",
+      "columns": {
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phrase_id": {
+          "name": "phrase_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_token_idx": {
+          "name": "start_token_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_token_idx": {
+          "name": "end_token_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "phrase_chapter_spans_chapter_idx": {
+          "name": "phrase_chapter_spans_chapter_idx",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "phrase_chapter_spans_phrase_idx": {
+          "name": "phrase_chapter_spans_phrase_idx",
+          "columns": [
+            {
+              "expression": "phrase_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "phrase_chapter_spans_chapter_id_text_chapters_id_fk": {
+          "name": "phrase_chapter_spans_chapter_id_text_chapters_id_fk",
+          "tableFrom": "phrase_chapter_spans",
+          "tableTo": "text_chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "phrase_chapter_spans_phrase_id_phrases_id_fk": {
+          "name": "phrase_chapter_spans_phrase_id_phrases_id_fk",
+          "tableFrom": "phrase_chapter_spans",
+          "tableTo": "phrases",
+          "columnsFrom": [
+            "phrase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "phrase_chapter_spans_chapter_id_start_token_idx_phrase_id_pk": {
+          "name": "phrase_chapter_spans_chapter_id_start_token_idx_phrase_id_pk",
+          "columns": [
+            "chapter_id",
+            "start_token_idx",
+            "phrase_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.phrase_proposals": {
+      "name": "phrase_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_normalised": {
+          "name": "surface_normalised",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern_id": {
+          "name": "pattern_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "promoted_at": {
+          "name": "promoted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promoted_phrase_id": {
+          "name": "promoted_phrase_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "phrase_proposals_promotion_lookup_idx": {
+          "name": "phrase_proposals_promotion_lookup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface_normalised",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "phrase_proposals_chapter_id_text_chapters_id_fk": {
+          "name": "phrase_proposals_chapter_id_text_chapters_id_fk",
+          "tableFrom": "phrase_proposals",
+          "tableTo": "text_chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "phrase_proposals_promoted_phrase_id_phrases_id_fk": {
+          "name": "phrase_proposals_promoted_phrase_id_phrases_id_fk",
+          "tableFrom": "phrase_proposals",
+          "tableTo": "phrases",
+          "columnsFrom": [
+            "promoted_phrase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "phrase_proposals_occurrence_uq": {
+          "name": "phrase_proposals_occurrence_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chapter_id",
+            "surface_normalised",
+            "pattern_id"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.phrase_tokens": {
+      "name": "phrase_tokens",
+      "schema": "",
+      "columns": {
+        "phrase_id": {
+          "name": "phrase_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "phrase_tokens_surface_idx": {
+          "name": "phrase_tokens_surface_idx",
+          "columns": [
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "phrase_tokens_phrase_id_phrases_id_fk": {
+          "name": "phrase_tokens_phrase_id_phrases_id_fk",
+          "tableFrom": "phrase_tokens",
+          "tableTo": "phrases",
+          "columnsFrom": [
+            "phrase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "phrase_tokens_lemma_id_lemmas_id_fk": {
+          "name": "phrase_tokens_lemma_id_lemmas_id_fk",
+          "tableFrom": "phrase_tokens",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "phrase_tokens_phrase_id_position_pk": {
+          "name": "phrase_tokens_phrase_id_position_pk",
+          "columns": [
+            "phrase_id",
+            "position"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.phrases": {
+      "name": "phrases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_normalised": {
+          "name": "surface_normalised",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos": {
+          "name": "pos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gloss_default": {
+          "name": "gloss_default",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_rank": {
+          "name": "frequency_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "translation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "curator_locked": {
+          "name": "curator_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "phrases_language_surface_idx": {
+          "name": "phrases_language_surface_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface_normalised",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "phrases_language_idx": {
+          "name": "phrases_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "phrases_language_frequency_idx": {
+          "name": "phrases_language_frequency_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "frequency_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "phrases_source_lookup_idx": {
+          "name": "phrases_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by": {
+          "name": "replaced_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "refresh_tokens_user_idx": {
+          "name": "refresh_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_expires_idx": {
+          "name": "refresh_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.text_chapters": {
+      "name": "text_chapters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idx": {
+          "name": "idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "text_chapters_text_idx": {
+          "name": "text_chapters_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_chapters_text_id_texts_id_fk": {
+          "name": "text_chapters_text_id_texts_id_fk",
+          "tableFrom": "text_chapters",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "text_chapters_text_idx_uq": {
+          "name": "text_chapters_text_idx_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "text_id",
+            "idx"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.text_group_shares": {
+      "name": "text_group_shares",
+      "schema": "",
+      "columns": {
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by_id": {
+          "name": "granted_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "text_group_shares_group_idx": {
+          "name": "text_group_shares_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_group_shares_text_id_texts_id_fk": {
+          "name": "text_group_shares_text_id_texts_id_fk",
+          "tableFrom": "text_group_shares",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_group_shares_group_id_groups_id_fk": {
+          "name": "text_group_shares_group_id_groups_id_fk",
+          "tableFrom": "text_group_shares",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_group_shares_granted_by_id_users_id_fk": {
+          "name": "text_group_shares_granted_by_id_users_id_fk",
+          "tableFrom": "text_group_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "text_group_shares_text_id_group_id_pk": {
+          "name": "text_group_shares_text_id_group_id_pk",
+          "columns": [
+            "text_id",
+            "group_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.text_shares": {
+      "name": "text_shares",
+      "schema": "",
+      "columns": {
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shared_with_user_id": {
+          "name": "shared_with_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "text_share_permission",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'read'"
+        },
+        "granted_by_id": {
+          "name": "granted_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "text_shares_recipient_idx": {
+          "name": "text_shares_recipient_idx",
+          "columns": [
+            {
+              "expression": "shared_with_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_shares_text_id_texts_id_fk": {
+          "name": "text_shares_text_id_texts_id_fk",
+          "tableFrom": "text_shares",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_shares_shared_with_user_id_users_id_fk": {
+          "name": "text_shares_shared_with_user_id_users_id_fk",
+          "tableFrom": "text_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "shared_with_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_shares_granted_by_id_users_id_fk": {
+          "name": "text_shares_granted_by_id_users_id_fk",
+          "tableFrom": "text_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "text_shares_text_id_shared_with_user_id_pk": {
+          "name": "text_shares_text_id_shared_with_user_id_pk",
+          "columns": [
+            "text_id",
+            "shared_with_user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.text_tokens": {
+      "name": "text_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idx": {
+          "name": "idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lemma_candidates": {
+          "name": "lemma_candidates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_ambiguous": {
+          "name": "is_ambiguous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_oov": {
+          "name": "is_oov",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_word": {
+          "name": "is_word",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sentence_idx": {
+          "name": "sentence_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "romanization": {
+          "name": "romanization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_forms": {
+          "name": "number_forms",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "text_tokens_chapter_scan_idx": {
+          "name": "text_tokens_chapter_scan_idx",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "text_tokens_lemma_idx": {
+          "name": "text_tokens_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_tokens_chapter_id_text_chapters_id_fk": {
+          "name": "text_tokens_chapter_id_text_chapters_id_fk",
+          "tableFrom": "text_tokens",
+          "tableTo": "text_chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_tokens_lemma_id_lemmas_id_fk": {
+          "name": "text_tokens_lemma_id_lemmas_id_fk",
+          "tableFrom": "text_tokens",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "text_tokens_chapter_idx_uq": {
+          "name": "text_tokens_chapter_idx_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chapter_id",
+            "idx"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.texts": {
+      "name": "texts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "status_error": {
+          "name": "status_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "texts_owner_idx": {
+          "name": "texts_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "texts_visibility_idx": {
+          "name": "texts_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "texts_owner_id_users_id_fk": {
+          "name": "texts_owner_id_users_id_fk",
+          "tableFrom": "texts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.token_corrections": {
+      "name": "token_corrections",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "token_correction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chosen_lemma_id": {
+          "name": "chosen_lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "token_corrections_token_idx": {
+          "name": "token_corrections_token_idx",
+          "columns": [
+            {
+              "expression": "token_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "token_corrections_chosen_lemma_idx": {
+          "name": "token_corrections_chosen_lemma_idx",
+          "columns": [
+            {
+              "expression": "chosen_lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "token_corrections_user_id_users_id_fk": {
+          "name": "token_corrections_user_id_users_id_fk",
+          "tableFrom": "token_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "token_corrections_token_id_text_tokens_id_fk": {
+          "name": "token_corrections_token_id_text_tokens_id_fk",
+          "tableFrom": "token_corrections",
+          "tableTo": "text_tokens",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "token_corrections_chosen_lemma_id_lemmas_id_fk": {
+          "name": "token_corrections_chosen_lemma_id_lemmas_id_fk",
+          "tableFrom": "token_corrections",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "chosen_lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "token_corrections_user_id_token_id_pk": {
+          "name": "token_corrections_user_id_token_id_pk",
+          "columns": [
+            "user_id",
+            "token_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.translation_reports": {
+      "name": "translation_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "translation_id": {
+          "name": "translation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "translation_report_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "translation_report_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_note": {
+          "name": "resolution_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "translation_reports_status_idx": {
+          "name": "translation_reports_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translation_reports_translation_idx": {
+          "name": "translation_reports_translation_idx",
+          "columns": [
+            {
+              "expression": "translation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "translation_reports_translation_id_translations_id_fk": {
+          "name": "translation_reports_translation_id_translations_id_fk",
+          "tableFrom": "translation_reports",
+          "tableTo": "translations",
+          "columnsFrom": [
+            "translation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "translation_reports_reporter_id_users_id_fk": {
+          "name": "translation_reports_reporter_id_users_id_fk",
+          "tableFrom": "translation_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "translation_reports_resolved_by_users_id_fk": {
+          "name": "translation_reports_resolved_by_users_id_fk",
+          "tableFrom": "translation_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "translation_reports_reporter_translation_uq": {
+          "name": "translation_reports_reporter_translation_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "reporter_id",
+            "translation_id"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.translation_votes": {
+      "name": "translation_votes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "translation_id": {
+          "name": "translation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "translation_vote_value",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "translation_votes_translation_idx": {
+          "name": "translation_votes_translation_idx",
+          "columns": [
+            {
+              "expression": "translation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translation_votes_user_idx": {
+          "name": "translation_votes_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "translation_votes_user_id_users_id_fk": {
+          "name": "translation_votes_user_id_users_id_fk",
+          "tableFrom": "translation_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "translation_votes_translation_id_translations_id_fk": {
+          "name": "translation_votes_translation_id_translations_id_fk",
+          "tableFrom": "translation_votes",
+          "tableTo": "translations",
+          "columnsFrom": [
+            "translation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "translation_votes_user_id_translation_id_pk": {
+          "name": "translation_votes_user_id_translation_id_pk",
+          "columns": [
+            "user_id",
+            "translation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.translations": {
+      "name": "translations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "translation_target_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'lemma'"
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "translation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_translation_id": {
+          "name": "parent_translation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_language": {
+          "name": "target_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_rank": {
+          "name": "display_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "translations_target_idx": {
+          "name": "translations_target_idx",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translations_submitted_by_idx": {
+          "name": "translations_submitted_by_idx",
+          "columns": [
+            {
+              "expression": "submitted_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translations_source_lookup_idx": {
+          "name": "translations_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "translations_submitted_by_users_id_fk": {
+          "name": "translations_submitted_by_users_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "translations_parent_translation_id_translations_id_fk": {
+          "name": "translations_parent_translation_id_translations_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "translations",
+          "columnsFrom": [
+            "parent_translation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_audio_listening": {
+      "name": "user_audio_listening",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audio_file_id": {
+          "name": "audio_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "listened_ms": {
+          "name": "listened_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_listened_at": {
+          "name": "last_listened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_audio_listening_user_text_idx": {
+          "name": "user_audio_listening_user_text_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_audio_listening_text_idx": {
+          "name": "user_audio_listening_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_audio_listening_user_id_users_id_fk": {
+          "name": "user_audio_listening_user_id_users_id_fk",
+          "tableFrom": "user_audio_listening",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_audio_listening_audio_file_id_audio_files_id_fk": {
+          "name": "user_audio_listening_audio_file_id_audio_files_id_fk",
+          "tableFrom": "user_audio_listening",
+          "tableTo": "audio_files",
+          "columnsFrom": [
+            "audio_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_audio_listening_text_id_texts_id_fk": {
+          "name": "user_audio_listening_text_id_texts_id_fk",
+          "tableFrom": "user_audio_listening",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_audio_listening_user_id_audio_file_id_pk": {
+          "name": "user_audio_listening_user_id_audio_file_id_pk",
+          "columns": [
+            "user_id",
+            "audio_file_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_known_lemmas": {
+      "name": "user_known_lemmas",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "known_lemma_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'learning'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_known_lemmas_user_idx": {
+          "name": "user_known_lemmas_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_known_lemmas_user_id_users_id_fk": {
+          "name": "user_known_lemmas_user_id_users_id_fk",
+          "tableFrom": "user_known_lemmas",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_known_lemmas_lemma_id_lemmas_id_fk": {
+          "name": "user_known_lemmas_lemma_id_lemmas_id_fk",
+          "tableFrom": "user_known_lemmas",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_known_lemmas_user_id_lemma_id_pk": {
+          "name": "user_known_lemmas_user_id_lemma_id_pk",
+          "columns": [
+            "user_id",
+            "lemma_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_known_phrases": {
+      "name": "user_known_phrases",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phrase_id": {
+          "name": "phrase_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "known_lemma_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'learning'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_known_phrases_user_idx": {
+          "name": "user_known_phrases_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_known_phrases_user_id_users_id_fk": {
+          "name": "user_known_phrases_user_id_users_id_fk",
+          "tableFrom": "user_known_phrases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_known_phrases_phrase_id_phrases_id_fk": {
+          "name": "user_known_phrases_phrase_id_phrases_id_fk",
+          "tableFrom": "user_known_phrases",
+          "tableTo": "phrases",
+          "columnsFrom": [
+            "phrase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_known_phrases_user_id_phrase_id_pk": {
+          "name": "user_known_phrases_user_id_phrase_id_pk",
+          "columns": [
+            "user_id",
+            "phrase_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_languages": {
+      "name": "user_languages",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script_preference": {
+          "name": "script_preference",
+          "type": "script_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "romanization_scheme": {
+          "name": "romanization_scheme",
+          "type": "romanization_scheme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'iso15919'"
+        },
+        "known_words_count_cache": {
+          "name": "known_words_count_cache",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "known_phrases_count_cache": {
+          "name": "known_phrases_count_cache",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reader_layout_mode": {
+          "name": "reader_layout_mode",
+          "type": "reader_layout_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'page'"
+        },
+        "words_per_page": {
+          "name": "words_per_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 250
+        },
+        "font_family": {
+          "name": "font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_size": {
+          "name": "font_size",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 18
+        },
+        "line_spacing": {
+          "name": "line_spacing",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1.6
+        },
+        "highlight_style": {
+          "name": "highlight_style",
+          "type": "highlight_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'background'"
+        },
+        "reading_width": {
+          "name": "reading_width",
+          "type": "reading_width",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "baseline": {
+          "name": "baseline",
+          "type": "language_baseline",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_languages_user_id_users_id_fk": {
+          "name": "user_languages_user_id_users_id_fk",
+          "tableFrom": "user_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_languages_user_id_language_pk": {
+          "name": "user_languages_user_id_language_pk",
+          "columns": [
+            "user_id",
+            "language"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_text_progress": {
+      "name": "user_text_progress",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_chapter_idx": {
+          "name": "last_chapter_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_token_idx": {
+          "name": "last_token_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pct_read": {
+          "name": "pct_read",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_text_progress_user_idx": {
+          "name": "user_text_progress_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_text_progress_user_id_users_id_fk": {
+          "name": "user_text_progress_user_id_users_id_fk",
+          "tableFrom": "user_text_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_text_progress_text_id_texts_id_fk": {
+          "name": "user_text_progress_text_id_texts_id_fk",
+          "tableFrom": "user_text_progress",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_text_progress_user_id_text_id_pk": {
+          "name": "user_text_progress_user_id_text_id_pk",
+          "columns": [
+            "user_id",
+            "text_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_preference": {
+          "name": "theme_preference",
+          "type": "theme_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarded_at": {
+          "name": "onboarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    }
+  },
+  "enums": {
+    "public.alignment_source": {
+      "name": "alignment_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "imported",
+        "whisper"
+      ]
+    },
+    "public.collection_kind": {
+      "name": "collection_kind",
+      "schema": "public",
+      "values": [
+        "chapter_book",
+        "course",
+        "anthology"
+      ]
+    },
+    "public.collection_visibility": {
+      "name": "collection_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "shared",
+        "official"
+      ]
+    },
+    "public.highlight_style": {
+      "name": "highlight_style",
+      "schema": "public",
+      "values": [
+        "underline",
+        "background",
+        "colored_text"
+      ]
+    },
+    "public.known_lemma_status": {
+      "name": "known_lemma_status",
+      "schema": "public",
+      "values": [
+        "unknown",
+        "learning",
+        "known",
+        "ignored"
+      ]
+    },
+    "public.language": {
+      "name": "language",
+      "schema": "public",
+      "values": [
+        "hi",
+        "mr",
+        "or"
+      ]
+    },
+    "public.language_baseline": {
+      "name": "language_baseline",
+      "schema": "public",
+      "values": [
+        "none",
+        "beginner",
+        "intermediate"
+      ]
+    },
+    "public.lemma_edit_change_type": {
+      "name": "lemma_edit_change_type",
+      "schema": "public",
+      "values": [
+        "lemma_update",
+        "lemma_unlock",
+        "lemma_lock",
+        "translation_insert",
+        "translation_update",
+        "translation_hide",
+        "translation_unhide",
+        "form_insert",
+        "form_delete",
+        "lemma_merge",
+        "lemma_split",
+        "translation_reorder",
+        "phrase_update",
+        "phrase_lock",
+        "phrase_unlock",
+        "phrase_hide",
+        "phrase_unhide",
+        "phrase_merge"
+      ]
+    },
+    "public.lemma_proposal_status": {
+      "name": "lemma_proposal_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.nlp_job_status": {
+      "name": "nlp_job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.parse_report_status": {
+      "name": "parse_report_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "triaged",
+        "resolved",
+        "rejected",
+        "duplicate",
+        "deferred"
+      ]
+    },
+    "public.reader_layout_mode": {
+      "name": "reader_layout_mode",
+      "schema": "public",
+      "values": [
+        "page",
+        "paged_scroll",
+        "continuous"
+      ]
+    },
+    "public.reading_width": {
+      "name": "reading_width",
+      "schema": "public",
+      "values": [
+        "narrow",
+        "medium",
+        "wide"
+      ]
+    },
+    "public.romanization_scheme": {
+      "name": "romanization_scheme",
+      "schema": "public",
+      "values": [
+        "iso15919",
+        "iast",
+        "hunterian",
+        "itrans"
+      ]
+    },
+    "public.script_preference": {
+      "name": "script_preference",
+      "schema": "public",
+      "values": [
+        "native",
+        "native_with_romanization",
+        "romanization_only"
+      ]
+    },
+    "public.text_share_permission": {
+      "name": "text_share_permission",
+      "schema": "public",
+      "values": [
+        "read"
+      ]
+    },
+    "public.text_source_type": {
+      "name": "text_source_type",
+      "schema": "public",
+      "values": [
+        "paste",
+        "txt",
+        "epub"
+      ]
+    },
+    "public.text_status": {
+      "name": "text_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.text_visibility": {
+      "name": "text_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "shared",
+        "official"
+      ]
+    },
+    "public.theme_preference": {
+      "name": "theme_preference",
+      "schema": "public",
+      "values": [
+        "system",
+        "light",
+        "dark"
+      ]
+    },
+    "public.token_correction_type": {
+      "name": "token_correction_type",
+      "schema": "public",
+      "values": [
+        "pick_candidate",
+        "manual_lemma",
+        "new_lemma",
+        "mark_proper_noun",
+        "mark_foreign",
+        "mark_not_a_word"
+      ]
+    },
+    "public.translation_report_reason": {
+      "name": "translation_report_reason",
+      "schema": "public",
+      "values": [
+        "spam",
+        "incorrect",
+        "offensive",
+        "duplicate",
+        "other"
+      ]
+    },
+    "public.translation_report_status": {
+      "name": "translation_report_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "resolved_hidden",
+        "resolved_kept",
+        "dismissed"
+      ]
+    },
+    "public.translation_source": {
+      "name": "translation_source",
+      "schema": "public",
+      "values": [
+        "official_dictionary",
+        "curator",
+        "user",
+        "nlp"
+      ]
+    },
+    "public.translation_target_type": {
+      "name": "translation_target_type",
+      "schema": "public",
+      "values": [
+        "lemma",
+        "phrase"
+      ]
+    },
+    "public.translation_vote_value": {
+      "name": "translation_vote_value",
+      "schema": "public",
+      "values": [
+        "up",
+        "down"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "curator",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1777555343432,
       "tag": "0033_calm_smasher",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1777998658759,
+      "tag": "0034_smiling_mockingbird",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -75,6 +75,14 @@ export default [
         HTMLAudioElement: 'readonly',
         // Alignment highlighter (T-9.3) — uses CSS.escape.
         CSS: 'readonly',
+        // Polling on the admin sources page (T-3.14).
+        setInterval: 'readonly',
+        clearInterval: 'readonly',
+        setTimeout: 'readonly',
+        clearTimeout: 'readonly',
+        queueMicrotask: 'readonly',
+        confirm: 'readonly',
+        SubmitEvent: 'readonly',
       },
     },
   },

--- a/apps/web/src/lib/components/shell/AppShell.svelte
+++ b/apps/web/src/lib/components/shell/AppShell.svelte
@@ -18,6 +18,7 @@
     visibleTabs,
     type Tab,
     type TabIcon,
+    type ViewerRole,
   } from './tabs.js';
   import {
     isImmersiveAttributeSet,
@@ -35,7 +36,13 @@
   }
 
   interface Props {
-    user: { id: string; displayName: string | null; email: string } | null;
+    user: {
+      id: string;
+      displayName: string | null;
+      email: string;
+      /** T-3.14: drives the curator/admin-gated nav entries (Moderation). */
+      role: ViewerRole;
+    } | null;
     /** Active language for the current visit. Drives the rail indicator
      *  + per-screen filters (T-5.25). Null when the user has no
      *  language data yet (anonymous fresh visitor). */
@@ -116,7 +123,12 @@
     }
   }
 
-  const tabs = $derived<Tab[]>(visibleTabs(TABS, user !== null));
+  const tabs = $derived<Tab[]>(
+    visibleTabs(TABS, {
+      authenticated: user !== null,
+      role: user?.role ?? null,
+    }),
+  );
   const activeId = $derived(getActiveTabId($page.url.pathname, tabs));
   const groups = $derived(groupTabsBySection(tabs));
 
@@ -161,6 +173,8 @@
       'M4 20a8 8 0 0116 0',
     ],
     signin: ['M11 8V5a2 2 0 012-2h6a2 2 0 012 2v14a2 2 0 01-2 2h-6a2 2 0 01-2-2v-3', 'M3 12h12', 'M9 8l-4 4 4 4'],
+    // T-3.14: shield outline for the curator/admin moderation tab.
+    moderation: ['M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6l8-3z'],
   };
 </script>
 

--- a/apps/web/src/lib/components/shell/tabs.test.ts
+++ b/apps/web/src/lib/components/shell/tabs.test.ts
@@ -5,11 +5,17 @@ import {
   groupTabsBySection,
   visibleTabs,
   type Tab,
+  type Viewer,
 } from './tabs.js';
+
+const ANON: Viewer = { authenticated: false, role: null };
+const USER: Viewer = { authenticated: true, role: 'user' };
+const CURATOR: Viewer = { authenticated: true, role: 'curator' };
+const ADMIN: Viewer = { authenticated: true, role: 'admin' };
 
 describe('visibleTabs', () => {
   it('shows authenticated + any tabs to signed-in users', () => {
-    const shown = visibleTabs(TABS, true).map((t) => t.id);
+    const shown = visibleTabs(TABS, USER).map((t) => t.id);
     expect(shown).toContain('home');
     expect(shown).toContain('library');
     expect(shown).toContain('upload');
@@ -18,16 +24,33 @@ describe('visibleTabs', () => {
   });
 
   it('shows the public library tab to signed-out users', () => {
-    const shown = visibleTabs(TABS, false).map((t) => t.id);
+    const shown = visibleTabs(TABS, ANON).map((t) => t.id);
     expect(shown).toContain('library');
   });
 
   it('shows anonymous + any tabs to signed-out users', () => {
-    const shown = visibleTabs(TABS, false).map((t) => t.id);
+    const shown = visibleTabs(TABS, ANON).map((t) => t.id);
     expect(shown).toContain('home');
     expect(shown).toContain('signin');
     expect(shown).not.toContain('upload');
     expect(shown).not.toContain('profile');
+  });
+
+  it('hides the moderation tab from regular signed-in users', () => {
+    expect(visibleTabs(TABS, USER).map((t) => t.id)).not.toContain('moderation');
+  });
+
+  it('shows the moderation tab to curators and admins', () => {
+    expect(visibleTabs(TABS, CURATOR).map((t) => t.id)).toContain('moderation');
+    expect(visibleTabs(TABS, ADMIN).map((t) => t.id)).toContain('moderation');
+  });
+
+  it('hides the moderation tab from signed-out users even if a stale role leaks through', () => {
+    // Defensive: if the layout ever serializes a role for a viewer
+    // whose session has expired, the unauthenticated check still
+    // wins.
+    const stale: Viewer = { authenticated: false, role: 'admin' };
+    expect(visibleTabs(TABS, stale).map((t) => t.id)).not.toContain('moderation');
   });
 
   it('highlights the library tab on /reader/* paths so the reader stays under Library', () => {
@@ -37,6 +60,12 @@ describe('visibleTabs', () => {
 
   it('highlights the upload tab on /upload', () => {
     expect(getActiveTabId('/upload', TABS)).toBe('upload');
+  });
+
+  it('highlights the moderation tab across every /moderation/* sub-route', () => {
+    expect(getActiveTabId('/moderation', TABS)).toBe('moderation');
+    expect(getActiveTabId('/moderation/dictionary', TABS)).toBe('moderation');
+    expect(getActiveTabId('/moderation/dictionary/sources', TABS)).toBe('moderation');
   });
 });
 
@@ -79,34 +108,40 @@ describe('getActiveTabId', () => {
 
 describe('groupTabsBySection', () => {
   it('places unsectioned tabs in their own bucket above the sectioned ones', () => {
-    const groups = groupTabsBySection(visibleTabs(TABS, true));
+    const groups = groupTabsBySection(visibleTabs(TABS, USER));
     // home has no section, so it's first.
     expect(groups[0]).toMatchObject({ section: null });
     expect(groups[0]!.tabs.map((t) => t.id)).toEqual(['home']);
   });
 
   it('groups Read-section tabs (Library + Upload) together', () => {
-    const groups = groupTabsBySection(visibleTabs(TABS, true));
+    const groups = groupTabsBySection(visibleTabs(TABS, USER));
     const read = groups.find((g) => g.section === 'Read');
     expect(read).toBeDefined();
     expect(read!.tabs.map((t) => t.id)).toEqual(['library', 'upload']);
   });
 
   it("groups Words under 'Track' (T-10.6)", () => {
-    const groups = groupTabsBySection(visibleTabs(TABS, true));
+    const groups = groupTabsBySection(visibleTabs(TABS, USER));
     const track = groups.find((g) => g.section === 'Track');
     expect(track).toBeDefined();
     expect(track!.tabs.map((t) => t.id)).toEqual(['words']);
   });
 
   it("groups Profile under 'You'", () => {
-    const groups = groupTabsBySection(visibleTabs(TABS, true));
+    const groups = groupTabsBySection(visibleTabs(TABS, USER));
     const you = groups.find((g) => g.section === 'You');
     expect(you!.tabs.map((t) => t.id)).toEqual(['profile']);
   });
 
+  it('appends the moderation tab to the You section for curators/admins', () => {
+    const groups = groupTabsBySection(visibleTabs(TABS, ADMIN));
+    const you = groups.find((g) => g.section === 'You');
+    expect(you!.tabs.map((t) => t.id)).toEqual(['profile', 'moderation']);
+  });
+
   it('skips empty sections so signed-out users do not see a stray Track / You header', () => {
-    const groups = groupTabsBySection(visibleTabs(TABS, false));
+    const groups = groupTabsBySection(visibleTabs(TABS, ANON));
     expect(groups.find((g) => g.section === 'Track')).toBeUndefined();
     expect(groups.find((g) => g.section === 'You')).toBeUndefined();
   });

--- a/apps/web/src/lib/components/shell/tabs.ts
+++ b/apps/web/src/lib/components/shell/tabs.ts
@@ -5,10 +5,22 @@
  * Groups, Collections, …) means adding an entry here, not editing every
  * layout file that references navigation.
  *
- * `auth`: 'any' shows to everyone, 'authenticated' only to signed-in users,
- *          'anonymous' only to signed-out users.
+ * `auth`:
+ *   - `any`: shown to everyone
+ *   - `authenticated`: only signed-in users
+ *   - `anonymous`: only signed-out users
+ *   - `curator-or-admin`: signed-in users with role `curator` or `admin`
+ *     (T-3.14 — exposes the moderation surface in the rail without
+ *     forcing a separate "admin section" UI)
  */
-export type TabAuth = 'any' | 'authenticated' | 'anonymous';
+export type TabAuth = 'any' | 'authenticated' | 'anonymous' | 'curator-or-admin';
+
+export type ViewerRole = 'user' | 'curator' | 'admin' | null;
+
+export interface Viewer {
+  authenticated: boolean;
+  role: ViewerRole;
+}
 
 /** Icon names supported by the shell. New entries map to a glyph in
  * `AppShell.svelte`'s icon switch. */
@@ -18,7 +30,8 @@ export type TabIcon =
   | 'upload'
   | 'words'
   | 'profile'
-  | 'signin';
+  | 'signin'
+  | 'moderation';
 
 /** Section heading the tab clusters under in the desktop rail (T-5.11).
  * `null` (the default) renders the tab outside any section, above the
@@ -77,6 +90,19 @@ export const TABS: readonly Tab[] = [
     section: 'You',
   },
   {
+    // T-3.14: top-level entry into the moderation surface so curators
+    // and admins don't have to hand-type `/moderation/...` URLs.
+    // Lands on the dictionary editor; the page itself surfaces
+    // admin-only sub-links (Bulk tools, Sources) in its sub-nav.
+    id: 'moderation',
+    label: 'Moderation',
+    href: '/moderation/dictionary',
+    auth: 'curator-or-admin',
+    match: ['/moderation'],
+    icon: 'moderation',
+    section: 'You',
+  },
+  {
     id: 'signin',
     label: 'Sign in',
     href: '/login',
@@ -86,11 +112,21 @@ export const TABS: readonly Tab[] = [
   },
 ];
 
-export function visibleTabs(tabs: readonly Tab[], isAuthenticated: boolean): Tab[] {
+export function visibleTabs(tabs: readonly Tab[], viewer: Viewer): Tab[] {
   return tabs.filter((t) => {
-    if (t.auth === 'any') return true;
-    if (t.auth === 'authenticated') return isAuthenticated;
-    return !isAuthenticated;
+    switch (t.auth) {
+      case 'any':
+        return true;
+      case 'authenticated':
+        return viewer.authenticated;
+      case 'anonymous':
+        return !viewer.authenticated;
+      case 'curator-or-admin':
+        return (
+          viewer.authenticated &&
+          (viewer.role === 'curator' || viewer.role === 'admin')
+        );
+    }
   });
 }
 

--- a/apps/web/src/lib/server/db/schema.ts
+++ b/apps/web/src/lib/server/db/schema.ts
@@ -662,6 +662,13 @@ export const translationReports = pgTable(
  * Audit row per dictionary-import run. One row written per `runImport(...)`
  * invocation so we can answer "when did we last pull Hindi WordNet and
  * what changed?" without re-reading the source file or scanning lemmas.
+ *
+ * T-3.14 added `triggered_by_user_id`, `status`, and `error_message` so
+ * the admin sources page can show "who kicked it off" and surface a
+ * failure without scraping logs. CLI runs via
+ * `pnpm dictionary:import` leave `triggered_by_user_id` null — they're
+ * still recorded as `succeeded` (or `failed`) so the page's "last
+ * import" cell is honest about CLI activity too.
  */
 export const dictionaryImports = pgTable(
   'dictionary_imports',
@@ -676,9 +683,15 @@ export const dictionaryImports = pgTable(
     translationsCreated: integer('translations_created').notNull().default(0),
     translationsUpdated: integer('translations_updated').notNull().default(0),
     notes: text('notes'),
+    triggeredByUserId: uuid('triggered_by_user_id').references(() => users.id, {
+      onDelete: 'set null',
+    }),
+    status: text('status').notNull().default('succeeded'),
+    errorMessage: text('error_message'),
   },
   (t) => ({
     languageIdx: index('dictionary_imports_language_idx').on(t.language, t.runAt),
+    sourceLatestIdx: index('dictionary_imports_source_latest_idx').on(t.sourceName, t.runAt),
   }),
 );
 

--- a/apps/web/src/lib/server/dictionary/admin-imports.test.ts
+++ b/apps/web/src/lib/server/dictionary/admin-imports.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment node
+/**
+ * Cache-status probing tests for the admin sources page (T-3.14).
+ *
+ * Hits the real filesystem under a tmpdir so the streaming line
+ * counter and stat-based probes exercise the actual code path
+ * production runs. The DB-touching helpers (`listSourceStatuses`,
+ * job triggers) are covered by the page-server test against the
+ * registry layer, so they're not duplicated here.
+ */
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  _resetActiveJobsForTest,
+  getDictionaryCacheStatus,
+} from './admin-imports.js';
+
+let dataRoot: string;
+
+beforeEach(async () => {
+  dataRoot = await mkdtemp(join(tmpdir(), 'cia-admin-imports-'));
+  _resetActiveJobsForTest();
+});
+
+afterEach(() => {
+  _resetActiveJobsForTest();
+});
+
+async function writeRaw(slug: string, body: string): Promise<void> {
+  const dir = join(dataRoot, slug);
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, 'raw.jsonl'), body);
+}
+
+async function writeTmp(slug: string, body: string): Promise<void> {
+  const dir = join(dataRoot, slug);
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, 'raw.jsonl.tmp'), body);
+}
+
+describe('getDictionaryCacheStatus', () => {
+  it('reports missing when neither raw nor tmp exist', async () => {
+    const status = await getDictionaryCacheStatus('nope', dataRoot);
+    expect(status.exists).toBe(false);
+    expect(status.hasPartial).toBe(false);
+    expect(status.state).toBe('missing');
+    expect(status.sizeBytes).toBeNull();
+    expect(status.lineCount).toBeNull();
+    expect(status.mtime).toBeNull();
+  });
+
+  it('reports cached + line count when raw.jsonl exists', async () => {
+    await writeRaw('kaikki-hindi', 'a\nb\nc\n');
+    const status = await getDictionaryCacheStatus('kaikki-hindi', dataRoot);
+    expect(status.exists).toBe(true);
+    expect(status.state).toBe('cached');
+    expect(status.lineCount).toBe(3);
+    expect(status.sizeBytes).toBe(6);
+    expect(status.mtime).toBeInstanceOf(Date);
+  });
+
+  it('counts a final line that lacks a trailing newline as zero new lines', async () => {
+    // Match `wc -l` semantics: lines are terminated by `\n`. Two
+    // \n bytes ⇒ count is 2 even if there's a partial trailing
+    // string. Surfacing the count to the curator should match
+    // their shell-side intuition.
+    await writeRaw('kaikki-marathi', 'foo\nbar\nbaz');
+    const status = await getDictionaryCacheStatus('kaikki-marathi', dataRoot);
+    expect(status.lineCount).toBe(2);
+  });
+
+  it('reports partial when only raw.jsonl.tmp exists', async () => {
+    await writeTmp('kaikki-odia', 'half-done\n');
+    const status = await getDictionaryCacheStatus('kaikki-odia', dataRoot);
+    expect(status.exists).toBe(false);
+    expect(status.hasPartial).toBe(true);
+    expect(status.state).toBe('partial');
+  });
+
+  it('prefers cached over partial when both files exist', async () => {
+    await writeRaw('kaikki-odia', 'a\n');
+    await writeTmp('kaikki-odia', 'b\n');
+    const status = await getDictionaryCacheStatus('kaikki-odia', dataRoot);
+    expect(status.state).toBe('cached');
+    expect(status.hasPartial).toBe(true);
+  });
+
+  it('treats an empty raw.jsonl as missing', async () => {
+    await writeRaw('empty', '');
+    const status = await getDictionaryCacheStatus('empty', dataRoot);
+    expect(status.exists).toBe(false);
+    expect(status.state).toBe('missing');
+  });
+});

--- a/apps/web/src/lib/server/dictionary/admin-imports.ts
+++ b/apps/web/src/lib/server/dictionary/admin-imports.ts
@@ -1,0 +1,436 @@
+/**
+ * Server-side helpers for the admin dictionary-sources page (T-3.14).
+ *
+ * Three responsibilities:
+ *
+ *  1. Probe each registered source's on-disk cache state
+ *     (`apps/web/data/dictionaries/<slug>/raw.jsonl`) without loading
+ *     the file — multi-GB Kaikki dumps would OOM otherwise. The cache
+ *     status returned by `getDictionaryCacheStatus` is what the page
+ *     renders in each row's "Raw cache" column.
+ *  2. Aggregate the per-source view: cache status + last
+ *     `dictionary_imports` row + current contribution (lemma /
+ *     translation row counts where `source = <slug>`). This shape is
+ *     what the page loader serializes.
+ *  3. Track and trigger background fetch + import jobs. The original
+ *     ticket pitched BullMQ + Redis; the codebase doesn't have a
+ *     queue at MVP (only a no-op `JobDispatcher` for NLP), so we use
+ *     a module-local Map of in-flight Promises. Single web replica
+ *     in prod, single process in dev — fine for now. The page polls
+ *     `getActiveJob(slug)` to decide when to refresh; no Redis hop.
+ *
+ * Errors during a triggered import write a `failed` row to
+ * `dictionary_imports` with the message, so the UI's "Last import"
+ * cell can show the error without us inventing a parallel store.
+ */
+import { spawn } from 'node:child_process';
+import { createReadStream } from 'node:fs';
+import { stat, unlink } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { desc, eq, sql } from 'drizzle-orm';
+
+import { db, schema } from '../db/index.js';
+import type { DictionaryImport } from '../db/schema.js';
+
+import { dictionarySources } from './sources/index.js';
+import type { RegistryEntry } from './sources/index.js';
+import { DrizzleDictionaryRepo } from './drizzle-repo.js';
+import { runDictionaryImport } from './runner.js';
+
+const APPS_WEB_ROOT = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../../../',
+);
+
+const DATA_ROOT = resolve(APPS_WEB_ROOT, 'data', 'dictionaries');
+
+export type CacheState = 'cached' | 'partial' | 'missing';
+
+export type DictionaryCacheStatus = {
+  slug: string;
+  /** Absolute path to the canonical `raw.jsonl`. Always set, even when missing. */
+  rawPath: string;
+  /** True iff `raw.jsonl` exists and is non-empty. */
+  exists: boolean;
+  /** True iff `raw.jsonl.tmp` exists — a stalled or in-flight transfer. */
+  hasPartial: boolean;
+  /**
+   * Coarse cache state for the UI. `partial` wins over `missing`
+   * because a `.tmp` without a final file means a fetch was started
+   * and didn't complete — the curator should know that, not just see
+   * "missing".
+   */
+  state: CacheState;
+  sizeBytes: number | null;
+  lineCount: number | null;
+  mtime: Date | null;
+};
+
+/**
+ * `wc -l` equivalent that doesn't load the file. Counts `\n` bytes in
+ * a stream so a 3 GB Kaikki dump is fine — we still pay the disk read,
+ * but RSS stays flat. Returns 0 for an empty file (matches `wc -l`).
+ */
+async function countLines(path: string): Promise<number> {
+  return new Promise((resolveLines, rejectLines) => {
+    let lines = 0;
+    const stream = createReadStream(path);
+    stream.on('data', (chunk: Buffer | string) => {
+      const buf = typeof chunk === 'string' ? Buffer.from(chunk) : chunk;
+      for (let i = 0; i < buf.length; i += 1) {
+        if (buf[i] === 0x0a) lines += 1;
+      }
+    });
+    stream.on('error', rejectLines);
+    stream.on('end', () => resolveLines(lines));
+  });
+}
+
+/**
+ * Probe the on-disk cache for one slug. Reads stats + line count of
+ * `raw.jsonl`, plus a stat-only check on `raw.jsonl.tmp` so the UI can
+ * surface "interrupted fetch — re-run to finish".
+ */
+export async function getDictionaryCacheStatus(
+  slug: string,
+  rootDir: string = DATA_ROOT,
+): Promise<DictionaryCacheStatus> {
+  const rawPath = resolve(rootDir, slug, 'raw.jsonl');
+  const tmpPath = `${rawPath}.tmp`;
+
+  let exists = false;
+  let sizeBytes: number | null = null;
+  let mtime: Date | null = null;
+  let lineCount: number | null = null;
+  try {
+    const s = await stat(rawPath);
+    if (s.size > 0) {
+      exists = true;
+      sizeBytes = s.size;
+      mtime = s.mtime;
+      lineCount = await countLines(rawPath);
+    }
+  } catch (e) {
+    if (!isNotFound(e)) throw e;
+  }
+
+  let hasPartial = false;
+  try {
+    const s = await stat(tmpPath);
+    if (s.size > 0) hasPartial = true;
+  } catch (e) {
+    if (!isNotFound(e)) throw e;
+  }
+
+  const state: CacheState = exists ? 'cached' : hasPartial ? 'partial' : 'missing';
+  return { slug, rawPath, exists, hasPartial, state, sizeBytes, lineCount, mtime };
+}
+
+function isNotFound(e: unknown): boolean {
+  return (
+    typeof e === 'object' && e !== null && 'code' in e && (e as { code: string }).code === 'ENOENT'
+  );
+}
+
+export type SourceContributionCounts = {
+  lemmas: number;
+  translations: number;
+};
+
+/**
+ * Count rows currently sourced from `slug` in `lemmas` and
+ * `translations`. The schema doesn't carry the registry slug, so we
+ * filter by `source_attribution` — every registered importer uses a
+ * distinct attribution string, so the count is exact in practice.
+ *
+ * Both columns are checked directly: lemmas attributed to the source
+ * (e.g. kaikki-hindi creates lemmas + translations both attributed to
+ * "Wiktionary Hindi via Kaikki.org"), and translations attributed to
+ * the source (e.g. kaikki-en-translations-hindi creates *only*
+ * translations on lemmas that already exist from another importer —
+ * those translations carry the en-translations attribution, the
+ * lemmas don't).
+ */
+export async function getSourceContribution(
+  slug: string,
+): Promise<SourceContributionCounts> {
+  const entry = dictionarySources.find((e) => e.name === slug);
+  if (!entry) return { lemmas: 0, translations: 0 };
+
+  const attribution = entry.source.sourceAttribution;
+
+  const [lemmaRow] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(schema.lemmas)
+    .where(eq(schema.lemmas.sourceAttribution, attribution));
+
+  const [translationRow] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(schema.translations)
+    .where(eq(schema.translations.sourceAttribution, attribution));
+
+  return {
+    lemmas: lemmaRow?.count ?? 0,
+    translations: translationRow?.count ?? 0,
+  };
+}
+
+export async function getLastImport(slug: string): Promise<DictionaryImport | null> {
+  const rows = await db
+    .select()
+    .from(schema.dictionaryImports)
+    .where(eq(schema.dictionaryImports.sourceName, slug))
+    .orderBy(desc(schema.dictionaryImports.runAt))
+    .limit(1);
+  return (rows[0] as DictionaryImport | undefined) ?? null;
+}
+
+// ─── Job tracking ────────────────────────────────────────────────────
+
+export type JobKind = 'fetch' | 'import';
+export type JobStatus = 'running' | 'failed' | 'done';
+
+export type ActiveJob = {
+  slug: string;
+  kind: JobKind;
+  status: JobStatus;
+  startedAt: Date;
+  finishedAt: Date | null;
+  triggeredByUserId: string;
+  errorMessage: string | null;
+};
+
+/**
+ * Module-local registry of in-flight (and recently finished) jobs.
+ * Keyed by slug so a row's "Re-fetch" + "Re-import" buttons can't
+ * stack two jobs on the same source — the second click sees a
+ * `running` status and is a no-op (the action returns immediately).
+ *
+ * Finished jobs live in the map for `JOB_RETENTION_MS` after they
+ * resolve so the polling UI can show "completed at hh:mm" before the
+ * row reverts to its idle state. After that, the map is pruned and
+ * the page falls back to the persisted `dictionary_imports` row.
+ */
+const activeJobs = new Map<string, ActiveJob>();
+const JOB_RETENTION_MS = 60_000;
+
+export function getActiveJob(slug: string): ActiveJob | null {
+  const job = activeJobs.get(slug);
+  if (!job) return null;
+  if (
+    job.status !== 'running' &&
+    job.finishedAt &&
+    Date.now() - job.finishedAt.getTime() > JOB_RETENTION_MS
+  ) {
+    activeJobs.delete(slug);
+    return null;
+  }
+  return job;
+}
+
+export function listActiveJobs(): ActiveJob[] {
+  return [...activeJobs.values()];
+}
+
+/** Test seam: clear the in-flight map (don't cancel anything). */
+export function _resetActiveJobsForTest(): void {
+  activeJobs.clear();
+}
+
+class JobAlreadyRunningError extends Error {
+  constructor(public readonly slug: string) {
+    super(`A job is already running for ${slug}`);
+    this.name = 'JobAlreadyRunningError';
+  }
+}
+
+export { JobAlreadyRunningError };
+
+/**
+ * Find the registry entry, throwing if the slug isn't registered.
+ * Centralized so every action surface gives the same error shape.
+ */
+export function requireSource(slug: string): RegistryEntry {
+  const entry = dictionarySources.find((e) => e.name === slug);
+  if (!entry) throw new Error(`Unknown dictionary source: ${slug}`);
+  return entry;
+}
+
+function startJob(slug: string, kind: JobKind, triggeredByUserId: string): ActiveJob {
+  const existing = activeJobs.get(slug);
+  if (existing && existing.status === 'running') {
+    throw new JobAlreadyRunningError(slug);
+  }
+  const job: ActiveJob = {
+    slug,
+    kind,
+    status: 'running',
+    startedAt: new Date(),
+    finishedAt: null,
+    triggeredByUserId,
+    errorMessage: null,
+  };
+  activeJobs.set(slug, job);
+  return job;
+}
+
+function finishJob(slug: string, error: Error | null): void {
+  const job = activeJobs.get(slug);
+  if (!job) return;
+  job.status = error ? 'failed' : 'done';
+  job.finishedAt = new Date();
+  job.errorMessage = error ? truncate(error.message) : null;
+}
+
+function truncate(s: string, max = 500): string {
+  return s.length > max ? `${s.slice(0, max)}…` : s;
+}
+
+// ─── Triggers ────────────────────────────────────────────────────────
+
+export type TriggerOpts = { triggeredByUserId: string };
+
+/**
+ * Kick off a re-fetch by spawning the existing
+ * `scripts/fetch-dictionary-sources.sh <slug> --force`. Returns
+ * immediately; the caller polls `getActiveJob(slug)`. We shell out
+ * (rather than re-implementing curl in TS) so the script stays the
+ * single source of truth for upstream URLs and resume logic.
+ *
+ * Sources without a case in the script (currently the kaikki-* family
+ * is the only set wired up) will surface the script's "unknown
+ * source" error in the failed-job message.
+ */
+export function triggerFetch(slug: string, opts: TriggerOpts): ActiveJob {
+  requireSource(slug);
+  const job = startJob(slug, 'fetch', opts.triggeredByUserId);
+  void runFetchInBackground(slug);
+  return job;
+}
+
+async function runFetchInBackground(slug: string): Promise<void> {
+  try {
+    await new Promise<void>((resolveFetch, rejectFetch) => {
+      const proc = spawn(
+        'bash',
+        ['scripts/fetch-dictionary-sources.sh', slug, '--force'],
+        { cwd: APPS_WEB_ROOT, env: { ...process.env, FORCE: '1' } },
+      );
+      let stderr = '';
+      proc.stderr.on('data', (d: Buffer) => {
+        stderr += d.toString();
+      });
+      proc.on('error', rejectFetch);
+      proc.on('close', (code) => {
+        if (code === 0) resolveFetch();
+        else rejectFetch(new Error(stderr.trim() || `fetch exited with code ${code}`));
+      });
+    });
+    finishJob(slug, null);
+  } catch (e) {
+    finishJob(slug, e instanceof Error ? e : new Error(String(e)));
+  }
+}
+
+/**
+ * Kick off a re-import from the cached `raw.jsonl`. Returns
+ * immediately; the iterator runs in the background and writes a
+ * `dictionary_imports` audit row on completion (succeeded or failed).
+ */
+export function triggerImport(slug: string, opts: TriggerOpts): ActiveJob {
+  requireSource(slug);
+  const job = startJob(slug, 'import', opts.triggeredByUserId);
+  void runImportInBackground(slug, opts);
+  return job;
+}
+
+async function runImportInBackground(slug: string, opts: TriggerOpts): Promise<void> {
+  const entry = requireSource(slug);
+  const repo = new DrizzleDictionaryRepo(db);
+  try {
+    await runDictionaryImport(repo, entry.source, {
+      triggeredByUserId: opts.triggeredByUserId,
+    });
+    finishJob(slug, null);
+  } catch (e) {
+    const err = e instanceof Error ? e : new Error(String(e));
+    // Persist a failed audit row so the page can surface the error
+    // even after JOB_RETENTION_MS elapses.
+    try {
+      await repo.recordImportRun({
+        sourceName: entry.source.name,
+        language: entry.source.language,
+        lemmasCreated: 0,
+        lemmasUpdated: 0,
+        lemmasSkippedCuratorLocked: 0,
+        translationsCreated: 0,
+        translationsUpdated: 0,
+        triggeredByUserId: opts.triggeredByUserId,
+        status: 'failed',
+        errorMessage: truncate(err.message),
+      });
+    } catch {
+      // If the failure-row write itself fails (DB down etc.), the
+      // in-memory `activeJobs` entry still carries the error for
+      // the polling window — that's the best we can do.
+    }
+    finishJob(slug, err);
+  }
+}
+
+// ─── Page snapshot ───────────────────────────────────────────────────
+
+export type SourceRow = {
+  slug: string;
+  language: string;
+  attribution: string;
+  license: string;
+  cache: DictionaryCacheStatus;
+  contribution: SourceContributionCounts;
+  lastImport: DictionaryImport | null;
+  activeJob: ActiveJob | null;
+};
+
+export async function listSourceStatuses(
+  rootDir: string = DATA_ROOT,
+): Promise<SourceRow[]> {
+  const rows: SourceRow[] = [];
+  for (const entry of dictionarySources) {
+    const [cache, lastImport, contribution] = await Promise.all([
+      getDictionaryCacheStatus(entry.name, rootDir),
+      getLastImport(entry.name),
+      getSourceContribution(entry.name),
+    ]);
+    rows.push({
+      slug: entry.name,
+      language: entry.source.language,
+      attribution: entry.source.sourceAttribution,
+      license: entry.source.license,
+      cache,
+      contribution,
+      lastImport,
+      activeJob: getActiveJob(entry.name),
+    });
+  }
+  return rows;
+}
+
+/**
+ * `Delete cache` action — `unlink` the canonical `raw.jsonl`. The
+ * `.tmp` sibling, if any, is left alone so a stalled fetch can be
+ * inspected; the next forced fetch will overwrite it.
+ */
+export async function deleteCache(
+  slug: string,
+  rootDir: string = DATA_ROOT,
+): Promise<void> {
+  requireSource(slug);
+  const path = resolve(rootDir, slug, 'raw.jsonl');
+  try {
+    await unlink(path);
+  } catch (e) {
+    if (!isNotFound(e)) throw e;
+  }
+}

--- a/apps/web/src/lib/server/dictionary/drizzle-repo.ts
+++ b/apps/web/src/lib/server/dictionary/drizzle-repo.ts
@@ -169,6 +169,9 @@ export class DrizzleDictionaryRepo implements DictionaryRepo {
       translationsCreated: audit.translationsCreated,
       translationsUpdated: audit.translationsUpdated,
       notes: audit.notes,
+      triggeredByUserId: audit.triggeredByUserId ?? null,
+      status: audit.status ?? 'succeeded',
+      errorMessage: audit.errorMessage ?? null,
     });
   }
 }

--- a/apps/web/src/lib/server/dictionary/repo.ts
+++ b/apps/web/src/lib/server/dictionary/repo.ts
@@ -61,6 +61,20 @@ export type ImportRunAudit = {
   translationsCreated: number;
   translationsUpdated: number;
   notes?: string;
+  /**
+   * T-3.14: who kicked off this run from the admin sources page.
+   * Null for CLI imports (`pnpm dictionary:import`) — the column
+   * stays nullable in the schema.
+   */
+  triggeredByUserId?: string | null;
+  /**
+   * T-3.14: 'succeeded' (default) or 'failed'. The runner only emits
+   * 'succeeded' itself; the admin job wrapper writes a 'failed' row
+   * when the iterator throws so the page can show the error.
+   */
+  status?: 'succeeded' | 'failed';
+  /** T-3.14: short error message when status='failed'. */
+  errorMessage?: string | null;
 };
 
 /**

--- a/apps/web/src/lib/server/dictionary/runner.ts
+++ b/apps/web/src/lib/server/dictionary/runner.ts
@@ -25,9 +25,19 @@ import type { LanguageCode } from '@ciareader/shared-types';
 import type { DictionaryRepo } from './repo.js';
 import type { DictionaryImportSource, ImportEntry, ImportResult } from './types.js';
 
+export type RunImportOptions = {
+  /**
+   * T-3.14: when the admin sources page kicks off an import, the
+   * triggering user is recorded on the `dictionary_imports` audit row.
+   * CLI runs (`pnpm dictionary:import`) leave this undefined.
+   */
+  triggeredByUserId?: string | null;
+};
+
 export async function runDictionaryImport(
   repo: DictionaryRepo,
   source: DictionaryImportSource,
+  opts: RunImportOptions = {},
 ): Promise<ImportResult> {
   const result: ImportResult = {
     sourceName: source.name,
@@ -53,6 +63,8 @@ export async function runDictionaryImport(
     lemmasSkippedCuratorLocked: result.lemmasSkippedCuratorLocked,
     translationsCreated: result.translationsCreated,
     translationsUpdated: result.translationsUpdated,
+    triggeredByUserId: opts.triggeredByUserId ?? null,
+    status: 'succeeded',
   });
 
   return result;

--- a/apps/web/src/routes/api/v1/admin/dictionary-sources/+server.ts
+++ b/apps/web/src/routes/api/v1/admin/dictionary-sources/+server.ts
@@ -1,0 +1,22 @@
+/**
+ * Polling endpoint for the admin dictionary-sources page (T-3.14).
+ *
+ * Returns the same row shape the page loader produces. The Svelte
+ * page polls this every 2 s while any row has an in-flight job so
+ * the "Re-fetch" / "Re-import" buttons can flip back to idle without
+ * a full server-rendered reload. Admin-only (the page itself is too,
+ * but the API has its own gate so a curl with stale auth doesn't get
+ * a list of source slugs + last-import errors).
+ */
+import { error, json } from '@sveltejs/kit';
+
+import { listSourceStatuses } from '$lib/server/dictionary/admin-imports.js';
+import { isAdmin } from '$lib/server/dictionary/permissions.js';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async ({ locals }) => {
+  if (!locals.user) throw error(401, 'Unauthorized');
+  if (!isAdmin({ role: locals.user.role })) throw error(403, 'Admin role required');
+  const sources = await listSourceStatuses();
+  return json({ sources });
+};

--- a/apps/web/src/routes/moderation/dictionary/+page.svelte
+++ b/apps/web/src/routes/moderation/dictionary/+page.svelte
@@ -40,6 +40,7 @@
       <a href="/moderation/stats">Stats →</a>
       {#if data.isAdmin}
         <a href="/moderation/dictionary/bulk">Bulk tools →</a>
+        <a href="/moderation/dictionary/sources">Sources →</a>
       {/if}
     </nav>
   </header>

--- a/apps/web/src/routes/moderation/dictionary/sources/+page.server.ts
+++ b/apps/web/src/routes/moderation/dictionary/sources/+page.server.ts
@@ -1,0 +1,134 @@
+/**
+ * Admin "Dictionary sources" page (T-3.14).
+ *
+ * Lists every registered importer and exposes per-row actions for the
+ * three operations the curator-on-call needs to do without dropping
+ * into a shell: re-fetch the upstream raw cache, re-import from that
+ * cache, and delete the cache.
+ *
+ * Lives under /moderation/* (not /admin/*) because the existing
+ * `/moderation/+layout.server.ts` already gates curator+admin access;
+ * this loader narrows further to admin-only, mirroring the bulk-tools
+ * page. The original ticket pitched a separate `/admin/` route group,
+ * but reusing the existing surface keeps the nav consistent and avoids
+ * a one-off layout file.
+ */
+import { error, fail, redirect } from '@sveltejs/kit';
+
+import {
+  deleteCache,
+  JobAlreadyRunningError,
+  listSourceStatuses,
+  triggerFetch,
+  triggerImport,
+} from '$lib/server/dictionary/admin-imports.js';
+import { isAdmin } from '$lib/server/dictionary/permissions.js';
+import type { Actions, PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ locals }) => {
+  if (!locals.user) throw redirect(303, '/login?next=/moderation/dictionary/sources');
+  if (!isAdmin({ role: locals.user.role })) {
+    throw error(403, 'Dictionary source management requires admin role');
+  }
+  const sources = await listSourceStatuses();
+  return { sources };
+};
+
+export type ActionSection = 'fetch' | 'import' | 'delete' | 'fetch-all';
+
+export type ActionResult =
+  | { ok: true; section: ActionSection; slug?: string; message?: string }
+  | { ok: false; section: ActionSection; slug?: string; message: string };
+
+function requireAdmin(locals: App.Locals): { id: string } {
+  if (!locals.user) throw error(401, 'Unauthorized');
+  if (!isAdmin({ role: locals.user.role })) throw error(403, 'Admin role required');
+  return { id: locals.user.id };
+}
+
+function describeError(e: unknown, slug: string): { status: number; message: string } {
+  if (e instanceof JobAlreadyRunningError) {
+    return { status: 409, message: `A job is already running for ${slug}` };
+  }
+  return { status: 500, message: e instanceof Error ? e.message : 'Unexpected error' };
+}
+
+export const actions: Actions = {
+  fetch: async ({ request, locals }) => {
+    const admin = requireAdmin(locals);
+    const form = await request.formData();
+    const slug = String(form.get('slug') ?? '');
+    if (!slug) {
+      return fail(400, { ok: false, section: 'fetch', message: 'Missing slug' } satisfies ActionResult);
+    }
+    try {
+      triggerFetch(slug, { triggeredByUserId: admin.id });
+      return { ok: true, section: 'fetch', slug } satisfies ActionResult;
+    } catch (e) {
+      const { status, message } = describeError(e, slug);
+      return fail(status, { ok: false, section: 'fetch', slug, message } satisfies ActionResult);
+    }
+  },
+
+  import: async ({ request, locals }) => {
+    const admin = requireAdmin(locals);
+    const form = await request.formData();
+    const slug = String(form.get('slug') ?? '');
+    if (!slug) {
+      return fail(400, { ok: false, section: 'import', message: 'Missing slug' } satisfies ActionResult);
+    }
+    try {
+      triggerImport(slug, { triggeredByUserId: admin.id });
+      return { ok: true, section: 'import', slug } satisfies ActionResult;
+    } catch (e) {
+      const { status, message } = describeError(e, slug);
+      return fail(status, { ok: false, section: 'import', slug, message } satisfies ActionResult);
+    }
+  },
+
+  delete: async ({ request, locals }) => {
+    requireAdmin(locals);
+    const form = await request.formData();
+    const slug = String(form.get('slug') ?? '');
+    if (!slug) {
+      return fail(400, { ok: false, section: 'delete', message: 'Missing slug' } satisfies ActionResult);
+    }
+    try {
+      await deleteCache(slug);
+      return { ok: true, section: 'delete', slug } satisfies ActionResult;
+    } catch (e) {
+      const { status, message } = describeError(e, slug);
+      return fail(status, { ok: false, section: 'delete', slug, message } satisfies ActionResult);
+    }
+  },
+
+  /**
+   * Convenience: trigger a fetch for every source whose cache is
+   * currently `missing`. Does not chain into a re-import — once the
+   * fetch lands the curator presses "Re-import" on each row. Adding
+   * an automatic chain (fetch → import) would mean tracking a multi-
+   * step job state machine, which is more than the current MVP needs.
+   */
+  fetchAllMissing: async ({ locals }) => {
+    const admin = requireAdmin(locals);
+    const sources = await listSourceStatuses();
+    const triggered: string[] = [];
+    const skipped: string[] = [];
+    for (const row of sources) {
+      if (row.cache.state !== 'missing') continue;
+      try {
+        triggerFetch(row.slug, { triggeredByUserId: admin.id });
+        triggered.push(row.slug);
+      } catch {
+        skipped.push(row.slug);
+      }
+    }
+    const plural = triggered.length === 1 ? '' : 's';
+    const skippedNote = skipped.length ? ` (${skipped.length} already running)` : '';
+    return {
+      ok: true,
+      section: 'fetch-all',
+      message: `Started fetch for ${triggered.length} source${plural}${skippedNote}`,
+    } satisfies ActionResult;
+  },
+};

--- a/apps/web/src/routes/moderation/dictionary/sources/+page.svelte
+++ b/apps/web/src/routes/moderation/dictionary/sources/+page.svelte
@@ -1,0 +1,368 @@
+<script lang="ts">
+  import { onDestroy } from 'svelte';
+  import { invalidateAll } from '$app/navigation';
+  import type { PageData } from './$types';
+
+  let { data, form }: { data: PageData; form: Record<string, unknown> | null } = $props();
+
+  // SSR data is the initial truth; the polling refresh below
+  // overwrites it. Re-syncs to the loader output whenever the page
+  // re-renders (e.g. after an action `invalidateAll`).
+  let polled = $state<PageData['sources'] | null>(null);
+  const sources = $derived(polled ?? data.sources);
+
+  // Poll the JSON endpoint every 2 s while any row shows a running
+  // job — when nothing's in flight, we don't poll, so an idle admin
+  // page is silent.
+  let pollHandle: ReturnType<typeof setInterval> | null = null;
+  $effect(() => {
+    const anyRunning = sources.some((s) => s.activeJob?.status === 'running');
+    if (anyRunning && !pollHandle) {
+      pollHandle = setInterval(refresh, 2000);
+    }
+    if (!anyRunning && pollHandle) {
+      clearInterval(pollHandle);
+      pollHandle = null;
+    }
+  });
+  onDestroy(() => {
+    if (pollHandle) clearInterval(pollHandle);
+  });
+
+  async function refresh() {
+    try {
+      const res = await fetch('/api/v1/admin/dictionary-sources');
+      if (!res.ok) return;
+      const json = (await res.json()) as { sources: PageData['sources'] };
+      polled = json.sources;
+    } catch {
+      // transient network errors: try again next tick
+    }
+  }
+
+  function formatBytes(n: number | null): string {
+    if (n == null) return '—';
+    if (n < 1024) return `${n} B`;
+    if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+    if (n < 1024 * 1024 * 1024) return `${(n / 1024 / 1024).toFixed(1)} MB`;
+    return `${(n / 1024 / 1024 / 1024).toFixed(2)} GB`;
+  }
+
+  function formatTime(d: string | Date | null): string {
+    if (!d) return '—';
+    const date = typeof d === 'string' ? new Date(d) : d;
+    return date.toLocaleString();
+  }
+
+  function relTime(d: string | Date | null): string {
+    if (!d) return '—';
+    const date = typeof d === 'string' ? new Date(d) : d;
+    const diffMs = Date.now() - date.getTime();
+    const sec = Math.round(diffMs / 1000);
+    if (sec < 60) return `${sec}s ago`;
+    const min = Math.round(sec / 60);
+    if (min < 60) return `${min}m ago`;
+    const hr = Math.round(min / 60);
+    if (hr < 48) return `${hr}h ago`;
+    const days = Math.round(hr / 24);
+    return `${days}d ago`;
+  }
+
+  function jobLabel(state: 'cached' | 'partial' | 'missing'): string {
+    switch (state) {
+      case 'cached':
+        return 'Cached';
+      case 'partial':
+        return 'Interrupted (.tmp present)';
+      case 'missing':
+        return 'Not cached';
+    }
+  }
+
+  async function onSubmit(e: SubmitEvent) {
+    // Refresh after the form action returns so a job that finishes
+    // synchronously (e.g. JobAlreadyRunningError) doesn't have to
+    // wait for the 2s poll.
+    queueMicrotask(() => invalidateAll());
+    void e;
+  }
+</script>
+
+<svelte:head>
+  <title>Dictionary sources — CIA Reader</title>
+  <meta name="robots" content="noindex" />
+</svelte:head>
+
+<div class="page">
+  <header>
+    <h1>Dictionary sources</h1>
+    <p class="sub">
+      Cache state, last import, and contribution counts for every registered importer.
+      Admin-only — actions kick off in-process jobs.
+    </p>
+    <nav class="mod-nav" aria-label="Moderation sections">
+      <a href="/moderation/dictionary">← Dictionary moderation</a>
+      <a href="/moderation/dictionary/bulk">Bulk tools</a>
+    </nav>
+  </header>
+
+  {#if form?.message}
+    <p class:error={form.ok === false} class:success={form.ok === true} class="flash" role="status">
+      {form.message}
+    </p>
+  {/if}
+
+  <form method="post" action="?/fetchAllMissing" class="bulk-row">
+    <button type="submit">Fetch all missing</button>
+    <span class="muted">Triggers a fetch for every row currently in <strong>Not cached</strong>.</span>
+  </form>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Source</th>
+        <th>Lang</th>
+        <th>Raw cache</th>
+        <th>Last import</th>
+        <th>Contribution</th>
+        <th>Job</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      {#each sources as row (row.slug)}
+        <tr>
+          <td>
+            <code>{row.slug}</code>
+            <div class="attribution">{row.attribution}</div>
+            <div class="license muted">{row.license}</div>
+          </td>
+          <td>{row.language}</td>
+          <td>
+            <div class:state-cached={row.cache.state === 'cached'} class:state-partial={row.cache.state === 'partial'} class:state-missing={row.cache.state === 'missing'} class="state">
+              {jobLabel(row.cache.state)}
+            </div>
+            {#if row.cache.exists}
+              <div class="muted">
+                {formatBytes(row.cache.sizeBytes)} · {row.cache.lineCount?.toLocaleString() ?? '—'} lines
+              </div>
+              <div class="muted" title={formatTime(row.cache.mtime)}>
+                {relTime(row.cache.mtime)}
+              </div>
+            {/if}
+          </td>
+          <td>
+            {#if row.lastImport}
+              <div class:status-failed={row.lastImport.status === 'failed'} class="status">
+                {row.lastImport.status}
+              </div>
+              <div class="muted" title={formatTime(row.lastImport.runAt)}>
+                {relTime(row.lastImport.runAt)}
+              </div>
+              {#if row.lastImport.errorMessage}
+                <div class="error-msg">{row.lastImport.errorMessage}</div>
+              {/if}
+            {:else}
+              <span class="muted">Never</span>
+            {/if}
+          </td>
+          <td>
+            <div>{row.contribution.lemmas.toLocaleString()} lemmas</div>
+            <div class="muted">{row.contribution.translations.toLocaleString()} translations</div>
+          </td>
+          <td>
+            {#if row.activeJob}
+              <div class="job-pill" class:running={row.activeJob.status === 'running'} class:failed={row.activeJob.status === 'failed'} class:done={row.activeJob.status === 'done'}>
+                {row.activeJob.kind} · {row.activeJob.status}
+              </div>
+              {#if row.activeJob.errorMessage}
+                <div class="error-msg">{row.activeJob.errorMessage}</div>
+              {/if}
+            {:else}
+              <span class="muted">—</span>
+            {/if}
+          </td>
+          <td>
+            <div class="actions">
+              <form method="post" action="?/fetch" onsubmit={onSubmit}>
+                <input type="hidden" name="slug" value={row.slug} />
+                <button type="submit" disabled={row.activeJob?.status === 'running'}>Re-fetch</button>
+              </form>
+              <form method="post" action="?/import" onsubmit={onSubmit}>
+                <input type="hidden" name="slug" value={row.slug} />
+                <button type="submit" disabled={!row.cache.exists || row.activeJob?.status === 'running'}>
+                  Re-import
+                </button>
+              </form>
+              <form method="post" action="?/delete" onsubmit={onSubmit}>
+                <input type="hidden" name="slug" value={row.slug} />
+                <button
+                  type="submit"
+                  class="danger"
+                  disabled={!row.cache.exists}
+                  onclick={(e) => {
+                    if (!confirm(`Delete cached raw.jsonl for ${row.slug}? Re-fetch is the slow operation, so confirm.`)) {
+                      e.preventDefault();
+                    }
+                  }}
+                >
+                  Delete cache
+                </button>
+              </form>
+            </div>
+          </td>
+        </tr>
+      {/each}
+    </tbody>
+  </table>
+</div>
+
+<style>
+  .page {
+    max-width: 78rem;
+    margin: 0 auto;
+    padding: 1.5rem 1.25rem 3rem;
+  }
+  h1 {
+    margin: 0 0 0.25rem;
+    font-size: 1.6rem;
+  }
+  .sub {
+    margin: 0 0 1rem;
+    color: var(--color-fg-muted);
+  }
+  .muted {
+    color: var(--color-fg-muted);
+    font-size: 0.85rem;
+  }
+  .mod-nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.85rem;
+    font-size: 0.85rem;
+    margin: 0.5rem 0 1.25rem;
+  }
+  .mod-nav a {
+    color: var(--color-fg-muted);
+    text-decoration: none;
+  }
+  .mod-nav a:hover {
+    color: var(--color-fg);
+    text-decoration: underline;
+  }
+  .flash {
+    padding: 0.6rem 0.85rem;
+    margin: 0.5rem 0 1rem;
+    border-radius: 6px;
+    border-left: 3px solid var(--color-accent);
+    background: var(--color-info-bg, #eef5ff);
+  }
+  .flash.error {
+    background: var(--color-error-bg, #fde2e2);
+    border-left-color: var(--color-error, #c62828);
+  }
+  .bulk-row {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 1rem;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.92rem;
+  }
+  th,
+  td {
+    padding: 0.6rem 0.5rem;
+    border-bottom: 1px solid var(--color-border);
+    vertical-align: top;
+    text-align: left;
+  }
+  th {
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--color-fg-muted);
+  }
+  code {
+    font-family: ui-monospace, monospace;
+    font-size: 0.9rem;
+  }
+  .attribution {
+    margin-top: 0.15rem;
+    font-size: 0.85rem;
+  }
+  .license {
+    font-size: 0.75rem;
+  }
+  .state {
+    font-weight: 500;
+  }
+  .state-cached {
+    color: var(--color-success, #2e7d32);
+  }
+  .state-partial {
+    color: var(--color-warn, #ef6c00);
+  }
+  .state-missing {
+    color: var(--color-fg-muted);
+  }
+  .status {
+    font-weight: 500;
+    text-transform: capitalize;
+  }
+  .status-failed {
+    color: var(--color-error, #c62828);
+  }
+  .job-pill {
+    display: inline-block;
+    padding: 0.1rem 0.5rem;
+    border-radius: 999px;
+    font-size: 0.78rem;
+    background: var(--color-border);
+  }
+  .job-pill.running {
+    background: var(--color-info-bg, #eef5ff);
+    color: var(--color-accent);
+  }
+  .job-pill.failed {
+    background: var(--color-error-bg, #fde2e2);
+    color: var(--color-error, #c62828);
+  }
+  .job-pill.done {
+    background: var(--color-success-bg, #e3f2da);
+    color: var(--color-success, #2e7d32);
+  }
+  .error-msg {
+    margin-top: 0.25rem;
+    font-size: 0.78rem;
+    color: var(--color-error, #c62828);
+    white-space: pre-wrap;
+    max-width: 22rem;
+  }
+  .actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+  }
+  .actions form {
+    margin: 0;
+  }
+  button {
+    padding: 0.35rem 0.7rem;
+    font-size: 0.85rem;
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    background: var(--color-bg);
+    color: var(--color-fg);
+    cursor: pointer;
+  }
+  button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  button.danger {
+    color: var(--color-error, #c62828);
+  }
+</style>

--- a/apps/web/src/routes/moderation/dictionary/sources/page-server.test.ts
+++ b/apps/web/src/routes/moderation/dictionary/sources/page-server.test.ts
@@ -1,0 +1,226 @@
+// @vitest-environment node
+/**
+ * Loader + action tests for /moderation/dictionary/sources (T-3.14).
+ *
+ * Mocks the admin-imports service to avoid filesystem and database
+ * touches; the goal here is the routing surface — that the loader
+ * gates non-admins and each action delegates to the right service
+ * call with the triggering user's id attached.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const listSourceStatuses = vi.fn();
+const triggerFetch = vi.fn();
+const triggerImport = vi.fn();
+const deleteCache = vi.fn();
+
+class JobAlreadyRunningError extends Error {
+  constructor(public readonly slug: string) {
+    super(`A job is already running for ${slug}`);
+    this.name = 'JobAlreadyRunningError';
+  }
+}
+
+vi.mock('$lib/server/dictionary/admin-imports.js', () => ({
+  listSourceStatuses: (...a: unknown[]) => listSourceStatuses(...a),
+  triggerFetch: (...a: unknown[]) => triggerFetch(...a),
+  triggerImport: (...a: unknown[]) => triggerImport(...a),
+  deleteCache: (...a: unknown[]) => deleteCache(...a),
+  JobAlreadyRunningError,
+}));
+
+type Mod = typeof import('./+page.server.js');
+const ADMIN = { id: 'admin-1', role: 'admin' as const };
+const CURATOR = { id: 'cur-1', role: 'curator' as const };
+
+async function callLoad(
+  user: { id: string; role: 'admin' | 'curator' | 'user' } | null,
+) {
+  const { load } = (await import('./+page.server.js')) as Mod;
+  const event = {
+    locals: { user },
+  } as unknown as Parameters<Mod['load']>[0];
+  try {
+    return await load(event);
+  } catch (e) {
+    return e as { status?: number; location?: string };
+  }
+}
+
+async function callAction(
+  name: 'fetch' | 'import' | 'delete' | 'fetchAllMissing',
+  fields: Record<string, string>,
+  user: { id: string; role: 'admin' | 'curator' | 'user' } | null = ADMIN,
+) {
+  const { actions } = (await import('./+page.server.js')) as Mod;
+  const fd = new FormData();
+  for (const [k, v] of Object.entries(fields)) fd.append(k, v);
+  const event = {
+    locals: { user },
+    request: {
+      formData: () => Promise.resolve(fd),
+    } as unknown as Request,
+  } as unknown as Parameters<Mod['actions'][string]>[0];
+  try {
+    return await actions[name]!(event);
+  } catch (e) {
+    return e;
+  }
+}
+
+beforeEach(() => {
+  listSourceStatuses.mockReset();
+  triggerFetch.mockReset();
+  triggerImport.mockReset();
+  deleteCache.mockReset();
+  listSourceStatuses.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('/moderation/dictionary/sources loader', () => {
+  it('admins see the list of source rows', async () => {
+    listSourceStatuses.mockResolvedValueOnce([
+      { slug: 'kaikki-hindi', language: 'hi' },
+    ]);
+    const data = (await callLoad(ADMIN)) as { sources: { slug: string }[] };
+    expect(data.sources).toHaveLength(1);
+    expect(data.sources[0]!.slug).toBe('kaikki-hindi');
+  });
+
+  it('curators get a 403', async () => {
+    const res = (await callLoad(CURATOR)) as { status: number };
+    expect(res.status).toBe(403);
+  });
+
+  it('unauthenticated users are redirected to /login', async () => {
+    const res = (await callLoad(null)) as { status: number; location?: string };
+    expect(res.status).toBe(303);
+    expect(res.location).toBe('/login?next=/moderation/dictionary/sources');
+  });
+});
+
+describe('actions: fetch', () => {
+  it('records the triggering admin id and returns ok', async () => {
+    triggerFetch.mockReturnValueOnce({ status: 'running' });
+    const res = (await callAction('fetch', { slug: 'kaikki-hindi' })) as {
+      ok: boolean;
+      slug: string;
+    };
+    expect(triggerFetch).toHaveBeenCalledWith('kaikki-hindi', {
+      triggeredByUserId: ADMIN.id,
+    });
+    expect(res.ok).toBe(true);
+    expect(res.slug).toBe('kaikki-hindi');
+  });
+
+  it('rejects non-admins with 403', async () => {
+    const res = (await callAction('fetch', { slug: 'kaikki-hindi' }, CURATOR)) as {
+      status: number;
+    };
+    expect(res.status).toBe(403);
+    expect(triggerFetch).not.toHaveBeenCalled();
+  });
+
+  it('returns a 409 when a job is already running', async () => {
+    triggerFetch.mockImplementationOnce(() => {
+      throw new JobAlreadyRunningError('kaikki-hindi');
+    });
+    const res = (await callAction('fetch', { slug: 'kaikki-hindi' })) as {
+      status: number;
+      data: { ok: boolean; message: string };
+    };
+    expect(res.status).toBe(409);
+    expect(res.data.ok).toBe(false);
+    expect(res.data.message).toContain('already running');
+  });
+
+  it('400s when slug is missing', async () => {
+    const res = (await callAction('fetch', {})) as { status: number };
+    expect(res.status).toBe(400);
+    expect(triggerFetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('actions: import', () => {
+  it('passes the triggering admin id to the importer', async () => {
+    triggerImport.mockReturnValueOnce({ status: 'running' });
+    const res = (await callAction('import', { slug: 'kaikki-hindi' })) as {
+      ok: boolean;
+    };
+    expect(triggerImport).toHaveBeenCalledWith('kaikki-hindi', {
+      triggeredByUserId: ADMIN.id,
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it('rejects non-admins with 403', async () => {
+    const res = (await callAction('import', { slug: 'x' }, CURATOR)) as {
+      status: number;
+    };
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('actions: delete', () => {
+  it('unlinks the cache and returns ok', async () => {
+    deleteCache.mockResolvedValueOnce(undefined);
+    const res = (await callAction('delete', { slug: 'kaikki-hindi' })) as {
+      ok: boolean;
+    };
+    expect(deleteCache).toHaveBeenCalledWith('kaikki-hindi');
+    expect(res.ok).toBe(true);
+  });
+
+  it('rejects non-admins', async () => {
+    const res = (await callAction('delete', { slug: 'x' }, CURATOR)) as {
+      status: number;
+    };
+    expect(res.status).toBe(403);
+    expect(deleteCache).not.toHaveBeenCalled();
+  });
+});
+
+describe('actions: fetchAllMissing', () => {
+  it('triggers a fetch only for sources whose cache is missing', async () => {
+    listSourceStatuses.mockResolvedValueOnce([
+      { slug: 'a', cache: { state: 'cached' } },
+      { slug: 'b', cache: { state: 'missing' } },
+      { slug: 'c', cache: { state: 'partial' } },
+      { slug: 'd', cache: { state: 'missing' } },
+    ]);
+    const res = (await callAction('fetchAllMissing', {})) as {
+      ok: boolean;
+      message: string;
+    };
+    expect(triggerFetch).toHaveBeenCalledTimes(2);
+    expect(triggerFetch).toHaveBeenCalledWith('b', { triggeredByUserId: ADMIN.id });
+    expect(triggerFetch).toHaveBeenCalledWith('d', { triggeredByUserId: ADMIN.id });
+    expect(res.ok).toBe(true);
+    expect(res.message).toContain('2 sources');
+  });
+
+  it('counts skipped slugs when a job is already running', async () => {
+    listSourceStatuses.mockResolvedValueOnce([
+      { slug: 'b', cache: { state: 'missing' } },
+      { slug: 'd', cache: { state: 'missing' } },
+    ]);
+    triggerFetch.mockImplementationOnce(() => {
+      throw new JobAlreadyRunningError('b');
+    });
+    const res = (await callAction('fetchAllMissing', {})) as {
+      message: string;
+    };
+    expect(res.message).toContain('1 source');
+    expect(res.message).toContain('1 already running');
+  });
+
+  it('rejects non-admins', async () => {
+    const res = (await callAction('fetchAllMissing', {}, CURATOR)) as {
+      status: number;
+    };
+    expect(res.status).toBe(403);
+  });
+});

--- a/docs/dictionary-sources.md
+++ b/docs/dictionary-sources.md
@@ -87,6 +87,32 @@ that ships forms will add duplicate rows if the upstream source ships
 the same form twice. The dedup pass is deliberately deferred to
 post-MVP; today we'd rather over-include than lose a form.
 
+## Admin UI (T-3.14)
+
+`/moderation/dictionary/sources` is an admin-only page that surfaces
+the cache + import state of every registered importer. Each row shows:
+
+- **Raw cache**: presence + size + line count + mtime of
+  `apps/web/data/dictionaries/<slug>/raw.jsonl`. A `partial` state
+  means a `.tmp` file is present without a final `raw.jsonl` — someone
+  interrupted a fetch.
+- **Last import**: most recent `dictionary_imports` row for the slug
+  (succeeded / failed, run-at, error message if any, triggering user).
+- **Contribution**: live count of lemmas + translations whose
+  `source_attribution` matches the importer's attribution string.
+
+Per-row actions: **Re-fetch** (shells out to
+`scripts/fetch-dictionary-sources.sh <slug> --force` in the background),
+**Re-import** (runs the in-process importer against the cached file and
+writes a `dictionary_imports` audit row, including a `failed` row with
+`error_message` if the iterator throws), and **Delete cache** (`unlink`
+the canonical `raw.jsonl`). A global **Fetch all missing** triggers a
+fetch for every row currently in `Not cached`.
+
+Job state is tracked in-process (single web replica in prod). The page
+polls `/api/v1/admin/dictionary-sources` every 2 s while any row has a
+running job; idle pages don't poll.
+
 ## Attribution surface
 
 Every imported lemma and translation stores a `source_attribution` string

--- a/services/nlp/app/pipelines/odia/__init__.py
+++ b/services/nlp/app/pipelines/odia/__init__.py
@@ -91,10 +91,50 @@ class OdiaPipeline(Pipeline):
         self._lemmas = lemmas
 
     def process(self, text: str) -> PipelineResult:
+        # Walk the original text alongside the tokenizer's output so the
+        # whitespace between tokens is preserved as `is_word=False` gap
+        # tokens. Without this the reader has no break opportunities and
+        # CSS multi-column flow can't fragment a long paragraph, which
+        # makes it overflow past the column edge. Mirrors the offset-walk
+        # in :class:`StanzaUDPipeline._tokens_from_doc`.
         tokens: list[Token] = []
-        for idx, surface in enumerate(s for s in self._tokenizer(text) if s):
+        idx = 0
+        cursor = 0
+        for surface in self._tokenizer(text):
+            if not surface:
+                continue
+            start = text.find(surface, cursor)
+            if start == -1:
+                # Tokenizer mutated the surface (NFC, escape tweaks, …).
+                # Emit the token as-is and advance the cursor by its
+                # length so we don't loop the same gap forever.
+                tokens.append(self._build_token(idx, surface))
+                idx += 1
+                cursor += len(surface)
+                continue
+            if start > cursor:
+                tokens.append(self._make_gap_token(idx, text[cursor:start]))
+                idx += 1
             tokens.append(self._build_token(idx, surface))
+            idx += 1
+            cursor = start + len(surface)
+        if cursor < len(text):
+            tail = text[cursor:]
+            if tail:
+                tokens.append(self._make_gap_token(idx, tail))
         return PipelineResult(pipeline_id=self.pipeline_id, tokens=tokens)
+
+    @staticmethod
+    def _make_gap_token(idx: int, surface: str) -> Token:
+        return Token(
+            idx=idx,
+            surface=surface,
+            is_word=False,
+            candidates=[],
+            is_ambiguous=False,
+            is_oov=False,
+            romanization=None,
+        )
 
     def _build_token(self, idx: int, surface: str) -> Token:
         if _is_punctuation(surface):

--- a/services/nlp/app/pipelines/odia/data/golden_corpus.json
+++ b/services/nlp/app/pipelines/odia/data/golden_corpus.json
@@ -6,8 +6,21 @@
       "source": "hand-written",
       "text": "ନମସ୍କାର ଦୁନିଆ",
       "tokens": [
-        { "surface": "ନମସ୍କାର", "lemma": "ନମସ୍କାର", "pos": "INTJ", "is_oov": false },
-        { "surface": "ଦୁନିଆ", "lemma": "ଦୁନିଆ", "pos": "NOUN", "is_oov": false }
+        {
+          "surface": "ନମସ୍କାର",
+          "lemma": "ନମସ୍କାର",
+          "pos": "INTJ",
+          "is_oov": false
+        },
+        {
+          "surface": " "
+        },
+        {
+          "surface": "ଦୁନିଆ",
+          "lemma": "ଦୁନିଆ",
+          "pos": "NOUN",
+          "is_oov": false
+        }
       ]
     },
     {
@@ -15,8 +28,21 @@
       "source": "hand-written",
       "text": "ଘର ବଡ଼",
       "tokens": [
-        { "surface": "ଘର", "lemma": "ଘର", "pos": "NOUN", "is_oov": false },
-        { "surface": "ବଡ଼", "lemma": "ବଡ଼", "pos": "ADJ", "is_oov": false }
+        {
+          "surface": "ଘର",
+          "lemma": "ଘର",
+          "pos": "NOUN",
+          "is_oov": false
+        },
+        {
+          "surface": " "
+        },
+        {
+          "surface": "ବଡ଼",
+          "lemma": "ବଡ଼",
+          "pos": "ADJ",
+          "is_oov": false
+        }
       ]
     },
     {
@@ -24,8 +50,24 @@
       "source": "hand-written",
       "text": "ଘରରେ ବହି",
       "tokens": [
-        { "surface": "ଘରରେ", "lemma": "ଘର", "pos": "NOUN", "features": { "Case": "Loc" }, "is_oov": false },
-        { "surface": "ବହି", "lemma": "ବହି", "pos": "NOUN", "is_oov": false }
+        {
+          "surface": "ଘରରେ",
+          "lemma": "ଘର",
+          "pos": "NOUN",
+          "features": {
+            "Case": "Loc"
+          },
+          "is_oov": false
+        },
+        {
+          "surface": " "
+        },
+        {
+          "surface": "ବହି",
+          "lemma": "ବହି",
+          "pos": "NOUN",
+          "is_oov": false
+        }
       ]
     },
     {
@@ -33,8 +75,24 @@
       "source": "hand-written",
       "text": "ପିଲାକୁ ବହି",
       "tokens": [
-        { "surface": "ପିଲାକୁ", "lemma": "ପିଲା", "pos": "NOUN", "features": { "Case": "Acc" }, "is_oov": false },
-        { "surface": "ବହି", "lemma": "ବହି", "pos": "NOUN", "is_oov": false }
+        {
+          "surface": "ପିଲାକୁ",
+          "lemma": "ପିଲା",
+          "pos": "NOUN",
+          "features": {
+            "Case": "Acc"
+          },
+          "is_oov": false
+        },
+        {
+          "surface": " "
+        },
+        {
+          "surface": "ବହି",
+          "lemma": "ବହି",
+          "pos": "NOUN",
+          "is_oov": false
+        }
       ]
     },
     {
@@ -42,8 +100,24 @@
       "source": "hand-written",
       "text": "ଘରର ପିଲା",
       "tokens": [
-        { "surface": "ଘରର", "lemma": "ଘର", "pos": "NOUN", "features": { "Case": "Gen" }, "is_oov": false },
-        { "surface": "ପିଲା", "lemma": "ପିଲା", "pos": "NOUN", "is_oov": false }
+        {
+          "surface": "ଘରର",
+          "lemma": "ଘର",
+          "pos": "NOUN",
+          "features": {
+            "Case": "Gen"
+          },
+          "is_oov": false
+        },
+        {
+          "surface": " "
+        },
+        {
+          "surface": "ପିଲା",
+          "lemma": "ପିଲା",
+          "pos": "NOUN",
+          "is_oov": false
+        }
       ]
     },
     {
@@ -51,8 +125,24 @@
       "source": "hand-written",
       "text": "ଘରରୁ ପିଲା",
       "tokens": [
-        { "surface": "ଘରରୁ", "lemma": "ଘର", "pos": "NOUN", "features": { "Case": "Abl" }, "is_oov": false },
-        { "surface": "ପିଲା", "lemma": "ପିଲା", "pos": "NOUN", "is_oov": false }
+        {
+          "surface": "ଘରରୁ",
+          "lemma": "ଘର",
+          "pos": "NOUN",
+          "features": {
+            "Case": "Abl"
+          },
+          "is_oov": false
+        },
+        {
+          "surface": " "
+        },
+        {
+          "surface": "ପିଲା",
+          "lemma": "ପିଲା",
+          "pos": "NOUN",
+          "is_oov": false
+        }
       ]
     },
     {
@@ -60,8 +150,25 @@
       "source": "hand-written",
       "text": "ପିଲାମାନେ ଭଲ",
       "tokens": [
-        { "surface": "ପିଲାମାନେ", "lemma": "ପିଲା", "pos": "NOUN", "features": { "Number": "Plur", "Case": "Nom" }, "is_oov": false },
-        { "surface": "ଭଲ", "lemma": "ଭଲ", "pos": "ADJ", "is_oov": false }
+        {
+          "surface": "ପିଲାମାନେ",
+          "lemma": "ପିଲା",
+          "pos": "NOUN",
+          "features": {
+            "Number": "Plur",
+            "Case": "Nom"
+          },
+          "is_oov": false
+        },
+        {
+          "surface": " "
+        },
+        {
+          "surface": "ଭଲ",
+          "lemma": "ଭଲ",
+          "pos": "ADJ",
+          "is_oov": false
+        }
       ]
     },
     {
@@ -69,8 +176,25 @@
       "source": "hand-written",
       "text": "ପିଲାମାନଙ୍କୁ ଦେଖ",
       "tokens": [
-        { "surface": "ପିଲାମାନଙ୍କୁ", "lemma": "ପିଲା", "pos": "NOUN", "features": { "Number": "Plur", "Case": "Acc" }, "is_oov": false },
-        { "surface": "ଦେଖ", "lemma": "ଦେଖ", "pos": "VERB", "is_oov": false }
+        {
+          "surface": "ପିଲାମାନଙ୍କୁ",
+          "lemma": "ପିଲା",
+          "pos": "NOUN",
+          "features": {
+            "Number": "Plur",
+            "Case": "Acc"
+          },
+          "is_oov": false
+        },
+        {
+          "surface": " "
+        },
+        {
+          "surface": "ଦେଖ",
+          "lemma": "ଦେଖ",
+          "pos": "VERB",
+          "is_oov": false
+        }
       ]
     },
     {
@@ -78,8 +202,25 @@
       "source": "hand-written",
       "text": "ପିଲାମାନଙ୍କ ବହି",
       "tokens": [
-        { "surface": "ପିଲାମାନଙ୍କ", "lemma": "ପିଲା", "pos": "NOUN", "features": { "Number": "Plur", "Case": "Gen" }, "is_oov": false },
-        { "surface": "ବହି", "lemma": "ବହି", "pos": "NOUN", "is_oov": false }
+        {
+          "surface": "ପିଲାମାନଙ୍କ",
+          "lemma": "ପିଲା",
+          "pos": "NOUN",
+          "features": {
+            "Number": "Plur",
+            "Case": "Gen"
+          },
+          "is_oov": false
+        },
+        {
+          "surface": " "
+        },
+        {
+          "surface": "ବହି",
+          "lemma": "ବହି",
+          "pos": "NOUN",
+          "is_oov": false
+        }
       ]
     },
     {
@@ -87,8 +228,25 @@
       "source": "hand-written",
       "text": "ସେ ଦେଖିବେ",
       "tokens": [
-        { "surface": "ସେ", "lemma": "ସେ", "pos": "PRON", "is_oov": false },
-        { "surface": "ଦେଖିବେ", "lemma": "ଦେଖ", "pos": "VERB", "features": { "Tense": "Fut", "Person": "3" }, "is_oov": false }
+        {
+          "surface": "ସେ",
+          "lemma": "ସେ",
+          "pos": "PRON",
+          "is_oov": false
+        },
+        {
+          "surface": " "
+        },
+        {
+          "surface": "ଦେଖିବେ",
+          "lemma": "ଦେଖ",
+          "pos": "VERB",
+          "features": {
+            "Tense": "Fut",
+            "Person": "3"
+          },
+          "is_oov": false
+        }
       ]
     },
     {
@@ -96,9 +254,33 @@
       "source": "hand-written",
       "text": "ବହି ପଢ଼ିବା ଭଲ",
       "tokens": [
-        { "surface": "ବହି", "lemma": "ବହି", "pos": "NOUN", "is_oov": false },
-        { "surface": "ପଢ଼ିବା", "lemma": "ପଢ଼", "pos": "VERB", "features": { "VerbForm": "Inf" }, "is_oov": false },
-        { "surface": "ଭଲ", "lemma": "ଭଲ", "pos": "ADJ", "is_oov": false }
+        {
+          "surface": "ବହି",
+          "lemma": "ବହି",
+          "pos": "NOUN",
+          "is_oov": false
+        },
+        {
+          "surface": " "
+        },
+        {
+          "surface": "ପଢ଼ିବା",
+          "lemma": "ପଢ଼",
+          "pos": "VERB",
+          "features": {
+            "VerbForm": "Inf"
+          },
+          "is_oov": false
+        },
+        {
+          "surface": " "
+        },
+        {
+          "surface": "ଭଲ",
+          "lemma": "ଭଲ",
+          "pos": "ADJ",
+          "is_oov": false
+        }
       ]
     },
     {
@@ -106,8 +288,25 @@
       "source": "hand-written",
       "text": "ସେ ଦେଖିଲା",
       "tokens": [
-        { "surface": "ସେ", "lemma": "ସେ", "pos": "PRON", "is_oov": false },
-        { "surface": "ଦେଖିଲା", "lemma": "ଦେଖ", "pos": "VERB", "features": { "Tense": "Past", "Number": "Sing" }, "is_oov": false }
+        {
+          "surface": "ସେ",
+          "lemma": "ସେ",
+          "pos": "PRON",
+          "is_oov": false
+        },
+        {
+          "surface": " "
+        },
+        {
+          "surface": "ଦେଖିଲା",
+          "lemma": "ଦେଖ",
+          "pos": "VERB",
+          "features": {
+            "Tense": "Past",
+            "Number": "Sing"
+          },
+          "is_oov": false
+        }
       ]
     },
     {
@@ -115,8 +314,25 @@
       "source": "hand-written",
       "text": "ସେ ଦେଖିଲେ",
       "tokens": [
-        { "surface": "ସେ", "lemma": "ସେ", "pos": "PRON", "is_oov": false },
-        { "surface": "ଦେଖିଲେ", "lemma": "ଦେଖ", "pos": "VERB", "features": { "Tense": "Past", "Person": "3" }, "is_oov": false }
+        {
+          "surface": "ସେ",
+          "lemma": "ସେ",
+          "pos": "PRON",
+          "is_oov": false
+        },
+        {
+          "surface": " "
+        },
+        {
+          "surface": "ଦେଖିଲେ",
+          "lemma": "ଦେଖ",
+          "pos": "VERB",
+          "features": {
+            "Tense": "Past",
+            "Person": "3"
+          },
+          "is_oov": false
+        }
       ]
     },
     {
@@ -124,8 +340,26 @@
       "source": "hand-written",
       "text": "ସେ ଦେଖନ୍ତି",
       "tokens": [
-        { "surface": "ସେ", "lemma": "ସେ", "pos": "PRON", "is_oov": false },
-        { "surface": "ଦେଖନ୍ତି", "lemma": "ଦେଖ", "pos": "VERB", "features": { "Tense": "Pres", "Person": "3", "Number": "Plur" }, "is_oov": false }
+        {
+          "surface": "ସେ",
+          "lemma": "ସେ",
+          "pos": "PRON",
+          "is_oov": false
+        },
+        {
+          "surface": " "
+        },
+        {
+          "surface": "ଦେଖନ୍ତି",
+          "lemma": "ଦେଖ",
+          "pos": "VERB",
+          "features": {
+            "Tense": "Pres",
+            "Person": "3",
+            "Number": "Plur"
+          },
+          "is_oov": false
+        }
       ]
     },
     {
@@ -133,8 +367,24 @@
       "source": "hand-written",
       "text": "ବଡ଼ତର ଘର",
       "tokens": [
-        { "surface": "ବଡ଼ତର", "lemma": "ବଡ଼", "pos": "ADJ", "features": { "Degree": "Cmp" }, "is_oov": false },
-        { "surface": "ଘର", "lemma": "ଘର", "pos": "NOUN", "is_oov": false }
+        {
+          "surface": "ବଡ଼ତର",
+          "lemma": "ବଡ଼",
+          "pos": "ADJ",
+          "features": {
+            "Degree": "Cmp"
+          },
+          "is_oov": false
+        },
+        {
+          "surface": " "
+        },
+        {
+          "surface": "ଘର",
+          "lemma": "ଘର",
+          "pos": "NOUN",
+          "is_oov": false
+        }
       ]
     },
     {
@@ -142,8 +392,24 @@
       "source": "hand-written",
       "text": "ବଡ଼ତମ ଘର",
       "tokens": [
-        { "surface": "ବଡ଼ତମ", "lemma": "ବଡ଼", "pos": "ADJ", "features": { "Degree": "Sup" }, "is_oov": false },
-        { "surface": "ଘର", "lemma": "ଘର", "pos": "NOUN", "is_oov": false }
+        {
+          "surface": "ବଡ଼ତମ",
+          "lemma": "ବଡ଼",
+          "pos": "ADJ",
+          "features": {
+            "Degree": "Sup"
+          },
+          "is_oov": false
+        },
+        {
+          "surface": " "
+        },
+        {
+          "surface": "ଘର",
+          "lemma": "ଘର",
+          "pos": "NOUN",
+          "is_oov": false
+        }
       ]
     },
     {
@@ -151,8 +417,21 @@
       "source": "hand-written",
       "text": "ମୁଁ ଜାଣ",
       "tokens": [
-        { "surface": "ମୁଁ", "lemma": "ମୁଁ", "pos": "PRON", "is_oov": false },
-        { "surface": "ଜାଣ", "lemma": "ଜାଣ", "pos": "VERB", "is_oov": false }
+        {
+          "surface": "ମୁଁ",
+          "lemma": "ମୁଁ",
+          "pos": "PRON",
+          "is_oov": false
+        },
+        {
+          "surface": " "
+        },
+        {
+          "surface": "ଜାଣ",
+          "lemma": "ଜାଣ",
+          "pos": "VERB",
+          "is_oov": false
+        }
       ]
     },
     {
@@ -160,8 +439,20 @@
       "source": "hand-written",
       "text": "ନମସ୍କାର ।",
       "tokens": [
-        { "surface": "ନମସ୍କାର", "lemma": "ନମସ୍କାର", "pos": "INTJ", "is_oov": false },
-        { "surface": "।", "pos": "PUNCT", "is_oov": false }
+        {
+          "surface": "ନମସ୍କାର",
+          "lemma": "ନମସ୍କାର",
+          "pos": "INTJ",
+          "is_oov": false
+        },
+        {
+          "surface": " "
+        },
+        {
+          "surface": "।",
+          "pos": "PUNCT",
+          "is_oov": false
+        }
       ]
     },
     {
@@ -170,7 +461,16 @@
       "comment": "'ଘରର' legitimately reads as either the Gen form of 'ଘର' OR a lemma in its own right if the dictionary adds it. With only 'ଘର' in seed the reading is unambiguous; this guard-rails against future seed edits accidentally introducing spurious ambiguity.",
       "text": "ଘରର",
       "tokens": [
-        { "surface": "ଘରର", "lemma": "ଘର", "pos": "NOUN", "features": { "Case": "Gen" }, "is_ambiguous": false, "is_oov": false }
+        {
+          "surface": "ଘରର",
+          "lemma": "ଘର",
+          "pos": "NOUN",
+          "features": {
+            "Case": "Gen"
+          },
+          "is_ambiguous": false,
+          "is_oov": false
+        }
       ]
     },
     {
@@ -179,7 +479,10 @@
       "comment": "A deliberately out-of-seed surface. Pipeline should flag is_oov=true with a fallback X candidate. Regression guard against the OOV fallback silently disappearing.",
       "text": "ଜଣେ",
       "tokens": [
-        { "surface": "ଜଣେ", "is_oov": true }
+        {
+          "surface": "ଜଣେ",
+          "is_oov": true
+        }
       ]
     }
   ]

--- a/services/nlp/tests/test_odia_pipeline.py
+++ b/services/nlp/tests/test_odia_pipeline.py
@@ -23,6 +23,9 @@ from app.pipelines.odia.lemmas import OdiaLemma, OdiaLemmaTable
 
 
 def _split(text: str) -> list[str]:
+    # Mirrors IndicNLP's ``trivial_tokenize`` shape — returns words and
+    # punctuation only, drops whitespace. The pipeline reconstructs the
+    # whitespace gaps by walking the original text.
     return text.split()
 
 
@@ -51,7 +54,37 @@ def test_token_indexes_are_contiguous():
         ବହି=OdiaLemma(headword="ବହି", pos="NOUN"),
     )
     result = _pipe(lemmas).process("ଘର ବହି ଘର")
-    assert [t.idx for t in result.tokens] == [0, 1, 2]
+    # Word + gap + word + gap + word.
+    assert [t.idx for t in result.tokens] == [0, 1, 2, 3, 4]
+
+
+def test_emits_whitespace_tokens_between_words():
+    """Without gap tokens the reader has no break opportunities and a
+    long paragraph overflows the column. Mirrors the offset-walk in
+    :class:`StanzaUDPipeline._tokens_from_doc`."""
+    lemmas = _table(
+        ଘର=OdiaLemma(headword="ଘର", pos="NOUN"),
+        ବହି=OdiaLemma(headword="ବହି", pos="NOUN"),
+    )
+    result = _pipe(lemmas).process("ଘର  ବହି")
+    surfaces = [t.surface for t in result.tokens]
+    is_word = [t.is_word for t in result.tokens]
+    # The double space between the two words is preserved verbatim so
+    # the reader's render matches the original text layout.
+    assert surfaces == ["ଘର", "  ", "ବହି"]
+    assert is_word == [True, False, True]
+    gap = result.tokens[1]
+    assert gap.candidates == []
+    assert gap.is_oov is False
+    assert gap.is_ambiguous is False
+
+
+def test_preserves_leading_and_trailing_whitespace():
+    result = _pipe(
+        _table(ଘର=OdiaLemma(headword="ଘର", pos="NOUN"))
+    ).process(" ଘର\n")
+    surfaces = [t.surface for t in result.tokens]
+    assert surfaces == [" ", "ଘର", "\n"]
 
 
 def test_known_lemma_exact_match_is_not_oov_and_not_ambiguous():
@@ -83,7 +116,7 @@ def test_unknown_surface_is_oov_with_fallback_candidate():
 def test_latin_only_surface_is_plain_text_not_oov_word():
     lemmas = _table(ଘର=OdiaLemma(headword="ଘର", pos="NOUN", gloss="house"))
     result = _pipe(lemmas).process("Edit ଘର")
-    english, odia = result.tokens
+    english, _gap, odia = result.tokens
     assert english.surface == "Edit"
     assert english.is_word is False
     assert english.is_oov is False
@@ -121,16 +154,15 @@ def test_multiple_analyses_set_is_ambiguous():
 
 def test_punctuation_is_not_a_word_and_not_oov():
     result = _pipe().process("ନମସ୍କାର ।")
-    words = result.tokens
-    assert len(words) == 2
+    word, _gap, danda = result.tokens
     # First token is OOV (empty lemma table) but is a word.
-    assert words[0].is_word is True
-    assert words[0].is_oov is True
+    assert word.is_word is True
+    assert word.is_oov is True
     # Danda punctuation: is_word=False, is_oov=False (matches Stanza path).
-    assert words[1].surface == "।"
-    assert words[1].is_word is False
-    assert words[1].is_oov is False
-    assert words[1].candidates[0].pos == "PUNCT"
+    assert danda.surface == "।"
+    assert danda.is_word is False
+    assert danda.is_oov is False
+    assert danda.candidates[0].pos == "PUNCT"
 
 
 def test_drops_empty_surfaces_from_tokenizer():

--- a/services/nlp/tests/test_smoke.py
+++ b/services/nlp/tests/test_smoke.py
@@ -41,7 +41,11 @@ def test_process_odia_canned():
     body = resp.json()
     assert body["language"] == "or"
     assert body["pipeline_id"] == "custom-or"
-    assert len(body["tokens"]) == 2
+    # Two words plus a whitespace gap token between them — the gap is
+    # required so the reader can break lines (otherwise the chapter
+    # renders as one unbreakable run).
+    word_tokens = [t for t in body["tokens"] if t["is_word"]]
+    assert len(word_tokens) == 2
 
 
 def test_process_rejects_unsupported_language():

--- a/services/nlp/tests/test_worker_jobs.py
+++ b/services/nlp/tests/test_worker_jobs.py
@@ -125,8 +125,10 @@ async def test_process_text_writes_tokens_for_each_chapter():
 
     assert "ch-1" in token_store.tokens_by_chapter
     # The real Odia pipeline should produce non-empty tokens for a
-    # recognised greeting.
-    assert len(token_store.tokens_by_chapter["ch-1"]) == 2
+    # recognised greeting (two words plus the whitespace gap between
+    # them — the gap is preserved so the reader can break lines).
+    word_tokens = [t for t in token_store.tokens_by_chapter["ch-1"] if t.is_word]
+    assert len(word_tokens) == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- New admin-only page at `/moderation/dictionary/sources` that surfaces the cache + import state of every registered importer (cache size/lines/mtime, last `dictionary_imports` row, live contribution counts).
- Per-row actions: **Re-fetch** (shells out to `scripts/fetch-dictionary-sources.sh <slug> --force` in the background), **Re-import** (in-process runner against the cached file), **Delete cache** (`unlink raw.jsonl`). Plus a global **Fetch all missing** button.
- `dictionary_imports` gains `triggered_by_user_id`, `status`, and `error_message` so failed re-imports surface in-page rather than only in the server log. CLI imports leave triggered_by null and default to `succeeded`.
- Job state is a module-local map (single web replica in prod). The page polls `/api/v1/admin/dictionary-sources` every 2s while any row is running; idle pages don't poll.

## Notes on scope

The original ticket pitched BullMQ + Redis for the job queue. The codebase doesn't have a queue at MVP — only a no-op `JobDispatcher` for NLP — so I used in-process state instead. Single replica in prod, single process in dev. If we add BullMQ later, the `admin-imports.ts` job-tracker functions are the only thing that needs to swap.

The page lives under `/moderation/*` rather than the originally proposed `/admin/*` so it inherits the existing curator/admin layout gate; the loader narrows further to admin-only, mirroring `/moderation/dictionary/bulk`.

## Test plan

- [x] Vitest: `admin-imports.test.ts` covers cache-status probing across cached / partial / missing / empty states + line counting on a no-trailing-newline file.
- [x] Vitest: `page-server.test.ts` covers loader gating (admin / curator / unauth), each form action delegating with the triggering admin's id, 409 for `JobAlreadyRunningError`, and `fetchAllMissing` filtering by cache state.
- [x] Full suite: 1349 tests pass, `pnpm check` clean, `pnpm lint` clean, `pnpm build` succeeds.
- [ ] Manual smoke against dev compose: trigger Re-fetch on `kaikki-hindi`, observe live job pill + 2s polling, verify `dictionary_imports` row written with triggered-by-user.

Refs #375.