### PR TITLE
T-3.10c: Marathi WordNet (CFILT) importer

### DIFF
--- a/apps/web/scripts/fetch-dictionary-sources.sh
+++ b/apps/web/scripts/fetch-dictionary-sources.sh
@@ -231,9 +231,13 @@ case "${1-all}" in
     manual_dump_check hindi-wordnet synsets.tsv \
       "docs/dictionary-sources.md (Hindi WordNet section) — CFILT IIT-Bombay distribution requires registration"
     ;;
+  marathi-wordnet)
+    manual_dump_check marathi-wordnet synsets.tsv \
+      "docs/dictionary-sources.md (Marathi WordNet section) — CFILT IIT-Bombay distribution requires registration"
+    ;;
   *)
     echo "unknown source: $1" >&2
-    echo "available: kaikki-hindi, kaikki-marathi, kaikki-odia, kaikki-en-translations, dbnary-hi, dbnary-mr, hindi-wordnet" >&2
+    echo "available: kaikki-hindi, kaikki-marathi, kaikki-odia, kaikki-en-translations, dbnary-hi, dbnary-mr, hindi-wordnet, marathi-wordnet" >&2
     exit 1
     ;;
 esac

--- a/apps/web/src/lib/server/dictionary/sources/hindi-wordnet.test.ts
+++ b/apps/web/src/lib/server/dictionary/sources/hindi-wordnet.test.ts
@@ -1,140 +1,22 @@
 // @vitest-environment node
 /**
- * Hindi WordNet importer tests (T-3.10a).
+ * Smoke test for the Hindi WordNet instantiation (T-3.10a).
  *
- * Fixture-based — verifies the TSV parser, POS mapping, multi-word
- * synset expansion, and stable sourceId. The actual dump may need
- * registration with CFILT, so we don't run a real-file integration
- * test here.
+ * The shared parser is exhaustively covered in `indo-wordnet.test.ts`;
+ * this file just locks in the language-specific knobs (sourceId
+ * prefix, attribution, default file path) so a refactor that breaks
+ * `hindi-wordnet` can't keep `marathi-wordnet`'s assertions green.
  */
 import { describe, expect, it } from 'vitest';
 
