### PR TITLE
T-3.10e: Dbnary Marathi-English importer

### DIFF
--- a/apps/web/scripts/fetch-dictionary-sources.sh
+++ b/apps/web/scripts/fetch-dictionary-sources.sh
@@ -185,6 +185,7 @@ case "${1-all}" in
     fetch_kaikki kaikki-odia Odia
     fetch_kaikki_en_translations
     fetch_dbnary dbnary-hi hin
+    fetch_dbnary dbnary-mr mar
     ;;
   kaikki-hindi)
     fetch_kaikki kaikki-hindi Hindi
@@ -201,9 +202,12 @@ case "${1-all}" in
   dbnary-hi)
     fetch_dbnary dbnary-hi hin
     ;;
+  dbnary-mr)
+    fetch_dbnary dbnary-mr mar
+    ;;
   *)
     echo "unknown source: $1" >&2
-    echo "available: kaikki-hindi, kaikki-marathi, kaikki-odia, kaikki-en-translations, dbnary-hi" >&2
+    echo "available: kaikki-hindi, kaikki-marathi, kaikki-odia, kaikki-en-translations, dbnary-hi, dbnary-mr" >&2
     exit 1
     ;;
 esac

--- a/apps/web/src/lib/server/dictionary/sources/dbnary-mr.test.ts
+++ b/apps/web/src/lib/server/dictionary/sources/dbnary-mr.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment node
+/**
+ * Smoke test for the Dbnary Marathi instantiation (T-3.10e).
+ *
+ * The shared parser is exhaustively covered in `dbnary.test.ts`; this
+ * file just locks in the language-specific knobs (lang tag, attribution,
+ * sourceId prefix) so a future refactor that breaks `dbnary-mr` doesn't
+ * silently keep `dbnary-hi`'s assertions green.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildImportEntry,
+  handleTriple,
+  parseTurtle,
+  type DbnarySourceOptions,
+} from './dbnary.js';
+import { dbnaryMarathiSource } from './dbnary-mr.js';
+
+const MARATHI_OPTS: DbnarySourceOptions = {
+  name: 'dbnary-mr',
+  language: 'mr',
+  script: 'Deva',
+  sourceIdPrefix: 'dbnary:mr',
+  attribution: 'Dbnary Marathi',
+  license: 'CC-BY-SA-3.0',
+  envVar: 'DBNARY_MARATHI_FILE',
+  defaultPath: 'data/dictionaries/dbnary-mr/raw.ttl',
+  headwordLang: 'mr',
+  translationLang: 'en',
+};
+
+describe('dbnaryMarathiSource registry shape', () => {
+  it('exposes the expected attribution + license + language', () => {
+    expect(dbnaryMarathiSource.name).toBe('dbnary-mr');
+    expect(dbnaryMarathiSource.language).toBe('mr');
+    expect(dbnaryMarathiSource.license).toBe('CC-BY-SA-3.0');
+    expect(dbnaryMarathiSource.sourceAttribution).toContain('GETALP');
+    expect(dbnaryMarathiSource.sourceAttribution).toContain('Marathi');
+  });
+});
+
+describe('Marathi-language gating', () => {
+  it('keeps mr-tagged headwords and drops hi-tagged ones', async () => {
+    const turtle = [
+      '@prefix ex: <http://example.org/> .',
+      '@prefix ontolex: <http://www.w3.org/ns/lemon/ontolex#> .',
+      '@prefix lexinfo: <http://www.lexinfo.net/ontology/2.0/lexinfo#> .',
+      '@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .',
+      '@prefix skos: <http://www.w3.org/2004/02/skos/core#> .',
+      '',
+      'ex:mr_entry a ontolex:LexicalEntry ;',
+      '    rdfs:label "पुस्तक"@mr ;',
+      '    lexinfo:partOfSpeech lexinfo:noun ;',
+      '    ontolex:sense ex:mr_sense .',
+      '',
+      'ex:mr_sense skos:definition "book"@en .',
+      '',
+      'ex:hi_entry a ontolex:LexicalEntry ;',
+      '    rdfs:label "किताब"@hi ;',
+      '    lexinfo:partOfSpeech lexinfo:noun ;',
+      '    ontolex:sense ex:hi_sense .',
+      '',
+      'ex:hi_sense skos:definition "book"@en .',
+    ].join('\n');
+
+    const entries = new Map();
+    const forms = new Map();
+    const senses = new Map();
+    for await (const triple of parseTurtle(turtle.split('\n'))) {
+      handleTriple(triple, entries, forms, senses, MARATHI_OPTS);
+    }
+    const built = [...entries.values()]
+      .map((e) => buildImportEntry(e, forms, senses, MARATHI_OPTS))
+      .filter(Boolean);
+
+    expect(built).toHaveLength(1);
+    expect(built[0]!.headword).toBe('पुस्तक');
+    expect(built[0]!.sourceId).toMatch(/^dbnary:mr:[0-9a-f]{12}$/);
+  });
+});

--- a/apps/web/src/lib/server/dictionary/sources/dbnary-mr.ts
+++ b/apps/web/src/lib/server/dictionary/sources/dbnary-mr.ts
@@ -1,0 +1,22 @@
+/**
+ * Dbnary Marathi-English importer (T-3.10e).
+ *
+ * Sibling of `dbnary-hi.ts` — same shared Turtle parser, different
+ * upstream language tag and on-disk default path. Adding more
+ * Indo-Aryan languages from Dbnary (Bengali, Punjabi, …) is one more
+ * block once those land in the registry.
+ */
+import { makeDbnarySource } from './dbnary.js';
+
+export const dbnaryMarathiSource = makeDbnarySource({
+  name: 'dbnary-mr',
+  language: 'mr',
+  script: 'Deva',
+  sourceIdPrefix: 'dbnary:mr',
+  attribution: 'Dbnary Marathi (GETALP / Univ. Grenoble Alpes)',
+  license: 'CC-BY-SA-3.0',
+  envVar: 'DBNARY_MARATHI_FILE',
+  defaultPath: 'data/dictionaries/dbnary-mr/raw.ttl',
+  headwordLang: 'mr',
+  translationLang: 'en',
+});

