### PR TITLE
Split sentence-end punctuation off the preceding word

### DIFF
--- a/services/nlp/app/pipelines/stanza_ud.py
+++ b/services/nlp/app/pipelines/stanza_ud.py
@@ -45,6 +45,17 @@ NON_OOV_UPOS: frozenset[str] = frozenset({"PUNCT", "SYM", "NUM", "PROPN", "X"})
 # skip these when counting known-words and when rendering the pop-up.
 NON_WORD_UPOS: frozenset[str] = frozenset({"PUNCT", "SYM"})
 
+# Sentence-end punctuation that Stanza occasionally fails to split off
+# the preceding word. The Hindi `hi_hdtb` model in particular leaves
+# the danda glued when no whitespace separates them — common in
+# user-generated Wikipedia / web text where a writer types
+# "अवस्थिति।" rather than "अवस्थिति ।". Split-on-output keeps the
+# popup pointed at a clean stem instead of an OOV "word + danda"
+# blob the dictionary will never match. The marks are limited to
+# end-of-sentence punctuation so we don't accidentally split numerals
+# at decimals or comma-joined phrases.
+_TRAILING_SPLIT_MARKS: tuple[str, ...] = ("।", "॥", "?", "!")
+
 _SCRIPT_RANGES: dict[str, tuple[tuple[int, int], ...]] = {
     "Deva": ((0x0900, 0x097F),),
     "Orya": ((0x0B00, 0x0B7F),),
@@ -100,6 +111,23 @@ def should_treat_as_word(surface: str, upos: str, *, script: str | None) -> bool
     if _has_letter(surface) and not _has_target_script(surface, script):
         return False
     return True
+
+
+def _trailing_split_mark(surface: str) -> str | None:
+    """Return the trailing sentence-end mark to peel off, or None.
+
+    A surface that is *only* the mark (Stanza already split it
+    correctly) is left alone; we only intervene when the mark is
+    glued to a non-trivial preceding word. Multi-character marks
+    aren't part of the current set, so a single character match
+    is sufficient.
+    """
+    if len(surface) < 2:
+        return None
+    last = surface[-1]
+    if last in _TRAILING_SPLIT_MARKS:
+        return last
+    return None
 
 
 def parse_feats(feats: str | None) -> dict[str, str]:
@@ -188,7 +216,22 @@ class StanzaUDPipeline(Pipeline):
                         tokens.append(self._make_gap_token(idx, gap))
                         idx += 1
                 surface = word.text
+                # Split a trailing sentence-end mark off the surface
+                # before the per-word Token shaping. Stanza's Hindi
+                # tokenizer occasionally glues the danda to its
+                # preceding word when there's no whitespace between
+                # them, leaving the dictionary lookup with no chance
+                # of matching. See `_TRAILING_SPLIT_MARKS`.
+                trailing_mark = _trailing_split_mark(surface)
                 lemma = word.lemma or surface
+                if trailing_mark:
+                    # Recompute lemma + surface for the word part. If
+                    # Stanza's lemma was the glued form (the OOV
+                    # fallback path), strip the same mark from it so
+                    # downstream dictionary lookup sees a clean stem.
+                    surface = surface[: -len(trailing_mark)]
+                    if lemma.endswith(trailing_mark):
+                        lemma = lemma[: -len(trailing_mark)]
                 upos = (word.upos or "X").upper()
                 features = parse_feats(word.feats)
                 is_word = should_treat_as_word(
@@ -217,6 +260,31 @@ class StanzaUDPipeline(Pipeline):
                     )
                 )
                 idx += 1
+                if trailing_mark:
+                    # Emit the punctuation as its own Token so the
+                    # reader paints it as a non-word boundary marker
+                    # and the phrase-create logic refuses to span
+                    # across sentence ends.
+                    tokens.append(
+                        Token(
+                            idx=idx,
+                            surface=trailing_mark,
+                            is_word=False,
+                            candidates=[
+                                LemmaCandidate(
+                                    lemma=trailing_mark,
+                                    pos="PUNCT",
+                                    score=1.0,
+                                    features={},
+                                ),
+                            ],
+                            is_ambiguous=False,
+                            is_oov=False,
+                            romanization=None,
+                            number_forms=None,
+                        )
+                    )
+                    idx += 1
                 if has_offsets and end is not None:
                     cursor = end
         # Trailing whitespace after the last word — only when we
@@ -269,6 +337,7 @@ __all__ = [
     "NON_WORD_UPOS",
     "StanzaLike",
     "StanzaUDPipeline",
+    "_trailing_split_mark",
     "parse_feats",
     "should_treat_as_word",
 ]