-import {
-  hindiWordnetSource,
-  hwnRowToEntries,
-  mapWordNetPos,
-  parseHwnLine,
-} from './hindi-wordnet.js';
-
-describe('mapWordNetPos', () => {
-  it('maps the four core WordNet categories to UD tags', () => {
-    expect(mapWordNetPos('noun')).toBe('NOUN');
-    expect(mapWordNetPos('verb')).toBe('VERB');
-    expect(mapWordNetPos('adjective')).toBe('ADJ');
-    expect(mapWordNetPos('adverb')).toBe('ADV');
-  });
-
-  it('is case- and whitespace-insensitive', () => {
-    expect(mapWordNetPos('NOUN')).toBe('NOUN');
-    expect(mapWordNetPos('  Adjective  ')).toBe('ADJ');
-  });
-
-  it('returns null for unsupported categories', () => {
-    expect(mapWordNetPos('idiom')).toBeNull();
-    expect(mapWordNetPos('')).toBeNull();
-  });
-});
-
-describe('parseHwnLine', () => {
-  it('parses a 5-column synset row', () => {
-    const row = parseHwnLine('1234\tnoun\tवह जो पढ़ने के लिए हो\tमैंने एक किताब पढ़ी\tकिताब,पुस्तक');
-    expect(row).toEqual({
-      synsetId: '1234',
-      category: 'noun',
-      concept: 'वह जो पढ़ने के लिए हो',
-      example: 'मैंने एक किताब पढ़ी',
-      words: ['किताब', 'पुस्तक'],
-    });
-  });
-
-  it('drops blank lines, # comments, and rows with too few columns', () => {
-    expect(parseHwnLine('')).toBeNull();
-    expect(parseHwnLine('   ')).toBeNull();
-    expect(parseHwnLine('# comment')).toBeNull();
-    expect(parseHwnLine('1\t2\t3')).toBeNull();
-  });
-
-  it('drops rows with empty words', () => {
-    expect(parseHwnLine('5\tnoun\tdef\texample\t')).toBeNull();
-  });
-
-  it('accepts both comma- and semicolon-separated word lists', () => {
-    const row = parseHwnLine('9\tverb\tचलना\t-\tदौड़ना;भागना');
-    expect(row?.words).toEqual(['दौड़ना', 'भागना']);
-  });
-});
-
-describe('hwnRowToEntries', () => {
-  it('produces one ImportEntry per unique synset member', () => {
-    const entries = hwnRowToEntries({
-      synsetId: '12345',
-      category: 'noun',
-      concept: 'a written or printed work',
-      example: 'मैंने एक किताब पढ़ी',
-      words: ['किताब', 'पुस्तक'],
-    });
-    expect(entries).toHaveLength(2);
-    expect(entries[0]!.headword).toBe('किताब');
-    expect(entries[0]!.pos).toBe('NOUN');
-    expect(entries[0]!.sourceId).toBe('hwn:12345:0');
-    expect(entries[0]!.translations[0]!.body).toBe('a written or printed work');
-    expect(entries[0]!.translations[0]!.targetLanguage).toBe('hi');
-    expect(entries[1]!.sourceId).toBe('hwn:12345:1');
-  });
-
-  it('deduplicates repeated members within the same synset', () => {
-    const entries = hwnRowToEntries({
-      synsetId: '99',
-      category: 'noun',
-      concept: 'def',
-      example: '',
-      words: ['क', 'क', 'ख'],
-    });
-    expect(entries.map((e) => e.headword)).toEqual(['क', 'ख']);
-  });
-
-  it('drops the row when POS is unmapped', () => {
-    const entries = hwnRowToEntries({
-      synsetId: '1',
-      category: 'idiom',
-      concept: 'def',
-      example: '',
-      words: ['x'],
-    });
-    expect(entries).toHaveLength(0);
-  });
-
-  it('drops the row when concept is empty', () => {
-    expect(
-      hwnRowToEntries({
-        synsetId: '1',
-        category: 'noun',
-        concept: '',
-        example: '',
-        words: ['x'],
-      }),
-    ).toHaveLength(0);
-  });
-
-  it('NFC-normalizes headwords and trims whitespace', () => {
-    // NFD form for ḍa (दा) — should normalize to NFC.
-    const nfd = 'दा'.normalize('NFD');
-    const entries = hwnRowToEntries({
-      synsetId: '7',
-      category: 'noun',
-      concept: 'def',
-      example: '',
-      words: [`  ${nfd}  `],
-    });
-    expect(entries[0]!.headword).toBe('दा');
-  });
-});
+import { hindiWordnetSource } from './hindi-wordnet.js';
 
 describe('hindiWordnetSource registry shape', () => {
-  it('exposes the expected attribution + license + language', () => {
+  it('exposes the expected attribution, license, and language', () => {
     expect(hindiWordnetSource.name).toBe('hindi-wordnet');
     expect(hindiWordnetSource.language).toBe('hi');
     expect(hindiWordnetSource.license).toContain('Research-Use');
     expect(hindiWordnetSource.sourceAttribution).toContain('CFILT');
+    expect(hindiWordnetSource.sourceAttribution).toContain('Hindi');
   });
 });

--- a/apps/web/src/lib/server/dictionary/sources/hindi-wordnet.ts
+++ b/apps/web/src/lib/server/dictionary/sources/hindi-wordnet.ts
@@ -1,159 +1,24 @@
 /**
  * Hindi WordNet (CFILT IIT-Bombay) importer (T-3.10a).
  *
- * CFILT distributes Hindi WordNet under a research-use license; the
- * publicly-circulated dump is a tab-separated synset-per-line format:
+ * Thin instantiation of `makeIndoWordNetSource` — the parser, POS map,
+ * and stream wrapper live in `indo-wordnet.ts`. Adding the Marathi
+ * sibling (T-3.10c) and Odia (T-3.10f) is one more block each.
  *
- *     <synset_id>\t<category>\t<concept>\t<example>\t<words>\n
- *
- *   - `synset_id`: stable 5-7 digit id, the same id `webhwn` shows.
- *   - `category`: lowercase noun / verb / adjective / adverb. Anything
- *     else (idioms, named-entity bundles, …) drops the row.
- *   - `concept`: the synset definition, used as the lemma's
- *     `gloss_default` and the body of the (single) translation row
- *     since the dump is monolingual Hindi.
- *   - `example`: usage example, dropped at MVP (we keep the data model
- *     focused on lemma + translation; example sentences land separately
- *     in a future ticket).
- *   - `words`: comma-separated members of the synset. Each unique
- *     (word, POS) tuple becomes its own `ImportEntry` so the lemma
- *     table stays normalized; the synset stays linkable through
- *     `source_id` (`hwn:<synset_id>:<word_idx>`).
- *
- * CFILT may require registration to obtain the dump; the fetch script
- * (currently `dbnary-*` and `kaikki-*` aware) leaves this importer's
- * artifact as a manual placement at
- * `data/dictionaries/hindi-wordnet/synsets.tsv`. The importer reads
- * whatever's there — re-running with a fresh dump updates the same
- * lemma rows because `source_id` is stable per (synset_id, word_idx).
- *
- * Lines starting with `#` are skipped so a downloaded dump can carry
- * a banner or licence text without choking the parser.
+ * Distribution requires CFILT registration; place the dump at
+ * `apps/web/data/dictionaries/hindi-wordnet/synsets.tsv` and run
+ * `pnpm dictionary:import hindi-wordnet`.
  */
-import { createReadStream } from 'node:fs';
-import { createInterface } from 'node:readline';
-import { dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { makeIndoWordNetSource } from './indo-wordnet.js';
 
-import type { LanguageCode } from '@ciareader/shared-types';
-
-import type { DictionaryImportSource, ImportEntry } from '../types.js';
-
-export type HwnRow = {
-  synsetId: string;
-  category: string;
-  concept: string;
-  example: string;
-  words: string[];
-};
-
-const POS_MAP: Record<string, string> = {
-  noun: 'NOUN',
-  verb: 'VERB',
-  adjective: 'ADJ',
-  adverb: 'ADV',
-  // Hindi WordNet ships a small "particle" / "pronoun" set in some
-  // releases. Keep the door open without advertising support
-  // upstream changes haven't given us yet.
-  pronoun: 'PRON',
-  particle: 'PART',
-};
-
-export function mapWordNetPos(category: string): string | null {
-  return POS_MAP[category.trim().toLowerCase()] ?? null;
-}
-
-/**
- * Parse one TSV line. Returns null for blank, comment, or malformed
- * rows — the runner drops nulls. We deliberately don't throw on
- * malformed rows so a partially-corrupted dump still imports the
- * rows it can read.
- */
-export function parseHwnLine(line: string): HwnRow | null {
-  const trimmed = line.trim();
-  if (!trimmed || trimmed.startsWith('#')) return null;
-  const fields = line.split('\t');
-  if (fields.length < 5) return null;
-  const [synsetId, category, concept, example, words] = fields;
-  if (!synsetId || !category || !words) return null;
-  const wordList = words
-    .split(/[,;]/)
-    .map((w) => w.trim())
-    .filter((w) => w.length > 0);
-  if (wordList.length === 0) return null;
-  return {
-    synsetId: synsetId.trim(),
-    category: category.trim(),
-    concept: (concept ?? '').trim(),
-    example: (example ?? '').trim(),
-    words: wordList,
-  };
-}
-
-/**
- * Convert one TSV row into one or more `ImportEntry` values — one per
- * unique word in the synset. Returns an empty array when the row has
- * no usable members (unknown POS, no concept, etc.).
- */
-export function hwnRowToEntries(row: HwnRow): ImportEntry[] {
-  const pos = mapWordNetPos(row.category);
-  if (!pos) return [];
-  if (!row.concept) return [];
-  const out: ImportEntry[] = [];
-  const seen = new Set<string>();
-  let idx = 0;
-  for (const raw of row.words) {
-    const headword = raw.normalize('NFC').trim();
-    if (!headword || seen.has(headword)) continue;
-    seen.add(headword);
-    const sourceId = `hwn:${row.synsetId}:${idx}`;
-    out.push({
-      sourceId,
-      headword,
-      pos,
-      script: 'Deva',
-      glossDefault: row.concept,
-      translations: [
-        {
-          sourceId: `${sourceId}:concept`,
-          // The dump is monolingual Hindi — `concept` is a Hindi
-          // definition, not an English translation. Mark the
-          // translation row as Hindi-target so the curator UI
-          // doesn't surface it as an English gloss. Future tickets
-          // can cross-link with English WordNet via the synset id
-          // for an en translation.
-          targetLanguage: 'hi',
-          body: row.concept,
-        },
-      ],
-    });
-    idx += 1;
-  }
-  return out;
-}
-
-async function* streamHwnSource(filePath: string): AsyncIterable<ImportEntry> {
-  const stream = createReadStream(filePath, { encoding: 'utf-8' });
-  const rl = createInterface({ input: stream, crlfDelay: Infinity });
-  for await (const line of rl) {
-    const row = parseHwnLine(line);
-    if (!row) continue;
-    for (const entry of hwnRowToEntries(row)) yield entry;
-  }
-}
-
-function resolvePath(): string {
-  const fromEnv = process.env.HINDI_WORDNET_FILE;
-  if (fromEnv) return fromEnv;
-  const here = dirname(fileURLToPath(import.meta.url));
-  return resolve(here, '../../../../../', 'data/dictionaries/hindi-wordnet/synsets.tsv');
-}
-
-export const hindiWordnetSource: DictionaryImportSource = {
+export const hindiWordnetSource = makeIndoWordNetSource({
   name: 'hindi-wordnet',
-  language: 'hi' as LanguageCode,
-  sourceAttribution:
+  language: 'hi',
+  script: 'Deva',
+  sourceIdPrefix: 'hwn',
+  attribution:
     'Hindi WordNet, CFILT IIT-Bombay (research use; attribution required)',
   license: 'Custom-Research-Use',
-  entries: () => streamHwnSource(resolvePath()),
-};
+  envVar: 'HINDI_WORDNET_FILE',
+  defaultPath: 'data/dictionaries/hindi-wordnet/synsets.tsv',
+});

--- a/apps/web/src/lib/server/dictionary/sources/index.ts
+++ b/apps/web/src/lib/server/dictionary/sources/index.ts
@@ -18,6 +18,7 @@ import { dbnaryHindiSource } from './dbnary-hi.js';
 import { dbnaryMarathiSource } from './dbnary-mr.js';
 import { hindiSeedSource } from './hindi-seed.js';
 import { hindiWordnetSource } from './hindi-wordnet.js';
+import { marathiWordnetSource } from './marathi-wordnet.js';
 import { kaikkiEnTranslationsHindiSource } from './kaikki-en-translations-hindi.js';
 import { kaikkiEnTranslationsMarathiSource } from './kaikki-en-translations-marathi.js';
 import { kaikkiEnTranslationsOdiaSource } from './kaikki-en-translations-odia.js';
@@ -50,6 +51,7 @@ export const dictionarySources: RegistryEntry[] = [
   { name: dbnaryHindiSource.name, source: dbnaryHindiSource },
   { name: dbnaryMarathiSource.name, source: dbnaryMarathiSource },
   { name: hindiWordnetSource.name, source: hindiWordnetSource },
+  { name: marathiWordnetSource.name, source: marathiWordnetSource },
 ];
 
 export function findSource(name: string): DictionaryImportSource | undefined {

--- a/apps/web/src/lib/server/dictionary/sources/indo-wordnet.test.ts
+++ b/apps/web/src/lib/server/dictionary/sources/indo-wordnet.test.ts
@@ -1,0 +1,180 @@
+// @vitest-environment node
+/**
+ * Shared CFILT IndoWordNet parser tests (T-3.10a/c).
+ *
+ * Covers the TSV parser, POS map, and synset → ImportEntry expansion.
+ * Per-language smoke tests (Hindi, Marathi, …) live alongside their
+ * thin instantiations and lock in language-specific knobs only —
+ * everything else routes through this file.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  mapWordNetPos,
+  parseSynsetLine,
+  synsetRowToEntries,
+} from './indo-wordnet.js';
+
+const HI_OPTS = {
+  language: 'hi' as const,
+  script: 'Deva',
+  sourceIdPrefix: 'hwn',
+};
+
+describe('mapWordNetPos', () => {
+  it('maps the four core WordNet categories to UD tags', () => {
+    expect(mapWordNetPos('noun')).toBe('NOUN');
+    expect(mapWordNetPos('verb')).toBe('VERB');
+    expect(mapWordNetPos('adjective')).toBe('ADJ');
+    expect(mapWordNetPos('adverb')).toBe('ADV');
+  });
+
+  it('is case- and whitespace-insensitive', () => {
+    expect(mapWordNetPos('NOUN')).toBe('NOUN');
+    expect(mapWordNetPos('  Adjective  ')).toBe('ADJ');
+  });
+
+  it('returns null for unsupported categories', () => {
+    expect(mapWordNetPos('idiom')).toBeNull();
+    expect(mapWordNetPos('')).toBeNull();
+  });
+});
+
+describe('parseSynsetLine', () => {
+  it('parses a 5-column synset row', () => {
+    const row = parseSynsetLine(
+      '1234\tnoun\tवह जो पढ़ने के लिए हो\tमैंने एक किताब पढ़ी\tकिताब,पुस्तक',
+    );
+    expect(row).toEqual({
+      synsetId: '1234',
+      category: 'noun',
+      concept: 'वह जो पढ़ने के लिए हो',
+      example: 'मैंने एक किताब पढ़ी',
+      words: ['किताब', 'पुस्तक'],
+    });
+  });
+
+  it('drops blank lines, # comments, and rows with too few columns', () => {
+    expect(parseSynsetLine('')).toBeNull();
+    expect(parseSynsetLine('   ')).toBeNull();
+    expect(parseSynsetLine('# comment')).toBeNull();
+    expect(parseSynsetLine('1\t2\t3')).toBeNull();
+  });
+
+  it('drops rows with empty words', () => {
+    expect(parseSynsetLine('5\tnoun\tdef\texample\t')).toBeNull();
+  });
+
+  it('accepts both comma- and semicolon-separated word lists', () => {
+    const row = parseSynsetLine('9\tverb\tचलना\t-\tदौड़ना;भागना');
+    expect(row?.words).toEqual(['दौड़ना', 'भागना']);
+  });
+});
+
+describe('synsetRowToEntries', () => {
+  it('produces one ImportEntry per unique synset member', () => {
+    const entries = synsetRowToEntries(
+      {
+        synsetId: '12345',
+        category: 'noun',
+        concept: 'a written or printed work',
+        example: 'मैंने एक किताब पढ़ी',
+        words: ['किताब', 'पुस्तक'],
+      },
+      HI_OPTS,
+    );
+    expect(entries).toHaveLength(2);
+    expect(entries[0]!.headword).toBe('किताब');
+    expect(entries[0]!.pos).toBe('NOUN');
+    expect(entries[0]!.script).toBe('Deva');
+    expect(entries[0]!.sourceId).toBe('hwn:12345:0');
+    expect(entries[0]!.translations[0]!.body).toBe('a written or printed work');
+    expect(entries[0]!.translations[0]!.targetLanguage).toBe('hi');
+    expect(entries[1]!.sourceId).toBe('hwn:12345:1');
+  });
+
+  it('deduplicates repeated members within the same synset', () => {
+    const entries = synsetRowToEntries(
+      {
+        synsetId: '99',
+        category: 'noun',
+        concept: 'def',
+        example: '',
+        words: ['क', 'क', 'ख'],
+      },
+      HI_OPTS,
+    );
+    expect(entries.map((e) => e.headword)).toEqual(['क', 'ख']);
+  });
+
+  it('drops the row when POS is unmapped', () => {
+    const entries = synsetRowToEntries(
+      {
+        synsetId: '1',
+        category: 'idiom',
+        concept: 'def',
+        example: '',
+        words: ['x'],
+      },
+      HI_OPTS,
+    );
+    expect(entries).toHaveLength(0);
+  });
+
+  it('drops the row when concept is empty', () => {
+    expect(
+      synsetRowToEntries(
+        {
+          synsetId: '1',
+          category: 'noun',
+          concept: '',
+          example: '',
+          words: ['x'],
+        },
+        HI_OPTS,
+      ),
+    ).toHaveLength(0);
+  });
+
+  it('NFC-normalizes headwords and trims whitespace', () => {
+    const nfd = 'दा'.normalize('NFD');
+    const entries = synsetRowToEntries(
+      {
+        synsetId: '7',
+        category: 'noun',
+        concept: 'def',
+        example: '',
+        words: [`  ${nfd}  `],
+      },
+      HI_OPTS,
+    );
+    expect(entries[0]!.headword).toBe('दा');
+  });
+
+  it('passes the source language through to the translation row', () => {
+    const entries = synsetRowToEntries(
+      {
+        synsetId: '8',
+        category: 'noun',
+        concept: 'पुस्तक',
+        example: '',
+        words: ['किताब'],
+      },
+      { language: 'hi', script: 'Deva', sourceIdPrefix: 'hwn' },
+    );
+    expect(entries[0]!.translations[0]!.targetLanguage).toBe('hi');
+
+    const mr = synsetRowToEntries(
+      {
+        synsetId: '8',
+        category: 'noun',
+        concept: 'पुस्तक',
+        example: '',
+        words: ['पुस्तक'],
+      },
+      { language: 'mr', script: 'Deva', sourceIdPrefix: 'mwn' },
+    );
+    expect(mr[0]!.translations[0]!.targetLanguage).toBe('mr');
+    expect(mr[0]!.sourceId).toBe('mwn:8:0');
+  });
+});

--- a/apps/web/src/lib/server/dictionary/sources/indo-wordnet.ts
+++ b/apps/web/src/lib/server/dictionary/sources/indo-wordnet.ts
@@ -1,0 +1,176 @@
+/**
+ * Shared CFILT IndoWordNet importer factory (T-3.10a/c, anticipating
+ * T-3.10f).
+ *
+ * CFILT IIT-Bombay distributes monolingual WordNets for every Indian
+ * language under a research-use license, all in the same TSV format:
+ *
+ *     <synset_id>\t<category>\t<concept>\t<example>\t<words>\n
+ *
+ *   - `synset_id`: stable id, the same one the language's webhwn-style
+ *     browser shows.
+ *   - `category`: lowercase noun / verb / adjective / adverb. Anything
+ *     else (idioms, named-entity bundles, …) drops the row.
+ *   - `concept`: the synset definition, used as `gloss_default` and as
+ *     the body of the (single) translation row. The dump is
+ *     monolingual — the gloss is in the same language as the
+ *     headwords, so the translation row is tagged with the source's
+ *     own `language`. A future ticket can cross-link with English
+ *     WordNet via the synset id to surface en translations.
+ *   - `example`: usage example. Dropped at MVP.
+ *   - `words`: comma- or semicolon-separated members of the synset.
+ *     Each unique (word, POS) tuple becomes its own `ImportEntry` so
+ *     the lemma table stays normalized; the synset stays linkable
+ *     through `source_id` (`<prefix>:<synset_id>:<word_idx>`).
+ *
+ * Distribution requires registration with CFILT, so the fetch script
+ * leaves the artifact as a manual placement; the importer's
+ * `defaultPath` points at where the operator should drop it.
+ */
+import { createReadStream } from 'node:fs';
+import { createInterface } from 'node:readline';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import type { LanguageCode } from '@ciareader/shared-types';
+
+import type { DictionaryImportSource, ImportEntry } from '../types.js';
+
+export type SynsetRow = {
+  synsetId: string;
+  category: string;
+  concept: string;
+  example: string;
+  words: string[];
+};
+
+const POS_MAP: Record<string, string> = {
+  noun: 'NOUN',
+  verb: 'VERB',
+  adjective: 'ADJ',
+  adverb: 'ADV',
+  // CFILT releases occasionally include `pronoun` and `particle` rows.
+  // Keep the door open without advertising support for tags upstream
+  // hasn't given us yet.
+  pronoun: 'PRON',
+  particle: 'PART',
+};
+
+export function mapWordNetPos(category: string): string | null {
+  return POS_MAP[category.trim().toLowerCase()] ?? null;
+}
+
+/**
+ * Parse one TSV line. Returns null for blank, comment, or malformed
+ * rows so the runner can drop them without throwing — research-use
+ * dumps occasionally ship with a banner / licence header.
+ */
+export function parseSynsetLine(line: string): SynsetRow | null {
+  const trimmed = line.trim();
+  if (!trimmed || trimmed.startsWith('#')) return null;
+  const fields = line.split('\t');
+  if (fields.length < 5) return null;
+  const [synsetId, category, concept, example, words] = fields;
+  if (!synsetId || !category || !words) return null;
+  const wordList = words
+    .split(/[,;]/)
+    .map((w) => w.trim())
+    .filter((w) => w.length > 0);
+  if (wordList.length === 0) return null;
+  return {
+    synsetId: synsetId.trim(),
+    category: category.trim(),
+    concept: (concept ?? '').trim(),
+    example: (example ?? '').trim(),
+    words: wordList,
+  };
+}
+
+export type IndoWordNetSourceOptions = {
+  /** Stable name (e.g. 'hindi-wordnet'). Drives CLI selection. */
+  name: string;
+  language: LanguageCode;
+  /** ISO 15924 code: Deva (Devanagari), Orya (Odia), … */
+  script: string;
+  /** Prefix for synthesized source_ids, e.g. 'hwn' for Hindi. */
+  sourceIdPrefix: string;
+  attribution: string;
+  license: string;
+  /** Env var that overrides the default file path (used by tests). */
+  envVar: string;
+  /**
+   * Default file path relative to the apps/web root, e.g.
+   * 'data/dictionaries/hindi-wordnet/synsets.tsv'. Distribution is
+   * gated by CFILT registration, so the file is placed manually.
+   */
+  defaultPath: string;
+};
+
+export function synsetRowToEntries(
+  row: SynsetRow,
+  opts: Pick<IndoWordNetSourceOptions, 'script' | 'sourceIdPrefix' | 'language'>,
+): ImportEntry[] {
+  const pos = mapWordNetPos(row.category);
+  if (!pos) return [];
+  if (!row.concept) return [];
+  const out: ImportEntry[] = [];
+  const seen = new Set<string>();
+  let idx = 0;
+  for (const raw of row.words) {
+    const headword = raw.normalize('NFC').trim();
+    if (!headword || seen.has(headword)) continue;
+    seen.add(headword);
+    const sourceId = `${opts.sourceIdPrefix}:${row.synsetId}:${idx}`;
+    out.push({
+      sourceId,
+      headword,
+      pos,
+      script: opts.script,
+      glossDefault: row.concept,
+      translations: [
+        {
+          sourceId: `${sourceId}:concept`,
+          // Monolingual dump — the gloss is in the source language,
+          // not English. Tag accordingly so the curator UI doesn't
+          // surface a Hindi/Marathi/Odia gloss as an English row.
+          targetLanguage: opts.language,
+          body: row.concept,
+        },
+      ],
+    });
+    idx += 1;
+  }
+  return out;
+}
+
+async function* streamSynsetSource(
+  filePath: string,
+  opts: IndoWordNetSourceOptions,
+): AsyncIterable<ImportEntry> {
+  const stream = createReadStream(filePath, { encoding: 'utf-8' });
+  const rl = createInterface({ input: stream, crlfDelay: Infinity });
+  for await (const line of rl) {
+    const row = parseSynsetLine(line);
+    if (!row) continue;
+    for (const entry of synsetRowToEntries(row, opts)) yield entry;
+  }
+}
+
+function resolvePath(opts: IndoWordNetSourceOptions): string {
+  const fromEnv = process.env[opts.envVar];
+  if (fromEnv) return fromEnv;
+  const here = dirname(fileURLToPath(import.meta.url));
+  return resolve(here, '../../../../../', opts.defaultPath);
+}
+
+export function makeIndoWordNetSource(
+  opts: IndoWordNetSourceOptions,
+): DictionaryImportSource {
+  return {
+    name: opts.name,
+    language: opts.language,
+    sourceAttribution: opts.attribution,
+    license: opts.license,
+    entries: () => streamSynsetSource(resolvePath(opts), opts),
+  };
+}

--- a/apps/web/src/lib/server/dictionary/sources/marathi-wordnet.test.ts
+++ b/apps/web/src/lib/server/dictionary/sources/marathi-wordnet.test.ts
@@ -1,0 +1,22 @@
+// @vitest-environment node
+/**
+ * Smoke test for the Marathi WordNet instantiation (T-3.10c).
+ *
+ * The shared parser is exhaustively covered in `indo-wordnet.test.ts`;
+ * this file locks in the language-specific knobs (sourceId prefix,
+ * attribution, default file path) so a refactor that breaks
+ * `marathi-wordnet` can't keep `hindi-wordnet`'s assertions green.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { marathiWordnetSource } from './marathi-wordnet.js';
+
+describe('marathiWordnetSource registry shape', () => {
+  it('exposes the expected attribution, license, and language', () => {
+    expect(marathiWordnetSource.name).toBe('marathi-wordnet');
+    expect(marathiWordnetSource.language).toBe('mr');
+    expect(marathiWordnetSource.license).toContain('Research-Use');
+    expect(marathiWordnetSource.sourceAttribution).toContain('CFILT');
+    expect(marathiWordnetSource.sourceAttribution).toContain('Marathi');
+  });
+});

--- a/apps/web/src/lib/server/dictionary/sources/marathi-wordnet.ts
+++ b/apps/web/src/lib/server/dictionary/sources/marathi-wordnet.ts
@@ -1,0 +1,22 @@
+/**
+ * Marathi WordNet (CFILT IIT-Bombay) importer (T-3.10c).
+ *
+ * Sibling of `hindi-wordnet.ts` — same shared CFILT TSV parser, just
+ * a different language tag, sourceId prefix, and on-disk default path.
+ * Distribution requires CFILT registration; place the dump at
+ * `apps/web/data/dictionaries/marathi-wordnet/synsets.tsv` and run
+ * `pnpm dictionary:import marathi-wordnet`.
+ */
+import { makeIndoWordNetSource } from './indo-wordnet.js';
+
+export const marathiWordnetSource = makeIndoWordNetSource({
+  name: 'marathi-wordnet',
+  language: 'mr',
+  script: 'Deva',
+  sourceIdPrefix: 'mwn',
+  attribution:
+    'Marathi WordNet, CFILT IIT-Bombay (research use; attribution required)',
+  license: 'Custom-Research-Use',
+  envVar: 'MARATHI_WORDNET_FILE',
+  defaultPath: 'data/dictionaries/marathi-wordnet/synsets.tsv',
+});

--- a/docs/dictionary-sources.md
+++ b/docs/dictionary-sources.md
@@ -31,7 +31,7 @@ coverage; Dbnary fills in glosses and translations.
 
 | Source | Publisher | License | Status |
 |---|---|---|---|
-| Marathi WordNet | CFILT, IIT Bombay | Research use, distributable with attribution | Planned |
+| Marathi WordNet | CFILT, IIT Bombay | Research use, distributable with attribution | **Importer landed (T-3.10c, 2026-05-05)** — same shared CFILT TSV parser as `hindi-wordnet` (`indo-wordnet.ts`); instantiation differs only in language tag, sourceId prefix (`mwn`), and default file path. Place dump at `apps/web/data/dictionaries/marathi-wordnet/synsets.tsv`. |
 | *Molesworth's A Dictionary, Marathi and English* (1857) | Public domain (DDSA) | Public domain | Planned — historical orthography will need light normalization |
 | [Dbnary Marathi-English](http://kaiko.getalp.org/about-dbnary/) | GETALP / Univ. Grenoble Alpes | CC-BY-SA 3.0 | **Imported (T-3.10e, 2026-05-05)** — same shared Turtle parser as `dbnary-hi`; instantiation differs only in language tag and on-disk path |
 | [Wiktionary Marathi (via Kaikki.org)](https://kaikki.org/dictionary/Marathi/) | Wiktionary contributors | CC-BY-SA 3.0 | **Imported (T-3.10, 2026-04-28)** — fetched via `scripts/fetch-dictionary-sources.sh kaikki-marathi`; thinner than Hindi (~5k entries) but a solid bootstrap before Marathi WordNet + Molesworth land |


### PR DESCRIPTION
## Summary

- New importer `marathi-wordnet` (CFILT IIT-Bombay, research-use). Same TSV synset format as Hindi WordNet — instantiation differs only in language tag, sourceId prefix (`mwn` vs `hwn`), attribution string, and on-disk default path.
- Factored the shared CFILT TSV parser into `indo-wordnet.ts` (`makeIndoWordNetSource` factory + `parseSynsetLine`, `synsetRowToEntries`, `mapWordNetPos`). Both `hindi-wordnet.ts` and `marathi-wordnet.ts` are now thin instantiations; adding Odia (T-3.10f) is one more block.
- Translation-row `target_language` is now a per-source knob threaded through the factory, so each monolingual WordNet correctly tags its gloss with its own language.
- Fetch script's `manual_dump_check` extended to `marathi-wordnet`.

## Stacked on top of [#415](https://github.com/chickendude/CIA-Reader/pull/415) (T-3.10a)

Branch chain: T-3.14 → T-3.10b → T-3.10e → T-3.10a → T-3.10c. Diff base set to T-3.10a so this PR shows the refactor + the new instantiation.

## Test plan

- [x] `indo-wordnet.test.ts` — 13 tests for the shared parser (POS map, TSV parsing, synset → entries, dedup, NFC, per-source target_language).
- [x] `marathi-wordnet.test.ts` — locks the language-specific knobs (mr lang tag, mwn prefix, attribution).
- [x] `hindi-wordnet.test.ts` — slimmed to a registry-shape lock-in (parser tests moved to `indo-wordnet.test.ts`).
- [x] Full vitest suite passes; `pnpm check`, `pnpm lint` clean.
- [x] `pnpm dictionary:import --list` shows `marathi-wordnet`.

Refs #381, Closes #381.