### PR TITLE
T-3.10f: Odia WordNet (ISI Kolkata) importer

### DIFF
--- a/apps/web/scripts/fetch-dictionary-sources.sh
+++ b/apps/web/scripts/fetch-dictionary-sources.sh
@@ -239,9 +239,13 @@ case "${1-all}" in
     manual_dump_check molesworth dsal.xml \
       "docs/dictionary-sources.md (Molesworth section) — DSAL XML; place dsal.xml at apps/web/data/dictionaries/molesworth/"
     ;;
+  odia-wordnet)
+    manual_dump_check odia-wordnet synsets.tsv \
+      "docs/dictionary-sources.md (Odia WordNet section) — ISI Kolkata distribution requires registration"
+    ;;
   *)
     echo "unknown source: $1" >&2
-    echo "available: kaikki-hindi, kaikki-marathi, kaikki-odia, kaikki-en-translations, dbnary-hi, dbnary-mr, hindi-wordnet, marathi-wordnet, molesworth" >&2
+    echo "available: kaikki-hindi, kaikki-marathi, kaikki-odia, kaikki-en-translations, dbnary-hi, dbnary-mr, hindi-wordnet, marathi-wordnet, molesworth, odia-wordnet" >&2
     exit 1
     ;;
 esac

--- a/apps/web/src/lib/server/dictionary/sources/index.ts
+++ b/apps/web/src/lib/server/dictionary/sources/index.ts
@@ -20,6 +20,7 @@ import { hindiSeedSource } from './hindi-seed.js';
 import { hindiWordnetSource } from './hindi-wordnet.js';
 import { marathiWordnetSource } from './marathi-wordnet.js';
 import { molesworthSource } from './molesworth.js';
+import { odiaWordnetSource } from './odia-wordnet.js';
 import { kaikkiEnTranslationsHindiSource } from './kaikki-en-translations-hindi.js';
 import { kaikkiEnTranslationsMarathiSource } from './kaikki-en-translations-marathi.js';
 import { kaikkiEnTranslationsOdiaSource } from './kaikki-en-translations-odia.js';
