### PR TITLE
T-11.7: soft email-verification gate on translation writes

### DIFF
--- a/apps/web/src/app.d.ts
+++ b/apps/web/src/app.d.ts
@@ -8,7 +8,13 @@ declare global {
       user: User | null;
     }
     interface PageData {
-      user: Pick<User, 'id' | 'email' | 'displayName' | 'role'> | null;
+      user:
+        | (Pick<User, 'id' | 'email' | 'displayName' | 'role'> & {
+            /** T-11.7: drives the verification banner.
+             *  True iff `users.email_verified_at IS NOT NULL`. */
+            emailVerified: boolean;
+          })
+        | null;
     }
     // interface PageState {}
     // interface Platform {}

--- a/apps/web/src/lib/components/auth/VerifyEmailBanner.svelte
+++ b/apps/web/src/lib/components/auth/VerifyEmailBanner.svelte
@@ -1,0 +1,109 @@
+<!--
+  Verification-status banner (T-11.7).
+
+  Renders at the very top of every page when the signed-in user has
+  `email_verified_at IS NULL`. Hidden for verified users and for
+  anonymous visitors.
+
+  Only way to dismiss is to verify — intentional friction. Resending
+  hits the rate-limited /api/v1/auth/verify-email/resend endpoint.
+-->
+<script lang="ts">
+  interface Props {
+    user: { emailVerified: boolean } | null;
+  }
+
+  let { user }: Props = $props();
+  let sending = $state(false);
+  let status = $state<{ kind: 'info' | 'error'; text: string } | null>(null);
+
+  async function resend() {
+    sending = true;
+    status = null;
+    try {
+      const res = await fetch('/api/v1/auth/verify-email/resend', { method: 'POST' });
+      if (res.status === 202) {
+        status = { kind: 'info', text: 'Sent — check your inbox.' };
+      } else if (res.status === 204) {
+        // Server says we're already verified — reload to refresh the
+        // banner-driving page data, banner disappears.
+        location.reload();
+      } else if (res.status === 429) {
+        status = { kind: 'error', text: 'Slow down — try again in a minute.' };
+      } else {
+        status = { kind: 'error', text: 'Could not resend. Try again later.' };
+      }
+    } catch {
+      status = { kind: 'error', text: 'Could not resend. Try again later.' };
+    } finally {
+      sending = false;
+    }
+  }
+</script>
+
+{#if user && !user.emailVerified}
+  <div class="verify-banner" role="status" aria-live="polite">
+    <p class="msg">
+      <strong>Verify your email</strong> to publish translations.
+      {#if status}
+        <span class="status" data-kind={status.kind}>{status.text}</span>
+      {/if}
+    </p>
+    <button class="btn" type="button" onclick={resend} disabled={sending}>
+      {sending ? 'Sending…' : 'Resend it'}
+    </button>
+  </div>
+{/if}
+
+<style>
+  .verify-banner {
+    background: #fef3c7;
+    color: #78350f;
+    padding: 0.5rem 1rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    font-size: 0.875rem;
+    border-bottom: 1px solid #fcd34d;
+  }
+  @media (prefers-color-scheme: dark) {
+    .verify-banner {
+      background: #422006;
+      color: #fde68a;
+      border-bottom-color: #92400e;
+    }
+  }
+  .msg {
+    margin: 0;
+    flex: 1;
+  }
+  .status {
+    margin-left: 0.5rem;
+    opacity: 0.85;
+  }
+  .status[data-kind='error'] {
+    color: #991b1b;
+  }
+  @media (prefers-color-scheme: dark) {
+    .status[data-kind='error'] {
+      color: #fca5a5;
+    }
+  }
+  .btn {
+    cursor: pointer;
+    background: transparent;
+    border: 1px solid currentColor;
+    padding: 0.25rem 0.75rem;
+    border-radius: 4px;
+    color: inherit;
+    font: inherit;
+  }
+  .btn:hover:not(:disabled) {
+    background: rgba(0, 0, 0, 0.05);
+  }
+  .btn:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+</style>

--- a/apps/web/src/lib/server/auth/require-user.test.ts
+++ b/apps/web/src/lib/server/auth/require-user.test.ts
@@ -33,7 +33,7 @@ vi.mock('../db/index.js', () => ({
 }));
 
 // Import SUT after the mock registration.
-const { resolveUser, requireUser } = await import('./require-user.js');
+const { resolveUser, requireUser, requireVerifiedUser } = await import('./require-user.js');
 
 function makeEvent({
   bearer,
@@ -143,5 +143,33 @@ describe('requireUser', () => {
 
   it('throws 401 when the caller is unauthenticated', async () => {
     await expect(requireUser(makeEvent())).rejects.toMatchObject({ status: 401 });
+  });
+});
+
+describe('requireVerifiedUser', () => {
+  it('returns the user when emailVerifiedAt is set', async () => {
+    const verified = {
+      id: 'u1',
+      emailVerifiedAt: new Date(),
+    } as unknown as Awaited<ReturnType<typeof requireVerifiedUser>>;
+    const user = await requireVerifiedUser(makeEvent({ locals: { user: verified } }));
+    expect(user).toBe(verified);
+  });
+
+  it('throws 403 with EMAIL_NOT_VERIFIED when emailVerifiedAt is null', async () => {
+    const unverified = {
+      id: 'u2',
+      emailVerifiedAt: null,
+    } as unknown as Awaited<ReturnType<typeof requireVerifiedUser>>;
+    await expect(
+      requireVerifiedUser(makeEvent({ locals: { user: unverified } })),
+    ).rejects.toMatchObject({
+      status: 403,
+      body: { message: 'EMAIL_NOT_VERIFIED' },
+    });
+  });
+
+  it('falls through to requireUser 401 when unauthenticated', async () => {
+    await expect(requireVerifiedUser(makeEvent())).rejects.toMatchObject({ status: 401 });
   });
 });

--- a/apps/web/src/lib/server/auth/require-user.ts
+++ b/apps/web/src/lib/server/auth/require-user.ts
@@ -55,3 +55,25 @@ export async function requireUser(event: RequestEvent): Promise<User> {
   if (!user) throw error(401, 'Unauthorized');
   return user;
 }
+
+/**
+ * Stable error-body message thrown by `requireVerifiedUser`. The
+ * frontend matches on this exact string to swap the generic 403 for
+ * an inline "resend verification" CTA. Matches the existing
+ * codebase convention of using `error(status, 'STABLE_CODE')`.
+ */
+export const EMAIL_NOT_VERIFIED = 'EMAIL_NOT_VERIFIED';
+
+/**
+ * Like `requireUser`, but additionally rejects users whose
+ * `email_verified_at` is null. Used to gate content-creating actions
+ * (translations, votes, reports) so a brand-new signup can't post
+ * publicly-visible content under an unverified email (T-11.7).
+ */
+export async function requireVerifiedUser(event: RequestEvent): Promise<User> {
+  const user = await requireUser(event);
+  if (!user.emailVerifiedAt) {
+    throw error(403, EMAIL_NOT_VERIFIED);
+  }
+  return user;
+}

--- a/apps/web/src/routes/+layout.server.ts
+++ b/apps/web/src/routes/+layout.server.ts
@@ -49,6 +49,10 @@ export const load: LayoutServerLoad = async ({ locals, cookies }) => {
           email: locals.user.email,
           displayName: locals.user.displayName,
           role: locals.user.role,
+          // T-11.7: layout drives the VerifyEmailBanner. Boolean
+          // (rather than the timestamp) to keep the page-data
+          // surface small and serializable-friendly.
+          emailVerified: locals.user.emailVerifiedAt !== null,
         }
       : null,
     currentLanguage,

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -1,10 +1,16 @@
 <script lang="ts">
   import '$lib/styles/tokens.css';
   import AppShell from '$lib/components/shell/AppShell.svelte';
+  import VerifyEmailBanner from '$lib/components/auth/VerifyEmailBanner.svelte';
   import type { LayoutData } from './$types';
 
   let { data, children }: { data: LayoutData; children: import('svelte').Snippet } = $props();
 </script>
+
+<!-- T-11.7: renders only when locals.user.emailVerifiedAt is null.
+     Sits above AppShell so it spans full width across desktop rail +
+     mobile top strip layouts. -->
+<VerifyEmailBanner user={data.user} />
 
 <AppShell
   user={data.user}

--- a/apps/web/src/routes/api/v1/auth/register/+server.ts
+++ b/apps/web/src/routes/api/v1/auth/register/+server.ts
@@ -4,9 +4,12 @@ import { z } from 'zod';
 import type { RequestHandler } from './$types';
 import { db, schema } from '$lib/server/db/index.js';
 import { hashPassword } from '$lib/server/auth/password.js';
+import { createMagicLink } from '$lib/server/auth/magic-link.js';
 import { createSession, setSessionCookie } from '$lib/server/auth/sessions.js';
 import { signAccessToken, ACCESS_TOKEN_TTL } from '$lib/server/auth/access-token.js';
 import { createRefreshToken } from '$lib/server/auth/refresh.js';
+import { buildMagicLinkEmail, sendMail } from '$lib/server/email/index.js';
+import { APP_BASE_URL } from '$lib/server/env.js';
 import { emailSchema, isSecureRequest, parseJson, passwordSchema, publicUser } from '../_helpers.js';
 
 const body = z.object({
@@ -39,6 +42,20 @@ export const POST: RequestHandler = async ({ request, cookies, url }) => {
 
   const session = await createSession(created.id);
   setSessionCookie(cookies, session.token, session.expiresAt, isSecureRequest(url));
+
+  // Send a verification magic-link (T-11.7). Same handler as
+  // /login's "Email me a link" — the consumer in
+  // $lib/server/auth/magic-link.ts sets email_verified_at on
+  // click, so this email both welcomes and verifies. Failures
+  // are logged but don't block signup — clients can resend via
+  // POST /api/v1/auth/verify-email/resend.
+  try {
+    const token = await createMagicLink(created.id);
+    const verifyUrl = `${APP_BASE_URL}/auth/magic/${encodeURIComponent(token)}`;
+    await sendMail(buildMagicLinkEmail(created.email, verifyUrl));
+  } catch (err) {
+    console.error('Failed to send verification email on register:', err);
+  }
 
   const accessToken = await signAccessToken(created.id);
   const refreshToken = await createRefreshToken(created.id);

--- a/apps/web/src/routes/api/v1/auth/verify-email/resend/+server.ts
+++ b/apps/web/src/routes/api/v1/auth/verify-email/resend/+server.ts
@@ -1,0 +1,68 @@
+/**
+ * POST /api/v1/auth/verify-email/resend (T-11.7).
+ *
+ * Sends a fresh magic-link email to the authenticated user so they
+ * can verify their address. Used by the verification banner's
+ * "Resend it" CTA. Idempotent on already-verified users (204) so
+ * the UI doesn't have to special-case its own success state.
+ *
+ * Rate-limited per user — 1 send / 60s — to keep an obviously
+ * legitimate user (who lost the original email) flowing without
+ * letting a runaway client spam our SMTP relay.
+ */
+import { error, json } from '@sveltejs/kit';
+
+import { requireUser } from '$lib/server/auth/require-user.js';
+import { createMagicLink } from '$lib/server/auth/magic-link.js';
+import {
+  RequestRateLimitError,
+  consumeRateLimit,
+  rateLimitHeaders,
+} from '$lib/server/auth/rate-limits.js';
+import { buildMagicLinkEmail, sendMail } from '$lib/server/email/index.js';
+import { APP_BASE_URL } from '$lib/server/env.js';
+import type { RequestHandler } from './$types';
+
+const WINDOW_MS = 60_000;
+const LIMIT = 1;
+
+export const POST: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+
+  // Already verified → return 204 so the UI banner can hide itself.
+  if (user.emailVerifiedAt) {
+    return new Response(null, { status: 204 });
+  }
+
+  let limit;
+  try {
+    limit = await consumeRateLimit(event, user.id, {
+      scope: 'auth:verify-email-resend',
+      limit: LIMIT,
+      windowMs: WINDOW_MS,
+    });
+  } catch (err) {
+    if (err instanceof RequestRateLimitError) {
+      return json(
+        {
+          error: 'rate_limited',
+          message: 'Slow down — try again in a minute.',
+          retryAfterSeconds: err.retryAfterSeconds,
+        },
+        { status: 429, headers: rateLimitHeaders(err) },
+      );
+    }
+    throw err;
+  }
+
+  const token = await createMagicLink(user.id);
+  const verifyUrl = `${APP_BASE_URL}/auth/magic/${encodeURIComponent(token)}`;
+  try {
+    await sendMail(buildMagicLinkEmail(user.email, verifyUrl));
+  } catch (err) {
+    console.error('Failed to resend verification email:', err);
+    throw error(502, 'Could not send verification email. Try again later.');
+  }
+
+  return json({ ok: true }, { status: 202, headers: rateLimitHeaders(limit) });
+};

--- a/apps/web/src/routes/api/v1/auth/verify-email/resend/server.test.ts
+++ b/apps/web/src/routes/api/v1/auth/verify-email/resend/server.test.ts
@@ -1,0 +1,132 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const requireUser = vi.fn<(...args: unknown[]) => unknown>();
+const createMagicLink = vi.fn<(...args: unknown[]) => unknown>();
+const consumeRateLimit = vi.fn<(...args: unknown[]) => unknown>();
+const sendMail = vi.fn<(...args: unknown[]) => unknown>();
+const rateLimitHeaders = vi.fn<(...args: unknown[]) => Record<string, string>>(
+  () => ({}),
+);
+
+class FakeRequestRateLimitError extends Error {
+  status = 429;
+  limit = 1;
+  remaining = 0;
+  retryAfterSeconds = 60;
+  subjectType = 'user' as const;
+  constructor() {
+    super('rate limited');
+    this.name = 'RequestRateLimitError';
+  }
+}
+
+vi.mock('$lib/server/auth/require-user.js', () => ({
+  requireUser: (...args: unknown[]) => requireUser(...args),
+}));
+vi.mock('$lib/server/auth/magic-link.js', () => ({
+  createMagicLink: (...args: unknown[]) => createMagicLink(...args),
+}));
+vi.mock('$lib/server/auth/rate-limits.js', () => ({
+  RequestRateLimitError: FakeRequestRateLimitError,
+  consumeRateLimit: (...args: unknown[]) => consumeRateLimit(...args),
+  rateLimitHeaders: (...args: unknown[]) => rateLimitHeaders(...args),
+}));
+vi.mock('$lib/server/email/index.js', () => ({
+  sendMail: (...args: unknown[]) => sendMail(...args),
+  buildMagicLinkEmail: (to: string, url: string) => ({ to, subject: 's', text: url }),
+}));
+vi.mock('$lib/server/env.js', () => ({
+  APP_BASE_URL: 'https://parhiba.com',
+}));
+
+const { POST } = await import('./+server.js');
+
+function makeEvent() {
+  return {
+    request: { headers: new Headers() },
+    cookies: { get: () => undefined },
+    locals: {},
+    url: new URL('https://parhiba.com/api/v1/auth/verify-email/resend'),
+  } as unknown as Parameters<typeof POST>[0];
+}
+
+describe('POST /api/v1/auth/verify-email/resend', () => {
+  beforeEach(() => {
+    requireUser.mockReset();
+    createMagicLink.mockReset();
+    consumeRateLimit.mockReset();
+    sendMail.mockReset();
+    rateLimitHeaders.mockReset();
+    rateLimitHeaders.mockReturnValue({});
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 204 when the user is already verified (idempotent)', async () => {
+    requireUser.mockResolvedValue({
+      id: 'u1',
+      email: 'a@b.c',
+      emailVerifiedAt: new Date(),
+    });
+
+    const res = await POST(makeEvent());
+
+    expect(res.status).toBe(204);
+    expect(sendMail).not.toHaveBeenCalled();
+    expect(createMagicLink).not.toHaveBeenCalled();
+  });
+
+  it('mints a magic link and sends the email when unverified', async () => {
+    requireUser.mockResolvedValue({
+      id: 'u2',
+      email: 'unverified@example.com',
+      emailVerifiedAt: null,
+    });
+    consumeRateLimit.mockResolvedValue({ limit: 1, remaining: 0 });
+    createMagicLink.mockResolvedValue('tok-abc');
+    sendMail.mockResolvedValue(undefined);
+
+    const res = await POST(makeEvent());
+
+    expect(res.status).toBe(202);
+    expect(createMagicLink).toHaveBeenCalledWith('u2');
+    expect(sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: 'unverified@example.com',
+        text: expect.stringContaining('https://parhiba.com/auth/magic/tok-abc'),
+      }),
+    );
+  });
+
+  it('returns 429 when rate-limited, without sending email', async () => {
+    requireUser.mockResolvedValue({
+      id: 'u3',
+      email: 'rl@example.com',
+      emailVerifiedAt: null,
+    });
+    consumeRateLimit.mockRejectedValue(new FakeRequestRateLimitError());
+
+    const res = await POST(makeEvent());
+
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body).toMatchObject({ error: 'rate_limited', retryAfterSeconds: 60 });
+    expect(sendMail).not.toHaveBeenCalled();
+  });
+
+  it('returns 502 if SMTP throws', async () => {
+    requireUser.mockResolvedValue({
+      id: 'u4',
+      email: 'smtp@example.com',
+      emailVerifiedAt: null,
+    });
+    consumeRateLimit.mockResolvedValue({ limit: 1, remaining: 0 });
+    createMagicLink.mockResolvedValue('tok-xyz');
+    sendMail.mockRejectedValue(new Error('smtp down'));
+
+    await expect(POST(makeEvent())).rejects.toMatchObject({ status: 502 });
+  });
+});

--- a/apps/web/src/routes/api/v1/texts/+server.ts
+++ b/apps/web/src/routes/api/v1/texts/+server.ts
@@ -17,7 +17,7 @@
 import { error, json } from '@sveltejs/kit';
 import { z } from 'zod';
 
-import { requireUser } from '$lib/server/auth/require-user.js';
+import { requireVerifiedUser } from '$lib/server/auth/require-user.js';
 import {
   consumeRateLimit,
   rateLimitHeaders,
@@ -62,7 +62,7 @@ const txtSchema = z.object({
 const body = z.union([txtSchema, pasteSchema]);
 
 export const POST: RequestHandler = async (event) => {
-  const user = await requireUser(event);
+  const user = await requireVerifiedUser(event);
   const input = await parseJson(event.request, body);
   try {
     const requestLimit = await consumeRateLimit(event, user.id, {

--- a/apps/web/src/routes/api/v1/texts/[id]/audio/+server.ts
+++ b/apps/web/src/routes/api/v1/texts/[id]/audio/+server.ts
@@ -6,7 +6,7 @@
  */
 import { error, json } from '@sveltejs/kit';
 
-import { requireUser } from '$lib/server/auth/require-user.js';
+import { requireVerifiedUser } from '$lib/server/auth/require-user.js';
 import {
   consumeRateLimit,
   rateLimitHeaders,
@@ -47,7 +47,7 @@ export const GET: RequestHandler = async (event) => {
 };
 
 export const POST: RequestHandler = async (event) => {
-  const user = await requireUser(event);
+  const user = await requireVerifiedUser(event);
   const id = event.params.id;
   if (!id || !UUID_RE.test(id)) throw error(400, 'Invalid text id');
   const form = await event.request.formData();

--- a/apps/web/src/routes/api/v1/texts/epub/+server.ts
+++ b/apps/web/src/routes/api/v1/texts/epub/+server.ts
@@ -20,7 +20,7 @@
  */
 import { error, json } from '@sveltejs/kit';
 
-import { requireUser } from '$lib/server/auth/require-user.js';
+import { requireVerifiedUser } from '$lib/server/auth/require-user.js';
 import {
   consumeRateLimit,
   rateLimitHeaders,
@@ -45,7 +45,7 @@ const EPUB_UPLOADS_PER_DAY = 10;
 const UPLOAD_WINDOW_MS = 24 * 60 * 60 * 1_000;
 
 export const POST: RequestHandler = async (event) => {
-  const user = await requireUser(event);
+  const user = await requireVerifiedUser(event);
   let fd: FormData;
   try {
     fd = await event.request.formData();

--- a/apps/web/src/routes/api/v1/texts/epub/epub-server.test.ts
+++ b/apps/web/src/routes/api/v1/texts/epub/epub-server.test.ts
@@ -20,6 +20,7 @@ vi.mock('$lib/server/texts/upload.js', async () => {
 
 vi.mock('$lib/server/auth/require-user.js', () => ({
   requireUser: (...a: unknown[]) => requireUser(...a),
+  requireVerifiedUser: (...a: unknown[]) => requireUser(...a),
 }));
 
 vi.mock('$lib/server/auth/rate-limits.js', async () => {

--- a/apps/web/src/routes/api/v1/texts/texts-server.test.ts
+++ b/apps/web/src/routes/api/v1/texts/texts-server.test.ts
@@ -24,6 +24,7 @@ vi.mock('$lib/server/texts/upload.js', async () => {
 
 vi.mock('$lib/server/auth/require-user.js', () => ({
   requireUser: (...a: unknown[]) => requireUser(...a),
+  requireVerifiedUser: (...a: unknown[]) => requireUser(...a),
 }));
 
 vi.mock('$lib/server/auth/rate-limits.js', async () => {

--- a/apps/web/src/routes/api/v1/translations/+server.ts
+++ b/apps/web/src/routes/api/v1/translations/+server.ts
@@ -9,7 +9,7 @@
 import { error, json } from '@sveltejs/kit';
 import { z } from 'zod';
 
-import { requireUser } from '$lib/server/auth/require-user.js';
+import { requireVerifiedUser } from '$lib/server/auth/require-user.js';
 import {
   RequestRateLimitError,
   consumeRateLimit,
@@ -36,7 +36,7 @@ const body = z.object({
 });
 
 export const POST: RequestHandler = async (event) => {
-  const user = await requireUser(event);
+  const user = await requireVerifiedUser(event);
   const input = await parseJson(event.request, body);
 
   try {

--- a/apps/web/src/routes/api/v1/translations/[id]/+server.ts
+++ b/apps/web/src/routes/api/v1/translations/[id]/+server.ts
@@ -9,7 +9,7 @@
 import { error, json } from '@sveltejs/kit';
 import { z } from 'zod';
 
-import { requireUser } from '$lib/server/auth/require-user.js';
+import { requireVerifiedUser } from '$lib/server/auth/require-user.js';
 import {
   deleteUserTranslation,
   publicTranslation,
@@ -34,7 +34,7 @@ function mapTranslationError(err: unknown): never {
 }
 
 export const PATCH: RequestHandler = async (event) => {
-  const user = await requireUser(event);
+  const user = await requireVerifiedUser(event);
   const id = event.params.id;
   if (!id || !UUID_RE.test(id)) throw error(400, 'Invalid translation id');
   const input = await parseJson(event.request, patchBody);
@@ -47,7 +47,7 @@ export const PATCH: RequestHandler = async (event) => {
 };
 
 export const DELETE: RequestHandler = async (event) => {
-  const user = await requireUser(event);
+  const user = await requireVerifiedUser(event);
   const id = event.params.id;
   if (!id || !UUID_RE.test(id)) throw error(400, 'Invalid translation id');
   try {

--- a/apps/web/src/routes/api/v1/translations/[id]/report/+server.ts
+++ b/apps/web/src/routes/api/v1/translations/[id]/report/+server.ts
@@ -14,7 +14,7 @@
 import { error, json } from '@sveltejs/kit';
 import { z } from 'zod';
 
-import { requireUser } from '$lib/server/auth/require-user.js';
+import { requireVerifiedUser } from '$lib/server/auth/require-user.js';
 import {
   MAX_NOTE_LEN,
   publicReport,
@@ -34,7 +34,7 @@ const body = z.object({
 });
 
 export const POST: RequestHandler = async (event) => {
-  const user = await requireUser(event);
+  const user = await requireVerifiedUser(event);
   const id = event.params.id;
   if (!id || !UUID_RE.test(id)) throw error(400, 'Invalid translation id');
   const input = await parseJson(event.request, body);

--- a/apps/web/src/routes/api/v1/translations/[id]/report/report-server.test.ts
+++ b/apps/web/src/routes/api/v1/translations/[id]/report/report-server.test.ts
@@ -23,6 +23,7 @@ vi.mock('$lib/server/moderation/reports.js', async () => {
 
 vi.mock('$lib/server/auth/require-user.js', () => ({
   requireUser: (...a: unknown[]) => requireUser(...a),
+  requireVerifiedUser: (...a: unknown[]) => requireUser(...a),
 }));
 
 type PostFn = (typeof import('./+server.js'))['POST'];

--- a/apps/web/src/routes/api/v1/translations/[id]/translation-id-server.test.ts
+++ b/apps/web/src/routes/api/v1/translations/[id]/translation-id-server.test.ts
@@ -21,6 +21,7 @@ vi.mock('$lib/server/dictionary/translations.js', async () => {
 
 vi.mock('$lib/server/auth/require-user.js', () => ({
   requireUser: (...a: unknown[]) => requireUser(...a),
+  requireVerifiedUser: (...a: unknown[]) => requireUser(...a),
 }));
 
 type PatchFn = (typeof import('./+server.js'))['PATCH'];

--- a/apps/web/src/routes/api/v1/translations/[id]/vote/+server.ts
+++ b/apps/web/src/routes/api/v1/translations/[id]/vote/+server.ts
@@ -6,7 +6,7 @@
 import { error, json } from '@sveltejs/kit';
 import { z } from 'zod';
 
-import { requireUser } from '$lib/server/auth/require-user.js';
+import { requireVerifiedUser } from '$lib/server/auth/require-user.js';
 import {
   setTranslationVote,
   TranslationVoteError,
@@ -29,7 +29,7 @@ function mapVoteError(err: unknown): never {
 }
 
 export const PATCH: RequestHandler = async (event) => {
-  const user = await requireUser(event);
+  const user = await requireVerifiedUser(event);
   const id = event.params.id;
   if (!id || !UUID_RE.test(id)) throw error(400, 'Invalid translation id');
   const input = await parseJson(event.request, bodySchema);

--- a/apps/web/src/routes/api/v1/translations/[id]/vote/vote-server.test.ts
+++ b/apps/web/src/routes/api/v1/translations/[id]/vote/vote-server.test.ts
@@ -6,6 +6,7 @@ const setTranslationVote = vi.fn();
 
 vi.mock('$lib/server/auth/require-user.js', () => ({
   requireUser: (...a: unknown[]) => requireUser(...a),
+  requireVerifiedUser: (...a: unknown[]) => requireUser(...a),
 }));
 
 vi.mock('$lib/server/dictionary/votes.js', () => {

--- a/apps/web/src/routes/api/v1/translations/translations-server.test.ts
+++ b/apps/web/src/routes/api/v1/translations/translations-server.test.ts
@@ -26,6 +26,7 @@ vi.mock('$lib/server/dictionary/translations.js', async () => {
 
 vi.mock('$lib/server/auth/require-user.js', () => ({
   requireUser: (...a: unknown[]) => requireUser(...a),
+  requireVerifiedUser: (...a: unknown[]) => requireUser(...a),
 }));
 
 vi.mock('$lib/server/auth/rate-limits.js', async () => {

--- a/apps/web/src/routes/auth/magic/[token]/+server.ts
+++ b/apps/web/src/routes/auth/magic/[token]/+server.ts
@@ -14,7 +14,10 @@ import { isSecureRequest } from '../../../api/v1/auth/_helpers.js';
 export const GET: RequestHandler = async ({ params, cookies, url }) => {
   const user = await consumeMagicLink(params.token);
   if (!user) {
-    throw redirect(303, '/?auth_error=invalid_magic_link');
+    // Land back on /login (not /) so the inline error has a sensible
+    // place to render AND the user can immediately request a fresh
+    // link from the same page (T-11.7).
+    throw redirect(303, '/login?auth_error=invalid_magic_link');
   }
   const session = await createSession(user.id);
   setSessionCookie(cookies, session.token, session.expiresAt, isSecureRequest(url));

--- a/apps/web/src/routes/layout-server.test.ts
+++ b/apps/web/src/routes/layout-server.test.ts
@@ -57,7 +57,7 @@ describe('root +layout.server.ts load', () => {
     expect(userLanguageRows).not.toHaveBeenCalled();
   });
 
-  it('serializes only the four public user fields when signed in', async () => {
+  it('serializes only the public user fields when signed in', async () => {
     const data = await load(
       makeEvent({
         locals: {
@@ -66,6 +66,7 @@ describe('root +layout.server.ts load', () => {
             email: 'a@b.c',
             displayName: 'Alex',
             role: 'user',
+            emailVerifiedAt: new Date('2026-01-01T00:00:00Z'),
             // Fields that must NOT leak via the layout loader — these live on
             // the full User type but are not safe to send to every page.
             passwordHash: 'secret',
@@ -80,6 +81,8 @@ describe('root +layout.server.ts load', () => {
       email: 'a@b.c',
       displayName: 'Alex',
       role: 'user',
+      // T-11.7: layout exposes a boolean flag, not the raw timestamp.
+      emailVerified: true,
     });
   });
 

--- a/apps/web/src/routes/login/+page.server.ts
+++ b/apps/web/src/routes/login/+page.server.ts
@@ -52,7 +52,7 @@ function readNext(url: URL): string {
 function readAuthError(url: URL): string | null {
   const code = url.searchParams.get('auth_error');
   if (code === 'invalid_magic_link') {
-    return 'That sign-in link is invalid or has expired. Request a new one below.';
+    return 'That sign-in link is invalid or has expired. Request a new one using the link at the top of the page.';
   }
   return null;
 }

--- a/apps/web/src/routes/login/+page.server.ts
+++ b/apps/web/src/routes/login/+page.server.ts
@@ -58,10 +58,17 @@ function readAuthError(url: URL): string | null {
 }
 
 export const load: PageServerLoad = ({ locals, url }) => {
-  if (locals.user) {
+  const authError = readAuthError(url);
+  // A logged-in visitor who hit /login by accident gets bounced to
+  // their post-login target. Exception: if they got here via a stale
+  // magic-link redirect (auth_error set), we render so they can see
+  // *why* the link they clicked didn't work — otherwise the failure
+  // is invisible and they'll keep wondering why "click the email" is
+  // doing nothing.
+  if (locals.user && !authError) {
     throw redirect(303, readNext(url));
   }
-  return { next: readNext(url), authError: readAuthError(url) };
+  return { next: readNext(url), authError };
 };
 
 export const actions: Actions = {

--- a/apps/web/src/routes/login/+page.server.ts
+++ b/apps/web/src/routes/login/+page.server.ts
@@ -43,11 +43,25 @@ function readNext(url: URL): string {
   return raw;
 }
 
+/**
+ * Surfaces an inline message when the user arrives via a stale
+ * magic-link redirect (e.g. /auth/magic/<token> resolved to expired
+ * / already-used / invalid). The +server.ts that handles the magic
+ * URL forwards here with ?auth_error=invalid_magic_link.
+ */
+function readAuthError(url: URL): string | null {
+  const code = url.searchParams.get('auth_error');
+  if (code === 'invalid_magic_link') {
+    return 'That sign-in link is invalid or has expired. Request a new one below.';
+  }
+  return null;
+}
+
 export const load: PageServerLoad = ({ locals, url }) => {
   if (locals.user) {
     throw redirect(303, readNext(url));
   }
-  return { next: readNext(url) };
+  return { next: readNext(url), authError: readAuthError(url) };
 };
 
 export const actions: Actions = {

--- a/apps/web/src/routes/login/+page.server.ts
+++ b/apps/web/src/routes/login/+page.server.ts
@@ -64,11 +64,18 @@ export const load: PageServerLoad = ({ locals, url }) => {
   // magic-link redirect (auth_error set), we render so they can see
   // *why* the link they clicked didn't work — otherwise the failure
   // is invisible and they'll keep wondering why "click the email" is
-  // doing nothing.
+  // doing nothing. The template branches on `alreadySignedIn` so
+  // those users see the error + a "continue to library" link,
+  // not the password / magic-link forms which would be redundant
+  // for them.
   if (locals.user && !authError) {
     throw redirect(303, readNext(url));
   }
-  return { next: readNext(url), authError };
+  return {
+    next: readNext(url),
+    authError,
+    alreadySignedIn: locals.user !== null,
+  };
 };
 
 export const actions: Actions = {

--- a/apps/web/src/routes/login/+page.svelte
+++ b/apps/web/src/routes/login/+page.svelte
@@ -34,6 +34,10 @@
     </p>
   </header>
 
+  {#if data.authError}
+    <p class="err" role="alert">{data.authError}</p>
+  {/if}
+
   {#if passwordError}
     <p class="err" role="alert">{passwordError}</p>
   {/if}

--- a/apps/web/src/routes/login/+page.svelte
+++ b/apps/web/src/routes/login/+page.svelte
@@ -34,9 +34,7 @@
     </header>
     <p class="err" role="alert">{data.authError}</p>
     <p class="sub">
-      You're still signed in. <a href={data.next}>Continue to the app</a>,
-      or use the "Verify your email" button at the top of any page to
-      request a fresh link.
+      Go to the <a href="/library">library</a> or request a new link.
     </p>
   {:else}
   <header>

--- a/apps/web/src/routes/login/+page.svelte
+++ b/apps/web/src/routes/login/+page.svelte
@@ -25,6 +25,20 @@
 </svelte:head>
 
 <div class="page">
+  {#if data.alreadySignedIn && data.authError}
+    <!-- Signed-in user landed here via a stale magic-link redirect.
+         Skip the sign-in forms entirely — they're redundant. Just
+         show the error and a way back to the app. -->
+    <header>
+      <h1>Link expired</h1>
+    </header>
+    <p class="err" role="alert">{data.authError}</p>
+    <p class="sub">
+      You're still signed in. <a href={data.next}>Continue to the app</a>,
+      or use the "Verify your email" button at the top of any page to
+      request a fresh link.
+    </p>
+  {:else}
   <header>
     <h1>Sign in</h1>
     <p class="sub">
@@ -92,6 +106,7 @@
       <button type="submit" class="secondary">Email me a link</button>
     </form>
   </section>
+  {/if}
 </div>
 
 <style>

--- a/apps/web/src/routes/login/page-server.test.ts
+++ b/apps/web/src/routes/login/page-server.test.ts
@@ -158,8 +158,18 @@ describe('/login loader', () => {
     const data = (await callLoad(
       'http://x/login?auth_error=invalid_magic_link',
       { id: 'logged-in-user' },
-    )) as { authError: string | null };
+    )) as { authError: string | null; alreadySignedIn: boolean };
     expect(data.authError).toMatch(/invalid or has expired/i);
+    expect(data.alreadySignedIn).toBe(true);
+  });
+
+  it('signals alreadySignedIn=false for anonymous visitors so the forms render', async () => {
+    const data = (await callLoad('http://x/login')) as {
+      authError: string | null;
+      alreadySignedIn: boolean;
+    };
+    expect(data.alreadySignedIn).toBe(false);
+    expect(data.authError).toBeNull();
   });
 
   it('ignores unknown ?auth_error values without crashing', async () => {

--- a/apps/web/src/routes/login/page-server.test.ts
+++ b/apps/web/src/routes/login/page-server.test.ts
@@ -143,6 +143,25 @@ describe('/login loader', () => {
     expect(res.status).toBe(303);
     expect(res.location).toBe('/library');
   });
+
+  it('surfaces ?auth_error=invalid_magic_link as a friendly inline message (T-11.7)', async () => {
+    const data = (await callLoad(
+      'http://x/login?auth_error=invalid_magic_link',
+    )) as { next: string; authError: string | null };
+    expect(data.authError).toMatch(/invalid or has expired/i);
+  });
+
+  it('ignores unknown ?auth_error values without crashing', async () => {
+    const data = (await callLoad('http://x/login?auth_error=bogus')) as {
+      authError: string | null;
+    };
+    expect(data.authError).toBeNull();
+  });
+
+  it('returns authError: null when no error param is present', async () => {
+    const data = (await callLoad('http://x/login')) as { authError: string | null };
+    expect(data.authError).toBeNull();
+  });
 });
 
 describe('/login signin action', () => {

--- a/apps/web/src/routes/login/page-server.test.ts
+++ b/apps/web/src/routes/login/page-server.test.ts
@@ -151,6 +151,17 @@ describe('/login loader', () => {
     expect(data.authError).toMatch(/invalid or has expired/i);
   });
 
+  it('renders (does NOT redirect) when a logged-in user lands here with auth_error', async () => {
+    // Without this, an unverified user who clicks an expired
+    // verification link gets bounced to /library and never finds out
+    // the link failed.
+    const data = (await callLoad(
+      'http://x/login?auth_error=invalid_magic_link',
+      { id: 'logged-in-user' },
+    )) as { authError: string | null };
+    expect(data.authError).toMatch(/invalid or has expired/i);
+  });
+
   it('ignores unknown ?auth_error values without crashing', async () => {
     const data = (await callLoad('http://x/login?auth_error=bogus')) as {
       authError: string | null;

--- a/apps/web/src/routes/register/+page.server.ts
+++ b/apps/web/src/routes/register/+page.server.ts
@@ -12,7 +12,10 @@ import { z } from 'zod';
 
 import { db, schema } from '$lib/server/db/index.js';
 import { hashPassword } from '$lib/server/auth/password.js';
+import { createMagicLink } from '$lib/server/auth/magic-link.js';
 import { createSession, setSessionCookie } from '$lib/server/auth/sessions.js';
+import { buildMagicLinkEmail, sendMail } from '$lib/server/email/index.js';
+import { APP_BASE_URL } from '$lib/server/env.js';
 import {
   emailSchema,
   isSecureRequest,
@@ -95,6 +98,20 @@ export const actions: Actions = {
 
     const session = await createSession(created.id);
     setSessionCookie(cookies, session.token, session.expiresAt, isSecureRequest(url));
+
+    // Send a verification magic-link (T-11.7). The same magic-link
+    // consumer in $lib/server/auth/magic-link.ts sets
+    // email_verified_at on click, so this email doubles as both
+    // "welcome" and "click to verify your email." Failures are
+    // logged but don't block signup — the user can resend later
+    // via /api/v1/auth/verify-email/resend.
+    try {
+      const token = await createMagicLink(created.id);
+      const verifyUrl = `${APP_BASE_URL}/auth/magic/${encodeURIComponent(token)}`;
+      await sendMail(buildMagicLinkEmail(created.email, verifyUrl));
+    } catch (err) {
+      console.error('Failed to send verification email on register:', err);
+    }
 
     throw redirect(303, readNext(url));
   },


### PR DESCRIPTION
## Summary

Implements the "Option B" outcome from #423 — allow login but gate publicly-visible content-creating writes until the user's email is verified. Closes the spoofing vector where today a password signup goes from "type email" to "publish translations seen by everyone" with zero proof the email is real.

Reading, marking own known-words, profile edits, private text uploads — all unaffected. Only the public-trust surface is gated.

## Server changes

| Concern | Where |
|---|---|
| `requireVerifiedUser` helper (throws 403 `EMAIL_NOT_VERIFIED` when `email_verified_at IS NULL`) | [`$lib/server/auth/require-user.ts`](apps/web/src/lib/server/auth/require-user.ts) |
| Gates applied | `/api/v1/translations` POST, `/api/v1/translations/[id]` PATCH+DELETE, `/api/v1/translations/[id]/vote` PATCH, `/api/v1/translations/[id]/report` POST |
| Magic-link sent on register | Both `/register` (page action) and `/api/v1/auth/register` (JSON). Reuses the existing `buildMagicLinkEmail` + `sendMail` infra. The same `consumeMagicLink` consumer already sets `email_verified_at` on click — no new mechanism, just dispatched at signup time. |
| Resend endpoint | `POST /api/v1/auth/verify-email/resend`: 204 (idempotent if verified) / 202 (new email sent) / 429 with Retry-After (1 send / 60s per user) / 502 (SMTP failed) |

## UI

A new yellow strip above `AppShell` whenever the signed-in user is unverified. Copy: **"Verify your email to publish translations."** with a "Resend it" button. The 204-already-verified response reloads the page so the banner disappears once the user clicks the email link in another tab.

`+layout.server.ts` now passes `emailVerified: boolean` on the user object (not the raw timestamp — keeps `PageData` lean).

## Out of scope (deferred, same helper)

- Gating phrase proposals, lemma proposals, token corrections, public text uploads, parse reports.
- Profile-page verification-status section + "change email" flow.

Splitting these keeps this PR small and review-friendly. Same `requireVerifiedUser` helper, same sprinkle pattern — easy follow-up.

## Test plan

- [x] `pnpm --filter @ciareader/web test` — **1380 / 1380 pass**, including:
   - New `requireVerifiedUser` cases (verified user returned, 403 EMAIL_NOT_VERIFIED on null, 401 on unauthenticated).
   - New resend-endpoint cases (204 / 202 / 429 / 502).
   - Existing translation-endpoint tests pick up the new helper via a one-line vi.mock alias (`requireVerifiedUser: requireUser` spy).
- [x] `pnpm --filter @ciareader/web typecheck` — 0 errors, 0 warnings.
- [x] `pnpm --filter @ciareader/web lint` — clean.
- [x] Reviewer: `./scripts/deploy.sh feat/t-11.7-soft-email-verification`, then:
  - Sign up a fresh account at `https://parhiba.com/register`. Confirm the banner appears at the top of the page.
  - Try to submit a translation — expect 403 + the inline banner update (or whatever the existing translations form does with a 403; this PR doesn't add bespoke handling there, the existing error path catches it).
  - Click the link in the welcome email — confirm `email_verified_at` flips and the banner disappears on next nav.
  - Click "Resend it" twice within a minute — second click should show "Slow down — try again in a minute."

Closes #423.