--- a/apps/web/src/lib/server/dictionary/sources/index.ts
+++ b/apps/web/src/lib/server/dictionary/sources/index.ts
@@ -15,6 +15,7 @@
 import type { DictionaryImportSource } from '../types.js';
 
 import { dbnaryHindiSource } from './dbnary-hi.js';
+import { dbnaryMarathiSource } from './dbnary-mr.js';
 import { hindiSeedSource } from './hindi-seed.js';
 import { kaikkiEnTranslationsHindiSource } from './kaikki-en-translations-hindi.js';
 import { kaikkiEnTranslationsMarathiSource } from './kaikki-en-translations-marathi.js';
@@ -46,6 +47,7 @@ export const dictionarySources: RegistryEntry[] = [
     source: kaikkiEnTranslationsOdiaSource,
   },
   { name: dbnaryHindiSource.name, source: dbnaryHindiSource },
+  { name: dbnaryMarathiSource.name, source: dbnaryMarathiSource },
 ];
 
 export function findSource(name: string): DictionaryImportSource | undefined {

--- a/docs/dictionary-sources.md
+++ b/docs/dictionary-sources.md
@@ -33,7 +33,7 @@ coverage; Dbnary fills in glosses and translations.
 |---|---|---|---|
 | Marathi WordNet | CFILT, IIT Bombay | Research use, distributable with attribution | Planned |
 | *Molesworth's A Dictionary, Marathi and English* (1857) | Public domain (DDSA) | Public domain | Planned — historical orthography will need light normalization |
-| Dbnary Marathi-English | GETALP / Univ. Grenoble Alpes | CC-BY-SA 3.0 | Planned |
+| [Dbnary Marathi-English](http://kaiko.getalp.org/about-dbnary/) | GETALP / Univ. Grenoble Alpes | CC-BY-SA 3.0 | **Imported (T-3.10e, 2026-05-05)** — same shared Turtle parser as `dbnary-hi`; instantiation differs only in language tag and on-disk path |
 | [Wiktionary Marathi (via Kaikki.org)](https://kaikki.org/dictionary/Marathi/) | Wiktionary contributors | CC-BY-SA 3.0 | **Imported (T-3.10, 2026-04-28)** — fetched via `scripts/fetch-dictionary-sources.sh kaikki-marathi`; thinner than Hindi (~5k entries) but a solid bootstrap before Marathi WordNet + Molesworth land |
 | [Wiktionary English Translations sections (via Kaikki.org)](https://kaikki.org/dictionary/English/) | Wiktionary contributors | CC-BY-SA 3.0 | **Imported (T-3.10, 2026-04-28)** — inverted from English entries' `translations[]`; the highest-leverage Marathi expansion since English Wiktionary's Translations sections substantially out-cover the Marathi sub-corpus |
 


### PR DESCRIPTION
## Summary

- New importer `dbnary-mr` (GETALP, CC-BY-SA-3.0). Thin instantiation of `makeDbnarySource` from T-3.10b — differs from `dbnary-hi` only in the language tag and on-disk default path.
- Fetch script gains a `dbnary-mr` case mirroring the Hindi one (downloads `mar_dbnary_ontolex.ttl.bz2`, decompresses to `raw.ttl`).

## Stacked on top of [#413](https://github.com/chickendude/CIA-Reader/pull/413) (T-3.10b)

Branch chain: `feat/t-3.14-admin-dictionaries` → `feat/t-3.10b-dbnary-hindi` → `feat/t-3.10e-dbnary-marathi`. Diff base is set to T-3.10b so this PR shows only the Marathi delta.

## Test plan

- [x] `dbnary-mr.test.ts` — locks in the language-specific knobs (mr lang tag, attribution string, `dbnary:mr` sourceId prefix) so a refactor that breaks `dbnary-mr` can't keep `dbnary-hi`'s assertions green.
- [x] Full vitest suite passes; `pnpm check`, `pnpm lint` clean.
- [x] `pnpm dictionary:import --list` shows `dbnary-mr`.

Refs #383, Closes #383.