@@ -54,6 +55,7 @@ export const dictionarySources: RegistryEntry[] = [
   { name: hindiWordnetSource.name, source: hindiWordnetSource },
   { name: marathiWordnetSource.name, source: marathiWordnetSource },
   { name: molesworthSource.name, source: molesworthSource },
+  { name: odiaWordnetSource.name, source: odiaWordnetSource },
 ];
 
 export function findSource(name: string): DictionaryImportSource | undefined {

--- a/apps/web/src/lib/server/dictionary/sources/odia-wordnet.test.ts
+++ b/apps/web/src/lib/server/dictionary/sources/odia-wordnet.test.ts
@@ -1,0 +1,22 @@
+// @vitest-environment node
+/**
+ * Smoke test for the Odia WordNet instantiation (T-3.10f).
+ *
+ * The shared parser is exhaustively covered in `indo-wordnet.test.ts`;
+ * this file locks in the Odia-specific knobs (script, sourceId
+ * prefix, attribution, language tag) so a refactor that breaks
+ * `odia-wordnet` can't keep `hindi-wordnet` / `marathi-wordnet` green.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { odiaWordnetSource } from './odia-wordnet.js';
+
+describe('odiaWordnetSource registry shape', () => {
+  it('exposes the expected attribution, license, and language', () => {
+    expect(odiaWordnetSource.name).toBe('odia-wordnet');
+    expect(odiaWordnetSource.language).toBe('or');
+    expect(odiaWordnetSource.license).toContain('Research-Use');
+    expect(odiaWordnetSource.sourceAttribution).toContain('ISI');
+    expect(odiaWordnetSource.sourceAttribution).toContain('Odia');
+  });
+});

--- a/apps/web/src/lib/server/dictionary/sources/odia-wordnet.ts
+++ b/apps/web/src/lib/server/dictionary/sources/odia-wordnet.ts
@@ -1,0 +1,31 @@
+/**
+ * Odia WordNet (ISI Kolkata) importer (T-3.10f).
+ *
+ * The ISI Kolkata Odia WordNet ships in the same CFILT-style TSV
+ * synset format as Hindi/Marathi WordNet (T-3.10a/c), so the
+ * importer is a thin instantiation of `makeIndoWordNetSource`. The
+ * `services/nlp/app/pipelines/odia` seed parser handles a tiny
+ * subset of this same dump for tokenizer bootstrap; this importer
+ * lets us pull the full WordNet into the dictionary database without
+ * routing through the NLP service.
+ *
+ * Distribution requires registration with ISI Kolkata; place the
+ * dump at `apps/web/data/dictionaries/odia-wordnet/synsets.tsv` and
+ * run `pnpm dictionary:import odia-wordnet`. Coverage is sparser than
+ * Hindi or Marathi (the browse page already flags this) — combining
+ * with the OdiaNLP curated subset (T-3.10g) is the path to better
+ * launch coverage.
+ */
+import { makeIndoWordNetSource } from './indo-wordnet.js';
+
+export const odiaWordnetSource = makeIndoWordNetSource({
+  name: 'odia-wordnet',
+  language: 'or',
+  script: 'Orya',
+  sourceIdPrefix: 'own',
+  attribution:
+    'Odia WordNet, ISI Kolkata (research use; attribution required)',
+  license: 'Custom-Research-Use',
+  envVar: 'ODIA_WORDNET_FILE',
+  defaultPath: 'data/dictionaries/odia-wordnet/synsets.tsv',
+});

--- a/docs/dictionary-sources.md
+++ b/docs/dictionary-sources.md
@@ -45,7 +45,7 @@ launch.
 
 | Source | Publisher | License | Status |
 |---|---|---|---|
-| Odia WordNet | ISI Kolkata | Research use, distributable with attribution | Planned — the seed for T-2.3a's custom pipeline already draws from this |
+| Odia WordNet | ISI Kolkata | Research use, distributable with attribution | **Importer landed (T-3.10f, 2026-05-05)** — same shared CFILT TSV parser as `hindi-wordnet` / `marathi-wordnet` (`indo-wordnet.ts`); instantiation differs only in language tag, script (`Orya`), sourceId prefix (`own`), and default file path. The seed for T-2.3a's custom NLP pipeline draws from the same dump; place at `apps/web/data/dictionaries/odia-wordnet/synsets.tsv`. |
 | OdiaNLP resources | Community / various | Mixed (MIT / CC-BY) | Planned — curated subset only, per-entry license check required |
 | [Wiktionary Odia (via Kaikki.org)](https://kaikki.org/dictionary/Odia/) | Wiktionary contributors | CC-BY-SA 3.0 | **Imported (T-3.10, 2026-04-28)** — fetched via `scripts/fetch-dictionary-sources.sh kaikki-odia`; the smallest Kaikki dump of the three MVP languages (~2k entries) but the first real Odia lexical data — proves the script-aware path works end-to-end with `Orya` |
 | [Wiktionary English Translations sections (via Kaikki.org)](https://kaikki.org/dictionary/English/) | Wiktionary contributors | CC-BY-SA 3.0 | **Imported (T-3.10, 2026-04-28)** — inverted from English entries' `translations[]`; biggest Odia coverage uplift since Wiktionary's Odia sub-corpus is tiny but the English-side Translations sections include Odia targets generously |


### PR DESCRIPTION
## Summary

- New importer `odia-wordnet` (ISI Kolkata, research-use). Thin instantiation of `makeIndoWordNetSource` from T-3.10c — same TSV synset format as Hindi/Marathi WordNet.
- Differs only in language tag (`or`), script (`Orya`), sourceId prefix (`own`), attribution, and on-disk default path.
- Fetch script's `manual_dump_check` extended to `odia-wordnet`.

## Stacked on top of [#417](https://github.com/chickendude/CIA-Reader/pull/417) (T-3.10d)

Branch chain: T-3.14 → T-3.10b → T-3.10e → T-3.10a → T-3.10c → T-3.10d → T-3.10f.

## Test plan

- [x] `odia-wordnet.test.ts` locks the Odia-specific knobs (`or` lang tag, `Orya` script, `own` prefix, ISI attribution).
- [x] Full vitest suite passes; `pnpm check`, `pnpm lint` clean.
- [x] `pnpm dictionary:import --list` shows `odia-wordnet`.

Refs #384, Closes #384.