--- a/services/nlp/tests/test_hindi_pipeline.py
+++ b/services/nlp/tests/test_hindi_pipeline.py
@@ -225,6 +225,82 @@ def test_process_marks_punctuation_as_non_word():
     assert tokens[1].is_word is False
 
 
+def test_process_splits_glued_danda_off_preceding_word():
+    # Stanza's `hi_hdtb` model leaves the danda glued to the
+    # preceding word when the writer types "अवस्थिति।" with no
+    # whitespace — common in Wikipedia / web text. The pipeline must
+    # split the punctuation off so the popup looks up the clean stem.
+    doc = FakeDoc(
+        sentences=[
+            FakeSentence(
+                words=[
+                    # Stanza's OOV fallback returns the surface as the
+                    # lemma in this glued case — the model's lemma
+                    # table never has "word + danda".
+                    FakeWord(
+                        text="अवस्थिति।",
+                        lemma="अवस्थिति।",
+                        upos="NOUN",
+                    ),
+                ]
+            )
+        ]
+    )
+    pipe, _ = _pipe(doc)
+    tokens = pipe.process("x").tokens
+    assert [t.surface for t in tokens] == ["अवस्थिति", "।"]
+    assert [t.is_word for t in tokens] == [True, False]
+    # The danda token mirrors what Stanza would have emitted on its
+    # own — PUNCT pos, lemma == surface, is_oov is False.
+    assert tokens[1].candidates[0].pos == "PUNCT"
+    assert tokens[1].candidates[0].lemma == "।"
+    assert tokens[1].is_oov is False
+    # Idx sequence stays contiguous across the synthesized split.
+    assert [t.idx for t in tokens] == [0, 1]
+    # The word-side lemma drops the glued mark too so the dictionary
+    # path doesn't have to deal with "word + danda" surfaces.
+    assert tokens[0].candidates[0].lemma == "अवस्थिति"
+
+
+def test_process_splits_double_danda_and_question_marks_off_words():
+    # Same fix applies to ॥ (Devanagari double danda) and the Latin
+    # `?` / `!` that creep in via translated content.
+    doc = FakeDoc(
+        sentences=[
+            FakeSentence(
+                words=[
+                    FakeWord(text="समाप्त॥", lemma="समाप्त॥", upos="ADJ"),
+                    FakeWord(text="कैसे?", lemma="कैसा", upos="ADV"),
+                    FakeWord(text="वाह!", lemma="वाह!", upos="INTJ"),
+                ]
+            )
+        ]
+    )
+    pipe, _ = _pipe(doc)
+    surfaces = [t.surface for t in pipe.process("x").tokens]
+    assert surfaces == ["समाप्त", "॥", "कैसे", "?", "वाह", "!"]
+
+
+def test_process_leaves_standalone_punctuation_unchanged():
+    # Stanza split correctly already — the surface is *just* the mark.
+    # Splitting again would emit a zero-length surface and would mark
+    # the empty string as a word. Guard via the len < 2 check in the
+    # helper.
+    doc = FakeDoc(
+        sentences=[
+            FakeSentence(
+                words=[
+                    FakeWord(text="नमस्ते", lemma="नमस्ते", upos="INTJ"),
+                    FakeWord(text="।", lemma="।", upos="PUNCT"),
+                ]
+            )
+        ]
+    )
+    pipe, _ = _pipe(doc)
+    tokens = pipe.process("x").tokens
+    assert [t.surface for t in tokens] == ["नमस्ते", "।"]
+
+
 def test_process_marks_coordinate_fragments_as_non_words():
     # Stanza may split a DMS coordinate like "113°43′6″W" into
     # "113°43" + "′6″W" and tag the first chunk as PROPN. The reader


### PR DESCRIPTION
## Summary

- Post-process Stanza output in \`StanzaUDPipeline._tokens_from_doc\` so that a Word whose surface ends with one of \`{ । ॥ ? ! }\` and is longer than the mark itself gets split into two emitted Tokens — the word part (with the mark stripped from its lemma if Stanza had glued it) and the punctuation as a regular PUNCT Token.
- Affects every Stanza-backed pipeline (Hindi, Marathi). Odia goes through its own custom tokenizer and isn't touched.

Closes #420.

## Test plan

- [x] \`pytest services/nlp\` — 459 passed, coverage 93.58%.
- [x] \`ruff check services/nlp\` — clean.
- [ ] Manual against a HI chapter that contains glued danda surfaces (e.g. the Wikipedia 'ग्लेशियर नेशनल पार्क' page) — verify the popup shows the bare word, not the word+danda blob.