### PR TITLE
Chapter-book uploads (EPUB + ZIP) and reader polish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,66 @@ jobs:
           path: apps/web/coverage
           if-no-files-found: ignore
 
+  web-e2e:
+    # Reader end-to-end tests (Playwright). Lives in its own job so
+    # the heavyweight browser + Postgres setup doesn't slow the
+    # main `web` lane and so a flake here doesn't block lint /
+    # typecheck / unit signal from landing.
+    name: web (playwright e2e)
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: ciareader
+          POSTGRES_PASSWORD: ciareader
+          POSTGRES_DB: ciareader
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U ciareader -d ciareader"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+    env:
+      DATABASE_URL: postgres://ciareader:ciareader@localhost:5432/ciareader
+      AUTH_SECRET: dev-only-secret-replace-in-prod-0000000000000000000000000000000
+      APP_BASE_URL: http://localhost:5173
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.18.0
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile=false
+      - run: pnpm --filter @ciareader/web exec svelte-kit sync
+      - name: Apply Drizzle migrations
+        working-directory: apps/web
+        run: pnpm db:migrate
+      - name: Install Playwright browsers
+        working-directory: apps/web
+        run: pnpm exec playwright install --with-deps chromium
+      - name: Run Playwright e2e
+        working-directory: apps/web
+        run: pnpm test:e2e
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: apps/web/playwright-report
+          if-no-files-found: ignore
+      - name: Upload Playwright traces
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces
+          path: apps/web/test-results
+          if-no-files-found: ignore
+
   nlp:
     name: nlp (ruff + pytest + coverage)
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,9 @@ coverage.lcov
 # checked-in fixtures, prod runs the fetch step on demand.
 apps/web/data/dictionaries/*/raw.*
 apps/web/data/dictionaries/*/raw_*
+
+# Playwright (e2e tests)
+apps/web/e2e/.auth/
+apps/web/playwright-report/
+apps/web/test-results/
+apps/web/playwright/.cache/

--- a/apps/web/drizzle/0040_quick_wolf_cub.sql
+++ b/apps/web/drizzle/0040_quick_wolf_cub.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."text_source_type" ADD VALUE 'zip';

--- a/apps/web/drizzle/0041_giant_khan.sql
+++ b/apps/web/drizzle/0041_giant_khan.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "collection_items" ADD COLUMN "section_title" text;

--- a/apps/web/drizzle/meta/0040_snapshot.json
+++ b/apps/web/drizzle/meta/0040_snapshot.json
@@ -1,0 +1,5712 @@
+{
+  "id": "afa658b0-91df-4f95-a213-79c74b0c1095",
+  "prevId": "63f9d5f3-e8be-4aa0-aa23-d1137d65ab01",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_rate_limit_events": {
+      "name": "api_rate_limit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_hash": {
+          "name": "subject_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_rate_limit_events_subject_window_idx": {
+          "name": "api_rate_limit_events_subject_window_idx",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_rate_limit_events_user_idx": {
+          "name": "api_rate_limit_events_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_rate_limit_events_user_id_users_id_fk": {
+          "name": "api_rate_limit_events_user_id_users_id_fk",
+          "tableFrom": "api_rate_limit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.audio_alignments": {
+      "name": "audio_alignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "audio_file_id": {
+          "name": "audio_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_ms": {
+          "name": "start_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_ms": {
+          "name": "end_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "alignment_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audio_alignments_timeline_idx": {
+          "name": "audio_alignments_timeline_idx",
+          "columns": [
+            {
+              "expression": "audio_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audio_alignments_audio_file_id_audio_files_id_fk": {
+          "name": "audio_alignments_audio_file_id_audio_files_id_fk",
+          "tableFrom": "audio_alignments",
+          "tableTo": "audio_files",
+          "columnsFrom": [
+            "audio_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audio_alignments_token_id_text_tokens_id_fk": {
+          "name": "audio_alignments_token_id_text_tokens_id_fk",
+          "tableFrom": "audio_alignments",
+          "tableTo": "text_tokens",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "audio_alignments_audio_file_id_token_id_uq": {
+          "name": "audio_alignments_audio_file_id_token_id_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "audio_file_id",
+            "token_id"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.audio_files": {
+      "name": "audio_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime": {
+          "name": "mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license": {
+          "name": "license",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by_id": {
+          "name": "uploaded_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audio_files_text_idx": {
+          "name": "audio_files_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audio_files_chapter_idx": {
+          "name": "audio_files_chapter_idx",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audio_files_text_id_texts_id_fk": {
+          "name": "audio_files_text_id_texts_id_fk",
+          "tableFrom": "audio_files",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audio_files_chapter_id_text_chapters_id_fk": {
+          "name": "audio_files_chapter_id_text_chapters_id_fk",
+          "tableFrom": "audio_files",
+          "tableTo": "text_chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audio_files_uploaded_by_id_users_id_fk": {
+          "name": "audio_files_uploaded_by_id_users_id_fk",
+          "tableFrom": "audio_files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.collection_items": {
+      "name": "collection_items",
+      "schema": "",
+      "columns": {
+        "collection_id": {
+          "name": "collection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collection_items_order_idx": {
+          "name": "collection_items_order_idx",
+          "columns": [
+            {
+              "expression": "collection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collection_items_collection_id_collections_id_fk": {
+          "name": "collection_items_collection_id_collections_id_fk",
+          "tableFrom": "collection_items",
+          "tableTo": "collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collection_items_text_id_texts_id_fk": {
+          "name": "collection_items_text_id_texts_id_fk",
+          "tableFrom": "collection_items",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "collection_items_collection_id_text_id_pk": {
+          "name": "collection_items_collection_id_text_id_pk",
+          "columns": [
+            "collection_id",
+            "text_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.collection_shares": {
+      "name": "collection_shares",
+      "schema": "",
+      "columns": {
+        "collection_id": {
+          "name": "collection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shared_with_user_id": {
+          "name": "shared_with_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by_id": {
+          "name": "granted_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collection_shares_recipient_idx": {
+          "name": "collection_shares_recipient_idx",
+          "columns": [
+            {
+              "expression": "shared_with_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collection_shares_collection_id_collections_id_fk": {
+          "name": "collection_shares_collection_id_collections_id_fk",
+          "tableFrom": "collection_shares",
+          "tableTo": "collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collection_shares_shared_with_user_id_users_id_fk": {
+          "name": "collection_shares_shared_with_user_id_users_id_fk",
+          "tableFrom": "collection_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "shared_with_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collection_shares_granted_by_id_users_id_fk": {
+          "name": "collection_shares_granted_by_id_users_id_fk",
+          "tableFrom": "collection_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "collection_shares_collection_id_shared_with_user_id_pk": {
+          "name": "collection_shares_collection_id_shared_with_user_id_pk",
+          "columns": [
+            "collection_id",
+            "shared_with_user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.collections": {
+      "name": "collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "collection_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'chapter_book'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "collection_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collections_owner_idx": {
+          "name": "collections_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collections_visibility_idx": {
+          "name": "collections_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collections_owner_id_users_id_fk": {
+          "name": "collections_owner_id_users_id_fk",
+          "tableFrom": "collections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.curator_languages": {
+      "name": "curator_languages",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "curator_languages_user_idx": {
+          "name": "curator_languages_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "curator_languages_user_id_users_id_fk": {
+          "name": "curator_languages_user_id_users_id_fk",
+          "tableFrom": "curator_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "curator_languages_granted_by_users_id_fk": {
+          "name": "curator_languages_granted_by_users_id_fk",
+          "tableFrom": "curator_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "curator_languages_user_id_language_pk": {
+          "name": "curator_languages_user_id_language_pk",
+          "columns": [
+            "user_id",
+            "language"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.dictionary_imports": {
+      "name": "dictionary_imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_name": {
+          "name": "source_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_at": {
+          "name": "run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lemmas_created": {
+          "name": "lemmas_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lemmas_updated": {
+          "name": "lemmas_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lemmas_skipped_curator_locked": {
+          "name": "lemmas_skipped_curator_locked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "translations_created": {
+          "name": "translations_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "translations_updated": {
+          "name": "translations_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by_user_id": {
+          "name": "triggered_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'succeeded'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "dictionary_imports_language_idx": {
+          "name": "dictionary_imports_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dictionary_imports_source_latest_idx": {
+          "name": "dictionary_imports_source_latest_idx",
+          "columns": [
+            {
+              "expression": "source_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dictionary_imports_triggered_by_user_id_users_id_fk": {
+          "name": "dictionary_imports_triggered_by_user_id_users_id_fk",
+          "tableFrom": "dictionary_imports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triggered_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.form_lemma_overrides": {
+      "name": "form_lemma_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_nfc": {
+          "name": "surface_nfc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_signature": {
+          "name": "context_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "chosen_lemma_id": {
+          "name": "chosen_lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "promoted_at": {
+          "name": "promoted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "promoted_by": {
+          "name": "promoted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "form_lemma_overrides_lookup_idx": {
+          "name": "form_lemma_overrides_lookup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface_nfc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "form_lemma_overrides_chosen_lemma_id_lemmas_id_fk": {
+          "name": "form_lemma_overrides_chosen_lemma_id_lemmas_id_fk",
+          "tableFrom": "form_lemma_overrides",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "chosen_lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_lemma_overrides_promoted_by_users_id_fk": {
+          "name": "form_lemma_overrides_promoted_by_users_id_fk",
+          "tableFrom": "form_lemma_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "promoted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "form_lemma_overrides_lang_surface_ctx_uq": {
+          "name": "form_lemma_overrides_lang_surface_ctx_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "language",
+            "surface_nfc",
+            "context_signature"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.grammar_features": {
+      "name": "grammar_features",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "feat_key": {
+          "name": "feat_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feat_value": {
+          "name": "feat_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos_scope": {
+          "name": "pos_scope",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "short_label": {
+          "name": "short_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "long_label": {
+          "name": "long_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "grammar_features_key_idx": {
+          "name": "grammar_features_key_idx",
+          "columns": [
+            {
+              "expression": "feat_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grammar_features_key_value_uq": {
+          "name": "grammar_features_key_value_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "feat_key",
+            "feat_value"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.group_memberships": {
+      "name": "group_memberships",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by_id": {
+          "name": "added_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_memberships_user_idx": {
+          "name": "group_memberships_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_memberships_group_id_groups_id_fk": {
+          "name": "group_memberships_group_id_groups_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_memberships_user_id_users_id_fk": {
+          "name": "group_memberships_user_id_users_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_memberships_added_by_id_users_id_fk": {
+          "name": "group_memberships_added_by_id_users_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "added_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "group_memberships_group_id_user_id_pk": {
+          "name": "group_memberships_group_id_user_id_pk",
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "groups_owner_idx": {
+          "name": "groups_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_owner_id_users_id_fk": {
+          "name": "groups_owner_id_users_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemma_edit_history": {
+      "name": "lemma_edit_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phrase_id": {
+          "name": "phrase_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "editor_id": {
+          "name": "editor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "lemma_edit_change_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change": {
+          "name": "change",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_edit_history_lemma_idx": {
+          "name": "lemma_edit_history_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_edit_history_phrase_idx": {
+          "name": "lemma_edit_history_phrase_idx",
+          "columns": [
+            {
+              "expression": "phrase_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_edit_history_editor_idx": {
+          "name": "lemma_edit_history_editor_idx",
+          "columns": [
+            {
+              "expression": "editor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_edit_history_lemma_id_lemmas_id_fk": {
+          "name": "lemma_edit_history_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_edit_history",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lemma_edit_history_phrase_id_phrases_id_fk": {
+          "name": "lemma_edit_history_phrase_id_phrases_id_fk",
+          "tableFrom": "lemma_edit_history",
+          "tableTo": "phrases",
+          "columnsFrom": [
+            "phrase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lemma_edit_history_editor_id_users_id_fk": {
+          "name": "lemma_edit_history_editor_id_users_id_fk",
+          "tableFrom": "lemma_edit_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "editor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemma_forms": {
+      "name": "lemma_forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "romanization": {
+          "name": "romanization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "lemma_form_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'import'"
+        },
+        "paradigm_slot_id": {
+          "name": "paradigm_slot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quarantined_at": {
+          "name": "quarantined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quarantine_reason": {
+          "name": "quarantine_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_forms_lemma_idx": {
+          "name": "lemma_forms_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_forms_surface_idx": {
+          "name": "lemma_forms_surface_idx",
+          "columns": [
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_forms_surface_lookup_idx": {
+          "name": "lemma_forms_surface_lookup_idx",
+          "columns": [
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "quarantined_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_forms_lemma_id_lemmas_id_fk": {
+          "name": "lemma_forms_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_forms",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lemma_forms_paradigm_slot_id_paradigm_slots_id_fk": {
+          "name": "lemma_forms_paradigm_slot_id_paradigm_slots_id_fk",
+          "tableFrom": "lemma_forms",
+          "tableTo": "paradigm_slots",
+          "columnsFrom": [
+            "paradigm_slot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemma_proposals": {
+      "name": "lemma_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "proposer_id": {
+          "name": "proposer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headword": {
+          "name": "headword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos": {
+          "name": "pos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gloss_default": {
+          "name": "gloss_default",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "lemma_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "promoted_lemma_id": {
+          "name": "promoted_lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_id": {
+          "name": "reviewer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_note": {
+          "name": "reviewer_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_proposals_lang_status_idx": {
+          "name": "lemma_proposals_lang_status_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_proposals_headword_idx": {
+          "name": "lemma_proposals_headword_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "headword",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pos",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_proposals_proposer_id_users_id_fk": {
+          "name": "lemma_proposals_proposer_id_users_id_fk",
+          "tableFrom": "lemma_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "proposer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "lemma_proposals_promoted_lemma_id_lemmas_id_fk": {
+          "name": "lemma_proposals_promoted_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_proposals",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "promoted_lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "lemma_proposals_reviewer_id_users_id_fk": {
+          "name": "lemma_proposals_reviewer_id_users_id_fk",
+          "tableFrom": "lemma_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemmas": {
+      "name": "lemmas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headword": {
+          "name": "headword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos": {
+          "name": "pos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script": {
+          "name": "script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gloss_default": {
+          "name": "gloss_default",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_rank": {
+          "name": "frequency_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "translation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "curator_locked": {
+          "name": "curator_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "headword_nukta_stripped": {
+          "name": "headword_nukta_stripped",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "translate(normalize(\"headword\", NFD), '़', '')",
+            "type": "stored"
+          }
+        },
+        "paradigm_id": {
+          "name": "paradigm_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stem": {
+          "name": "stem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "lemmas_language_headword_pos_idx": {
+          "name": "lemmas_language_headword_pos_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "headword",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pos",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_language_idx": {
+          "name": "lemmas_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_language_frequency_idx": {
+          "name": "lemmas_language_frequency_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "frequency_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_source_lookup_idx": {
+          "name": "lemmas_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_language_headword_stripped_idx": {
+          "name": "lemmas_language_headword_stripped_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "headword_nukta_stripped",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemmas_paradigm_id_paradigms_id_fk": {
+          "name": "lemmas_paradigm_id_paradigms_id_fk",
+          "tableFrom": "lemmas",
+          "tableTo": "paradigms",
+          "columnsFrom": [
+            "paradigm_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.magic_links": {
+      "name": "magic_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "magic_links_user_idx": {
+          "name": "magic_links_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "magic_links_expires_idx": {
+          "name": "magic_links_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "magic_links_user_id_users_id_fk": {
+          "name": "magic_links_user_id_users_id_fk",
+          "tableFrom": "magic_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.nlp_jobs": {
+      "name": "nlp_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "nlp_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nlp_jobs_text_idx": {
+          "name": "nlp_jobs_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nlp_jobs_status_idx": {
+          "name": "nlp_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nlp_jobs_text_id_texts_id_fk": {
+          "name": "nlp_jobs_text_id_texts_id_fk",
+          "tableFrom": "nlp_jobs",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.paradigm_slots": {
+      "name": "paradigm_slots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "paradigm_id": {
+          "name": "paradigm_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot_key": {
+          "name": "slot_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "suffix": {
+          "name": "suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "paradigm_slots_paradigm_idx": {
+          "name": "paradigm_slots_paradigm_idx",
+          "columns": [
+            {
+              "expression": "paradigm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "paradigm_slots_paradigm_id_paradigms_id_fk": {
+          "name": "paradigm_slots_paradigm_id_paradigms_id_fk",
+          "tableFrom": "paradigm_slots",
+          "tableTo": "paradigms",
+          "columnsFrom": [
+            "paradigm_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "paradigm_slots_paradigm_key_uq": {
+          "name": "paradigm_slots_paradigm_key_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "paradigm_id",
+            "slot_key"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.paradigms": {
+      "name": "paradigms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos": {
+          "name": "pos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "paradigms_language_pos_idx": {
+          "name": "paradigms_language_pos_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pos",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "paradigms_language_pos_name_uq": {
+          "name": "paradigms_language_pos_name_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "language",
+            "pos",
+            "name"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.parse_reports": {
+      "name": "parse_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_nfc": {
+          "name": "surface_nfc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_signature": {
+          "name": "context_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "original_candidates": {
+          "name": "original_candidates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "corrected_lemma_id": {
+          "name": "corrected_lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "correction_type": {
+          "name": "correction_type",
+          "type": "token_correction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "parse_report_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "assigned_reviewer_id": {
+          "name": "assigned_reviewer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_note": {
+          "name": "resolution_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duplicate_count": {
+          "name": "duplicate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parse_reports_lang_status_idx": {
+          "name": "parse_reports_lang_status_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parse_reports_dedup_idx": {
+          "name": "parse_reports_dedup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface_nfc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_signature",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "corrected_lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parse_reports_token_id_text_tokens_id_fk": {
+          "name": "parse_reports_token_id_text_tokens_id_fk",
+          "tableFrom": "parse_reports",
+          "tableTo": "text_tokens",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "parse_reports_corrected_lemma_id_lemmas_id_fk": {
+          "name": "parse_reports_corrected_lemma_id_lemmas_id_fk",
+          "tableFrom": "parse_reports",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "corrected_lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "parse_reports_reporter_id_users_id_fk": {
+          "name": "parse_reports_reporter_id_users_id_fk",
+          "tableFrom": "parse_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "parse_reports_assigned_reviewer_id_users_id_fk": {
+          "name": "parse_reports_assigned_reviewer_id_users_id_fk",
+          "tableFrom": "parse_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_reviewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.personal_api_keys": {
+      "name": "personal_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "personal_api_keys_user_idx": {
+          "name": "personal_api_keys_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "personal_api_keys_active_user_idx": {
+          "name": "personal_api_keys_active_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personal_api_keys_user_id_users_id_fk": {
+          "name": "personal_api_keys_user_id_users_id_fk",
+          "tableFrom": "personal_api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "personal_api_keys_hash_unique": {
+          "name": "personal_api_keys_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.phrase_chapter_spans": {
+      "name": "phrase_chapter_spans",
+      "schema": "",
+      "columns": {
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phrase_id": {
+          "name": "phrase_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_token_idx": {
+          "name": "start_token_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_token_idx": {
+          "name": "end_token_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "phrase_chapter_spans_chapter_idx": {
+          "name": "phrase_chapter_spans_chapter_idx",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "phrase_chapter_spans_phrase_idx": {
+          "name": "phrase_chapter_spans_phrase_idx",
+          "columns": [
+            {
+              "expression": "phrase_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "phrase_chapter_spans_chapter_id_text_chapters_id_fk": {
+          "name": "phrase_chapter_spans_chapter_id_text_chapters_id_fk",
+          "tableFrom": "phrase_chapter_spans",
+          "tableTo": "text_chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "phrase_chapter_spans_phrase_id_phrases_id_fk": {
+          "name": "phrase_chapter_spans_phrase_id_phrases_id_fk",
+          "tableFrom": "phrase_chapter_spans",
+          "tableTo": "phrases",
+          "columnsFrom": [
+            "phrase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "phrase_chapter_spans_chapter_id_start_token_idx_phrase_id_pk": {
+          "name": "phrase_chapter_spans_chapter_id_start_token_idx_phrase_id_pk",
+          "columns": [
+            "chapter_id",
+            "start_token_idx",
+            "phrase_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.phrase_proposals": {
+      "name": "phrase_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_normalised": {
+          "name": "surface_normalised",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern_id": {
+          "name": "pattern_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "promoted_at": {
+          "name": "promoted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promoted_phrase_id": {
+          "name": "promoted_phrase_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "phrase_proposals_promotion_lookup_idx": {
+          "name": "phrase_proposals_promotion_lookup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface_normalised",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "phrase_proposals_chapter_id_text_chapters_id_fk": {
+          "name": "phrase_proposals_chapter_id_text_chapters_id_fk",
+          "tableFrom": "phrase_proposals",
+          "tableTo": "text_chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "phrase_proposals_promoted_phrase_id_phrases_id_fk": {
+          "name": "phrase_proposals_promoted_phrase_id_phrases_id_fk",
+          "tableFrom": "phrase_proposals",
+          "tableTo": "phrases",
+          "columnsFrom": [
+            "promoted_phrase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "phrase_proposals_occurrence_uq": {
+          "name": "phrase_proposals_occurrence_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chapter_id",
+            "surface_normalised",
+            "pattern_id"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.phrase_tokens": {
+      "name": "phrase_tokens",
+      "schema": "",
+      "columns": {
+        "phrase_id": {
+          "name": "phrase_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "phrase_tokens_surface_idx": {
+          "name": "phrase_tokens_surface_idx",
+          "columns": [
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "phrase_tokens_phrase_id_phrases_id_fk": {
+          "name": "phrase_tokens_phrase_id_phrases_id_fk",
+          "tableFrom": "phrase_tokens",
+          "tableTo": "phrases",
+          "columnsFrom": [
+            "phrase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "phrase_tokens_lemma_id_lemmas_id_fk": {
+          "name": "phrase_tokens_lemma_id_lemmas_id_fk",
+          "tableFrom": "phrase_tokens",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "phrase_tokens_phrase_id_position_pk": {
+          "name": "phrase_tokens_phrase_id_position_pk",
+          "columns": [
+            "phrase_id",
+            "position"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.phrases": {
+      "name": "phrases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_normalised": {
+          "name": "surface_normalised",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos": {
+          "name": "pos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gloss_default": {
+          "name": "gloss_default",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_rank": {
+          "name": "frequency_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "translation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "curator_locked": {
+          "name": "curator_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "phrases_language_surface_idx": {
+          "name": "phrases_language_surface_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface_normalised",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "phrases_language_idx": {
+          "name": "phrases_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "phrases_language_frequency_idx": {
+          "name": "phrases_language_frequency_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "frequency_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "phrases_source_lookup_idx": {
+          "name": "phrases_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by": {
+          "name": "replaced_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "refresh_tokens_user_idx": {
+          "name": "refresh_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_expires_idx": {
+          "name": "refresh_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.text_chapters": {
+      "name": "text_chapters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idx": {
+          "name": "idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "text_chapters_text_idx": {
+          "name": "text_chapters_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_chapters_text_id_texts_id_fk": {
+          "name": "text_chapters_text_id_texts_id_fk",
+          "tableFrom": "text_chapters",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "text_chapters_text_idx_uq": {
+          "name": "text_chapters_text_idx_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "text_id",
+            "idx"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.text_group_shares": {
+      "name": "text_group_shares",
+      "schema": "",
+      "columns": {
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by_id": {
+          "name": "granted_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "text_group_shares_group_idx": {
+          "name": "text_group_shares_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_group_shares_text_id_texts_id_fk": {
+          "name": "text_group_shares_text_id_texts_id_fk",
+          "tableFrom": "text_group_shares",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_group_shares_group_id_groups_id_fk": {
+          "name": "text_group_shares_group_id_groups_id_fk",
+          "tableFrom": "text_group_shares",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_group_shares_granted_by_id_users_id_fk": {
+          "name": "text_group_shares_granted_by_id_users_id_fk",
+          "tableFrom": "text_group_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "text_group_shares_text_id_group_id_pk": {
+          "name": "text_group_shares_text_id_group_id_pk",
+          "columns": [
+            "text_id",
+            "group_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.text_shares": {
+      "name": "text_shares",
+      "schema": "",
+      "columns": {
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shared_with_user_id": {
+          "name": "shared_with_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "text_share_permission",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'read'"
+        },
+        "granted_by_id": {
+          "name": "granted_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "text_shares_recipient_idx": {
+          "name": "text_shares_recipient_idx",
+          "columns": [
+            {
+              "expression": "shared_with_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_shares_text_id_texts_id_fk": {
+          "name": "text_shares_text_id_texts_id_fk",
+          "tableFrom": "text_shares",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_shares_shared_with_user_id_users_id_fk": {
+          "name": "text_shares_shared_with_user_id_users_id_fk",
+          "tableFrom": "text_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "shared_with_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_shares_granted_by_id_users_id_fk": {
+          "name": "text_shares_granted_by_id_users_id_fk",
+          "tableFrom": "text_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "text_shares_text_id_shared_with_user_id_pk": {
+          "name": "text_shares_text_id_shared_with_user_id_pk",
+          "columns": [
+            "text_id",
+            "shared_with_user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.text_tokens": {
+      "name": "text_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idx": {
+          "name": "idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lemma_candidates": {
+          "name": "lemma_candidates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_ambiguous": {
+          "name": "is_ambiguous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_oov": {
+          "name": "is_oov",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_word": {
+          "name": "is_word",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sentence_idx": {
+          "name": "sentence_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "romanization": {
+          "name": "romanization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_forms": {
+          "name": "number_forms",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "text_tokens_chapter_scan_idx": {
+          "name": "text_tokens_chapter_scan_idx",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "text_tokens_lemma_idx": {
+          "name": "text_tokens_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_tokens_chapter_id_text_chapters_id_fk": {
+          "name": "text_tokens_chapter_id_text_chapters_id_fk",
+          "tableFrom": "text_tokens",
+          "tableTo": "text_chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_tokens_lemma_id_lemmas_id_fk": {
+          "name": "text_tokens_lemma_id_lemmas_id_fk",
+          "tableFrom": "text_tokens",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "text_tokens_chapter_idx_uq": {
+          "name": "text_tokens_chapter_idx_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chapter_id",
+            "idx"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.texts": {
+      "name": "texts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "status_error": {
+          "name": "status_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "texts_owner_idx": {
+          "name": "texts_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "texts_visibility_idx": {
+          "name": "texts_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "texts_owner_id_users_id_fk": {
+          "name": "texts_owner_id_users_id_fk",
+          "tableFrom": "texts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.token_corrections": {
+      "name": "token_corrections",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "token_correction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chosen_lemma_id": {
+          "name": "chosen_lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "token_corrections_token_idx": {
+          "name": "token_corrections_token_idx",
+          "columns": [
+            {
+              "expression": "token_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "token_corrections_chosen_lemma_idx": {
+          "name": "token_corrections_chosen_lemma_idx",
+          "columns": [
+            {
+              "expression": "chosen_lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "token_corrections_user_id_users_id_fk": {
+          "name": "token_corrections_user_id_users_id_fk",
+          "tableFrom": "token_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "token_corrections_token_id_text_tokens_id_fk": {
+          "name": "token_corrections_token_id_text_tokens_id_fk",
+          "tableFrom": "token_corrections",
+          "tableTo": "text_tokens",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "token_corrections_chosen_lemma_id_lemmas_id_fk": {
+          "name": "token_corrections_chosen_lemma_id_lemmas_id_fk",
+          "tableFrom": "token_corrections",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "chosen_lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "token_corrections_user_id_token_id_pk": {
+          "name": "token_corrections_user_id_token_id_pk",
+          "columns": [
+            "user_id",
+            "token_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.translation_reports": {
+      "name": "translation_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "translation_id": {
+          "name": "translation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "translation_report_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "translation_report_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_note": {
+          "name": "resolution_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "translation_reports_status_idx": {
+          "name": "translation_reports_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translation_reports_translation_idx": {
+          "name": "translation_reports_translation_idx",
+          "columns": [
+            {
+              "expression": "translation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "translation_reports_translation_id_translations_id_fk": {
+          "name": "translation_reports_translation_id_translations_id_fk",
+          "tableFrom": "translation_reports",
+          "tableTo": "translations",
+          "columnsFrom": [
+            "translation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "translation_reports_reporter_id_users_id_fk": {
+          "name": "translation_reports_reporter_id_users_id_fk",
+          "tableFrom": "translation_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "translation_reports_resolved_by_users_id_fk": {
+          "name": "translation_reports_resolved_by_users_id_fk",
+          "tableFrom": "translation_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "translation_reports_reporter_translation_uq": {
+          "name": "translation_reports_reporter_translation_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "reporter_id",
+            "translation_id"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.translation_votes": {
+      "name": "translation_votes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "translation_id": {
+          "name": "translation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "translation_vote_value",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "translation_votes_translation_idx": {
+          "name": "translation_votes_translation_idx",
+          "columns": [
+            {
+              "expression": "translation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translation_votes_user_idx": {
+          "name": "translation_votes_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "translation_votes_user_id_users_id_fk": {
+          "name": "translation_votes_user_id_users_id_fk",
+          "tableFrom": "translation_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "translation_votes_translation_id_translations_id_fk": {
+          "name": "translation_votes_translation_id_translations_id_fk",
+          "tableFrom": "translation_votes",
+          "tableTo": "translations",
+          "columnsFrom": [
+            "translation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "translation_votes_user_id_translation_id_pk": {
+          "name": "translation_votes_user_id_translation_id_pk",
+          "columns": [
+            "user_id",
+            "translation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.translations": {
+      "name": "translations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "translation_target_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'lemma'"
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "translation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_translation_id": {
+          "name": "parent_translation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_language": {
+          "name": "target_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_rank": {
+          "name": "display_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "translations_target_idx": {
+          "name": "translations_target_idx",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translations_submitted_by_idx": {
+          "name": "translations_submitted_by_idx",
+          "columns": [
+            {
+              "expression": "submitted_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translations_source_lookup_idx": {
+          "name": "translations_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "translations_submitted_by_users_id_fk": {
+          "name": "translations_submitted_by_users_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "translations_parent_translation_id_translations_id_fk": {
+          "name": "translations_parent_translation_id_translations_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "translations",
+          "columnsFrom": [
+            "parent_translation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_audio_listening": {
+      "name": "user_audio_listening",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audio_file_id": {
+          "name": "audio_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "listened_ms": {
+          "name": "listened_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_listened_at": {
+          "name": "last_listened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_audio_listening_user_text_idx": {
+          "name": "user_audio_listening_user_text_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_audio_listening_text_idx": {
+          "name": "user_audio_listening_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_audio_listening_user_id_users_id_fk": {
+          "name": "user_audio_listening_user_id_users_id_fk",
+          "tableFrom": "user_audio_listening",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_audio_listening_audio_file_id_audio_files_id_fk": {
+          "name": "user_audio_listening_audio_file_id_audio_files_id_fk",
+          "tableFrom": "user_audio_listening",
+          "tableTo": "audio_files",
+          "columnsFrom": [
+            "audio_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_audio_listening_text_id_texts_id_fk": {
+          "name": "user_audio_listening_text_id_texts_id_fk",
+          "tableFrom": "user_audio_listening",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_audio_listening_user_id_audio_file_id_pk": {
+          "name": "user_audio_listening_user_id_audio_file_id_pk",
+          "columns": [
+            "user_id",
+            "audio_file_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_known_lemmas": {
+      "name": "user_known_lemmas",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "known_lemma_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'learning'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_known_lemmas_user_idx": {
+          "name": "user_known_lemmas_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_known_lemmas_user_id_users_id_fk": {
+          "name": "user_known_lemmas_user_id_users_id_fk",
+          "tableFrom": "user_known_lemmas",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_known_lemmas_lemma_id_lemmas_id_fk": {
+          "name": "user_known_lemmas_lemma_id_lemmas_id_fk",
+          "tableFrom": "user_known_lemmas",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_known_lemmas_user_id_lemma_id_pk": {
+          "name": "user_known_lemmas_user_id_lemma_id_pk",
+          "columns": [
+            "user_id",
+            "lemma_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_known_phrases": {
+      "name": "user_known_phrases",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phrase_id": {
+          "name": "phrase_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "known_lemma_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'learning'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_known_phrases_user_idx": {
+          "name": "user_known_phrases_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_known_phrases_user_id_users_id_fk": {
+          "name": "user_known_phrases_user_id_users_id_fk",
+          "tableFrom": "user_known_phrases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_known_phrases_phrase_id_phrases_id_fk": {
+          "name": "user_known_phrases_phrase_id_phrases_id_fk",
+          "tableFrom": "user_known_phrases",
+          "tableTo": "phrases",
+          "columnsFrom": [
+            "phrase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_known_phrases_user_id_phrase_id_pk": {
+          "name": "user_known_phrases_user_id_phrase_id_pk",
+          "columns": [
+            "user_id",
+            "phrase_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_languages": {
+      "name": "user_languages",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script_preference": {
+          "name": "script_preference",
+          "type": "script_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "romanization_scheme": {
+          "name": "romanization_scheme",
+          "type": "romanization_scheme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'iso15919'"
+        },
+        "known_words_count_cache": {
+          "name": "known_words_count_cache",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "known_phrases_count_cache": {
+          "name": "known_phrases_count_cache",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reader_layout_mode": {
+          "name": "reader_layout_mode",
+          "type": "reader_layout_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'page'"
+        },
+        "words_per_page": {
+          "name": "words_per_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 250
+        },
+        "font_family": {
+          "name": "font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_size": {
+          "name": "font_size",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 18
+        },
+        "line_spacing": {
+          "name": "line_spacing",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1.6
+        },
+        "highlight_style": {
+          "name": "highlight_style",
+          "type": "highlight_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'background'"
+        },
+        "reading_width": {
+          "name": "reading_width",
+          "type": "reading_width",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "baseline": {
+          "name": "baseline",
+          "type": "language_baseline",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_languages_user_id_users_id_fk": {
+          "name": "user_languages_user_id_users_id_fk",
+          "tableFrom": "user_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_languages_user_id_language_pk": {
+          "name": "user_languages_user_id_language_pk",
+          "columns": [
+            "user_id",
+            "language"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_text_progress": {
+      "name": "user_text_progress",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_chapter_idx": {
+          "name": "last_chapter_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_token_idx": {
+          "name": "last_token_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pct_read": {
+          "name": "pct_read",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_text_progress_user_idx": {
+          "name": "user_text_progress_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_text_progress_user_id_users_id_fk": {
+          "name": "user_text_progress_user_id_users_id_fk",
+          "tableFrom": "user_text_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_text_progress_text_id_texts_id_fk": {
+          "name": "user_text_progress_text_id_texts_id_fk",
+          "tableFrom": "user_text_progress",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_text_progress_user_id_text_id_pk": {
+          "name": "user_text_progress_user_id_text_id_pk",
+          "columns": [
+            "user_id",
+            "text_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_preference": {
+          "name": "theme_preference",
+          "type": "theme_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarded_at": {
+          "name": "onboarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    }
+  },
+  "enums": {
+    "public.alignment_source": {
+      "name": "alignment_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "imported",
+        "whisper"
+      ]
+    },
+    "public.collection_kind": {
+      "name": "collection_kind",
+      "schema": "public",
+      "values": [
+        "chapter_book",
+        "course",
+        "anthology"
+      ]
+    },
+    "public.collection_visibility": {
+      "name": "collection_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "shared",
+        "official"
+      ]
+    },
+    "public.highlight_style": {
+      "name": "highlight_style",
+      "schema": "public",
+      "values": [
+        "underline",
+        "background",
+        "colored_text"
+      ]
+    },
+    "public.known_lemma_status": {
+      "name": "known_lemma_status",
+      "schema": "public",
+      "values": [
+        "unknown",
+        "learning",
+        "known",
+        "ignored"
+      ]
+    },
+    "public.language": {
+      "name": "language",
+      "schema": "public",
+      "values": [
+        "hi",
+        "mr",
+        "or"
+      ]
+    },
+    "public.language_baseline": {
+      "name": "language_baseline",
+      "schema": "public",
+      "values": [
+        "none",
+        "beginner",
+        "intermediate"
+      ]
+    },
+    "public.lemma_edit_change_type": {
+      "name": "lemma_edit_change_type",
+      "schema": "public",
+      "values": [
+        "lemma_update",
+        "lemma_unlock",
+        "lemma_lock",
+        "translation_insert",
+        "translation_update",
+        "translation_hide",
+        "translation_unhide",
+        "form_insert",
+        "form_delete",
+        "lemma_merge",
+        "lemma_split",
+        "translation_reorder",
+        "phrase_update",
+        "phrase_lock",
+        "phrase_unlock",
+        "phrase_hide",
+        "phrase_unhide",
+        "phrase_merge"
+      ]
+    },
+    "public.lemma_form_source": {
+      "name": "lemma_form_source",
+      "schema": "public",
+      "values": [
+        "import",
+        "pipeline",
+        "curator",
+        "generator"
+      ]
+    },
+    "public.lemma_proposal_status": {
+      "name": "lemma_proposal_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.nlp_job_status": {
+      "name": "nlp_job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.parse_report_status": {
+      "name": "parse_report_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "triaged",
+        "resolved",
+        "rejected",
+        "duplicate",
+        "deferred"
+      ]
+    },
+    "public.reader_layout_mode": {
+      "name": "reader_layout_mode",
+      "schema": "public",
+      "values": [
+        "page",
+        "paged_scroll",
+        "continuous"
+      ]
+    },
+    "public.reading_width": {
+      "name": "reading_width",
+      "schema": "public",
+      "values": [
+        "narrow",
+        "medium",
+        "wide"
+      ]
+    },
+    "public.romanization_scheme": {
+      "name": "romanization_scheme",
+      "schema": "public",
+      "values": [
+        "iso15919",
+        "iast",
+        "hunterian",
+        "itrans"
+      ]
+    },
+    "public.script_preference": {
+      "name": "script_preference",
+      "schema": "public",
+      "values": [
+        "native",
+        "native_with_romanization",
+        "romanization_only"
+      ]
+    },
+    "public.text_share_permission": {
+      "name": "text_share_permission",
+      "schema": "public",
+      "values": [
+        "read"
+      ]
+    },
+    "public.text_source_type": {
+      "name": "text_source_type",
+      "schema": "public",
+      "values": [
+        "paste",
+        "txt",
+        "epub",
+        "zip"
+      ]
+    },
+    "public.text_status": {
+      "name": "text_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.text_visibility": {
+      "name": "text_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "shared",
+        "official"
+      ]
+    },
+    "public.theme_preference": {
+      "name": "theme_preference",
+      "schema": "public",
+      "values": [
+        "system",
+        "light",
+        "dark"
+      ]
+    },
+    "public.token_correction_type": {
+      "name": "token_correction_type",
+      "schema": "public",
+      "values": [
+        "pick_candidate",
+        "manual_lemma",
+        "new_lemma",
+        "mark_proper_noun",
+        "mark_foreign",
+        "mark_not_a_word"
+      ]
+    },
+    "public.translation_report_reason": {
+      "name": "translation_report_reason",
+      "schema": "public",
+      "values": [
+        "spam",
+        "incorrect",
+        "offensive",
+        "duplicate",
+        "other"
+      ]
+    },
+    "public.translation_report_status": {
+      "name": "translation_report_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "resolved_hidden",
+        "resolved_kept",
+        "dismissed"
+      ]
+    },
+    "public.translation_source": {
+      "name": "translation_source",
+      "schema": "public",
+      "values": [
+        "official_dictionary",
+        "curator",
+        "user",
+        "nlp"
+      ]
+    },
+    "public.translation_target_type": {
+      "name": "translation_target_type",
+      "schema": "public",
+      "values": [
+        "lemma",
+        "phrase"
+      ]
+    },
+    "public.translation_vote_value": {
+      "name": "translation_vote_value",
+      "schema": "public",
+      "values": [
+        "up",
+        "down"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "curator",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/0041_snapshot.json
+++ b/apps/web/drizzle/meta/0041_snapshot.json
@@ -1,0 +1,5718 @@
+{
+  "id": "3c31d4d6-098a-44db-8b60-759689fab021",
+  "prevId": "afa658b0-91df-4f95-a213-79c74b0c1095",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_rate_limit_events": {
+      "name": "api_rate_limit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_hash": {
+          "name": "subject_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_rate_limit_events_subject_window_idx": {
+          "name": "api_rate_limit_events_subject_window_idx",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_rate_limit_events_user_idx": {
+          "name": "api_rate_limit_events_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_rate_limit_events_user_id_users_id_fk": {
+          "name": "api_rate_limit_events_user_id_users_id_fk",
+          "tableFrom": "api_rate_limit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.audio_alignments": {
+      "name": "audio_alignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "audio_file_id": {
+          "name": "audio_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_ms": {
+          "name": "start_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_ms": {
+          "name": "end_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "alignment_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audio_alignments_timeline_idx": {
+          "name": "audio_alignments_timeline_idx",
+          "columns": [
+            {
+              "expression": "audio_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audio_alignments_audio_file_id_audio_files_id_fk": {
+          "name": "audio_alignments_audio_file_id_audio_files_id_fk",
+          "tableFrom": "audio_alignments",
+          "tableTo": "audio_files",
+          "columnsFrom": [
+            "audio_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audio_alignments_token_id_text_tokens_id_fk": {
+          "name": "audio_alignments_token_id_text_tokens_id_fk",
+          "tableFrom": "audio_alignments",
+          "tableTo": "text_tokens",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "audio_alignments_audio_file_id_token_id_uq": {
+          "name": "audio_alignments_audio_file_id_token_id_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "audio_file_id",
+            "token_id"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.audio_files": {
+      "name": "audio_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime": {
+          "name": "mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license": {
+          "name": "license",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by_id": {
+          "name": "uploaded_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audio_files_text_idx": {
+          "name": "audio_files_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audio_files_chapter_idx": {
+          "name": "audio_files_chapter_idx",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audio_files_text_id_texts_id_fk": {
+          "name": "audio_files_text_id_texts_id_fk",
+          "tableFrom": "audio_files",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audio_files_chapter_id_text_chapters_id_fk": {
+          "name": "audio_files_chapter_id_text_chapters_id_fk",
+          "tableFrom": "audio_files",
+          "tableTo": "text_chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audio_files_uploaded_by_id_users_id_fk": {
+          "name": "audio_files_uploaded_by_id_users_id_fk",
+          "tableFrom": "audio_files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.collection_items": {
+      "name": "collection_items",
+      "schema": "",
+      "columns": {
+        "collection_id": {
+          "name": "collection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_title": {
+          "name": "section_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collection_items_order_idx": {
+          "name": "collection_items_order_idx",
+          "columns": [
+            {
+              "expression": "collection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collection_items_collection_id_collections_id_fk": {
+          "name": "collection_items_collection_id_collections_id_fk",
+          "tableFrom": "collection_items",
+          "tableTo": "collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collection_items_text_id_texts_id_fk": {
+          "name": "collection_items_text_id_texts_id_fk",
+          "tableFrom": "collection_items",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "collection_items_collection_id_text_id_pk": {
+          "name": "collection_items_collection_id_text_id_pk",
+          "columns": [
+            "collection_id",
+            "text_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.collection_shares": {
+      "name": "collection_shares",
+      "schema": "",
+      "columns": {
+        "collection_id": {
+          "name": "collection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shared_with_user_id": {
+          "name": "shared_with_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by_id": {
+          "name": "granted_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collection_shares_recipient_idx": {
+          "name": "collection_shares_recipient_idx",
+          "columns": [
+            {
+              "expression": "shared_with_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collection_shares_collection_id_collections_id_fk": {
+          "name": "collection_shares_collection_id_collections_id_fk",
+          "tableFrom": "collection_shares",
+          "tableTo": "collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collection_shares_shared_with_user_id_users_id_fk": {
+          "name": "collection_shares_shared_with_user_id_users_id_fk",
+          "tableFrom": "collection_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "shared_with_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collection_shares_granted_by_id_users_id_fk": {
+          "name": "collection_shares_granted_by_id_users_id_fk",
+          "tableFrom": "collection_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "collection_shares_collection_id_shared_with_user_id_pk": {
+          "name": "collection_shares_collection_id_shared_with_user_id_pk",
+          "columns": [
+            "collection_id",
+            "shared_with_user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.collections": {
+      "name": "collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "collection_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'chapter_book'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "collection_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collections_owner_idx": {
+          "name": "collections_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collections_visibility_idx": {
+          "name": "collections_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collections_owner_id_users_id_fk": {
+          "name": "collections_owner_id_users_id_fk",
+          "tableFrom": "collections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.curator_languages": {
+      "name": "curator_languages",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "curator_languages_user_idx": {
+          "name": "curator_languages_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "curator_languages_user_id_users_id_fk": {
+          "name": "curator_languages_user_id_users_id_fk",
+          "tableFrom": "curator_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "curator_languages_granted_by_users_id_fk": {
+          "name": "curator_languages_granted_by_users_id_fk",
+          "tableFrom": "curator_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "curator_languages_user_id_language_pk": {
+          "name": "curator_languages_user_id_language_pk",
+          "columns": [
+            "user_id",
+            "language"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.dictionary_imports": {
+      "name": "dictionary_imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_name": {
+          "name": "source_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_at": {
+          "name": "run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lemmas_created": {
+          "name": "lemmas_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lemmas_updated": {
+          "name": "lemmas_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lemmas_skipped_curator_locked": {
+          "name": "lemmas_skipped_curator_locked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "translations_created": {
+          "name": "translations_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "translations_updated": {
+          "name": "translations_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by_user_id": {
+          "name": "triggered_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'succeeded'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "dictionary_imports_language_idx": {
+          "name": "dictionary_imports_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dictionary_imports_source_latest_idx": {
+          "name": "dictionary_imports_source_latest_idx",
+          "columns": [
+            {
+              "expression": "source_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dictionary_imports_triggered_by_user_id_users_id_fk": {
+          "name": "dictionary_imports_triggered_by_user_id_users_id_fk",
+          "tableFrom": "dictionary_imports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triggered_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.form_lemma_overrides": {
+      "name": "form_lemma_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_nfc": {
+          "name": "surface_nfc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_signature": {
+          "name": "context_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "chosen_lemma_id": {
+          "name": "chosen_lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "promoted_at": {
+          "name": "promoted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "promoted_by": {
+          "name": "promoted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "form_lemma_overrides_lookup_idx": {
+          "name": "form_lemma_overrides_lookup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface_nfc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "form_lemma_overrides_chosen_lemma_id_lemmas_id_fk": {
+          "name": "form_lemma_overrides_chosen_lemma_id_lemmas_id_fk",
+          "tableFrom": "form_lemma_overrides",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "chosen_lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_lemma_overrides_promoted_by_users_id_fk": {
+          "name": "form_lemma_overrides_promoted_by_users_id_fk",
+          "tableFrom": "form_lemma_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "promoted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "form_lemma_overrides_lang_surface_ctx_uq": {
+          "name": "form_lemma_overrides_lang_surface_ctx_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "language",
+            "surface_nfc",
+            "context_signature"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.grammar_features": {
+      "name": "grammar_features",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "feat_key": {
+          "name": "feat_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feat_value": {
+          "name": "feat_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos_scope": {
+          "name": "pos_scope",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "short_label": {
+          "name": "short_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "long_label": {
+          "name": "long_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "grammar_features_key_idx": {
+          "name": "grammar_features_key_idx",
+          "columns": [
+            {
+              "expression": "feat_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grammar_features_key_value_uq": {
+          "name": "grammar_features_key_value_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "feat_key",
+            "feat_value"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.group_memberships": {
+      "name": "group_memberships",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by_id": {
+          "name": "added_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_memberships_user_idx": {
+          "name": "group_memberships_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_memberships_group_id_groups_id_fk": {
+          "name": "group_memberships_group_id_groups_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_memberships_user_id_users_id_fk": {
+          "name": "group_memberships_user_id_users_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_memberships_added_by_id_users_id_fk": {
+          "name": "group_memberships_added_by_id_users_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "added_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "group_memberships_group_id_user_id_pk": {
+          "name": "group_memberships_group_id_user_id_pk",
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "groups_owner_idx": {
+          "name": "groups_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_owner_id_users_id_fk": {
+          "name": "groups_owner_id_users_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemma_edit_history": {
+      "name": "lemma_edit_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phrase_id": {
+          "name": "phrase_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "editor_id": {
+          "name": "editor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "lemma_edit_change_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change": {
+          "name": "change",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_edit_history_lemma_idx": {
+          "name": "lemma_edit_history_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_edit_history_phrase_idx": {
+          "name": "lemma_edit_history_phrase_idx",
+          "columns": [
+            {
+              "expression": "phrase_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_edit_history_editor_idx": {
+          "name": "lemma_edit_history_editor_idx",
+          "columns": [
+            {
+              "expression": "editor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_edit_history_lemma_id_lemmas_id_fk": {
+          "name": "lemma_edit_history_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_edit_history",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lemma_edit_history_phrase_id_phrases_id_fk": {
+          "name": "lemma_edit_history_phrase_id_phrases_id_fk",
+          "tableFrom": "lemma_edit_history",
+          "tableTo": "phrases",
+          "columnsFrom": [
+            "phrase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lemma_edit_history_editor_id_users_id_fk": {
+          "name": "lemma_edit_history_editor_id_users_id_fk",
+          "tableFrom": "lemma_edit_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "editor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemma_forms": {
+      "name": "lemma_forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "romanization": {
+          "name": "romanization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "lemma_form_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'import'"
+        },
+        "paradigm_slot_id": {
+          "name": "paradigm_slot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quarantined_at": {
+          "name": "quarantined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quarantine_reason": {
+          "name": "quarantine_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_forms_lemma_idx": {
+          "name": "lemma_forms_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_forms_surface_idx": {
+          "name": "lemma_forms_surface_idx",
+          "columns": [
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_forms_surface_lookup_idx": {
+          "name": "lemma_forms_surface_lookup_idx",
+          "columns": [
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "quarantined_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_forms_lemma_id_lemmas_id_fk": {
+          "name": "lemma_forms_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_forms",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lemma_forms_paradigm_slot_id_paradigm_slots_id_fk": {
+          "name": "lemma_forms_paradigm_slot_id_paradigm_slots_id_fk",
+          "tableFrom": "lemma_forms",
+          "tableTo": "paradigm_slots",
+          "columnsFrom": [
+            "paradigm_slot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemma_proposals": {
+      "name": "lemma_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "proposer_id": {
+          "name": "proposer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headword": {
+          "name": "headword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos": {
+          "name": "pos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gloss_default": {
+          "name": "gloss_default",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "lemma_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "promoted_lemma_id": {
+          "name": "promoted_lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_id": {
+          "name": "reviewer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_note": {
+          "name": "reviewer_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_proposals_lang_status_idx": {
+          "name": "lemma_proposals_lang_status_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_proposals_headword_idx": {
+          "name": "lemma_proposals_headword_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "headword",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pos",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_proposals_proposer_id_users_id_fk": {
+          "name": "lemma_proposals_proposer_id_users_id_fk",
+          "tableFrom": "lemma_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "proposer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "lemma_proposals_promoted_lemma_id_lemmas_id_fk": {
+          "name": "lemma_proposals_promoted_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_proposals",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "promoted_lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "lemma_proposals_reviewer_id_users_id_fk": {
+          "name": "lemma_proposals_reviewer_id_users_id_fk",
+          "tableFrom": "lemma_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemmas": {
+      "name": "lemmas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headword": {
+          "name": "headword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos": {
+          "name": "pos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script": {
+          "name": "script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gloss_default": {
+          "name": "gloss_default",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_rank": {
+          "name": "frequency_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "translation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "curator_locked": {
+          "name": "curator_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "headword_nukta_stripped": {
+          "name": "headword_nukta_stripped",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "translate(normalize(\"headword\", NFD), '़', '')",
+            "type": "stored"
+          }
+        },
+        "paradigm_id": {
+          "name": "paradigm_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stem": {
+          "name": "stem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "lemmas_language_headword_pos_idx": {
+          "name": "lemmas_language_headword_pos_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "headword",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pos",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_language_idx": {
+          "name": "lemmas_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_language_frequency_idx": {
+          "name": "lemmas_language_frequency_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "frequency_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_source_lookup_idx": {
+          "name": "lemmas_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_language_headword_stripped_idx": {
+          "name": "lemmas_language_headword_stripped_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "headword_nukta_stripped",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemmas_paradigm_id_paradigms_id_fk": {
+          "name": "lemmas_paradigm_id_paradigms_id_fk",
+          "tableFrom": "lemmas",
+          "tableTo": "paradigms",
+          "columnsFrom": [
+            "paradigm_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.magic_links": {
+      "name": "magic_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "magic_links_user_idx": {
+          "name": "magic_links_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "magic_links_expires_idx": {
+          "name": "magic_links_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "magic_links_user_id_users_id_fk": {
+          "name": "magic_links_user_id_users_id_fk",
+          "tableFrom": "magic_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.nlp_jobs": {
+      "name": "nlp_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "nlp_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nlp_jobs_text_idx": {
+          "name": "nlp_jobs_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nlp_jobs_status_idx": {
+          "name": "nlp_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nlp_jobs_text_id_texts_id_fk": {
+          "name": "nlp_jobs_text_id_texts_id_fk",
+          "tableFrom": "nlp_jobs",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.paradigm_slots": {
+      "name": "paradigm_slots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "paradigm_id": {
+          "name": "paradigm_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot_key": {
+          "name": "slot_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "suffix": {
+          "name": "suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "paradigm_slots_paradigm_idx": {
+          "name": "paradigm_slots_paradigm_idx",
+          "columns": [
+            {
+              "expression": "paradigm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "paradigm_slots_paradigm_id_paradigms_id_fk": {
+          "name": "paradigm_slots_paradigm_id_paradigms_id_fk",
+          "tableFrom": "paradigm_slots",
+          "tableTo": "paradigms",
+          "columnsFrom": [
+            "paradigm_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "paradigm_slots_paradigm_key_uq": {
+          "name": "paradigm_slots_paradigm_key_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "paradigm_id",
+            "slot_key"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.paradigms": {
+      "name": "paradigms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos": {
+          "name": "pos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "paradigms_language_pos_idx": {
+          "name": "paradigms_language_pos_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pos",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "paradigms_language_pos_name_uq": {
+          "name": "paradigms_language_pos_name_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "language",
+            "pos",
+            "name"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.parse_reports": {
+      "name": "parse_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_nfc": {
+          "name": "surface_nfc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_signature": {
+          "name": "context_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "original_candidates": {
+          "name": "original_candidates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "corrected_lemma_id": {
+          "name": "corrected_lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "correction_type": {
+          "name": "correction_type",
+          "type": "token_correction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "parse_report_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "assigned_reviewer_id": {
+          "name": "assigned_reviewer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_note": {
+          "name": "resolution_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duplicate_count": {
+          "name": "duplicate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parse_reports_lang_status_idx": {
+          "name": "parse_reports_lang_status_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parse_reports_dedup_idx": {
+          "name": "parse_reports_dedup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface_nfc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_signature",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "corrected_lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parse_reports_token_id_text_tokens_id_fk": {
+          "name": "parse_reports_token_id_text_tokens_id_fk",
+          "tableFrom": "parse_reports",
+          "tableTo": "text_tokens",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "parse_reports_corrected_lemma_id_lemmas_id_fk": {
+          "name": "parse_reports_corrected_lemma_id_lemmas_id_fk",
+          "tableFrom": "parse_reports",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "corrected_lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "parse_reports_reporter_id_users_id_fk": {
+          "name": "parse_reports_reporter_id_users_id_fk",
+          "tableFrom": "parse_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "parse_reports_assigned_reviewer_id_users_id_fk": {
+          "name": "parse_reports_assigned_reviewer_id_users_id_fk",
+          "tableFrom": "parse_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_reviewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.personal_api_keys": {
+      "name": "personal_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "personal_api_keys_user_idx": {
+          "name": "personal_api_keys_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "personal_api_keys_active_user_idx": {
+          "name": "personal_api_keys_active_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personal_api_keys_user_id_users_id_fk": {
+          "name": "personal_api_keys_user_id_users_id_fk",
+          "tableFrom": "personal_api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "personal_api_keys_hash_unique": {
+          "name": "personal_api_keys_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.phrase_chapter_spans": {
+      "name": "phrase_chapter_spans",
+      "schema": "",
+      "columns": {
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phrase_id": {
+          "name": "phrase_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_token_idx": {
+          "name": "start_token_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_token_idx": {
+          "name": "end_token_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "phrase_chapter_spans_chapter_idx": {
+          "name": "phrase_chapter_spans_chapter_idx",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "phrase_chapter_spans_phrase_idx": {
+          "name": "phrase_chapter_spans_phrase_idx",
+          "columns": [
+            {
+              "expression": "phrase_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "phrase_chapter_spans_chapter_id_text_chapters_id_fk": {
+          "name": "phrase_chapter_spans_chapter_id_text_chapters_id_fk",
+          "tableFrom": "phrase_chapter_spans",
+          "tableTo": "text_chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "phrase_chapter_spans_phrase_id_phrases_id_fk": {
+          "name": "phrase_chapter_spans_phrase_id_phrases_id_fk",
+          "tableFrom": "phrase_chapter_spans",
+          "tableTo": "phrases",
+          "columnsFrom": [
+            "phrase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "phrase_chapter_spans_chapter_id_start_token_idx_phrase_id_pk": {
+          "name": "phrase_chapter_spans_chapter_id_start_token_idx_phrase_id_pk",
+          "columns": [
+            "chapter_id",
+            "start_token_idx",
+            "phrase_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.phrase_proposals": {
+      "name": "phrase_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_normalised": {
+          "name": "surface_normalised",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern_id": {
+          "name": "pattern_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "promoted_at": {
+          "name": "promoted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promoted_phrase_id": {
+          "name": "promoted_phrase_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "phrase_proposals_promotion_lookup_idx": {
+          "name": "phrase_proposals_promotion_lookup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface_normalised",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "phrase_proposals_chapter_id_text_chapters_id_fk": {
+          "name": "phrase_proposals_chapter_id_text_chapters_id_fk",
+          "tableFrom": "phrase_proposals",
+          "tableTo": "text_chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "phrase_proposals_promoted_phrase_id_phrases_id_fk": {
+          "name": "phrase_proposals_promoted_phrase_id_phrases_id_fk",
+          "tableFrom": "phrase_proposals",
+          "tableTo": "phrases",
+          "columnsFrom": [
+            "promoted_phrase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "phrase_proposals_occurrence_uq": {
+          "name": "phrase_proposals_occurrence_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chapter_id",
+            "surface_normalised",
+            "pattern_id"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.phrase_tokens": {
+      "name": "phrase_tokens",
+      "schema": "",
+      "columns": {
+        "phrase_id": {
+          "name": "phrase_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "phrase_tokens_surface_idx": {
+          "name": "phrase_tokens_surface_idx",
+          "columns": [
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "phrase_tokens_phrase_id_phrases_id_fk": {
+          "name": "phrase_tokens_phrase_id_phrases_id_fk",
+          "tableFrom": "phrase_tokens",
+          "tableTo": "phrases",
+          "columnsFrom": [
+            "phrase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "phrase_tokens_lemma_id_lemmas_id_fk": {
+          "name": "phrase_tokens_lemma_id_lemmas_id_fk",
+          "tableFrom": "phrase_tokens",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "phrase_tokens_phrase_id_position_pk": {
+          "name": "phrase_tokens_phrase_id_position_pk",
+          "columns": [
+            "phrase_id",
+            "position"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.phrases": {
+      "name": "phrases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_normalised": {
+          "name": "surface_normalised",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos": {
+          "name": "pos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gloss_default": {
+          "name": "gloss_default",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_rank": {
+          "name": "frequency_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "translation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "curator_locked": {
+          "name": "curator_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "phrases_language_surface_idx": {
+          "name": "phrases_language_surface_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface_normalised",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "phrases_language_idx": {
+          "name": "phrases_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "phrases_language_frequency_idx": {
+          "name": "phrases_language_frequency_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "frequency_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "phrases_source_lookup_idx": {
+          "name": "phrases_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by": {
+          "name": "replaced_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "refresh_tokens_user_idx": {
+          "name": "refresh_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_expires_idx": {
+          "name": "refresh_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.text_chapters": {
+      "name": "text_chapters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idx": {
+          "name": "idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "text_chapters_text_idx": {
+          "name": "text_chapters_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_chapters_text_id_texts_id_fk": {
+          "name": "text_chapters_text_id_texts_id_fk",
+          "tableFrom": "text_chapters",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "text_chapters_text_idx_uq": {
+          "name": "text_chapters_text_idx_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "text_id",
+            "idx"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.text_group_shares": {
+      "name": "text_group_shares",
+      "schema": "",
+      "columns": {
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by_id": {
+          "name": "granted_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "text_group_shares_group_idx": {
+          "name": "text_group_shares_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_group_shares_text_id_texts_id_fk": {
+          "name": "text_group_shares_text_id_texts_id_fk",
+          "tableFrom": "text_group_shares",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_group_shares_group_id_groups_id_fk": {
+          "name": "text_group_shares_group_id_groups_id_fk",
+          "tableFrom": "text_group_shares",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_group_shares_granted_by_id_users_id_fk": {
+          "name": "text_group_shares_granted_by_id_users_id_fk",
+          "tableFrom": "text_group_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "text_group_shares_text_id_group_id_pk": {
+          "name": "text_group_shares_text_id_group_id_pk",
+          "columns": [
+            "text_id",
+            "group_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.text_shares": {
+      "name": "text_shares",
+      "schema": "",
+      "columns": {
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shared_with_user_id": {
+          "name": "shared_with_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "text_share_permission",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'read'"
+        },
+        "granted_by_id": {
+          "name": "granted_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "text_shares_recipient_idx": {
+          "name": "text_shares_recipient_idx",
+          "columns": [
+            {
+              "expression": "shared_with_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_shares_text_id_texts_id_fk": {
+          "name": "text_shares_text_id_texts_id_fk",
+          "tableFrom": "text_shares",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_shares_shared_with_user_id_users_id_fk": {
+          "name": "text_shares_shared_with_user_id_users_id_fk",
+          "tableFrom": "text_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "shared_with_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_shares_granted_by_id_users_id_fk": {
+          "name": "text_shares_granted_by_id_users_id_fk",
+          "tableFrom": "text_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "text_shares_text_id_shared_with_user_id_pk": {
+          "name": "text_shares_text_id_shared_with_user_id_pk",
+          "columns": [
+            "text_id",
+            "shared_with_user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.text_tokens": {
+      "name": "text_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idx": {
+          "name": "idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lemma_candidates": {
+          "name": "lemma_candidates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_ambiguous": {
+          "name": "is_ambiguous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_oov": {
+          "name": "is_oov",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_word": {
+          "name": "is_word",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sentence_idx": {
+          "name": "sentence_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "romanization": {
+          "name": "romanization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_forms": {
+          "name": "number_forms",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "text_tokens_chapter_scan_idx": {
+          "name": "text_tokens_chapter_scan_idx",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "text_tokens_lemma_idx": {
+          "name": "text_tokens_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_tokens_chapter_id_text_chapters_id_fk": {
+          "name": "text_tokens_chapter_id_text_chapters_id_fk",
+          "tableFrom": "text_tokens",
+          "tableTo": "text_chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_tokens_lemma_id_lemmas_id_fk": {
+          "name": "text_tokens_lemma_id_lemmas_id_fk",
+          "tableFrom": "text_tokens",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "text_tokens_chapter_idx_uq": {
+          "name": "text_tokens_chapter_idx_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chapter_id",
+            "idx"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.texts": {
+      "name": "texts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "status_error": {
+          "name": "status_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "texts_owner_idx": {
+          "name": "texts_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "texts_visibility_idx": {
+          "name": "texts_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "texts_owner_id_users_id_fk": {
+          "name": "texts_owner_id_users_id_fk",
+          "tableFrom": "texts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.token_corrections": {
+      "name": "token_corrections",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "token_correction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chosen_lemma_id": {
+          "name": "chosen_lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "token_corrections_token_idx": {
+          "name": "token_corrections_token_idx",
+          "columns": [
+            {
+              "expression": "token_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "token_corrections_chosen_lemma_idx": {
+          "name": "token_corrections_chosen_lemma_idx",
+          "columns": [
+            {
+              "expression": "chosen_lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "token_corrections_user_id_users_id_fk": {
+          "name": "token_corrections_user_id_users_id_fk",
+          "tableFrom": "token_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "token_corrections_token_id_text_tokens_id_fk": {
+          "name": "token_corrections_token_id_text_tokens_id_fk",
+          "tableFrom": "token_corrections",
+          "tableTo": "text_tokens",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "token_corrections_chosen_lemma_id_lemmas_id_fk": {
+          "name": "token_corrections_chosen_lemma_id_lemmas_id_fk",
+          "tableFrom": "token_corrections",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "chosen_lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "token_corrections_user_id_token_id_pk": {
+          "name": "token_corrections_user_id_token_id_pk",
+          "columns": [
+            "user_id",
+            "token_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.translation_reports": {
+      "name": "translation_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "translation_id": {
+          "name": "translation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "translation_report_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "translation_report_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_note": {
+          "name": "resolution_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "translation_reports_status_idx": {
+          "name": "translation_reports_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translation_reports_translation_idx": {
+          "name": "translation_reports_translation_idx",
+          "columns": [
+            {
+              "expression": "translation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "translation_reports_translation_id_translations_id_fk": {
+          "name": "translation_reports_translation_id_translations_id_fk",
+          "tableFrom": "translation_reports",
+          "tableTo": "translations",
+          "columnsFrom": [
+            "translation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "translation_reports_reporter_id_users_id_fk": {
+          "name": "translation_reports_reporter_id_users_id_fk",
+          "tableFrom": "translation_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "translation_reports_resolved_by_users_id_fk": {
+          "name": "translation_reports_resolved_by_users_id_fk",
+          "tableFrom": "translation_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "translation_reports_reporter_translation_uq": {
+          "name": "translation_reports_reporter_translation_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "reporter_id",
+            "translation_id"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.translation_votes": {
+      "name": "translation_votes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "translation_id": {
+          "name": "translation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "translation_vote_value",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "translation_votes_translation_idx": {
+          "name": "translation_votes_translation_idx",
+          "columns": [
+            {
+              "expression": "translation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translation_votes_user_idx": {
+          "name": "translation_votes_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "translation_votes_user_id_users_id_fk": {
+          "name": "translation_votes_user_id_users_id_fk",
+          "tableFrom": "translation_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "translation_votes_translation_id_translations_id_fk": {
+          "name": "translation_votes_translation_id_translations_id_fk",
+          "tableFrom": "translation_votes",
+          "tableTo": "translations",
+          "columnsFrom": [
+            "translation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "translation_votes_user_id_translation_id_pk": {
+          "name": "translation_votes_user_id_translation_id_pk",
+          "columns": [
+            "user_id",
+            "translation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.translations": {
+      "name": "translations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "translation_target_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'lemma'"
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "translation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_translation_id": {
+          "name": "parent_translation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_language": {
+          "name": "target_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_rank": {
+          "name": "display_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "translations_target_idx": {
+          "name": "translations_target_idx",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translations_submitted_by_idx": {
+          "name": "translations_submitted_by_idx",
+          "columns": [
+            {
+              "expression": "submitted_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translations_source_lookup_idx": {
+          "name": "translations_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "translations_submitted_by_users_id_fk": {
+          "name": "translations_submitted_by_users_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "translations_parent_translation_id_translations_id_fk": {
+          "name": "translations_parent_translation_id_translations_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "translations",
+          "columnsFrom": [
+            "parent_translation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_audio_listening": {
+      "name": "user_audio_listening",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audio_file_id": {
+          "name": "audio_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "listened_ms": {
+          "name": "listened_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_listened_at": {
+          "name": "last_listened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_audio_listening_user_text_idx": {
+          "name": "user_audio_listening_user_text_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_audio_listening_text_idx": {
+          "name": "user_audio_listening_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_audio_listening_user_id_users_id_fk": {
+          "name": "user_audio_listening_user_id_users_id_fk",
+          "tableFrom": "user_audio_listening",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_audio_listening_audio_file_id_audio_files_id_fk": {
+          "name": "user_audio_listening_audio_file_id_audio_files_id_fk",
+          "tableFrom": "user_audio_listening",
+          "tableTo": "audio_files",
+          "columnsFrom": [
+            "audio_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_audio_listening_text_id_texts_id_fk": {
+          "name": "user_audio_listening_text_id_texts_id_fk",
+          "tableFrom": "user_audio_listening",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_audio_listening_user_id_audio_file_id_pk": {
+          "name": "user_audio_listening_user_id_audio_file_id_pk",
+          "columns": [
+            "user_id",
+            "audio_file_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_known_lemmas": {
+      "name": "user_known_lemmas",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "known_lemma_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'learning'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_known_lemmas_user_idx": {
+          "name": "user_known_lemmas_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_known_lemmas_user_id_users_id_fk": {
+          "name": "user_known_lemmas_user_id_users_id_fk",
+          "tableFrom": "user_known_lemmas",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_known_lemmas_lemma_id_lemmas_id_fk": {
+          "name": "user_known_lemmas_lemma_id_lemmas_id_fk",
+          "tableFrom": "user_known_lemmas",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_known_lemmas_user_id_lemma_id_pk": {
+          "name": "user_known_lemmas_user_id_lemma_id_pk",
+          "columns": [
+            "user_id",
+            "lemma_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_known_phrases": {
+      "name": "user_known_phrases",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phrase_id": {
+          "name": "phrase_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "known_lemma_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'learning'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_known_phrases_user_idx": {
+          "name": "user_known_phrases_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_known_phrases_user_id_users_id_fk": {
+          "name": "user_known_phrases_user_id_users_id_fk",
+          "tableFrom": "user_known_phrases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_known_phrases_phrase_id_phrases_id_fk": {
+          "name": "user_known_phrases_phrase_id_phrases_id_fk",
+          "tableFrom": "user_known_phrases",
+          "tableTo": "phrases",
+          "columnsFrom": [
+            "phrase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_known_phrases_user_id_phrase_id_pk": {
+          "name": "user_known_phrases_user_id_phrase_id_pk",
+          "columns": [
+            "user_id",
+            "phrase_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_languages": {
+      "name": "user_languages",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script_preference": {
+          "name": "script_preference",
+          "type": "script_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "romanization_scheme": {
+          "name": "romanization_scheme",
+          "type": "romanization_scheme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'iso15919'"
+        },
+        "known_words_count_cache": {
+          "name": "known_words_count_cache",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "known_phrases_count_cache": {
+          "name": "known_phrases_count_cache",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reader_layout_mode": {
+          "name": "reader_layout_mode",
+          "type": "reader_layout_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'page'"
+        },
+        "words_per_page": {
+          "name": "words_per_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 250
+        },
+        "font_family": {
+          "name": "font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_size": {
+          "name": "font_size",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 18
+        },
+        "line_spacing": {
+          "name": "line_spacing",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1.6
+        },
+        "highlight_style": {
+          "name": "highlight_style",
+          "type": "highlight_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'background'"
+        },
+        "reading_width": {
+          "name": "reading_width",
+          "type": "reading_width",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "baseline": {
+          "name": "baseline",
+          "type": "language_baseline",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_languages_user_id_users_id_fk": {
+          "name": "user_languages_user_id_users_id_fk",
+          "tableFrom": "user_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_languages_user_id_language_pk": {
+          "name": "user_languages_user_id_language_pk",
+          "columns": [
+            "user_id",
+            "language"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_text_progress": {
+      "name": "user_text_progress",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_chapter_idx": {
+          "name": "last_chapter_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_token_idx": {
+          "name": "last_token_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pct_read": {
+          "name": "pct_read",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_text_progress_user_idx": {
+          "name": "user_text_progress_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_text_progress_user_id_users_id_fk": {
+          "name": "user_text_progress_user_id_users_id_fk",
+          "tableFrom": "user_text_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_text_progress_text_id_texts_id_fk": {
+          "name": "user_text_progress_text_id_texts_id_fk",
+          "tableFrom": "user_text_progress",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_text_progress_user_id_text_id_pk": {
+          "name": "user_text_progress_user_id_text_id_pk",
+          "columns": [
+            "user_id",
+            "text_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_preference": {
+          "name": "theme_preference",
+          "type": "theme_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarded_at": {
+          "name": "onboarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    }
+  },
+  "enums": {
+    "public.alignment_source": {
+      "name": "alignment_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "imported",
+        "whisper"
+      ]
+    },
+    "public.collection_kind": {
+      "name": "collection_kind",
+      "schema": "public",
+      "values": [
+        "chapter_book",
+        "course",
+        "anthology"
+      ]
+    },
+    "public.collection_visibility": {
+      "name": "collection_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "shared",
+        "official"
+      ]
+    },
+    "public.highlight_style": {
+      "name": "highlight_style",
+      "schema": "public",
+      "values": [
+        "underline",
+        "background",
+        "colored_text"
+      ]
+    },
+    "public.known_lemma_status": {
+      "name": "known_lemma_status",
+      "schema": "public",
+      "values": [
+        "unknown",
+        "learning",
+        "known",
+        "ignored"
+      ]
+    },
+    "public.language": {
+      "name": "language",
+      "schema": "public",
+      "values": [
+        "hi",
+        "mr",
+        "or"
+      ]
+    },
+    "public.language_baseline": {
+      "name": "language_baseline",
+      "schema": "public",
+      "values": [
+        "none",
+        "beginner",
+        "intermediate"
+      ]
+    },
+    "public.lemma_edit_change_type": {
+      "name": "lemma_edit_change_type",
+      "schema": "public",
+      "values": [
+        "lemma_update",
+        "lemma_unlock",
+        "lemma_lock",
+        "translation_insert",
+        "translation_update",
+        "translation_hide",
+        "translation_unhide",
+        "form_insert",
+        "form_delete",
+        "lemma_merge",
+        "lemma_split",
+        "translation_reorder",
+        "phrase_update",
+        "phrase_lock",
+        "phrase_unlock",
+        "phrase_hide",
+        "phrase_unhide",
+        "phrase_merge"
+      ]
+    },
+    "public.lemma_form_source": {
+      "name": "lemma_form_source",
+      "schema": "public",
+      "values": [
+        "import",
+        "pipeline",
+        "curator",
+        "generator"
+      ]
+    },
+    "public.lemma_proposal_status": {
+      "name": "lemma_proposal_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.nlp_job_status": {
+      "name": "nlp_job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.parse_report_status": {
+      "name": "parse_report_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "triaged",
+        "resolved",
+        "rejected",
+        "duplicate",
+        "deferred"
+      ]
+    },
+    "public.reader_layout_mode": {
+      "name": "reader_layout_mode",
+      "schema": "public",
+      "values": [
+        "page",
+        "paged_scroll",
+        "continuous"
+      ]
+    },
+    "public.reading_width": {
+      "name": "reading_width",
+      "schema": "public",
+      "values": [
+        "narrow",
+        "medium",
+        "wide"
+      ]
+    },
+    "public.romanization_scheme": {
+      "name": "romanization_scheme",
+      "schema": "public",
+      "values": [
+        "iso15919",
+        "iast",
+        "hunterian",
+        "itrans"
+      ]
+    },
+    "public.script_preference": {
+      "name": "script_preference",
+      "schema": "public",
+      "values": [
+        "native",
+        "native_with_romanization",
+        "romanization_only"
+      ]
+    },
+    "public.text_share_permission": {
+      "name": "text_share_permission",
+      "schema": "public",
+      "values": [
+        "read"
+      ]
+    },
+    "public.text_source_type": {
+      "name": "text_source_type",
+      "schema": "public",
+      "values": [
+        "paste",
+        "txt",
+        "epub",
+        "zip"
+      ]
+    },
+    "public.text_status": {
+      "name": "text_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.text_visibility": {
+      "name": "text_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "shared",
+        "official"
+      ]
+    },
+    "public.theme_preference": {
+      "name": "theme_preference",
+      "schema": "public",
+      "values": [
+        "system",
+        "light",
+        "dark"
+      ]
+    },
+    "public.token_correction_type": {
+      "name": "token_correction_type",
+      "schema": "public",
+      "values": [
+        "pick_candidate",
+        "manual_lemma",
+        "new_lemma",
+        "mark_proper_noun",
+        "mark_foreign",
+        "mark_not_a_word"
+      ]
+    },
+    "public.translation_report_reason": {
+      "name": "translation_report_reason",
+      "schema": "public",
+      "values": [
+        "spam",
+        "incorrect",
+        "offensive",
+        "duplicate",
+        "other"
+      ]
+    },
+    "public.translation_report_status": {
+      "name": "translation_report_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "resolved_hidden",
+        "resolved_kept",
+        "dismissed"
+      ]
+    },
+    "public.translation_source": {
+      "name": "translation_source",
+      "schema": "public",
+      "values": [
+        "official_dictionary",
+        "curator",
+        "user",
+        "nlp"
+      ]
+    },
+    "public.translation_target_type": {
+      "name": "translation_target_type",
+      "schema": "public",
+      "values": [
+        "lemma",
+        "phrase"
+      ]
+    },
+    "public.translation_vote_value": {
+      "name": "translation_vote_value",
+      "schema": "public",
+      "values": [
+        "up",
+        "down"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "curator",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -281,6 +281,20 @@
       "when": 1778170100000,
       "tag": "0039_extend_odia_verb_politeness",
       "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "7",
+      "when": 1778555297304,
+      "tag": "0040_quick_wolf_cub",
+      "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "7",
+      "when": 1778610962475,
+      "tag": "0041_giant_khan",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/e2e/auth.setup.ts
+++ b/apps/web/e2e/auth.setup.ts
@@ -48,24 +48,47 @@ async function ensureTestUser(sql: postgres.Sql): Promise<string> {
   return inserted[0]!.id;
 }
 
-/** Generate paragraphs of approximately `wordsPerParagraph` words,
- *  for `paragraphCount` paragraphs. Used to fill seed chapter bodies
- *  with enough content to span multiple display pages at the test
- *  viewport (800×600). */
-function generateBody(paragraphCount: number, wordsPerParagraph: number): string {
-  const wordPool = [
-    'lorem', 'ipsum', 'dolor', 'sit', 'amet', 'consectetur', 'adipiscing',
-    'elit', 'sed', 'do', 'eiusmod', 'tempor', 'incididunt', 'ut', 'labore',
-    'magna', 'aliqua', 'enim', 'minim', 'veniam', 'quis', 'nostrud',
-    'exercitation', 'ullamco', 'laboris', 'nisi', 'aliquip', 'commodo',
-  ];
+/** Generate `count` words from a small pool — deterministic so seed
+ *  runs reproduce, but big enough that adjacent paragraphs don't
+ *  share the exact same prefix. */
+const WORD_POOL = [
+  'lorem', 'ipsum', 'dolor', 'sit', 'amet', 'consectetur', 'adipiscing',
+  'elit', 'sed', 'do', 'eiusmod', 'tempor', 'incididunt', 'ut', 'labore',
+  'magna', 'aliqua', 'enim', 'minim', 'veniam', 'quis', 'nostrud',
+  'exercitation', 'ullamco', 'laboris', 'nisi', 'aliquip', 'commodo',
+];
+function generateWords(count: number, seed: number): string {
+  const out: string[] = [];
+  for (let i = 0; i < count; i += 1) {
+    out.push(WORD_POOL[(seed + i) % WORD_POOL.length]!);
+  }
+  return out.join(' ') + '.';
+}
+
+/** Generate a body with varied paragraph lengths. We deliberately
+ *  mix short paragraphs (~10 words) with long ones (~200 words) so
+ *  the multi-page chapter has the kind of dense-vs-sparse variance
+ *  the progress edge-case test asserts on. Uniform paragraphs would
+ *  pack each display page with roughly the same word count, making
+ *  the test trivially close to 1.0× variance and unable to catch
+ *  the "uniform pages/N split" bug it's there to prevent. */
+function generateVariedBody(totalParagraphs: number): string {
+  const sizes = [12, 180, 35, 220, 8, 160, 50, 200, 15, 140, 28, 175];
+  const paragraphs: string[] = [];
+  for (let i = 0; i < totalParagraphs; i += 1) {
+    const size = sizes[i % sizes.length]!;
+    paragraphs.push(generateWords(size, i * 7));
+  }
+  return paragraphs.join('\n\n');
+}
+
+/** Generate uniform paragraphs — used for short chapters where
+ *  variance isn't a concern (the cross-text-nav test just needs a
+ *  multi-page chapter, not specifically a varied one). */
+function generateUniformBody(paragraphCount: number, wordsPerParagraph: number): string {
   const paragraphs: string[] = [];
   for (let p = 0; p < paragraphCount; p += 1) {
-    const words: string[] = [];
-    for (let w = 0; w < wordsPerParagraph; w += 1) {
-      words.push(wordPool[(p * wordsPerParagraph + w) % wordPool.length]!);
-    }
-    paragraphs.push(words.join(' ') + '.');
+    paragraphs.push(generateWords(wordsPerParagraph, p * 11));
   }
   return paragraphs.join('\n\n');
 }
@@ -99,9 +122,15 @@ async function ensureChapterBook(sql: postgres.Sql, ownerId: string): Promise<vo
     const collectionId = collection!.id;
 
     const chapters = [
-      { title: 'Chapter One — Intro', body: generateBody(8, 120) },
-      { title: 'Chapter Two — Body', body: generateBody(10, 140) },
-      { title: 'Chapter Three — Coda', body: generateBody(6, 100) },
+      // Uniform paragraphs are fine for the cross-text nav test —
+      // it just needs a multi-page chapter to step back into.
+      { title: 'Chapter One — Intro', body: generateUniformBody(8, 120) },
+      // Mixed paragraph sizes so the "dense vs sparse pages" test
+      // sees real per-page variance. ~1700 words across 12 paragraphs
+      // of widely varying sizes lays out as 8-10 display pages whose
+      // word counts differ by 2-3×.
+      { title: 'Chapter Two — Body', body: generateVariedBody(12) },
+      { title: 'Chapter Three — Coda', body: generateUniformBody(6, 100) },
     ];
 
     for (let i = 0; i < chapters.length; i += 1) {

--- a/apps/web/e2e/auth.setup.ts
+++ b/apps/web/e2e/auth.setup.ts
@@ -1,15 +1,20 @@
 /**
- * Authentication setup for Playwright e2e tests.
+ * Authentication + test-data setup for Playwright e2e tests.
  *
- * Avoids the brittleness of logging in via the UI by minting a
- * session row directly in the dev Postgres for the seeded test user
- * (`crush@test.local`), then saving the resulting cookie to
- * `e2e/.auth/crush.json` for downstream specs to load via
- * `storageState`. The token shape matches the runtime: SHA-256 of
- * the cookie value is stored in `sessions.id`, raw token is the
- * cookie. See `src/lib/server/auth/sessions.ts` for the production
- * helpers; we duplicate the minimum here to avoid pulling in
- * SvelteKit at test-runtime.
+ * 1. Ensures the seeded test user (`crush@test.local`) exists.
+ *    Local dev DBs have it from the bootstrap script; CI starts
+ *    with an empty DB so we upsert it here. Admin role so it can
+ *    do everything the reader / library tests need.
+ * 2. Ensures a chapter-book collection with multiple multi-page
+ *    chapters exists. The cross-text-nav + progress specs need
+ *    real-looking content (consecutive chapters, at least one with
+ *    enough words to span multiple display pages); a tiny seed
+ *    keeps CI runs fast while still exercising the real paths.
+ * 3. Mints a session row directly in the dev Postgres for that
+ *    user, saving the cookie to `e2e/.auth/crush.json` for
+ *    downstream specs to load via `storageState`. The token shape
+ *    matches the runtime: SHA-256 of the cookie value is stored in
+ *    `sessions.id`, raw token is the cookie.
  */
 import { test as setup, expect } from '@playwright/test';
 import postgres from 'postgres';
@@ -25,18 +30,107 @@ const TEST_EMAIL = 'crush@test.local';
 // Matches the runtime cookie name + path (src/lib/server/auth/sessions.ts).
 const SESSION_COOKIE = 'cia_session';
 
-setup('mint a session for the seeded test user', async ({ baseURL }) => {
+/** Idempotent: return the existing user id if one is there, else
+ *  insert. We don't set a password — the e2e tests never log in
+ *  via the UI, they mint a session directly. `onboarded_at` is set
+ *  so `hooks.server.ts` doesn't redirect every page to /onboarding
+ *  (an unboarded user can't reach the reader at all). */
+async function ensureTestUser(sql: postgres.Sql): Promise<string> {
+  const existing = await sql<Array<{ id: string }>>`
+    SELECT id FROM users WHERE email = ${TEST_EMAIL} LIMIT 1
+  `;
+  if (existing[0]) return existing[0].id;
+  const inserted = await sql<Array<{ id: string }>>`
+    INSERT INTO users (email, role, email_verified_at, onboarded_at)
+    VALUES (${TEST_EMAIL}, 'admin', NOW(), NOW())
+    RETURNING id
+  `;
+  return inserted[0]!.id;
+}
+
+/** Generate paragraphs of approximately `wordsPerParagraph` words,
+ *  for `paragraphCount` paragraphs. Used to fill seed chapter bodies
+ *  with enough content to span multiple display pages at the test
+ *  viewport (800×600). */
+function generateBody(paragraphCount: number, wordsPerParagraph: number): string {
+  const wordPool = [
+    'lorem', 'ipsum', 'dolor', 'sit', 'amet', 'consectetur', 'adipiscing',
+    'elit', 'sed', 'do', 'eiusmod', 'tempor', 'incididunt', 'ut', 'labore',
+    'magna', 'aliqua', 'enim', 'minim', 'veniam', 'quis', 'nostrud',
+    'exercitation', 'ullamco', 'laboris', 'nisi', 'aliquip', 'commodo',
+  ];
+  const paragraphs: string[] = [];
+  for (let p = 0; p < paragraphCount; p += 1) {
+    const words: string[] = [];
+    for (let w = 0; w < wordsPerParagraph; w += 1) {
+      words.push(wordPool[(p * wordsPerParagraph + w) % wordPool.length]!);
+    }
+    paragraphs.push(words.join(' ') + '.');
+  }
+  return paragraphs.join('\n\n');
+}
+
+/** Idempotent: if the user already owns a chapter-book collection
+ *  with at least one ready ≥800-word chapter, leave it alone.
+ *  Otherwise create one with three chapters — two consecutive
+ *  multi-page chapters (for the cross-text nav specs) and a short
+ *  trailing chapter (so chapter-count assertions stay meaningful). */
+async function ensureChapterBook(sql: postgres.Sql, ownerId: string): Promise<void> {
+  const existing = await sql<Array<{ id: string }>>`
+    SELECT c.id
+    FROM collections c
+    JOIN collection_items ci ON ci.collection_id = c.id
+    JOIN texts t ON t.id = ci.text_id
+    JOIN text_chapters tc ON tc.text_id = t.id
+    WHERE c.owner_id = ${ownerId}
+      AND c.kind = 'chapter_book'
+      AND t.status = 'ready'
+      AND tc.token_count >= 800
+    LIMIT 1
+  `;
+  if (existing[0]) return;
+
+  await sql.begin(async (tx) => {
+    const [collection] = await tx<Array<{ id: string }>>`
+      INSERT INTO collections (owner_id, language, kind, title, visibility)
+      VALUES (${ownerId}, 'hi', 'chapter_book', 'E2E Test Book', 'private')
+      RETURNING id
+    `;
+    const collectionId = collection!.id;
+
+    const chapters = [
+      { title: 'Chapter One — Intro', body: generateBody(8, 120) },
+      { title: 'Chapter Two — Body', body: generateBody(10, 140) },
+      { title: 'Chapter Three — Coda', body: generateBody(6, 100) },
+    ];
+
+    for (let i = 0; i < chapters.length; i += 1) {
+      const c = chapters[i]!;
+      const [text] = await tx<Array<{ id: string }>>`
+        INSERT INTO texts (owner_id, language, title, source_type, status, visibility)
+        VALUES (${ownerId}, 'hi', ${c.title}, 'zip', 'ready', 'private')
+        RETURNING id
+      `;
+      const bodyWithTitle = `${c.title}\n\n${c.body}`;
+      const tokenCount = bodyWithTitle.trim().split(/\s+/).length;
+      await tx`
+        INSERT INTO text_chapters (text_id, idx, title, body, token_count)
+        VALUES (${text!.id}, 0, ${c.title}, ${bodyWithTitle}, ${tokenCount})
+      `;
+      await tx`
+        INSERT INTO collection_items (collection_id, text_id, position)
+        VALUES (${collectionId}, ${text!.id}, ${i})
+      `;
+    }
+  });
+}
+
+setup('seed test data and mint a session', async ({ baseURL }) => {
   const url = new URL(baseURL ?? 'http://localhost:5173');
   const sql = postgres(DATABASE_URL);
   try {
-    const rows = await sql<Array<{ id: string }>>`
-      SELECT id FROM users WHERE email = ${TEST_EMAIL} LIMIT 1
-    `;
-    const user = rows[0];
-    expect(
-      user,
-      `seed user ${TEST_EMAIL} not found — run the dev DB bootstrap first`,
-    ).toBeDefined();
+    const userId = await ensureTestUser(sql);
+    await ensureChapterBook(sql, userId);
 
     const token = randomBytes(32).toString('base64url');
     const id = createHash('sha256').update(token).digest('hex');
@@ -45,7 +139,7 @@ setup('mint a session for the seeded test user', async ({ baseURL }) => {
 
     await sql`
       INSERT INTO sessions (id, user_id, expires_at)
-      VALUES (${id}, ${user!.id}, ${expiresAt})
+      VALUES (${id}, ${userId}, ${expiresAt})
     `;
 
     const storage = {
@@ -65,6 +159,25 @@ setup('mint a session for the seeded test user', async ({ baseURL }) => {
     };
     await mkdir(dirname(AUTH_FILE), { recursive: true });
     await writeFile(AUTH_FILE, JSON.stringify(storage, null, 2));
+
+    // Sanity check that the seed produced what downstream specs
+    // need — if not, fail fast with a useful message rather than
+    // letting the spec timeout looking for a chapter pair.
+    const pair = await sql<Array<{ count: number }>>`
+      SELECT count(*)::int AS count
+      FROM collection_items ci
+      JOIN texts t ON t.id = ci.text_id
+      JOIN text_chapters tc ON tc.text_id = t.id
+      JOIN collections c ON c.id = ci.collection_id
+      WHERE c.owner_id = ${userId}
+        AND c.kind = 'chapter_book'
+        AND t.status = 'ready'
+        AND tc.token_count >= 500
+    `;
+    expect(
+      pair[0]?.count ?? 0,
+      'seed should produce at least two ≥500-word chapters in a chapter book',
+    ).toBeGreaterThanOrEqual(2);
   } finally {
     await sql.end();
   }

--- a/apps/web/e2e/auth.setup.ts
+++ b/apps/web/e2e/auth.setup.ts
@@ -1,0 +1,71 @@
+/**
+ * Authentication setup for Playwright e2e tests.
+ *
+ * Avoids the brittleness of logging in via the UI by minting a
+ * session row directly in the dev Postgres for the seeded test user
+ * (`crush@test.local`), then saving the resulting cookie to
+ * `e2e/.auth/crush.json` for downstream specs to load via
+ * `storageState`. The token shape matches the runtime: SHA-256 of
+ * the cookie value is stored in `sessions.id`, raw token is the
+ * cookie. See `src/lib/server/auth/sessions.ts` for the production
+ * helpers; we duplicate the minimum here to avoid pulling in
+ * SvelteKit at test-runtime.
+ */
+import { test as setup, expect } from '@playwright/test';
+import postgres from 'postgres';
+import { createHash, randomBytes } from 'node:crypto';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+const AUTH_FILE = 'e2e/.auth/crush.json';
+const DATABASE_URL =
+  process.env.DATABASE_URL ??
+  'postgres://ciareader:ciareader@localhost:5432/ciareader';
+const TEST_EMAIL = 'crush@test.local';
+// Matches the runtime cookie name + path (src/lib/server/auth/sessions.ts).
+const SESSION_COOKIE = 'cia_session';
+
+setup('mint a session for the seeded test user', async ({ baseURL }) => {
+  const url = new URL(baseURL ?? 'http://localhost:5173');
+  const sql = postgres(DATABASE_URL);
+  try {
+    const rows = await sql<Array<{ id: string }>>`
+      SELECT id FROM users WHERE email = ${TEST_EMAIL} LIMIT 1
+    `;
+    const user = rows[0];
+    expect(
+      user,
+      `seed user ${TEST_EMAIL} not found — run the dev DB bootstrap first`,
+    ).toBeDefined();
+
+    const token = randomBytes(32).toString('base64url');
+    const id = createHash('sha256').update(token).digest('hex');
+    // 30 days — plenty for a test run.
+    const expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+
+    await sql`
+      INSERT INTO sessions (id, user_id, expires_at)
+      VALUES (${id}, ${user!.id}, ${expiresAt})
+    `;
+
+    const storage = {
+      cookies: [
+        {
+          name: SESSION_COOKIE,
+          value: token,
+          domain: url.hostname,
+          path: '/',
+          expires: Math.floor(expiresAt.getTime() / 1000),
+          httpOnly: true,
+          secure: url.protocol === 'https:',
+          sameSite: 'Lax' as const,
+        },
+      ],
+      origins: [],
+    };
+    await mkdir(dirname(AUTH_FILE), { recursive: true });
+    await writeFile(AUTH_FILE, JSON.stringify(storage, null, 2));
+  } finally {
+    await sql.end();
+  }
+});

--- a/apps/web/e2e/reader-cross-text-nav.spec.ts
+++ b/apps/web/e2e/reader-cross-text-nav.spec.ts
@@ -108,6 +108,12 @@ test.describe('Reader cross-text prev navigation', () => {
     // Land on the current chapter in page mode at page 1.
     await page.goto(`/reader/${currentChapter.id}?mode=page&chapter=0&token=0`);
     await expect(page.locator('.pager-pages').first()).toBeVisible({ timeout: 10_000 });
+    // Wait for hydration to settle before clicking — in CI's cold
+    // start the SSR'd button is on the page before Svelte's onclick
+    // handler is attached, so a too-early click was firing without
+    // triggering navigation. `networkidle` is a robust proxy for
+    // "the page has finished hydrating" in dev mode.
+    await page.waitForLoadState('networkidle');
     const start = await readPageState(page);
     expect(start.current).toBe(1);
 
@@ -154,6 +160,7 @@ test.describe('Reader cross-text prev navigation', () => {
     // first exceeds 1.
     await page.goto(`/reader/${prevChapter.id}?mode=page&endOfChapter=1`);
     await expect(page.locator('.pager-pages').first()).toBeVisible({ timeout: 10_000 });
+    await page.waitForLoadState('networkidle');
     await expect
       .poll(
         async () => {

--- a/apps/web/e2e/reader-cross-text-nav.spec.ts
+++ b/apps/web/e2e/reader-cross-text-nav.spec.ts
@@ -147,14 +147,25 @@ test.describe('Reader cross-text prev navigation', () => {
   }) => {
     const { prevChapter, currentChapter } = await findChapterPair();
 
-    // Land at the end of the previous chapter.
+    // Land at the end of the previous chapter. The reader measures
+    // the column flow in waves (initial paint, then again after
+    // token spans render), so we poll until current === total
+    // rather than reading the state in one shot the moment current
+    // first exceeds 1.
     await page.goto(`/reader/${prevChapter.id}?mode=page&endOfChapter=1`);
     await expect(page.locator('.pager-pages').first()).toBeVisible({ timeout: 10_000 });
     await expect
-      .poll(async () => (await readPageState(page)).current, { timeout: 10_000 })
-      .toBeGreaterThan(1);
-    const start = await readPageState(page);
-    expect(start.current).toBe(start.total);
+      .poll(
+        async () => {
+          const s = await readPageState(page);
+          return s.current === s.total;
+        },
+        {
+          timeout: 10_000,
+          message: 'reader should settle on the last page of the previous chapter',
+        },
+      )
+      .toBe(true);
 
     // Click next — should walk into the next text at its first page.
     const nextButton = page.getByRole('button', { name: /^Next (chapter|page)$/ });

--- a/apps/web/e2e/reader-cross-text-nav.spec.ts
+++ b/apps/web/e2e/reader-cross-text-nav.spec.ts
@@ -1,0 +1,172 @@
+/**
+ * Reader cross-text prev navigation lands on the LAST page of the
+ * previous chapter, not page 1.
+ *
+ * Repro:
+ *   - Open chapter N (a chapter-book member) on its first page.
+ *   - Click the prev arrow (no prev page or prev internal chapter
+ *     in this text → it must walk into the previous text).
+ *   - Verify the URL becomes /reader/<prevTextId>?...endOfChapter=1
+ *     AND the footer reads "Page N of N" (last page), not "Page 1".
+ *
+ * Reads a multi-chapter chapter-book collection from the dev DB at
+ * setup time so the test doesn't hardcode chapter UUIDs.
+ */
+import { test, expect, type Page } from '@playwright/test';
+import postgres from 'postgres';
+
+const DATABASE_URL =
+  process.env.DATABASE_URL ??
+  'postgres://ciareader:ciareader@localhost:5432/ciareader';
+const TEST_EMAIL = 'crush@test.local';
+
+type ChapterSibling = { id: string; title: string };
+
+/** Find two consecutive chapters of an owned chapter-book collection
+ *  for the seeded test user. The prev chapter MUST have enough text
+ *  to span multiple display pages — otherwise "last page" equals
+ *  "page 1" and we can't tell whether the cross-text handoff
+ *  actually jumped to the end. We filter by chapter `token_count`
+ *  and pick the earliest qualifying neighbour-pair. */
+async function findChapterPair(): Promise<{
+  prevChapter: ChapterSibling;
+  currentChapter: ChapterSibling;
+}> {
+  const sql = postgres(DATABASE_URL);
+  try {
+    const rows = await sql<
+      Array<{
+        prev_id: string;
+        prev_title: string;
+        cur_id: string;
+        cur_title: string;
+      }>
+    >`
+      WITH owned_books AS (
+        SELECT c.id
+        FROM collections c
+        JOIN users u ON u.id = c.owner_id
+        WHERE u.email = ${TEST_EMAIL} AND c.kind = 'chapter_book'
+      ),
+      members AS (
+        SELECT
+          ci.collection_id,
+          ci.position,
+          t.id AS text_id,
+          t.title,
+          tc.token_count
+        FROM collection_items ci
+        JOIN texts t ON t.id = ci.text_id
+        JOIN text_chapters tc ON tc.text_id = t.id
+        WHERE ci.collection_id IN (SELECT id FROM owned_books)
+          AND t.status = 'ready'
+      )
+      SELECT
+        a.text_id AS prev_id,
+        a.title AS prev_title,
+        b.text_id AS cur_id,
+        b.title AS cur_title
+      FROM members a
+      JOIN members b
+        ON b.collection_id = a.collection_id
+       AND b.position = a.position + 1
+      WHERE a.token_count >= 500
+      ORDER BY a.position
+      LIMIT 1
+    `;
+    const row = rows[0];
+    expect(
+      row,
+      `need an owned chapter_book with a multi-page chapter for ${TEST_EMAIL}`,
+    ).toBeDefined();
+    return {
+      prevChapter: { id: row!.prev_id, title: row!.prev_title },
+      currentChapter: { id: row!.cur_id, title: row!.cur_title },
+    };
+  } finally {
+    await sql.end();
+  }
+}
+
+/** Parse the reader footer to read out the current and total pages.
+ *  The footer renders "Page X of Y · Ch. … / …" inside `.pager-pages`. */
+async function readPageState(page: Page): Promise<{ current: number; total: number }> {
+  const pager = page.locator('.pager-pages').first();
+  await expect(pager).toBeVisible();
+  const text = (await pager.innerText()).trim();
+  const m = /Page\s+(\d+)\s+of\s+(\d+)/.exec(text);
+  if (!m) throw new Error(`Pager text didn't match: ${text}`);
+  return { current: Number.parseInt(m[1]!, 10), total: Number.parseInt(m[2]!, 10) };
+}
+
+test.describe('Reader cross-text prev navigation', () => {
+  test('clicking prev from page 1 of chapter N lands on the LAST page of chapter N-1', async ({
+    page,
+  }) => {
+    const { prevChapter, currentChapter } = await findChapterPair();
+
+    // Land on the current chapter in page mode at page 1.
+    await page.goto(`/reader/${currentChapter.id}?mode=page&chapter=0&token=0`);
+    await expect(page.locator('.pager-pages').first()).toBeVisible({ timeout: 10_000 });
+    const start = await readPageState(page);
+    expect(start.current).toBe(1);
+
+    // Click the prev arrow. Its aria-label says "Previous chapter"
+    // when the click will leave the current chapter — that's our
+    // case here because the chapter-book chapter has a single
+    // internal chapter, so prev-page at page 1 = prev-text.
+    const prevButton = page.getByRole('button', { name: /^Previous (chapter|page)$/ });
+    await expect(prevButton).toBeEnabled();
+    await prevButton.click();
+
+    // After navigation, URL points at the previous chapter's text
+    // with the `endOfChapter=1` handoff flag.
+    await page.waitForURL(
+      (url) =>
+        url.pathname === `/reader/${prevChapter.id}` &&
+        url.searchParams.get('endOfChapter') === '1',
+      { timeout: 10_000 },
+    );
+
+    // The footer should report we're on the LAST page — not page 1.
+    // Wait for measurement to settle (pageCount > 0 + the
+    // pendingJumpToLast effect to fire).
+    await expect(page.locator('.pager-pages').first()).toBeVisible({ timeout: 10_000 });
+    await expect
+      .poll(async () => (await readPageState(page)).current, {
+        message: 'reader should jump to the last page, not stay on page 1',
+        timeout: 10_000,
+      })
+      .toBeGreaterThan(1);
+    const end = await readPageState(page);
+    expect(end.current).toBe(end.total);
+  });
+
+  test('clicking next from the last page of chapter N-1 returns to page 1 of chapter N', async ({
+    page,
+  }) => {
+    const { prevChapter, currentChapter } = await findChapterPair();
+
+    // Land at the end of the previous chapter.
+    await page.goto(`/reader/${prevChapter.id}?mode=page&endOfChapter=1`);
+    await expect(page.locator('.pager-pages').first()).toBeVisible({ timeout: 10_000 });
+    await expect
+      .poll(async () => (await readPageState(page)).current, { timeout: 10_000 })
+      .toBeGreaterThan(1);
+    const start = await readPageState(page);
+    expect(start.current).toBe(start.total);
+
+    // Click next — should walk into the next text at its first page.
+    const nextButton = page.getByRole('button', { name: /^Next (chapter|page)$/ });
+    await expect(nextButton).toBeEnabled();
+    await nextButton.click();
+
+    await page.waitForURL(
+      (url) => url.pathname === `/reader/${currentChapter.id}`,
+      { timeout: 10_000 },
+    );
+    await expect(page.locator('.pager-pages').first()).toBeVisible({ timeout: 10_000 });
+    const end = await readPageState(page);
+    expect(end.current).toBe(1);
+  });
+});

--- a/apps/web/e2e/reader-progress.spec.ts
+++ b/apps/web/e2e/reader-progress.spec.ts
@@ -1,0 +1,273 @@
+/**
+ * Reader page-counter, progress-percentage, and progress-bar tests.
+ *
+ * Covered behaviors:
+ *   - The "Page X of Y" counter increments on next-page click and
+ *     resets to 1 on a fresh chapter load.
+ *   - The displayed start/end percentage range stays in sync with
+ *     the inline `width: %` on the `.read` / `.current` progress
+ *     bar segments.
+ *   - Word-based math: pages with many words advance the bar more
+ *     than pages with few words (the per-page range varies with
+ *     actual word density, not with a uniform pages/N split).
+ *   - Walking from page 1 to the last page covers ~100% of the bar.
+ *
+ * Reads a multi-page owned chapter from the dev DB (`crush@test.local`)
+ * so we don't hardcode UUIDs and so edge-cases naturally surface in
+ * real publisher content (chapter intros / outros are often sparse,
+ * mid-chapter prose is dense).
+ */
+import { test, expect, type Page } from '@playwright/test';
+import postgres from 'postgres';
+
+const DATABASE_URL =
+  process.env.DATABASE_URL ??
+  'postgres://ciareader:ciareader@localhost:5432/ciareader';
+const TEST_EMAIL = 'crush@test.local';
+
+// Tight viewport so a multi-thousand-word chapter reliably renders
+// across multiple display pages. The default Desktop Chrome viewport
+// (1280×720) can fit a 5k-word chapter into a single column on a
+// wide screen — fine in practice but it makes the page-counter
+// assertions meaningless.
+test.use({ viewport: { width: 800, height: 600 } });
+
+/** Smallest chapter token count we accept — enough to span at least
+ *  several display pages at the default viewport. */
+const MIN_CHAPTER_TOKENS = 800;
+
+async function findMultiPageChapter(): Promise<{ id: string; title: string }> {
+  const sql = postgres(DATABASE_URL);
+  try {
+    const rows = await sql<Array<{ id: string; title: string }>>`
+      SELECT t.id, t.title
+      FROM texts t
+      JOIN text_chapters tc ON tc.text_id = t.id
+      JOIN collection_items ci ON ci.text_id = t.id
+      JOIN collections c ON c.id = ci.collection_id
+      JOIN users u ON u.id = c.owner_id
+      WHERE u.email = ${TEST_EMAIL}
+        AND c.kind = 'chapter_book'
+        AND t.status = 'ready'
+        AND tc.token_count >= ${MIN_CHAPTER_TOKENS}
+      ORDER BY tc.token_count DESC
+      LIMIT 1
+    `;
+    expect(
+      rows[0],
+      `need a ready chapter-book chapter with >= ${MIN_CHAPTER_TOKENS} words for ${TEST_EMAIL}`,
+    ).toBeDefined();
+    return rows[0]!;
+  } finally {
+    await sql.end();
+  }
+}
+
+function parsePageCounter(text: string): { current: number; total: number } {
+  const m = /Page\s+(\d+)\s+of\s+(\d+)/.exec(text);
+  if (!m) throw new Error(`Could not parse page counter from "${text}"`);
+  return { current: Number.parseInt(m[1]!, 10), total: Number.parseInt(m[2]!, 10) };
+}
+
+/** Parse the formatted `startPct–endPct%` range (or single `endPct%`
+ *  when start equals end at the formatted precision). Note: the
+ *  separator is an en-dash (U+2013), not a hyphen. */
+function parsePctRange(text: string): { start: number; end: number } {
+  const range = /([\d.]+)[–-]([\d.]+)\s*%/.exec(text);
+  if (range)
+    return {
+      start: Number.parseFloat(range[1]!),
+      end: Number.parseFloat(range[2]!),
+    };
+  const single = /([\d.]+)\s*%/.exec(text);
+  if (!single) throw new Error(`Could not parse pct range from "${text}"`);
+  const v = Number.parseFloat(single[1]!);
+  return { start: v, end: v };
+}
+
+async function readPageCounter(page: Page): Promise<{ current: number; total: number }> {
+  return parsePageCounter(await page.locator('.pager-pages').first().innerText());
+}
+
+/** Wait for the column-flow measurement to settle so `pageCount`
+ *  reflects the real chapter (initially 1 until measure() runs). */
+async function waitForMeasureSettled(page: Page): Promise<{ current: number; total: number }> {
+  await expect.poll(
+    async () => (await readPageCounter(page)).total,
+    {
+      message: 'pageCount should rise above 1 once measure() has run',
+      timeout: 10_000,
+    },
+  ).toBeGreaterThan(1);
+  return readPageCounter(page);
+}
+
+async function readPctRange(page: Page): Promise<{ start: number; end: number }> {
+  return parsePctRange(
+    await page.locator('.reader-foot-meta > .muted').last().innerText(),
+  );
+}
+
+/** Inline `width: N%` on the .read element of the progress bar. */
+async function readBarReadWidth(page: Page): Promise<number> {
+  return await page
+    .locator('.reader-foot-bar > .read')
+    .evaluate((el) => Number.parseFloat((el as HTMLElement).style.width) || 0);
+}
+
+/** Inline `width: N%` on the .current element of the progress bar. */
+async function readBarCurrentWidth(page: Page): Promise<number> {
+  return await page
+    .locator('.reader-foot-bar > .current')
+    .evaluate((el) => Number.parseFloat((el as HTMLElement).style.width) || 0);
+}
+
+/** Click the within-chapter next-page arrow. Either label fires
+ *  the same handler — the label flips to "Next chapter" when the
+ *  next click will leave the current chapter. */
+async function clickNext(page: Page) {
+  await page
+    .getByRole('button', { name: /^Next (page|chapter)$/ })
+    .click();
+}
+
+/** Wait until the page counter reports the expected page number.
+ *  Allows the click + measure + layout flush to settle. */
+async function expectOnPage(page: Page, expected: number) {
+  await expect
+    .poll(async () => (await readPageCounter(page)).current, {
+      timeout: 10_000,
+      message: `expected to be on page ${expected}`,
+    })
+    .toBe(expected);
+}
+
+test.describe('Reader page counter + progress', () => {
+  let chapterId: string;
+  test.beforeAll(async () => {
+    chapterId = (await findMultiPageChapter()).id;
+  });
+
+  test('page counter increments on next-page click and shows total', async ({ page }) => {
+    await page.goto(`/reader/${chapterId}?mode=page&chapter=0&token=0`);
+    const initial = await waitForMeasureSettled(page);
+    expect(initial.current).toBe(1);
+
+    await clickNext(page);
+    await expectOnPage(page, 2);
+    const second = await readPageCounter(page);
+    expect(second.total).toBe(initial.total);
+
+    await clickNext(page);
+    await expectOnPage(page, 3);
+  });
+
+  test('start percentage on page 1 is 0%', async ({ page }) => {
+    await page.goto(`/reader/${chapterId}?mode=page&chapter=0&token=0`);
+    await waitForMeasureSettled(page);
+    await expect.poll(async () => (await readPctRange(page)).start, {
+      timeout: 5_000,
+    }).toBe(0);
+    // Bar's "read" segment should also be 0%.
+    expect(await readBarReadWidth(page)).toBe(0);
+  });
+
+  test('progress bar widths track the displayed startPct and (endPct - startPct)', async ({
+    page,
+  }) => {
+    await page.goto(`/reader/${chapterId}?mode=page&chapter=0&token=0`);
+    const total = (await waitForMeasureSettled(page)).total;
+    const pagesToCheck = Math.min(total, 5);
+
+    for (let i = 0; i < pagesToCheck; i += 1) {
+      // Wait for the current page state to settle (poll until the
+      // bar width is stable for one iteration).
+      await page.waitForTimeout(150);
+      const { start, end } = await readPctRange(page);
+      const barRead = await readBarReadWidth(page);
+      const barCurrent = await readBarCurrentWidth(page);
+      // Displayed values are rounded to integer percent precision
+      // for short chapters, so we allow a 1.5%-point tolerance to
+      // cover the parse-then-compare round-trip. The .read bar
+      // tracks startPct verbatim; the .current bar tracks the
+      // (end - start) range.
+      expect(
+        Math.abs(barRead - start),
+        `page ${i + 1}: bar read width (${barRead}) should match startPct (${start})`,
+      ).toBeLessThanOrEqual(1.5);
+      expect(
+        Math.abs(barCurrent - (end - start)),
+        `page ${i + 1}: bar current width (${barCurrent}) should match endPct - startPct (${end - start})`,
+      ).toBeLessThanOrEqual(1.5);
+
+      if (i < pagesToCheck - 1) {
+        await clickNext(page);
+        await expectOnPage(page, i + 2);
+      }
+    }
+  });
+
+  test('pages with many words advance the bar more than pages with few words', async ({
+    page,
+  }) => {
+    // Word-based math: each page contributes (wordsOnPage / totalWords)
+    // to the bar. Real publisher content is uneven — chapter intros
+    // / outros pack fewer words per page than mid-chapter prose. If
+    // the per-page range were uniform, this test would fail.
+    await page.goto(`/reader/${chapterId}?mode=page&chapter=0&token=0`);
+    const total = (await waitForMeasureSettled(page)).total;
+    test.skip(total < 4, 'need at least 4 pages to see meaningful variance');
+
+    const ranges: number[] = [];
+    for (let i = 1; i <= total; i += 1) {
+      await page.waitForTimeout(120);
+      const { start, end } = await readPctRange(page);
+      ranges.push(end - start);
+      if (i < total) {
+        await clickNext(page);
+        await expectOnPage(page, i + 1);
+      }
+    }
+
+    const minRange = Math.min(...ranges);
+    const maxRange = Math.max(...ranges);
+    expect(
+      minRange,
+      `minimum per-page range was ${minRange}; expected > 0`,
+    ).toBeGreaterThan(0);
+    // The denser page should contribute meaningfully more than the
+    // sparser one — strictly more, with a clear gap so we're not
+    // testing rounding noise. Most real chapters show 2-3x variance
+    // between their densest and sparsest pages.
+    expect(
+      maxRange / Math.max(0.1, minRange),
+      `max/min range ratio ${maxRange}/${minRange}; expected > 1.5x`,
+    ).toBeGreaterThan(1.5);
+  });
+
+  test('walking from page 1 to the last page covers ~100% of the chapter', async ({
+    page,
+  }) => {
+    await page.goto(`/reader/${chapterId}?mode=page&chapter=0&token=0`);
+    const total = (await waitForMeasureSettled(page)).total;
+
+    // First page should start at 0%.
+    await expect.poll(async () => (await readPctRange(page)).start).toBe(0);
+
+    // Jump straight to the last page via the cross-text "endOfChapter"
+    // handoff URL — the same flag the reader uses internally when
+    // arriving via prev-text nav. Verifies endPct hits ~100% there.
+    await page.goto(`/reader/${chapterId}?mode=page&endOfChapter=1`);
+    await waitForMeasureSettled(page);
+    await expect
+      .poll(async () => (await readPageCounter(page)).current, {
+        timeout: 10_000,
+      })
+      .toBe(total);
+    const last = await readPctRange(page);
+    expect(
+      last.end,
+      `last page endPct was ${last.end}; expected ≥ 95`,
+    ).toBeGreaterThanOrEqual(95);
+  });
+});

--- a/apps/web/e2e/reader-progress.spec.ts
+++ b/apps/web/e2e/reader-progress.spec.ts
@@ -236,13 +236,16 @@ test.describe('Reader page counter + progress', () => {
       `minimum per-page range was ${minRange}; expected > 0`,
     ).toBeGreaterThan(0);
     // The denser page should contribute meaningfully more than the
-    // sparser one — strictly more, with a clear gap so we're not
-    // testing rounding noise. Most real chapters show 2-3x variance
-    // between their densest and sparsest pages.
+    // sparser one. Real publisher content shows 2-3× variance; the
+    // CI seed (lorem-ipsum with mixed paragraph sizes) typically
+    // settles around 1.3-1.6× because CSS column packing smooths
+    // variance. 1.3× is comfortably above the "uniform pages/N
+    // split" bug pattern (which would produce ~1.0×) and still
+    // strict enough that a regression to "all pages equal" fails.
     expect(
       maxRange / Math.max(0.1, minRange),
-      `max/min range ratio ${maxRange}/${minRange}; expected > 1.5x`,
-    ).toBeGreaterThan(1.5);
+      `max/min range ratio ${maxRange}/${minRange}; expected > 1.3×`,
+    ).toBeGreaterThan(1.3);
   });
 
   test('walking from page 1 to the last page covers ~100% of the chapter', async ({

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",
@@ -32,6 +34,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@sveltejs/adapter-node": "^5.2.6",
     "@sveltejs/kit": "^2.7.2",
     "@sveltejs/vite-plugin-svelte": "^4.0.0",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,46 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright config for end-to-end reader tests.
+ *
+ * Assumes a dev server is already running at the URL below (no
+ * `webServer` block here — running `pnpm dev` from this directory
+ * already serves the worktree, and Playwright shouldn't fight it
+ * for the port). Override the base URL via `BASE_URL` env if you
+ * point at a deployed instance.
+ *
+ * Auth is handled via a global setup project that mints a session
+ * for `crush@test.local` directly into the dev database and saves
+ * the resulting cookies to `e2e/.auth/crush.json`. Specs that need
+ * an authenticated viewer attach this storage state in their
+ * project config below.
+ */
+export default defineConfig({
+  testDir: './e2e',
+  // Serial — tests share a single dev DB + dev server, and several
+  // hit the same chapter content. Parallel runs raced on the
+  // chapter caches and made the cross-text nav flaky. The whole
+  // suite runs in well under a minute, so the cost is small.
+  fullyParallel: false,
+  workers: 1,
+  reporter: process.env.CI ? 'github' : 'list',
+  use: {
+    baseURL: process.env.BASE_URL ?? 'http://localhost:5173',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'setup',
+      testMatch: /auth\.setup\.ts/,
+    },
+    {
+      name: 'chromium',
+      dependencies: ['setup'],
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'e2e/.auth/crush.json',
+      },
+    },
+  ],
+});

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -3,17 +3,15 @@ import { defineConfig, devices } from '@playwright/test';
 /**
  * Playwright config for end-to-end reader tests.
  *
- * Assumes a dev server is already running at the URL below (no
- * `webServer` block here — running `pnpm dev` from this directory
- * already serves the worktree, and Playwright shouldn't fight it
- * for the port). Override the base URL via `BASE_URL` env if you
- * point at a deployed instance.
+ * Locally: if `pnpm dev` is already serving the worktree on the
+ * configured port, Playwright reuses it (faster turnaround between
+ * runs). Otherwise — and always in CI — Playwright starts its own
+ * `pnpm dev` and tears it down at the end.
  *
- * Auth is handled via a global setup project that mints a session
- * for `crush@test.local` directly into the dev database and saves
- * the resulting cookies to `e2e/.auth/crush.json`. Specs that need
- * an authenticated viewer attach this storage state in their
- * project config below.
+ * Auth + test-data seeding is handled by a global setup project
+ * that talks directly to the dev database (test user, sample
+ * chapter-book collection if missing, session cookie). See
+ * `e2e/auth.setup.ts`.
  */
 export default defineConfig({
   testDir: './e2e',
@@ -28,6 +26,17 @@ export default defineConfig({
     baseURL: process.env.BASE_URL ?? 'http://localhost:5173',
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
+  },
+  webServer: {
+    command: 'pnpm dev',
+    url: process.env.BASE_URL ?? 'http://localhost:5173',
+    // Locally we reuse a developer's already-running `pnpm dev`. In
+    // CI the workspace is clean each run, so we let Playwright own
+    // the dev server's lifecycle.
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    stdout: 'ignore',
+    stderr: 'pipe',
   },
   projects: [
     {

--- a/apps/web/src/lib/components/reader/ReaderContinuous.svelte
+++ b/apps/web/src/lib/components/reader/ReaderContinuous.svelte
@@ -244,7 +244,7 @@
       {#if chapter.title || renderedChapters.length > 1}
         <h2>
           {chapter.title ?? `Chapter ${chapter.idx + 1}`}
-          <span class="muted">({chapter.tokenCount.toLocaleString()} tokens)</span>
+          <span class="muted">({chapter.tokenCount.toLocaleString()} words)</span>
         </h2>
       {/if}
       <ChapterBody {chapter} {language} {showRomanization} {isOwner} />

--- a/apps/web/src/lib/components/reader/ReaderPage.svelte
+++ b/apps/web/src/lib/components/reader/ReaderPage.svelte
@@ -16,7 +16,7 @@
 -->
 <script lang="ts">
   import { goto } from '$app/navigation';
-  import { onMount, tick } from 'svelte';
+  import { onMount, tick, untrack } from 'svelte';
 
   import ChapterBody from './ChapterBody.svelte';
   import { clampPage, pageCountFor, pageOffset } from './paginate.js';
@@ -49,6 +49,11 @@
     lineSpacing,
     fontFamily,
     readingWidth,
+    prevTextId = null,
+    nextTextId = null,
+    collectionPosition = null,
+    collectionTotal = null,
+    startAtEndOfChapter = false,
   }: {
     chapters: ChapterView[];
     chapterIdx: number;
@@ -62,11 +67,60 @@
     lineSpacing?: number;
     fontFamily?: string | null;
     readingWidth?: string;
+    /** When true, mount on the LAST page of the chapter rather than
+     *  page 0. Used by the cross-text "prev" handoff so a reader
+     *  stepping back off page 1 of chapter N lands at the end of
+     *  chapter N-1 (where they'd naturally resume reading). */
+    startAtEndOfChapter?: boolean;
+    /** Sibling text in the containing collection — when supplied,
+     *  the prev/next buttons advance into that text once we exhaust
+     *  pages + chapters in the current text. Critical for chapter
+     *  books where each chapter is its own one-chapter `texts` row
+     *  (otherwise the next button greys out at the end of every
+     *  chapter). */
+    prevTextId?: string | null;
+    nextTextId?: string | null;
+    /** Current text's 0-based position within its containing
+     *  collection (null when not in a collection). Used to show
+     *  "Ch. 6 / 48" in the chapter counter instead of the
+     *  uninformative "Ch. 1 / 1" you'd see on a one-chapter text. */
+    collectionPosition?: number | null;
+    collectionTotal?: number | null;
   } = $props();
 
   const current = $derived(chapters[Math.max(0, Math.min(chapterIdx, chapters.length - 1))]);
+  // Chapter-book chapters prepend the title to their body so the
+  // NLP pipeline tokenizes the title alongside the rest. When that
+  // happened, the body's first paragraph IS the title — render only
+  // that, not a duplicate `<header>` chrome on top.
+  const titleInBody = $derived.by(() => {
+    const t = current?.title?.trim();
+    if (!t) return false;
+    const body = current?.body?.trimStart() ?? '';
+    return body.startsWith(t);
+  });
   const hasPrevChapter = $derived(chapterIdx > 0);
   const hasNextChapter = $derived(chapterIdx < chapters.length - 1);
+  const hasPrevText = $derived(prevTextId !== null);
+  const hasNextText = $derived(nextTextId !== null);
+
+  // For chapter counters, prefer the collection-level position when
+  // this text is itself a single-chapter member of a chapter-book
+  // (otherwise the counter would always read "Ch. 1 / 1"). For
+  // multi-chapter texts — paste/.txt with auto-split, or
+  // course-style collections of multi-chapter texts — the
+  // within-text position stays correct.
+  const useCollectionCounter = $derived(
+    chapters.length === 1 &&
+      collectionPosition !== null &&
+      collectionTotal !== null,
+  );
+  const counterCurrent = $derived(
+    useCollectionCounter ? collectionPosition! + 1 : chapterIdx + 1,
+  );
+  const counterTotal = $derived(
+    useCollectionCounter ? collectionTotal! : chapters.length,
+  );
 
   // Pagination state. Recomputed on resize / chapter change /
   // showRomanization toggle (which changes line-height).
@@ -111,8 +165,19 @@
 
   const hasPrevPage = $derived(pageInChapter > 0);
   const hasNextPage = $derived(pageInChapter < pageCount - 1);
-  const hasPrev = $derived(hasPrevPage || hasPrevChapter);
-  const hasNext = $derived(hasNextPage || hasNextChapter);
+  const hasPrev = $derived(hasPrevPage || hasPrevChapter || hasPrevText);
+  const hasNext = $derived(hasNextPage || hasNextChapter || hasNextText);
+  // True when clicking next / prev will leave the current chapter
+  // (advance to a sibling chapter within this text OR to a sibling
+  // text in the surrounding collection). Used to give the arrow
+  // button a slightly different appearance + aria-label so readers
+  // notice they're crossing a chapter boundary.
+  const nextLeavesChapter = $derived(
+    !hasNextPage && (hasNextChapter || hasNextText),
+  );
+  const prevLeavesChapter = $derived(
+    !hasPrevPage && (hasPrevChapter || hasPrevText),
+  );
 
   // Overall progress — fraction of the whole text in *words*, not pages.
   // A page with 10 words must advance the bar less than a page with 500.
@@ -146,7 +211,24 @@
     pendingJumpToLast = opts.lastPage === true;
   }
 
-  let pendingJumpToLast = $state(false);
+  // Seeded from the cross-text "prev" handoff flag so the new
+  // chapter mounts on its last page. The effect below applies the
+  // jump once measurement finishes (pageCount > 0).
+  let pendingJumpToLast = $state(untrack(() => startAtEndOfChapter));
+  // SvelteKit reuses the page component across navigations between
+  // /reader/<id> URLs — the $state initializer only fires once on
+  // first mount, so a fresh `startAtEndOfChapter=true` prop arriving
+  // via navigation wouldn't otherwise re-trigger the jump. This
+  // effect re-arms `pendingJumpToLast` whenever the prop flips to
+  // true AND forces a re-measure so the consumer effect below sees
+  // the NEW chapter's pageCount rather than whatever was measured
+  // for the previous chapter (otherwise we'd jump to the wrong page
+  // and the clamp would push us to 0).
+  $effect(() => {
+    if (!startAtEndOfChapter) return;
+    pendingJumpToLast = true;
+    measure();
+  });
   $effect(() => {
     if (!pendingJumpToLast) return;
     if (pageCount > 0) {
@@ -160,6 +242,10 @@
       pageInChapter += 1;
     } else if (hasNextChapter) {
       go(chapterIdx + 1);
+    } else if (nextTextId) {
+      // Walk off the end of this text — advance into the next text
+      // in the containing collection. Keeps page mode active.
+      void goto(`/reader/${nextTextId}?mode=page`, { keepFocus: true });
     }
   }
   function prevPage() {
@@ -167,6 +253,15 @@
       pageInChapter -= 1;
     } else if (hasPrevChapter) {
       go(chapterIdx - 1, { lastPage: true });
+    } else if (prevTextId) {
+      // Stepping back off the start of this text lands on the LAST
+      // page of the previous text — the reading-direction-natural
+      // place to resume. The destination reader treats
+      // `endOfChapter=1` as a URL anchor and jumps to the last page
+      // of its last internal chapter after measurement.
+      void goto(`/reader/${prevTextId}?mode=page&endOfChapter=1`, {
+        keepFocus: true,
+      });
     }
   }
 
@@ -253,8 +348,17 @@
   // settings driven by CSS vars on the .reader root. ResizeObserver
   // fires on box-size changes only, so font-size / line-height swaps
   // (which only change scrollWidth) need an explicit nudge.
+  //
+  // `textId` + `chapters` are listed so a cross-text navigation
+  // (chapter-book "prev"/"next" that swaps the whole chapter content
+  // while leaving chapterIdx at 0) also re-measures. Without those
+  // deps, contentW stayed at the OLD chapter's value and pageCount
+  // was stale, so `pendingJumpToLast` jumped to the wrong page (or
+  // got clamped back to 0).
   $effect(() => {
     void chapterIdx;
+    void textId;
+    void chapters;
     void showRomanization;
     void fontSize;
     void lineSpacing;
@@ -329,10 +433,55 @@
       currentAnchor: anchor,
       nextAnchor: nextPageAnchor,
     });
-    const startPctNext = computePctRead(chapters, anchor.chapterIdx, anchor.tokenIdx);
-    const endPctNext = computePctRead(chapters, boundary.chapterIdx, boundary.tokenIdx, {
-      completedText: boundary.completed,
-    });
+    // Word-based progress using actual per-column word counts from
+    // the DOM index. Each page contributes EXACTLY the words it
+    // visibly carries, so a sparse page near the end moves the bar
+    // a little and a dense page moves it a lot — matching what the
+    // reader sees rather than assuming uniform distribution.
+    //
+    //   chapterDomTotal = words rendered in this chapter (all columns)
+    //   beforePage      = words in columns < current
+    //   throughPage     = words in columns <= current
+    //   ratio           = chapter.tokenCount / chapterDomTotal
+    //                     (scales DOM counts to the canonical
+    //                      tokenCount so cross-chapter math stays
+    //                      consistent with what other chapters
+    //                      contribute when not in view)
+    //   startWords      = wordsBeforeChapter + beforePage × ratio
+    //   endWords        = wordsBeforeChapter + throughPage × ratio
+    //
+    // 100% is only hit on the last page of the last chapter.
+    const totalWordsInText = chapters.reduce(
+      (sum, c) => sum + Math.max(0, c.tokenCount),
+      0,
+    );
+    const wordsBeforeChapter = chapters
+      .slice(0, chapterIdx)
+      .reduce((sum, c) => sum + Math.max(0, c.tokenCount), 0);
+    const currentChapterWords = Math.max(
+      0,
+      chapters[chapterIdx]?.tokenCount ?? 0,
+    );
+
+    let domBeforePage = 0;
+    let domThroughPage = 0;
+    let domTotal = 0;
+    for (const entry of index.entries) {
+      domTotal += 1;
+      if (entry.columnIndex < pageInChapter) domBeforePage += 1;
+      if (entry.columnIndex <= pageInChapter) domThroughPage += 1;
+    }
+    const ratio = domTotal > 0 ? currentChapterWords / domTotal : 0;
+    const startWords = wordsBeforeChapter + domBeforePage * ratio;
+    const endWords = wordsBeforeChapter + domThroughPage * ratio;
+
+    const startPctNext =
+      totalWordsInText > 0 ? (startWords / totalWordsInText) * 100 : 0;
+    const endPctNext = boundary.completed
+      ? 100
+      : totalWordsInText > 0
+        ? (endWords / totalWordsInText) * 100
+        : 0;
     startPct = startPctNext;
     endPct = endPctNext;
     if (!onProgress) return;
@@ -388,11 +537,40 @@
   <button
     type="button"
     class="page-arrow page-arrow-l"
-    aria-label="Previous page"
+    data-step={prevLeavesChapter ? 'chapter' : 'page'}
+    aria-label={prevLeavesChapter ? 'Previous chapter' : 'Previous page'}
     disabled={!hasPrev}
     onclick={prevPage}
   >
-    <span class="arrow-glyph" aria-hidden="true">‹</span>
+    <span class="arrow-glyph" aria-hidden="true">
+      {#if prevLeavesChapter}
+        <!-- Previous-chapter icon: left-pointing chevron + open
+             book to its right. 24x24 viewBox; strokes inherit
+             currentColor so the icon follows the button's text
+             color in light/dark themes and the chapter-step
+             accent state. -->
+        <svg
+          class="step-icon"
+          width="22"
+          height="22"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.8"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <!-- chevron pointing left, x=2..7 -->
+          <path d="M7 7 L2 12 L7 17" />
+          <!-- open book shifted right, x=13..23, leaving a ~6-unit
+               gap between chevron and book so they don't crowd -->
+          <path d="M13 18V8c0-1.1 1.2-2 3-2H18v10H16c-1.8 0-3 .9-3 2Z" />
+          <path d="M18 18V8c0-1.1 1.2-2 3-2H23v10H21c-1.8 0-3 .9-3 2Z" />
+        </svg>
+      {:else}
+        ‹
+      {/if}
+    </span>
   </button>
 
   <div class="reader-page-viewport">
@@ -408,14 +586,12 @@
       >
         <div class="reader-page-content" bind:this={contentEl}>
           {#if current}
-            <header class="chapter-h">
-              {current.title ?? `Chapter ${current.idx + 1}`}
-              <span class="roman">
-                Chapter {current.idx + 1} of {chapters.length}
-                · {current.tokenCount.toLocaleString()} tokens
-              </span>
-            </header>
-            <article>
+            {#if !titleInBody}
+              <header class="chapter-h">
+                {current.title ?? `Chapter ${current.idx + 1}`}
+              </header>
+            {/if}
+            <article class:title-in-body={titleInBody}>
               <ChapterBody chapter={current} {language} {showRomanization} {isOwner} />
             </article>
           {/if}
@@ -427,11 +603,39 @@
   <button
     type="button"
     class="page-arrow page-arrow-r"
-    aria-label="Next page"
+    data-step={nextLeavesChapter ? 'chapter' : 'page'}
+    aria-label={nextLeavesChapter ? 'Next chapter' : 'Next page'}
     disabled={!hasNext}
     onclick={nextPage}
   >
-    <span class="arrow-glyph" aria-hidden="true">›</span>
+    <span class="arrow-glyph" aria-hidden="true">
+      {#if nextLeavesChapter}
+        <!-- Next-chapter icon: open book on the left + a
+             right-pointing chevron to its right. Mirror of the
+             previous-chapter glyph. -->
+        <svg
+          class="step-icon"
+          width="22"
+          height="22"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.8"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <!-- open book on the left, x=1..11 -->
+          <path d="M1 18V8c0-1.1 1.2-2 3-2H6v10H4c-1.8 0-3 .9-3 2Z" />
+          <path d="M6 18V8c0-1.1 1.2-2 3-2H11v10H9c-1.8 0-3 .9-3 2Z" />
+          <!-- chevron pointing right, x=17..22 — ~6-unit gap from
+               the book so the two parts of the glyph are clearly
+               separate rather than crowding into each other. -->
+          <path d="M17 7 L22 12 L17 17" />
+        </svg>
+      {:else}
+        ›
+      {/if}
+    </span>
   </button>
 </div>
 
@@ -439,7 +643,7 @@
   <div class="reader-foot-meta">
     <span class="pager-pages">
       Page {pageInChapter + 1} of {pageCount}
-      <span class="muted">· Ch. {chapterIdx + 1} / {chapters.length}</span>
+      <span class="muted">· Ch. {counterCurrent} / {counterTotal}</span>
     </span>
     <span class="muted">{formatPctRange(startPct, endPct, pctPrecision)}</span>
   </div>
@@ -546,14 +750,21 @@
     margin: 0 0 1.75rem;
     font-weight: 400;
   }
-  .chapter-h .roman {
-    display: block;
-    font-family: var(--font-mono-display, var(--font-mono));
-    font-size: 0.7rem;
-    color: var(--ink-4, var(--color-fg-subtle));
-    letter-spacing: 0.04em;
-    margin-top: 0.3rem;
-    text-transform: uppercase;
+  /* When the chapter title lives inside the body (chapter-book
+     uploads — see `createChapterBookCollection`), the body's first
+     paragraph IS the title. Style it like a heading so the typography
+     reads as "title above body" rather than two equal paragraphs.
+     Words inside stay tokenized + clickable for lookup. The
+     `:global()` reaches into ChapterBody's scoped CSS. */
+  .title-in-body :global(.body:first-of-type) {
+    font-family: var(--font-serif-dev, var(--font-serif));
+    font-size: 1.35rem;
+    line-height: 1.4;
+    font-weight: 500;
+    color: var(--ink, var(--color-fg));
+    border-bottom: 1px solid var(--rule, var(--color-border));
+    padding-bottom: 0.875rem;
+    margin: 0 0 1.5rem;
   }
 
   /* Page arrows fill the full vertical strip on either side of the
@@ -567,7 +778,11 @@
     width: 3rem;
     background: transparent;
     border: 0;
-    color: var(--ink-2, var(--color-fg-muted));
+    /* Use the full-contrast ink token so the chevron reads clearly
+       on both light and dark surfaces. The muted token (--ink-2)
+       was too low-contrast — at small sizes the glyph looked
+       disabled even when the button was active. */
+    color: var(--ink, var(--color-fg));
     display: grid;
     place-items: center;
     cursor: pointer;
@@ -601,9 +816,25 @@
       color 150ms ease,
       transform 150ms ease;
   }
+  /* Inline SVG glyph used for the chapter-step variant. Sits inside
+     the round .arrow-glyph and inherits stroke=currentColor so it
+     follows the parent's text color through theme + hover + accent
+     states. */
+  .step-icon {
+    display: block;
+  }
   .page-arrow:hover:not(:disabled) .arrow-glyph {
-    background: var(--accent-soft, var(--color-accent));
+    /* Solid accent fill on hover — same for page and chapter-step
+       buttons. The chapter-step variant signals itself purely
+       through the open-book SVG glyph; styling otherwise stays
+       identical so the buttons feel like the same control. The
+       previous translucent `--accent-soft` overlay paired badly
+       with `--accent-ink` (which expects a solid accent surface for
+       WCAG contrast), making the hover state look disabled in dark
+       mode. */
+    background: var(--accent, var(--color-accent));
     color: var(--accent-ink, var(--color-accent-fg, #fff));
+    border-color: var(--accent, var(--color-accent));
     transform: scale(1.05);
   }
   .page-arrow:disabled {

--- a/apps/web/src/lib/server/collections.test.ts
+++ b/apps/web/src/lib/server/collections.test.ts
@@ -75,6 +75,7 @@ vi.mock('./db/index.js', () => ({
 const {
   CollectionError,
   createCollection,
+  createChapterBookCollection,
   updateCollection,
   deleteCollection,
   addCollectionItem,
@@ -177,6 +178,129 @@ describe('createCollection', () => {
     await expect(
       createCollection({ ownerId: OWNER.id, language: 'hi', title: 't' }),
     ).rejects.toThrow(/insert returned no row/);
+  });
+});
+
+describe('createChapterBookCollection', () => {
+  /** Per-chapter draft used across the happy-path tests. */
+  const draft = (idx: number, title: string | null = null) => ({
+    idx,
+    title,
+    body: `body of chapter ${idx}.`,
+    tokenCount: 4,
+  });
+
+  it('creates collection + N texts + N items + N nlp jobs in one transaction', async () => {
+    // Queue stages: collection insert, then per chapter (text, textChapter,
+    // collectionItem, nlpJob) × 2 = 9 entries.
+    queue.push([{ ...baseCollection, id: 'col-1' }]);
+    queue.push([{ id: 'text-1', ownerId: OWNER.id, language: 'hi' }]);
+    queue.push([{ id: 'chap-1', textId: 'text-1', idx: 0 }]);
+    queue.push([{ collectionId: 'col-1', textId: 'text-1', position: 0 }]);
+    queue.push([{ id: 'job-1', textId: 'text-1', status: 'pending' }]);
+    queue.push([{ id: 'text-2', ownerId: OWNER.id, language: 'hi' }]);
+    queue.push([{ id: 'chap-2', textId: 'text-2', idx: 0 }]);
+    queue.push([{ collectionId: 'col-1', textId: 'text-2', position: 1 }]);
+    queue.push([{ id: 'job-2', textId: 'text-2', status: 'pending' }]);
+
+    const result = await createChapterBookCollection({
+      ownerId: OWNER.id,
+      language: 'hi',
+      title: 'My book',
+      sourceType: 'epub',
+      chapters: [draft(0, 'Chapter One'), draft(1, 'Chapter Two')],
+    });
+
+    expect(result.collection.id).toBe('col-1');
+    expect(result.texts.map((t) => t.id)).toEqual(['text-1', 'text-2']);
+    expect(result.items.map((i) => i.position)).toEqual([0, 1]);
+    expect(fakeDb.transaction).toHaveBeenCalledOnce();
+  });
+
+  it('uses each chapter draft title, falling back to "Untitled"', async () => {
+    queue.push([{ ...baseCollection, id: 'col-1' }]);
+    // chapter without title → fallback "Untitled"
+    queue.push([{ id: 'text-1' }]);
+    queue.push([{ id: 'chap-1' }]);
+    queue.push([{ collectionId: 'col-1', textId: 'text-1', position: 0 }]);
+    queue.push([{ id: 'job-1' }]);
+    // chapter with title → preserved verbatim
+    queue.push([{ id: 'text-2' }]);
+    queue.push([{ id: 'chap-2' }]);
+    queue.push([{ collectionId: 'col-1', textId: 'text-2', position: 1 }]);
+    queue.push([{ id: 'job-2' }]);
+
+    await createChapterBookCollection({
+      ownerId: OWNER.id,
+      language: 'hi',
+      title: 'My book',
+      sourceType: 'zip',
+      chapters: [draft(0, null), draft(1, 'Real Title')],
+    });
+
+    // chain.values is called for every insert. The text inserts are
+    // 2 and 6 in zero-indexed order: collection, text1, chap1, item1,
+    // job1, text2, chap2, item2, job2.
+    const textInserts = chain.values.mock.calls
+      .map((c) => c[0] as Record<string, unknown>)
+      .filter((v) => v.sourceType === 'zip');
+    expect(textInserts).toHaveLength(2);
+    expect(textInserts[0]!.title).toBe('Untitled');
+    expect(textInserts[1]!.title).toBe('Real Title');
+  });
+
+  it('prepends the chapter title to the body so NLP tokenizes it for lookup', async () => {
+    queue.push([{ ...baseCollection, id: 'col-1' }]);
+    queue.push([{ id: 'text-1' }]);
+    queue.push([{ id: 'chap-1' }]);
+    queue.push([{ collectionId: 'col-1', textId: 'text-1', position: 0 }]);
+    queue.push([{ id: 'job-1' }]);
+
+    await createChapterBookCollection({
+      ownerId: OWNER.id,
+      language: 'hi',
+      title: 'Book',
+      sourceType: 'epub',
+      chapters: [
+        { idx: 0, title: 'Compound Effect', body: 'Body content here.', tokenCount: 3 },
+      ],
+    });
+
+    // text_chapters insert is the only `.values()` call with a
+    // `body` field. Pull it out and check the body now leads with
+    // the title separated by a blank line.
+    const chapterInsert = chain.values.mock.calls
+      .map((c) => c[0] as Record<string, unknown>)
+      .find((v) => typeof v.body === 'string');
+    expect(chapterInsert).toBeDefined();
+    expect(chapterInsert!.body).toBe('Compound Effect\n\nBody content here.');
+    // tokenCount should reflect the title's words too, not just the
+    // original body's.
+    expect(chapterInsert!.tokenCount).toBeGreaterThan(3);
+  });
+
+  it('rejects an empty chapter list', async () => {
+    await expect(
+      createChapterBookCollection({
+        ownerId: OWNER.id,
+        language: 'hi',
+        title: 'X',
+        sourceType: 'epub',
+        chapters: [],
+      }),
+    ).rejects.toBeInstanceOf(CollectionError);
+  });
+
+  it('rejects a blank title', async () => {
+    await expect(
+      createChapterBookCollection({
+        ownerId: OWNER.id,
+        language: 'hi',
+        title: '   ',
+        sourceType: 'epub',
+        chapters: [draft(0)],
+      }),
+    ).rejects.toBeInstanceOf(CollectionError);
   });
 });
 
@@ -286,11 +410,33 @@ describe('deleteCollection', () => {
     ).rejects.toMatchObject({ status: 403 });
   });
 
-  it('issues a delete for the owner', async () => {
-    queue.push([baseCollection]); // loadCollection
+  it('issues a delete for the owner of a non-chapter-book collection', async () => {
+    queue.push([{ ...baseCollection, kind: 'course' }]); // loadCollection
     queue.push([]); // delete().where() resolution
     await deleteCollection({ collectionId: 'col-1', actor: OWNER });
     expect(fakeDb.delete).toHaveBeenCalledOnce();
+    // Single tx-less delete — non-chapter-book path.
+    expect(fakeDb.transaction).not.toHaveBeenCalled();
+  });
+
+  it('cascades to member texts when deleting a chapter_book', async () => {
+    queue.push([{ ...baseCollection, kind: 'chapter_book' }]); // loadCollection
+    queue.push([{ textId: 'text-1' }, { textId: 'text-2' }, { textId: 'text-3' }]); // member ids
+    queue.push([]); // tx delete collection
+    queue.push([]); // tx delete texts
+    await deleteCollection({ collectionId: 'col-1', actor: OWNER });
+    expect(fakeDb.transaction).toHaveBeenCalledOnce();
+    // Two deletes inside the tx: collection + texts.
+    expect(fakeDb.delete).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips the texts-delete when the chapter book is empty', async () => {
+    queue.push([{ ...baseCollection, kind: 'chapter_book' }]);
+    queue.push([]); // no member ids
+    queue.push([]); // tx delete collection
+    await deleteCollection({ collectionId: 'col-1', actor: OWNER });
+    expect(fakeDb.transaction).toHaveBeenCalledOnce();
+    expect(fakeDb.delete).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/web/src/lib/server/collections.test.ts
+++ b/apps/web/src/lib/server/collections.test.ts
@@ -279,6 +279,42 @@ describe('createChapterBookCollection', () => {
     expect(chapterInsert!.tokenCount).toBeGreaterThan(3);
   });
 
+  it('does NOT duplicate the title when the body already starts with it', async () => {
+    // Repro: an EPUB whose `<h1>Title</h1>` survived htmlToText and
+    // shows up as the body's first paragraph. Without dedup, the
+    // stored body would be `Title\n\nTitle\n\n…` and the reader
+    // would render the heading twice.
+    queue.push([{ ...baseCollection, id: 'col-1' }]);
+    queue.push([{ id: 'text-1' }]);
+    queue.push([{ id: 'chap-1' }]);
+    queue.push([{ collectionId: 'col-1', textId: 'text-1', position: 0 }]);
+    queue.push([{ id: 'job-1' }]);
+
+    await createChapterBookCollection({
+      ownerId: OWNER.id,
+      language: 'hi',
+      title: 'Book',
+      sourceType: 'epub',
+      chapters: [
+        {
+          idx: 0,
+          title: 'Compound Effect',
+          body: 'Compound Effect\n\nReal opening paragraph.',
+          tokenCount: 5,
+        },
+      ],
+    });
+
+    const chapterInsert = chain.values.mock.calls
+      .map((c) => c[0] as Record<string, unknown>)
+      .find((v) => typeof v.body === 'string');
+    expect(chapterInsert).toBeDefined();
+    // No duplicated heading — the body stays as-is (normalized).
+    expect(chapterInsert!.body).toBe(
+      'Compound Effect\n\nReal opening paragraph.',
+    );
+  });
+
   it('rejects an empty chapter list', async () => {
     await expect(
       createChapterBookCollection({

--- a/apps/web/src/lib/server/collections.ts
+++ b/apps/web/src/lib/server/collections.ts
@@ -16,9 +16,12 @@ import type {
   CollectionItem,
   CollectionShare,
   Text,
+  TextChapter,
   User,
 } from './db/schema.js';
 import type { LanguageCode } from '@ciareader/shared-types';
+import { enqueueNlpJob } from './texts/jobs.js';
+import { estimateTokenCount, type ChapterDraft } from './texts/chunking.js';
 
 export class CollectionError extends Error {
   constructor(
@@ -57,6 +60,178 @@ export async function createCollection(
     .returning();
   if (!row) throw new CollectionError('insert returned no row');
   return row as Collection;
+}
+
+export type CreateChapterBookInput = {
+  ownerId: string;
+  language: LanguageCode;
+  title: string;
+  /** `'epub'` or `'zip'` — surfaced on each child `texts` row so the
+   *  library / admin views can tell where a chapter book came from. */
+  sourceType: 'epub' | 'zip';
+  /** Per-chapter drafts in display order. `idx` on each draft is the
+   *  position within the collection (0-based, contiguous). Each draft
+   *  becomes its own `texts` row plus a single-chapter
+   *  `text_chapters` row, then a `collection_items` row linking the
+   *  text to the new collection at `position = draft.idx`.
+   *
+   *  Optional `section` is the parent-heading from the publisher's
+   *  TOC (EPUB nav doc) — when present we persist it on
+   *  `collection_items.section_title` so the detail page can group
+   *  chapters under their Part heading. ZIP uploads and flat EPUBs
+   *  leave it null. */
+  chapters: Array<ChapterDraft & { section?: string | null }>;
+  now?: Date;
+};
+
+export type ChapterBookCreated = {
+  collection: Collection;
+  texts: Text[];
+  items: CollectionItem[];
+};
+
+/**
+ * Create a chapter-book collection from EPUB / ZIP-style chapter
+ * drafts in one transaction. Each draft becomes:
+ *
+ *   1. A `texts` row (single-chapter doc, `status='pending'`,
+ *      `visibility='private'`). The chapter title is the draft's
+ *      title, falling back to `Chapter N` when the source didn't
+ *      provide one.
+ *   2. A `text_chapters` row at `idx=0` holding the body.
+ *   3. A `collection_items` row at `position = draft.idx` linking the
+ *      text to the new collection.
+ *
+ * After the transaction commits, an NLP job is enqueued per child
+ * text — same shape the paste / .txt path uses, so every chapter gets
+ * its own status / progress / known-word coverage rather than being
+ * lumped under the book-level row.
+ *
+ * Rolls back the whole thing if any insert (or the NLP enqueue)
+ * throws — no orphan rows.
+ */
+export async function createChapterBookCollection(
+  input: CreateChapterBookInput,
+): Promise<ChapterBookCreated> {
+  const title = input.title.trim();
+  if (!title) throw new CollectionError('title required');
+  if (input.chapters.length === 0) {
+    throw new CollectionError('chapter book must have at least one chapter');
+  }
+  const now = input.now ?? new Date();
+
+  // Deferred dispatcher calls collected during the transaction —
+  // fired AFTER commit so the in-process worker sees rows the
+  // global `db` connection can read. Firing inside the tx makes
+  // `processTextNow`'s SELECT against `db` miss the not-yet-
+  // committed text and leave the chapter stuck at 'pending'.
+  const flushes: Array<() => Promise<void>> = [];
+
+  const result = await db.transaction(async (tx) => {
+    const [collection] = (await tx
+      .insert(schema.collections)
+      .values({
+        ownerId: input.ownerId,
+        language: input.language,
+        kind: 'chapter_book',
+        title,
+        visibility: 'private',
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning()) as Collection[];
+    if (!collection) throw new CollectionError('collection insert returned no row');
+
+    const createdTexts: Text[] = [];
+    const createdItems: CollectionItem[] = [];
+
+    for (const draft of input.chapters) {
+      // "Untitled" rather than "Chapter N" because the chapter card
+      // and reader nav already surface the position number — a
+      // separate "Chapter N" prefix would just duplicate that. The
+      // fallback fires for EPUBs whose nav doc + chapter <title> are
+      // both junk auto-IDs (see `isJunkTitle` in epub.ts).
+      const chapterTitle = draft.title?.trim() || 'Untitled';
+      const [text] = (await tx
+        .insert(schema.texts)
+        .values({
+          ownerId: input.ownerId,
+          language: input.language,
+          title: chapterTitle,
+          sourceType: input.sourceType,
+          status: 'pending',
+          visibility: 'private',
+          createdAt: now,
+          updatedAt: now,
+        })
+        .returning()) as Text[];
+      if (!text) throw new CollectionError('text insert returned no row');
+
+      // Prepend the chapter title to the body as its first
+      // paragraph. The NLP pipeline tokenizes the whole body, so the
+      // title gets lemma resolution + popups + known-word tracking
+      // just like any other content — the reader knows to skip its
+      // own `<header>` chrome when the body already starts with the
+      // title to avoid showing it twice.
+      const bodyWithTitle = `${chapterTitle}\n\n${draft.body}`;
+      const tokenCountWithTitle = estimateTokenCount(bodyWithTitle);
+      const [chapterRow] = (await tx
+        .insert(schema.textChapters)
+        .values({
+          textId: text.id,
+          idx: 0,
+          title: chapterTitle,
+          body: bodyWithTitle,
+          tokenCount: tokenCountWithTitle,
+          createdAt: now,
+        })
+        .returning()) as TextChapter[];
+      if (!chapterRow) {
+        throw new CollectionError('chapter insert returned no row');
+      }
+
+      const [item] = (await tx
+        .insert(schema.collectionItems)
+        .values({
+          collectionId: collection.id,
+          textId: text.id,
+          position: draft.idx,
+          sectionTitle: draft.section ?? null,
+          createdAt: now,
+        })
+        .returning()) as CollectionItem[];
+      if (!item) throw new CollectionError('item insert returned no row');
+
+      // Insert the nlp_jobs row inside the tx (FK needs the text);
+      // defer the dispatcher until after commit.
+      const enqueued = await enqueueNlpJob({
+        textId: text.id,
+        chapterIds: [chapterRow.id],
+        now,
+        tx,
+      });
+      if (enqueued.flush) flushes.push(enqueued.flush);
+
+      createdTexts.push(text);
+      createdItems.push(item);
+    }
+
+    return {
+      collection,
+      texts: createdTexts,
+      items: createdItems,
+    };
+  });
+
+  // Transaction committed — now safe to wake the worker for every
+  // chapter text. We fire sequentially so a thrown dispatcher (e.g.
+  // unreachable NLP service) surfaces predictably; the in-process
+  // dispatcher is fire-and-forget per text so this is cheap.
+  for (const flush of flushes) {
+    await flush();
+  }
+
+  return result;
 }
 
 async function loadCollection(id: string): Promise<Collection | null> {
@@ -137,12 +312,48 @@ export type CollectionActor = {
   actor: Pick<User, 'id' | 'role'>;
 };
 
+/**
+ * Delete a collection. For `chapter_book` collections, also cascades
+ * to the member texts — those rows only exist as chapters of the
+ * book, so a "delete book" gesture should clean them up too.
+ *
+ * For `course` and `anthology` kinds the member texts are
+ * independent (curators just group them), so we leave the texts
+ * alone and only break the collection-item links.
+ *
+ * Wrapped in a transaction so a chapter_book delete is all-or-
+ * nothing: either every chapter goes with the book, or none do.
+ */
 export async function deleteCollection(input: CollectionActor): Promise<void> {
   const c = await loadCollection(input.collectionId);
   if (!c) throw new CollectionError('collection not found', 404);
   if (!canManage(c, input.actor)) {
     throw new CollectionError('only the owner can delete', 403);
   }
+
+  if (c.kind === 'chapter_book') {
+    // Snapshot member ids before we drop the collection, since the
+    // `collection_items` rows cascade away with the parent.
+    const items = (await db
+      .select({ textId: schema.collectionItems.textId })
+      .from(schema.collectionItems)
+      .where(eq(schema.collectionItems.collectionId, c.id))) as Array<{
+      textId: string;
+    }>;
+    const textIds = items.map((r) => r.textId);
+    await db.transaction(async (tx) => {
+      await tx
+        .delete(schema.collections)
+        .where(eq(schema.collections.id, c.id));
+      if (textIds.length > 0) {
+        await tx
+          .delete(schema.texts)
+          .where(inArray(schema.texts.id, textIds));
+      }
+    });
+    return;
+  }
+
   await db
     .delete(schema.collections)
     .where(eq(schema.collections.id, input.collectionId));
@@ -343,6 +554,9 @@ export type CollectionDetail = {
   collection: Collection;
   items: Array<{
     position: number;
+    /** Parent-section title from the source TOC (Part heading, etc.).
+     *  `null` for flat collections + manually-curated ones. */
+    sectionTitle: string | null;
     text: Text;
   }>;
 };
@@ -355,6 +569,7 @@ export async function loadCollectionDetail(
   const rows = (await db
     .select({
       position: schema.collectionItems.position,
+      sectionTitle: schema.collectionItems.sectionTitle,
       text: schema.texts,
     })
     .from(schema.collectionItems)
@@ -365,6 +580,7 @@ export async function loadCollectionDetail(
     .where(eq(schema.collectionItems.collectionId, collectionId))
     .orderBy(asc(schema.collectionItems.position))) as Array<{
     position: number;
+    sectionTitle: string | null;
     text: Text;
   }>;
   return { collection: c, items: rows };

--- a/apps/web/src/lib/server/collections.ts
+++ b/apps/web/src/lib/server/collections.ts
@@ -21,7 +21,7 @@ import type {
 } from './db/schema.js';
 import type { LanguageCode } from '@ciareader/shared-types';
 import { enqueueNlpJob } from './texts/jobs.js';
-import { estimateTokenCount, type ChapterDraft } from './texts/chunking.js';
+import { prependTitleToBody, type ChapterDraft } from './texts/chunking.js';
 
 export class CollectionError extends Error {
   constructor(
@@ -167,14 +167,14 @@ export async function createChapterBookCollection(
         .returning()) as Text[];
       if (!text) throw new CollectionError('text insert returned no row');
 
-      // Prepend the chapter title to the body as its first
-      // paragraph. The NLP pipeline tokenizes the whole body, so the
-      // title gets lemma resolution + popups + known-word tracking
-      // just like any other content — the reader knows to skip its
-      // own `<header>` chrome when the body already starts with the
-      // title to avoid showing it twice.
-      const bodyWithTitle = `${chapterTitle}\n\n${draft.body}`;
-      const tokenCountWithTitle = estimateTokenCount(bodyWithTitle);
+      // Prepend the chapter title to the body so the NLP pipeline
+      // tokenizes the title alongside the rest of the content (its
+      // words become clickable + known-word-tracked). The helper is
+      // idempotent: an EPUB whose `htmlToText` output already starts
+      // with the title — e.g. `<h1>Chapter One</h1>` in the body
+      // matching the nav title — doesn't get a duplicated heading.
+      const { body: bodyWithTitle, tokenCount: tokenCountWithTitle } =
+        prependTitleToBody(chapterTitle, draft.body);
       const [chapterRow] = (await tx
         .insert(schema.textChapters)
         .values({

--- a/apps/web/src/lib/server/db/schema.ts
+++ b/apps/web/src/lib/server/db/schema.ts
@@ -1018,6 +1018,7 @@ export const textSourceType = pgEnum('text_source_type', [
   'paste',
   'txt',
   'epub',
+  'zip',
 ]);
 
 export const textStatus = pgEnum('text_status', [
@@ -1949,6 +1950,14 @@ export const collectionItems = pgTable(
       .notNull()
       .references(() => texts.id, { onDelete: 'cascade' }),
     position: integer('position').notNull(),
+    // Optional parent-section label sourced from the publisher's
+    // EPUB navigation document. When the source TOC nests chapters
+    // under a Part heading (e.g. "Part 1: Make It Obvious"), each
+    // member chapter records its parent here so the collection
+    // detail page can render the same grouping. Null when the
+    // chapter has no parent section (flat books, manually-curated
+    // collections, etc.).
+    sectionTitle: text('section_title'),
     createdAt: timestamp('created_at', { withTimezone: true })
       .notNull()
       .defaultNow(),

--- a/apps/web/src/lib/server/texts/chunking.test.ts
+++ b/apps/web/src/lib/server/texts/chunking.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   CHUNK_THRESHOLD_TOKENS,
   estimateTokenCount,
+  prependTitleToBody,
   splitIntoChapters,
   TARGET_CHAPTER_TOKENS,
 } from './chunking.js';
@@ -20,6 +21,61 @@ describe('estimateTokenCount', () => {
   it('returns 0 on whitespace-only', () => {
     expect(estimateTokenCount('   ')).toBe(0);
     expect(estimateTokenCount('')).toBe(0);
+  });
+});
+
+describe('prependTitleToBody', () => {
+  it('prepends the title separated by a blank line when the body does not start with it', () => {
+    const { body, tokenCount } = prependTitleToBody(
+      'Compound Effect',
+      'Body content here.',
+    );
+    expect(body).toBe('Compound Effect\n\nBody content here.');
+    expect(tokenCount).toBe(estimateTokenCount(body));
+  });
+
+  it('skips prepending when the body already starts with the title — no duplication', () => {
+    // EPUB chapter whose `<h1>Title</h1>` body heading survived
+    // `htmlToText` as the first paragraph: prepending would
+    // duplicate it in the reader + NLP.
+    const { body } = prependTitleToBody(
+      'Compound Effect',
+      'Compound Effect\n\nOpening paragraph.',
+    );
+    expect(body).toBe('Compound Effect\n\nOpening paragraph.');
+  });
+
+  it('matches the title against an NFC + LF-normalized body', () => {
+    const { body } = prependTitleToBody(
+      'Title',
+      'Title\r\n\r\nContent.',
+    );
+    expect(body).toBe('Title\n\nContent.');
+  });
+
+  it('treats whitespace at the start of the body as harmless', () => {
+    const { body } = prependTitleToBody(
+      'Chapter One',
+      '   \n\nChapter One\n\nBody.',
+    );
+    // The leading whitespace is preserved (we only normalize line
+    // endings + NFC, not collapse whitespace); the dedup just
+    // checks `trimStart().startsWith(...)`.
+    expect(body.includes('Chapter One\n\nChapter One')).toBe(false);
+  });
+
+  it('returns the body untouched when title is empty or null', () => {
+    expect(prependTitleToBody(null, 'body').body).toBe('body');
+    expect(prependTitleToBody('', 'body').body).toBe('body');
+    expect(prependTitleToBody('   ', 'body').body).toBe('body');
+  });
+
+  it('does NOT match a title that appears mid-word at the start', () => {
+    // `Chapt` should not be considered a prefix-of "Chapter One"
+    // — the next char after the supposed prefix must be whitespace
+    // or end-of-text.
+    const { body } = prependTitleToBody('Chapt', 'Chapter One starts here.');
+    expect(body.startsWith('Chapt\n\nChapter One')).toBe(true);
   });
 });
 

--- a/apps/web/src/lib/server/texts/chunking.ts
+++ b/apps/web/src/lib/server/texts/chunking.ts
@@ -78,6 +78,44 @@ export function estimateTokenCount(body: string): number {
   return trimmed.split(/\s+/).length;
 }
 
+/**
+ * Ensure a chapter body starts with its title so the NLP pipeline
+ * tokenizes the title alongside the rest of the content — that's
+ * what makes title words clickable + known-word-tracked in the
+ * reader, same as body words.
+ *
+ * Idempotent: when the body already opens with the title (e.g. an
+ * EPUB whose `<h1>Title</h1>` survived `htmlToText` as the first
+ * paragraph), we return the body unchanged. Without this, the
+ * stored body would be `Title\n\nTitle\n\n…` — duplicated heading
+ * in the reader AND duplicated tokens flowing into NLP.
+ *
+ * Normalizes to NFC + LF newlines either way so the prefix check
+ * is comparing in the same shape the reader / NLP will see.
+ */
+export function prependTitleToBody(
+  title: string | null,
+  body: string,
+): { body: string; tokenCount: number } {
+  const normalizedBody = body.normalize('NFC').replace(/\r\n?/g, '\n');
+  const t = (title ?? '').trim();
+  if (t.length === 0) {
+    return { body: normalizedBody, tokenCount: estimateTokenCount(normalizedBody) };
+  }
+  const leading = normalizedBody.trimStart();
+  if (leading.startsWith(t)) {
+    const rest = leading.slice(t.length);
+    if (rest.length === 0 || /^\s/.test(rest)) {
+      return {
+        body: normalizedBody,
+        tokenCount: estimateTokenCount(normalizedBody),
+      };
+    }
+  }
+  const next = `${t}\n\n${normalizedBody}`;
+  return { body: next, tokenCount: estimateTokenCount(next) };
+}
+
 const EXPLICIT_DELIMITER_RE = /(?:^|\n)(?:\f|-{3,}\s*)(?=\n|$)/g;
 
 function hasExplicitDelimiters(body: string): boolean {

--- a/apps/web/src/lib/server/texts/epub.test.ts
+++ b/apps/web/src/lib/server/texts/epub.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import JSZip from 'jszip';
 
-import { EpubParseError, htmlToText, parseEpub } from './epub.js';
+import {
+  EpubParseError,
+  extractEpubLanguage,
+  htmlToText,
+  parseEpub,
+} from './epub.js';
 
 // -----------------------------------------------------------------------
 // htmlToText
@@ -60,12 +65,63 @@ describe('htmlToText', () => {
  * Calibre / Sigil emit: META-INF/container.xml → content.opf → spine
  * of XHTML chapters under OEBPS/.
  */
+type NavEntryFixture = {
+  href: string;
+  title: string;
+  children?: NavEntryFixture[];
+};
+type NcxEntryFixture = {
+  src: string;
+  title: string;
+  children?: NcxEntryFixture[];
+};
+
+function renderNavOl(entries: NavEntryFixture[]): string {
+  const items = entries
+    .map(
+      (n) =>
+        `<li><a href="${n.href}">${n.title}</a>${n.children && n.children.length > 0 ? `<ol>${renderNavOl(n.children)}</ol>` : ''}</li>`,
+    )
+    .join('\n');
+  return items;
+}
+
+function renderNcxPoints(entries: NcxEntryFixture[]): string {
+  return entries
+    .map(
+      (n, i) =>
+        `<navPoint id="np-${i}-${Math.random().toString(36).slice(2, 6)}" playOrder="${i + 1}"><navLabel><text>${n.title}</text></navLabel><content src="${n.src}"/>${n.children && n.children.length > 0 ? renderNcxPoints(n.children) : ''}</navPoint>`,
+    )
+    .join('\n');
+}
+
 async function buildFixtureEpub(args: {
   chapters: Array<{ id: string; href: string; title: string; bodyHtml: string }>;
   /** Override fields for negative tests. */
   containerXml?: string;
   opfPath?: string;
   opfXml?: string;
+  /** Optional `<dc:language>` value. Inserted into the OPF metadata when set. */
+  language?: string;
+  /**
+   * Optional EPUB3 nav.xhtml content — when set, the manifest grows
+   * an extra item declaring `properties="nav"` and the spine omits
+   * the nav item. Each entry maps a chapter href → user-facing title;
+   * the fixture builder renders these as `<a href>` links inside a
+   * `<nav epub:type="toc"><ol>` block. Each entry may itself carry
+   * `children` to produce a nested `<ol>` (used to exercise the
+   * parent-section detection).
+   */
+  nav?: NavEntryFixture[];
+  /**
+   * Optional EPUB2 NCX content — when set, the manifest gains a
+   * `toc.ncx` entry, the spine carries `toc="ncx"`, and a toc.ncx
+   * file is written alongside content.opf. Each entry is rendered as
+   * a `<navPoint>` with `<navLabel><text>` and `<content src>`. As
+   * with `nav`, entries may carry `children` to produce nested
+   * navPoints.
+   */
+  ncx?: NcxEntryFixture[];
 }): Promise<Uint8Array> {
   const opfPath = args.opfPath ?? 'OEBPS/content.opf';
   const zip = new JSZip();
@@ -83,22 +139,64 @@ async function buildFixtureEpub(args: {
   </rootfiles>
 </container>`,
   );
-  const manifest = args.chapters
+  const manifestEntries = args.chapters
     .map(
       (c) =>
         `<item id="${c.id}" href="${c.href}" media-type="application/xhtml+xml"/>`,
-    )
-    .join('\n');
+    );
+  if (args.nav) {
+    manifestEntries.push(
+      `<item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>`,
+    );
+  }
+  if (args.ncx) {
+    manifestEntries.push(
+      `<item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml"/>`,
+    );
+  }
+  const manifest = manifestEntries.join('\n');
   const spine = args.chapters.map((c) => `<itemref idref="${c.id}"/>`).join('\n');
+  const spineOpen = args.ncx ? '<spine toc="ncx">' : '<spine>';
+  const metadata = args.language
+    ? `<metadata xmlns:dc="http://purl.org/dc/elements/1.1/"><dc:language>${args.language}</dc:language></metadata>`
+    : '';
   zip.file(
     opfPath,
     args.opfXml ??
       `<?xml version="1.0"?>
 <package version="3.0">
+  ${metadata}
   <manifest>${manifest}</manifest>
-  <spine>${spine}</spine>
+  ${spineOpen}${spine}</spine>
 </package>`,
   );
+  if (args.nav) {
+    const items = renderNavOl(args.nav);
+    const navDir = opfPath.includes('/') ? opfPath.replace(/\/[^/]+$/, '') + '/' : '';
+    zip.file(
+      navDir + 'nav.xhtml',
+      `<?xml version="1.0"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+<head><title>nav</title></head>
+<body>
+  <nav epub:type="toc">
+    <ol>${items}</ol>
+  </nav>
+</body>
+</html>`,
+    );
+  }
+  if (args.ncx) {
+    const points = renderNcxPoints(args.ncx);
+    const ncxDir = opfPath.includes('/') ? opfPath.replace(/\/[^/]+$/, '') + '/' : '';
+    zip.file(
+      ncxDir + 'toc.ncx',
+      `<?xml version="1.0"?>
+<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1">
+  <navMap>${points}</navMap>
+</ncx>`,
+    );
+  }
   for (const c of args.chapters) {
     const dir = opfPath.includes('/') ? opfPath.replace(/\/[^/]+$/, '') + '/' : '';
     zip.file(
@@ -131,13 +229,15 @@ describe('parseEpub — happy path', () => {
         },
       ],
     });
-    const chapters = await parseEpub(bytes);
+    const { chapters, language } = await parseEpub(bytes);
     expect(chapters).toHaveLength(2);
     expect(chapters[0]!.title).toBe('Chapter One');
     expect(chapters[0]!.body).toBe('First paragraph.\n\nSecond paragraph.');
     expect(chapters[1]!.title).toBe('Chapter Two');
     expect(chapters[1]!.body).toContain('Heading');
     expect(chapters[1]!.body).toContain('Body of two.');
+    // No <dc:language> in this fixture → null.
+    expect(language).toBeNull();
   });
 
   it('skips empty / whitespace-only chapters', async () => {
@@ -152,9 +252,220 @@ describe('parseEpub — happy path', () => {
         },
       ],
     });
-    const chapters = await parseEpub(bytes);
+    const { chapters } = await parseEpub(bytes);
     expect(chapters).toHaveLength(1);
     expect(chapters[0]!.title).toBe('Real');
+  });
+
+  it('sources chapter titles from EPUB3 nav.xhtml when present', async () => {
+    // Chapter <title> tags are Calibre-style junk IDs; the publisher's
+    // nav.xhtml carries the real names. The parser should prefer the
+    // nav titles over the chapter file's own <title>.
+    const bytes = await buildFixtureEpub({
+      chapters: [
+        {
+          id: 'ch1',
+          href: 'ch1.xhtml',
+          title: 'c9',
+          bodyHtml: '<p>Body of chapter one.</p>',
+        },
+        {
+          id: 'ch2',
+          href: 'ch2.xhtml',
+          title: 'cG',
+          bodyHtml: '<p>Body of chapter two.</p>',
+        },
+      ],
+      nav: [
+        { href: 'ch1.xhtml', title: 'The Compound Effect' },
+        { href: 'ch2.xhtml#start', title: 'Habit Stacking' },
+      ],
+    });
+    const { chapters } = await parseEpub(bytes);
+    expect(chapters[0]!.title).toBe('The Compound Effect');
+    // Fragment in the nav href is stripped before matching.
+    expect(chapters[1]!.title).toBe('Habit Stacking');
+  });
+
+  it('sources chapter titles from EPUB2 toc.ncx when no nav.xhtml', async () => {
+    const bytes = await buildFixtureEpub({
+      chapters: [
+        {
+          id: 'ch1',
+          href: 'ch1.xhtml',
+          title: 'c9',
+          bodyHtml: '<p>Body one.</p>',
+        },
+        {
+          id: 'ch2',
+          href: 'ch2.xhtml',
+          title: 'cG',
+          bodyHtml: '<p>Body two.</p>',
+        },
+      ],
+      ncx: [
+        { src: 'ch1.xhtml', title: 'Chapter One — Ncx' },
+        { src: 'ch2.xhtml#section-1', title: 'Chapter Two — Ncx' },
+      ],
+    });
+    const { chapters } = await parseEpub(bytes);
+    expect(chapters[0]!.title).toBe('Chapter One — Ncx');
+    expect(chapters[1]!.title).toBe('Chapter Two — Ncx');
+  });
+
+  it('falls back to chapter <title> when the nav entry is just a page-number marker', async () => {
+    // Some publisher EPUBs (Hindi titles especially) populate the
+    // nav with page-marker anchors like `<a href="...">5</a>`. Those
+    // entries point at spine items with real content, but the link
+    // text is unusable as a chapter title. The parser should fall
+    // back to the chapter file's own <title> / heading in that case.
+    const bytes = await buildFixtureEpub({
+      chapters: [
+        {
+          id: 'pm1',
+          href: 'p5.xhtml',
+          title: 'एटॉमिक',
+          bodyHtml:
+            '<p>The definition of atomic habits is a small change…</p>',
+        },
+      ],
+      nav: [{ href: 'p5.xhtml', title: '5' }],
+    });
+    const { chapters } = await parseEpub(bytes);
+    expect(chapters[0]!.title).toBe('एटॉमिक');
+  });
+
+  it('returns null when both the nav title and the chapter <title> are junk identifiers', async () => {
+    // Worst-case Calibre book: nav.xhtml says `<a>cJS</a>`, the
+    // chapter file's <head><title> also says `c25`. Neither is
+    // usable — the parser surfaces null so the upload pipeline can
+    // render "Untitled" instead.
+    const bytes = await buildFixtureEpub({
+      chapters: [
+        { id: 'ch1', href: 'ch1.xhtml', title: 'c25', bodyHtml: '<p>Body.</p>' },
+      ],
+      nav: [{ href: 'ch1.xhtml', title: 'cJS' }],
+    });
+    const { chapters } = await parseEpub(bytes);
+    expect(chapters[0]!.title).toBeNull();
+  });
+
+  it('keeps the nav title when it has any non-digit characters (not a page marker)', async () => {
+    // Real chapter titles in numbered series ("1.", "Ch 3", "Chapter 4")
+    // contain words or punctuation alongside numbers and should NOT
+    // be replaced by the chapter file's <title>.
+    const bytes = await buildFixtureEpub({
+      chapters: [
+        {
+          id: 'ch1',
+          href: 'ch1.xhtml',
+          title: 'Internal Calibre Id',
+          bodyHtml: '<p>Body.</p>',
+        },
+      ],
+      nav: [{ href: 'ch1.xhtml', title: '1. Compound Effect' }],
+    });
+    const { chapters } = await parseEpub(bytes);
+    expect(chapters[0]!.title).toBe('1. Compound Effect');
+  });
+
+  it('falls back to <title> for spine items the nav doc does not list', async () => {
+    const bytes = await buildFixtureEpub({
+      chapters: [
+        {
+          id: 'ch1',
+          href: 'ch1.xhtml',
+          title: 'Chapter One Title',
+          bodyHtml: '<p>Body one.</p>',
+        },
+        {
+          id: 'ch2',
+          href: 'ch2.xhtml',
+          title: 'Chapter Two Title',
+          bodyHtml: '<p>Body two.</p>',
+        },
+      ],
+      // Nav only covers ch1; ch2 has to fall back to <title>.
+      nav: [{ href: 'ch1.xhtml', title: 'From Nav' }],
+    });
+    const { chapters } = await parseEpub(bytes);
+    expect(chapters[0]!.title).toBe('From Nav');
+    expect(chapters[1]!.title).toBe('Chapter Two Title');
+    // No nested nav, so every chapter's section is null.
+    expect(chapters[0]!.section).toBeNull();
+    expect(chapters[1]!.section).toBeNull();
+  });
+
+  it('extracts parent-section titles from a nested EPUB3 nav.xhtml', async () => {
+    // Mirrors the Atomic Habits TOC: a flat list of chapter XHTML
+    // files in the spine, but the nav nests them under Part headings.
+    // The Part entries also point at a real spine file (the part
+    // intro), so they're rendered as their own top-level chapters
+    // with section=null; their child chapters carry the Part title.
+    const bytes = await buildFixtureEpub({
+      chapters: [
+        { id: 'p1', href: 'part1.xhtml', title: 'p1', bodyHtml: '<p>Part 1 intro.</p>' },
+        { id: 'c1', href: 'ch1.xhtml', title: 'c1', bodyHtml: '<p>Chapter 1.</p>' },
+        { id: 'c2', href: 'ch2.xhtml', title: 'c2', bodyHtml: '<p>Chapter 2.</p>' },
+        { id: 'p2', href: 'part2.xhtml', title: 'p2', bodyHtml: '<p>Part 2 intro.</p>' },
+        { id: 'c3', href: 'ch3.xhtml', title: 'c3', bodyHtml: '<p>Chapter 3.</p>' },
+      ],
+      nav: [
+        {
+          href: 'part1.xhtml',
+          title: 'Part 1: Foundations',
+          children: [
+            { href: 'ch1.xhtml', title: '1. Compound Effect' },
+            { href: 'ch2.xhtml', title: '2. Identity' },
+          ],
+        },
+        {
+          href: 'part2.xhtml',
+          title: 'Part 2: Make It Obvious',
+          children: [
+            { href: 'ch3.xhtml', title: '3. Cues' },
+          ],
+        },
+      ],
+    });
+    const { chapters } = await parseEpub(bytes);
+    expect(chapters.map((c) => c.title)).toEqual([
+      'Part 1: Foundations',
+      '1. Compound Effect',
+      '2. Identity',
+      'Part 2: Make It Obvious',
+      '3. Cues',
+    ]);
+    expect(chapters.map((c) => c.section)).toEqual([
+      null,
+      'Part 1: Foundations',
+      'Part 1: Foundations',
+      null,
+      'Part 2: Make It Obvious',
+    ]);
+  });
+
+  it('extracts parent-section titles from a nested EPUB2 NCX', async () => {
+    const bytes = await buildFixtureEpub({
+      chapters: [
+        { id: 'p1', href: 'part1.xhtml', title: 'p1', bodyHtml: '<p>Part 1 intro.</p>' },
+        { id: 'c1', href: 'ch1.xhtml', title: 'c1', bodyHtml: '<p>Chapter 1.</p>' },
+        { id: 'c2', href: 'ch2.xhtml', title: 'c2', bodyHtml: '<p>Chapter 2.</p>' },
+      ],
+      ncx: [
+        {
+          src: 'part1.xhtml',
+          title: 'Part 1',
+          children: [
+            { src: 'ch1.xhtml', title: 'Ch 1' },
+            { src: 'ch2.xhtml', title: 'Ch 2' },
+          ],
+        },
+      ],
+    });
+    const { chapters } = await parseEpub(bytes);
+    expect(chapters.map((c) => c.title)).toEqual(['Part 1', 'Ch 1', 'Ch 2']);
+    expect(chapters.map((c) => c.section)).toEqual([null, 'Part 1', 'Part 1']);
   });
 
   it('falls back to a heading when the document has no <title>', async () => {
@@ -172,8 +483,69 @@ describe('parseEpub — happy path', () => {
         },
       ],
     });
-    const chapters = await parseEpub(bytes);
+    const { chapters } = await parseEpub(bytes);
     expect(chapters[0]!.title).toBe('Fallback Title');
+  });
+});
+
+describe('parseEpub — dc:language extraction', () => {
+  it('returns the primary BCP47 subtag, lowercased', async () => {
+    const bytes = await buildFixtureEpub({
+      language: 'hi',
+      chapters: [
+        { id: 'a', href: 'a.xhtml', title: 'A', bodyHtml: '<p>body.</p>' },
+      ],
+    });
+    const { language } = await parseEpub(bytes);
+    expect(language).toBe('hi');
+  });
+
+  it('strips region / script subtags (hi-IN → hi, mr-Deva → mr)', async () => {
+    const a = await buildFixtureEpub({
+      language: 'hi-IN',
+      chapters: [
+        { id: 'a', href: 'a.xhtml', title: 'A', bodyHtml: '<p>body.</p>' },
+      ],
+    });
+    expect((await parseEpub(a)).language).toBe('hi');
+    const b = await buildFixtureEpub({
+      language: 'mr-Deva',
+      chapters: [
+        { id: 'a', href: 'a.xhtml', title: 'A', bodyHtml: '<p>body.</p>' },
+      ],
+    });
+    expect((await parseEpub(b)).language).toBe('mr');
+  });
+
+  it('lowercases an uppercase tag', async () => {
+    const bytes = await buildFixtureEpub({
+      language: 'OR',
+      chapters: [
+        { id: 'a', href: 'a.xhtml', title: 'A', bodyHtml: '<p>body.</p>' },
+      ],
+    });
+    expect((await parseEpub(bytes)).language).toBe('or');
+  });
+
+  it('returns null when <dc:language> is missing or empty', async () => {
+    const bytes = await buildFixtureEpub({
+      chapters: [
+        { id: 'a', href: 'a.xhtml', title: 'A', bodyHtml: '<p>body.</p>' },
+      ],
+    });
+    expect((await parseEpub(bytes)).language).toBeNull();
+  });
+
+  it('extracts language from a malformed OPF as long as chapters still parse', async () => {
+    // Whitespace + capitalization weirdness; non-namespaced <language>
+    // tag (older OPF flavors omit the dc: prefix).
+    expect(extractEpubLanguage('<language>  HI  </language>')).toBe('hi');
+    // Numeric entity → still works because we decode before splitting.
+    expect(extractEpubLanguage('<dc:language>m&#114;</dc:language>')).toBe('mr');
+    // Missing closing tag → no match, null.
+    expect(extractEpubLanguage('<dc:language>hi')).toBeNull();
+    // Empty tag → null, not ''.
+    expect(extractEpubLanguage('<dc:language></dc:language>')).toBeNull();
   });
 });
 

--- a/apps/web/src/lib/server/texts/epub.ts
+++ b/apps/web/src/lib/server/texts/epub.ts
@@ -35,14 +35,53 @@ export class EpubParseError extends Error {
 export type EpubChapter = {
   title: string | null;
   body: string;
+  /** Parent section heading from the publisher's nav doc (e.g. the
+   *  "Part 1: Make It Obvious" entry that contains chapters 4–7).
+   *  `null` when the chapter sits at the top level of the TOC, when
+   *  the EPUB has no nav doc, or when the nav doesn't cover this
+   *  particular spine item. */
+  section: string | null;
+};
+
+/**
+ * Result of `parseEpub`: ordered chapters + the OPF-declared language
+ * (BCP47 primary subtag, lowercased; `null` if the EPUB omits the tag
+ * or it can't be parsed). Callers use the language to verify the user
+ * picked the right reader-language at upload time — see
+ * `createChapterBookFromEpub` in `upload.ts`.
+ */
+export type ParsedEpub = {
+  chapters: EpubChapter[];
+  language: string | null;
 };
 
 const OPF_PATH_RE = /<rootfile\b[^>]*\bfull-path="([^"]+)"/i;
 const MANIFEST_ITEM_RE = /<item\b([^>]*?)\/?>/gi;
 const ATTR_RE = (name: string) => new RegExp(`\\b${name}="([^"]*)"`, 'i');
 const SPINE_ITEMREF_RE = /<itemref\b[^>]*\bidref="([^"]+)"/gi;
+const SPINE_TOC_RE = /<spine\b[^>]*\btoc="([^"]+)"/i;
 const TITLE_TAG_RE = /<title[^>]*>([\s\S]*?)<\/title>/i;
 const HEADING_RE = /<h[1-6][^>]*>([\s\S]*?)<\/h[1-6]>/i;
+// SAX-style tokenizer regexes — the nav parser walks these in
+// document order and maintains a section stack so it can record
+// each TOC entry's parent heading (e.g. "Part 1") alongside the
+// entry's own title.
+//
+// EPUB3 nav.xhtml: <ol>/<li>/<a href="...">Title</a> with nesting
+// for sub-sections. The toolkit captures every <ol>/<li> tag open
+// + close so the walker can track depth.
+const NAV_TOKEN_RE =
+  /<(\/?)(ol|li)\b[^>]*>|<a\b[^>]*\bhref="([^"]+)"[^>]*>([\s\S]*?)<\/a>/gi;
+// EPUB2 NCX: <navPoint>/<navLabel><text>Title</text>/<content src> with
+// nesting for hierarchical TOCs. Captures every navPoint open/close
+// plus each (label, content) pair so the walker can track depth.
+const NCX_TOKEN_RE =
+  /<(\/?)navPoint\b[^>]*>|<navLabel\b[^>]*>[\s\S]*?<text\b[^>]*>([\s\S]*?)<\/text>[\s\S]*?<\/navLabel>\s*<content\b[^>]*\bsrc="([^"]+)"/gi;
+// dc:language inside the OPF metadata. EPUB authors sometimes namespace
+// it (`<dc:language>hi</dc:language>`) and sometimes don't
+// (`<language>hi</language>`); accept both. Region/script subtags
+// (`hi-IN`, `mr-Deva`) are normalized down to the primary subtag below.
+const DC_LANGUAGE_RE = /<(?:dc:)?language\b[^>]*>([\s\S]*?)<\/(?:dc:)?language>/i;
 
 function joinPath(base: string, rel: string): string {
   // EPUB hrefs are relative to the OPF file's directory. Resolve them
@@ -121,9 +160,60 @@ export function htmlToText(html: string): string {
   return s;
 }
 
+/**
+ * Pull `<dc:language>` out of the OPF metadata, lowercase it, and
+ * return only the primary BCP47 subtag (so `hi-IN`, `mr-Deva`, and
+ * `HI` all become `hi`). Returns `null` when the tag is missing or
+ * empty — the upload pipeline treats that as "no claim, trust the
+ * user's selection."
+ */
+export function extractEpubLanguage(opfXml: string): string | null {
+  const m = DC_LANGUAGE_RE.exec(opfXml);
+  if (!m) return null;
+  const raw = decodeEntities(m[1] ?? '').trim();
+  if (!raw) return null;
+  const primary = raw.split(/[-_]/)[0]!.trim().toLowerCase();
+  return primary.length > 0 ? primary : null;
+}
+
+/**
+ * Heuristic: would this string be a sensible thing to show as a
+ * chapter title in the library UI? Returns true for strings that
+ * look like auto-generated identifiers — purely-digit page markers
+ * (`"5"`, `"103"`) or short alphanumeric IDs (`"c25"`, `"cJS"`) that
+ * many publisher/Calibre EPUBs embed in their nav docs and chapter
+ * `<title>` tags. No human-authored chapter title is ever that
+ * shape — the shortest real chapter names ("Intro", "Foreword") are
+ * 5+ chars or include punctuation.
+ */
+function isJunkTitle(raw: string | null | undefined): boolean {
+  if (!raw) return true;
+  const t = raw.trim();
+  if (t.length === 0) return true;
+  // Purely-digits page-marker titles like "5", "103".
+  if (/^\d+$/.test(t)) return true;
+  // Calibre-style identifier: ≤4 chars, all alphanumeric (no spaces
+  // or punctuation), AND containing either a digit or a
+  // lowercase→uppercase case transition. The shape rules out real
+  // short word-titles ("Intro", "Soup", "Real") while still flagging
+  // `c9`, `c25`, `c2M`, `cG`, `cJS`, etc.
+  if (
+    t.length <= 4
+    && /^[A-Za-z][A-Za-z0-9]*$/.test(t)
+    && (/\d/.test(t) || /[a-z][A-Z]/.test(t))
+  ) {
+    return true;
+  }
+  return false;
+}
+
 function extractFirstTitle(html: string): string | null {
-  // Prefer the document <title> tag (Calibre puts the chapter name
-  // there); fall back to the first heading inside the body.
+  // Per-file fallback once the navigation document has been
+  // exhausted: prefer the document <title> tag — that's the
+  // standard EPUB location for the chapter's user-facing name and
+  // what publishers (and Sigil / InDesign exports) populate. Fall
+  // back to the first body heading when <title> is missing or
+  // empty.
   const t = TITLE_TAG_RE.exec(html);
   if (t) {
     const text = htmlToText(t[1]!).trim();
@@ -138,16 +228,179 @@ function extractFirstTitle(html: string): string | null {
 }
 
 /**
- * Parse an EPUB blob into ordered `{ title, body }` chapters.
+ * Information sourced from the publisher's navigation document for
+ * one chapter (spine item).
+ */
+type NavEntry = {
+  /** Human-readable chapter title from the TOC entry. */
+  title: string;
+  /** Parent-section title from the TOC's hierarchy. `null` for
+   *  top-level entries or flat TOCs. */
+  section: string | null;
+};
+
+/**
+ * Parse the navigation document — EPUB3 `nav.xhtml` (declared via
+ * `properties="nav"` on its manifest item) or, as a fallback, an
+ * EPUB2 NCX (referenced by the `<spine toc="ncx-id">` attribute).
+ *
+ * Returns a map of absolute-within-zip chapter path → `{ title,
+ * section }`. The publisher's TOC is the most reliable source for
+ * chapter names AND the only place that records the hierarchy
+ * (Parts containing chapters, etc.) — we use it before consulting
+ * the chapter file's own `<title>` or heading.
+ *
+ * Fragment identifiers (`#section`) are stripped — the spine
+ * references whole files, not anchors. When the same chapter is
+ * listed under multiple TOC entries (publisher subdivisions), the
+ * first wins so the user gets the top-level chapter name on the
+ * library card.
+ */
+async function loadNavTitles(args: {
+  zip: JSZip;
+  opfPath: string;
+  opfXml: string;
+  manifest: Map<string, { href: string; mediaType: string }>;
+}): Promise<Map<string, NavEntry>> {
+  const { zip, opfPath, opfXml, manifest } = args;
+  const out = new Map<string, NavEntry>();
+
+  // EPUB3 first: manifest item with `properties="nav"` (the property
+  // list is space-separated, so we tokenize before checking).
+  let navHref: string | null = null;
+  let navIsNcx = false;
+  let m: RegExpExecArray | null;
+  while ((m = MANIFEST_ITEM_RE.exec(opfXml))) {
+    const attrs = m[1] ?? '';
+    const properties = (ATTR_RE('properties').exec(attrs)?.[1] ?? '')
+      .split(/\s+/)
+      .filter(Boolean);
+    if (properties.includes('nav')) {
+      navHref = ATTR_RE('href').exec(attrs)?.[1] ?? null;
+      if (navHref) break;
+    }
+  }
+  // Reset so a later spine-iteration pass over MANIFEST_ITEM_RE starts
+  // from the top.
+  MANIFEST_ITEM_RE.lastIndex = 0;
+
+  // EPUB2 fallback: <spine toc="ncx-id">.
+  if (!navHref) {
+    const tocId = SPINE_TOC_RE.exec(opfXml)?.[1];
+    if (tocId) {
+      const ncxItem = manifest.get(tocId);
+      if (ncxItem) {
+        navHref = ncxItem.href;
+        navIsNcx = true;
+      }
+    }
+  }
+
+  if (!navHref) return out;
+
+  const navPath = joinPath(opfPath, navHref);
+  const navEntry = zip.file(navPath);
+  if (!navEntry) return out;
+  const navXml = await navEntry.async('string');
+
+  if (navIsNcx) {
+    // SAX walk: each <navPoint> opens a level; the (label, content)
+    // pair inside it identifies that level's TOC entry. Children of
+    // a navPoint inherit the parent's title as their section.
+    const sectionStack: (string | null)[] = [null];
+    let p: RegExpExecArray | null;
+    while ((p = NCX_TOKEN_RE.exec(navXml))) {
+      const tagSlash = p[1];
+      const labelText = p[2];
+      const contentSrc = p[3];
+      if (tagSlash !== undefined && labelText === undefined) {
+        // <navPoint> or </navPoint>
+        if (tagSlash === '/') {
+          // Closing a navPoint pops its title off the section stack.
+          if (sectionStack.length > 1) sectionStack.pop();
+        } else {
+          // Opening a navPoint — push a placeholder; the upcoming
+          // navLabel will replace it.
+          sectionStack.push(sectionStack[sectionStack.length - 1] ?? null);
+        }
+      } else if (labelText !== undefined && contentSrc !== undefined) {
+        const title = htmlToText(labelText).trim();
+        const hrefNoFrag = contentSrc.split('#')[0]!;
+        if (!title || !hrefNoFrag) continue;
+        // Section = the parent's title (the level above us in the
+        // stack). The current level's slot is at top of stack and
+        // we're about to overwrite it with this entry's title for
+        // any nested children.
+        const section = sectionStack.length >= 2
+          ? sectionStack[sectionStack.length - 2]!
+          : null;
+        const resolved = joinPath(navPath, hrefNoFrag);
+        if (!out.has(resolved)) out.set(resolved, { title, section });
+        sectionStack[sectionStack.length - 1] = title;
+      }
+    }
+    NCX_TOKEN_RE.lastIndex = 0;
+  } else {
+    // EPUB3 nav.xhtml. We walk every <ol>/<li> open + close plus each
+    // <a href> and maintain a section stack indexed by <ol> depth:
+    // sectionStack[d] is the title of the most recent <a> seen at
+    // depth d. A new <a> at depth d records section = sectionStack[d-1].
+    const sectionStack: (string | null)[] = [];
+    let depth = 0;
+    let a: RegExpExecArray | null;
+    while ((a = NAV_TOKEN_RE.exec(navXml))) {
+      const tagSlash = a[1];
+      const tagName = a[2]?.toLowerCase();
+      const href = a[3];
+      const inner = a[4];
+      if (tagName === 'ol') {
+        if (tagSlash === '/') {
+          depth = Math.max(0, depth - 1);
+          if (sectionStack.length > depth) sectionStack.length = depth;
+        } else {
+          depth += 1;
+          // Make sure the stack is long enough for this depth so
+          // sectionStack[depth-1] reads back the parent's title.
+          while (sectionStack.length < depth) sectionStack.push(null);
+        }
+      } else if (tagName === 'li') {
+        // <li> tags don't change section depth — sections come from
+        // <ol> nesting. No-op.
+      } else if (href !== undefined && inner !== undefined) {
+        const title = htmlToText(inner).trim();
+        const hrefNoFrag = href.split('#')[0]!;
+        if (!title || !hrefNoFrag) continue;
+        const section =
+          depth >= 2 ? sectionStack[depth - 2] ?? null : null;
+        const resolved = joinPath(navPath, hrefNoFrag);
+        if (!out.has(resolved)) out.set(resolved, { title, section });
+        // This entry becomes the candidate section title for any
+        // nested <ol> that follows inside the current <li>.
+        if (depth >= 1) sectionStack[depth - 1] = title;
+      }
+    }
+    NAV_TOKEN_RE.lastIndex = 0;
+  }
+
+  return out;
+}
+
+/**
+ * Parse an EPUB blob into ordered chapters + the declared language.
  *
  * `epubBytes` is the raw archive (ArrayBuffer / Uint8Array / Buffer).
  * Throws `EpubParseError` on malformed archives or missing OPF; the
  * caller maps it to a 400 with the message verbatim so the user knows
  * what went wrong with their file.
+ *
+ * Language is read from `<dc:language>` in the OPF and normalized to
+ * its primary BCP47 subtag (e.g. `hi-IN` → `hi`). When the tag is
+ * absent we return `null` and let the caller fall back to the user's
+ * dropdown selection.
  */
 export async function parseEpub(
   epubBytes: ArrayBuffer | Uint8Array,
-): Promise<EpubChapter[]> {
+): Promise<ParsedEpub> {
   let zip: JSZip;
   try {
     zip = await JSZip.loadAsync(epubBytes);
@@ -172,6 +425,7 @@ export async function parseEpub(
     throw new EpubParseError(`EPUB OPF file '${opfPath}' is missing from the archive`);
   }
   const opfXml = await opfEntry.async('string');
+  const language = extractEpubLanguage(opfXml);
 
   // Build manifest map: id → { href, mediaType }.
   const manifest = new Map<string, { href: string; mediaType: string }>();
@@ -194,6 +448,12 @@ export async function parseEpub(
     throw new EpubParseError('EPUB spine is empty (no chapters to import)');
   }
 
+  // Publisher-declared TOC — most authoritative source of chapter
+  // titles AND the only place that records the parent-section
+  // hierarchy. The per-chapter `<title>` / heading heuristic is the
+  // fallback for items the nav doc doesn't cover.
+  const navEntries = await loadNavTitles({ zip, opfPath, opfXml, manifest });
+
   const chapters: EpubChapter[] = [];
   for (const id of spineIds) {
     const item = manifest.get(id);
@@ -211,19 +471,30 @@ export async function parseEpub(
     const chapterEntry = zip.file(chapterPath);
     if (!chapterEntry) continue;
     const html = await chapterEntry.async('string');
-    const title = extractFirstTitle(html);
+    const navEntry = navEntries.get(chapterPath);
+    // Pick the first non-junk source: nav title → chapter file
+    // <title>/heading → null (the caller renders "Untitled"). Both
+    // sources can produce identifier-shaped garbage (page-marker
+    // numbers, Calibre auto-IDs), so we filter each before taking
+    // it. See `isJunkTitle` for the exact shape.
+    const navTitle = navEntry?.title ?? null;
+    const fileTitle = extractFirstTitle(html);
+    const cleanNav = !isJunkTitle(navTitle) ? navTitle : null;
+    const cleanFile = !isJunkTitle(fileTitle) ? fileTitle : null;
+    const title = cleanNav ?? cleanFile;
+    const section = navEntry?.section ?? null;
     const body = htmlToText(html);
     if (body.trim().length === 0) {
       // Empty chapters (e.g. nav landmarks) are useless — skip them
       // rather than persisting placeholder rows.
       continue;
     }
-    chapters.push({ title, body });
+    chapters.push({ title, body, section });
   }
   if (chapters.length === 0) {
     throw new EpubParseError(
       'EPUB contains no readable chapters (every spine item was empty or non-HTML)',
     );
   }
-  return chapters;
+  return { chapters, language };
 }

--- a/apps/web/src/lib/server/texts/jobs.ts
+++ b/apps/web/src/lib/server/texts/jobs.ts
@@ -64,19 +64,41 @@ export type EnqueueResult = {
 };
 
 /**
+ * A subset of the Drizzle `db` API that both the top-level `db` and a
+ * transaction handle expose — enough for `enqueueNlpJob` to run inside
+ * a transaction (so newly-inserted `texts` rows are visible for the
+ * FK) without coupling the helper to the transaction's full type.
+ */
+type DbOrTx = Pick<typeof db, 'insert'>;
+
+/**
  * Insert a `nlp_jobs` row and tell the dispatcher to wake the worker.
  * The text's own `status` stays `pending` until the worker flips it
  * via `markTextProcessing` — splitting "queued" from "started" lets
  * the UI show "waiting in queue" vs "processing" if we add that
  * distinction later.
+ *
+ * Pass `tx` when calling from inside `db.transaction(...)` so the
+ * insert participates in the same transaction — otherwise the
+ * `nlp_jobs.text_id` FK fires against rows that aren't visible yet.
+ *
+ * Dispatch behavior:
+ *  - Without `tx`: the dispatcher fires immediately (legacy contract).
+ *  - With `tx`: dispatch is deferred — the result carries a `flush()`
+ *    the caller MUST call after the transaction commits. Firing it
+ *    inside the tx would race the worker against uncommitted rows
+ *    (the in-process dispatcher's `processTextNow` reads via the
+ *    global `db`, which doesn't see in-flight tx writes).
  */
 export async function enqueueNlpJob(args: {
   textId: string;
   chapterIds: string[];
   now?: Date;
-}): Promise<EnqueueResult> {
+  tx?: DbOrTx;
+}): Promise<EnqueueResult & { flush?: () => Promise<void> }> {
   const now = args.now ?? new Date();
-  const [job] = await db
+  const conn: DbOrTx = args.tx ?? db;
+  const [job] = await conn
     .insert(schema.nlpJobs)
     .values({
       textId: args.textId,
@@ -85,11 +107,18 @@ export async function enqueueNlpJob(args: {
     })
     .returning();
   if (!job) throw new Error('Failed to insert nlp_jobs row');
-  await activeDispatcher.dispatch({
+  const dispatchArgs = {
     jobId: (job as NlpJob).id,
     textId: args.textId,
     chapterIds: args.chapterIds,
-  });
+  };
+  if (args.tx) {
+    return {
+      job: job as NlpJob,
+      flush: () => activeDispatcher.dispatch(dispatchArgs),
+    };
+  }
+  await activeDispatcher.dispatch(dispatchArgs);
   return { job: job as NlpJob };
 }
 

--- a/apps/web/src/lib/server/texts/library.ts
+++ b/apps/web/src/lib/server/texts/library.ts
@@ -70,6 +70,23 @@ function clampPage(opts: { limit?: number; offset?: number }): {
 }
 
 /**
+ * Exclude texts that exist purely as chapters of a chapter-book
+ * collection. The collection card carries the user-facing entry point
+ * — surfacing each chapter as its own library card would mean a
+ * 30-chapter EPUB clutters the index with 30 extra rows.
+ *
+ * `course` / `anthology` member texts still surface as their own
+ * cards: those collections curate standalone texts that the user may
+ * also want to find directly.
+ */
+const NOT_A_CHAPTER_BOOK_MEMBER = sql`NOT EXISTS (
+  SELECT 1 FROM collection_items ci
+  INNER JOIN collections c ON c.id = ci.collection_id
+  WHERE ci.text_id = ${schema.texts.id}
+    AND c.kind = 'chapter_book'
+)`;
+
+/**
  * The user's own imports, newest first.
  */
 export async function listOwnedTexts(
@@ -77,7 +94,7 @@ export async function listOwnedTexts(
   opts: { limit?: number; offset?: number; language?: LanguageCode } = {},
 ): Promise<ListPage> {
   const { limit, offset } = clampPage(opts);
-  const conditions = [eq(schema.texts.ownerId, viewer.id)];
+  const conditions = [eq(schema.texts.ownerId, viewer.id), NOT_A_CHAPTER_BOOK_MEMBER];
   if (opts.language) {
     conditions.push(eq(schema.texts.language, opts.language));
   }
@@ -145,6 +162,7 @@ export async function listSharedTexts(
       sql`, `,
     )})`,
     sql`${schema.texts.ownerId} IS DISTINCT FROM ${viewer.id}`,
+    NOT_A_CHAPTER_BOOK_MEMBER,
   ];
   if (opts.language) {
     conditions.push(eq(schema.texts.language, opts.language));
@@ -183,7 +201,7 @@ export async function listOfficialTexts(
   opts: { limit?: number; offset?: number; language?: LanguageCode } = {},
 ): Promise<ListPage> {
   const { limit, offset } = clampPage(opts);
-  const conditions = [eq(schema.texts.visibility, 'official')];
+  const conditions = [eq(schema.texts.visibility, 'official'), NOT_A_CHAPTER_BOOK_MEMBER];
   if (opts.language) {
     conditions.push(eq(schema.texts.language, opts.language));
   }

--- a/apps/web/src/lib/server/texts/upload.test.ts
+++ b/apps/web/src/lib/server/texts/upload.test.ts
@@ -557,6 +557,17 @@ describe('createChapterBookFromEpub', () => {
     if (result.kind !== 'text') throw new Error('unreachable');
     expect(result.text.sourceType).toBe('epub');
     expect(createChapterBookCollectionMock).not.toHaveBeenCalled();
+
+    // Single-chapter fallback should ALSO prepend the title to the
+    // body so NLP tokenizes it — same contract as the multi-chapter
+    // chapter_book path. The text_chapters insert is the second
+    // .values() call (after the texts row).
+    const chapterInsert = calls
+      .filter((c): c is Extract<Call, { kind: 'insert' }> => c.kind === 'insert')
+      .map((c) => c.values as Array<Record<string, unknown>>)
+      .find((v) => Array.isArray(v) && typeof v[0]?.body === 'string');
+    expect(chapterInsert).toBeDefined();
+    expect((chapterInsert![0]!.body as string).startsWith('Only chapter')).toBe(true);
   });
 
   it('rejects when EPUB dc:language disagrees with selected language (both supported)', async () => {
@@ -761,6 +772,15 @@ describe('createChapterBookFromZip', () => {
     if (result.kind !== 'text') throw new Error('unreachable');
     expect(result.text.sourceType).toBe('zip');
     expect(createChapterBookCollectionMock).not.toHaveBeenCalled();
+
+    // Single-file ZIP fallback also prepends the chapter title
+    // (filename minus extension) so its words land in NLP.
+    const chapterInsert = calls
+      .filter((c): c is Extract<Call, { kind: 'insert' }> => c.kind === 'insert')
+      .map((c) => c.values as Array<Record<string, unknown>>)
+      .find((v) => Array.isArray(v) && typeof v[0]?.body === 'string');
+    expect(chapterInsert).toBeDefined();
+    expect((chapterInsert![0]!.body as string).startsWith('only')).toBe(true);
   });
 
   it('rejects an unsupported language without parsing', async () => {

--- a/apps/web/src/lib/server/texts/upload.test.ts
+++ b/apps/web/src/lib/server/texts/upload.test.ts
@@ -54,16 +54,42 @@ const selectFn = vi.fn(() => {
 const insertFn = vi.fn(() => makeInsertChain());
 
 // T-8.4: canReadText consults collections.js for collection-share
-// access. Mock to "no share" so existing tests stay focused on
-// visibility / owner branches.
+// access. The chapter-book EPUB/ZIP path also delegates to
+// `createChapterBookCollection` here — mocked to a stub that records
+// args and returns a synthetic collection so the upload-side tests
+// can verify the orchestration without booting the real transactional
+// helper (that's tested in collections.test.ts).
+const createChapterBookCollectionMock = vi.fn();
 vi.mock('../collections.js', () => ({
   viewerHasCollectionShareForText: async () => false,
+  createChapterBookCollection: (...a: unknown[]) =>
+    createChapterBookCollectionMock(...a),
 }));
+
+// db.delete(...).where(...) — the deletion path used by `deleteText`.
+// Records the call so tests can assert it fired (or didn't). Resolves
+// to `undefined` to mirror the real builder.
+type DeleteCall = { table: unknown };
+const deleteCalls: DeleteCall[] = [];
+function makeDeleteChain() {
+  const entry: DeleteCall = { table: null };
+  deleteCalls.push(entry);
+  const chain: Record<string, unknown> = {};
+  chain.where = vi.fn(() => chain);
+  chain.then = (resolve: (v: unknown) => unknown) => resolve(undefined);
+  return chain;
+}
+const deleteFn = vi.fn((table: unknown) => {
+  const chain = makeDeleteChain();
+  deleteCalls[deleteCalls.length - 1]!.table = table;
+  return chain;
+});
 
 vi.mock('../db/index.js', () => ({
   db: {
     select: () => selectFn(),
     insert: () => insertFn(),
+    delete: (table: unknown) => deleteFn(table),
   },
   schema: {
     texts: {
@@ -102,14 +128,20 @@ vi.mock('../groups.js', () => ({
 const {
   TextValidationError,
   EpubParseError,
+  EpubLanguageMismatchError,
+  EpubLanguageUnsupportedError,
+  ZipParseError,
   createPastedText,
   createTxtText,
-  createEpubText,
+  createChapterBookFromEpub,
+  createChapterBookFromZip,
+  deleteText,
   estimateTokenCount,
   getOwnedText,
   MAX_PASTE_BYTES,
   MAX_TXT_BYTES,
   MAX_EPUB_BYTES,
+  MAX_ZIP_BYTES,
   MAX_TITLE_LEN,
 } = await import('./upload.js');
 
@@ -117,6 +149,8 @@ const JSZip = (await import('jszip')).default;
 
 async function buildFixtureEpub(
   chapters: Array<{ id: string; href: string; title: string; bodyHtml: string }>,
+  /** Optional `<dc:language>` to include in the OPF metadata. */
+  language?: string,
 ): Promise<Uint8Array> {
   const zip = new JSZip();
   zip.file('mimetype', 'application/epub+zip');
@@ -133,10 +167,14 @@ async function buildFixtureEpub(
     .map((c) => `<item id="${c.id}" href="${c.href}" media-type="application/xhtml+xml"/>`)
     .join('\n');
   const spine = chapters.map((c) => `<itemref idref="${c.id}"/>`).join('\n');
+  const metadata = language
+    ? `<metadata xmlns:dc="http://purl.org/dc/elements/1.1/"><dc:language>${language}</dc:language></metadata>`
+    : '';
   zip.file(
     'OEBPS/content.opf',
     `<?xml version="1.0"?>
 <package version="3.0">
+  ${metadata}
   <manifest>${manifest}</manifest>
   <spine>${spine}</spine>
 </package>`,
@@ -213,8 +251,11 @@ function stageHappyPath(opts: {
 beforeEach(() => {
   calls.length = 0;
   staged.length = 0;
+  deleteCalls.length = 0;
   selectFn.mockClear();
   insertFn.mockClear();
+  deleteFn.mockClear();
+  createChapterBookCollectionMock.mockReset();
 });
 
 afterEach(() => {
@@ -429,17 +470,29 @@ describe('createTxtText', () => {
 });
 
 // -----------------------------------------------------------------------
-// createEpubText (T-4.3)
+// createChapterBookFromEpub
 // -----------------------------------------------------------------------
 
-describe('createEpubText', () => {
-  it('parses an EPUB and inserts one chapter row per spine item', async () => {
-    stage([textRow({ sourceType: 'epub' })]);
-    stage([
-      chapterRow({ id: 'c0', idx: 0, body: 'one body.' }),
-      chapterRow({ id: 'c1', idx: 1, body: 'two body.' }),
-    ]);
-    stage([jobRow()]);
+describe('createChapterBookFromEpub', () => {
+  it('creates a chapter-book collection for a multi-chapter EPUB', async () => {
+    createChapterBookCollectionMock.mockResolvedValueOnce({
+      collection: {
+        id: 'col-1',
+        ownerId: OWNER.id,
+        language: 'hi',
+        title: 'Imported novel',
+        kind: 'chapter_book',
+        visibility: 'private',
+      },
+      texts: [
+        { id: 'text-1' },
+        { id: 'text-2' },
+      ],
+      items: [
+        { collectionId: 'col-1', textId: 'text-1', position: 0 },
+        { collectionId: 'col-1', textId: 'text-2', position: 1 },
+      ],
+    });
 
     const epubBytes = await buildFixtureEpub([
       {
@@ -456,33 +509,157 @@ describe('createEpubText', () => {
       },
     ]);
 
-    const result = await createEpubText(OWNER, {
+    const result = await createChapterBookFromEpub(OWNER, {
       language: 'hi',
       title: 'Imported novel',
       epubBytes,
     });
 
-    expect(result.chapters).toHaveLength(2);
-    const insertCalls = calls.filter(
-      (c): c is Extract<Call, { kind: 'insert' }> => c.kind === 'insert',
-    );
-    expect(insertCalls[0]!.values).toMatchObject({ sourceType: 'epub' });
-    const chapterValues = insertCalls[1]!.values as Array<{
-      idx: number;
-      title: string | null;
-      body: string;
-    }>;
-    expect(chapterValues).toHaveLength(2);
-    expect(chapterValues.map((c) => c.title)).toEqual(['Chapter One', 'Chapter Two']);
-    expect(chapterValues[0]!.body).toBe('one body.');
+    expect(result.kind).toBe('collection');
+    if (result.kind !== 'collection') throw new Error('unreachable');
+    expect(result.collection.id).toBe('col-1');
+    expect(result.texts).toHaveLength(2);
+
+    expect(createChapterBookCollectionMock).toHaveBeenCalledOnce();
+    const args = createChapterBookCollectionMock.mock.calls[0]![0];
+    expect(args).toMatchObject({
+      ownerId: OWNER.id,
+      language: 'hi',
+      title: 'Imported novel',
+      sourceType: 'epub',
+    });
+    expect(args.chapters).toHaveLength(2);
+    expect(args.chapters.map((c: { title: string }) => c.title)).toEqual([
+      'Chapter One',
+      'Chapter Two',
+    ]);
   });
 
-  it('rejects an unsupported language without parsing', async () => {
+  it('falls back to a single plain text when only one chapter is present', async () => {
+    stageHappyPath({ text: textRow({ sourceType: 'epub' }) });
+
+    const epubBytes = await buildFixtureEpub([
+      {
+        id: 'ch1',
+        href: 'ch1.xhtml',
+        title: 'Only chapter',
+        bodyHtml: '<p>solo body.</p>',
+      },
+    ]);
+
+    const result = await createChapterBookFromEpub(OWNER, {
+      language: 'hi',
+      title: 'Imported novel',
+      epubBytes,
+    });
+
+    expect(result.kind).toBe('text');
+    if (result.kind !== 'text') throw new Error('unreachable');
+    expect(result.text.sourceType).toBe('epub');
+    expect(createChapterBookCollectionMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects when EPUB dc:language disagrees with selected language (both supported)', async () => {
+    const epubBytes = await buildFixtureEpub(
+      [
+        {
+          id: 'ch1',
+          href: 'ch1.xhtml',
+          title: 'A',
+          bodyHtml: '<p>body.</p>',
+        },
+        {
+          id: 'ch2',
+          href: 'ch2.xhtml',
+          title: 'B',
+          bodyHtml: '<p>body.</p>',
+        },
+      ],
+      'mr',
+    );
+    await expect(
+      createChapterBookFromEpub(OWNER, {
+        language: 'hi',
+        title: 'X',
+        epubBytes,
+      }),
+    ).rejects.toBeInstanceOf(EpubLanguageMismatchError);
+    expect(createChapterBookCollectionMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects an EPUB declared as an unsupported language', async () => {
+    const epubBytes = await buildFixtureEpub(
+      [
+        {
+          id: 'ch1',
+          href: 'ch1.xhtml',
+          title: 'A',
+          bodyHtml: '<p>body.</p>',
+        },
+        {
+          id: 'ch2',
+          href: 'ch2.xhtml',
+          title: 'B',
+          bodyHtml: '<p>body.</p>',
+        },
+      ],
+      'en',
+    );
+    await expect(
+      createChapterBookFromEpub(OWNER, {
+        language: 'hi',
+        title: 'X',
+        epubBytes,
+      }),
+    ).rejects.toBeInstanceOf(EpubLanguageUnsupportedError);
+  });
+
+  it('trusts the user selection when the EPUB has no <dc:language>', async () => {
+    createChapterBookCollectionMock.mockResolvedValueOnce({
+      collection: { id: 'col-1' },
+      texts: [{ id: 'text-1' }, { id: 'text-2' }],
+      items: [],
+    });
+    const epubBytes = await buildFixtureEpub([
+      { id: 'ch1', href: 'ch1.xhtml', title: 'A', bodyHtml: '<p>body.</p>' },
+      { id: 'ch2', href: 'ch2.xhtml', title: 'B', bodyHtml: '<p>body.</p>' },
+    ]);
+    const result = await createChapterBookFromEpub(OWNER, {
+      language: 'or',
+      title: 'X',
+      epubBytes,
+    });
+    expect(result.kind).toBe('collection');
+    expect(createChapterBookCollectionMock).toHaveBeenCalledOnce();
+  });
+
+  it('accepts a matching dc:language and strips region subtags', async () => {
+    createChapterBookCollectionMock.mockResolvedValueOnce({
+      collection: { id: 'col-1' },
+      texts: [{ id: 'text-1' }, { id: 'text-2' }],
+      items: [],
+    });
+    const epubBytes = await buildFixtureEpub(
+      [
+        { id: 'ch1', href: 'ch1.xhtml', title: 'A', bodyHtml: '<p>body.</p>' },
+        { id: 'ch2', href: 'ch2.xhtml', title: 'B', bodyHtml: '<p>body.</p>' },
+      ],
+      'hi-IN',
+    );
+    const result = await createChapterBookFromEpub(OWNER, {
+      language: 'hi',
+      title: 'X',
+      epubBytes,
+    });
+    expect(result.kind).toBe('collection');
+  });
+
+  it('rejects an unsupported user-selected language without parsing', async () => {
     const epubBytes = await buildFixtureEpub([
       { id: 'ch1', href: 'ch1.xhtml', title: 'X', bodyHtml: '<p>body.</p>' },
     ]);
     await expect(
-      createEpubText(OWNER, { language: 'xx', title: 'X', epubBytes }),
+      createChapterBookFromEpub(OWNER, { language: 'xx', title: 'X', epubBytes }),
     ).rejects.toBeInstanceOf(TextValidationError);
   });
 
@@ -491,13 +668,13 @@ describe('createEpubText', () => {
       { id: 'ch1', href: 'ch1.xhtml', title: 'X', bodyHtml: '<p>body.</p>' },
     ]);
     await expect(
-      createEpubText(OWNER, { language: 'hi', title: '', epubBytes }),
+      createChapterBookFromEpub(OWNER, { language: 'hi', title: '', epubBytes }),
     ).rejects.toBeInstanceOf(TextValidationError);
   });
 
   it('rejects an empty file', async () => {
     await expect(
-      createEpubText(OWNER, {
+      createChapterBookFromEpub(OWNER, {
         language: 'hi',
         title: 'X',
         epubBytes: new Uint8Array(0),
@@ -506,11 +683,9 @@ describe('createEpubText', () => {
   });
 
   it('rejects an oversize archive', async () => {
-    // We don't actually allocate 50MB — just lie about the byte length
-    // via a fake ArrayBuffer subview that reports the cap.
     const tooBig = new ArrayBuffer(MAX_EPUB_BYTES + 1);
     await expect(
-      createEpubText(OWNER, {
+      createChapterBookFromEpub(OWNER, {
         language: 'hi',
         title: 'X',
         epubBytes: tooBig,
@@ -520,12 +695,154 @@ describe('createEpubText', () => {
 
   it('surfaces parse failures as EpubParseError', async () => {
     await expect(
-      createEpubText(OWNER, {
+      createChapterBookFromEpub(OWNER, {
         language: 'hi',
         title: 'X',
         epubBytes: new Uint8Array([1, 2, 3, 4]),
       }),
     ).rejects.toBeInstanceOf(EpubParseError);
+  });
+});
+
+// -----------------------------------------------------------------------
+// createChapterBookFromZip
+// -----------------------------------------------------------------------
+
+async function buildFixtureZip(
+  entries: Record<string, string | Uint8Array>,
+): Promise<Uint8Array> {
+  const zip = new JSZip();
+  for (const [name, body] of Object.entries(entries)) {
+    zip.file(name, body);
+  }
+  return zip.generateAsync({ type: 'uint8array' });
+}
+
+describe('createChapterBookFromZip', () => {
+  it('creates a chapter-book collection for a multi-file ZIP', async () => {
+    createChapterBookCollectionMock.mockResolvedValueOnce({
+      collection: { id: 'col-1' },
+      texts: [{ id: 'text-1' }, { id: 'text-2' }],
+      items: [],
+    });
+    const zipBytes = await buildFixtureZip({
+      '01-intro.txt': 'Intro body.',
+      '02-end.txt': 'Ending body.',
+    });
+    const result = await createChapterBookFromZip(OWNER, {
+      language: 'hi',
+      title: 'My ZIP book',
+      zipBytes,
+    });
+    expect(result.kind).toBe('collection');
+    expect(createChapterBookCollectionMock).toHaveBeenCalledOnce();
+    const args = createChapterBookCollectionMock.mock.calls[0]![0];
+    expect(args).toMatchObject({
+      ownerId: OWNER.id,
+      language: 'hi',
+      title: 'My ZIP book',
+      sourceType: 'zip',
+    });
+    expect(args.chapters.map((c: { title: string }) => c.title)).toEqual([
+      '01-intro',
+      '02-end',
+    ]);
+  });
+
+  it('falls back to a single plain text for a 1-file ZIP', async () => {
+    stageHappyPath({ text: textRow({ sourceType: 'zip' }) });
+    const zipBytes = await buildFixtureZip({ 'only.txt': 'Solo body.' });
+    const result = await createChapterBookFromZip(OWNER, {
+      language: 'hi',
+      title: 'X',
+      zipBytes,
+    });
+    expect(result.kind).toBe('text');
+    if (result.kind !== 'text') throw new Error('unreachable');
+    expect(result.text.sourceType).toBe('zip');
+    expect(createChapterBookCollectionMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unsupported language without parsing', async () => {
+    const zipBytes = await buildFixtureZip({ 'a.txt': 'Body.' });
+    await expect(
+      createChapterBookFromZip(OWNER, { language: 'xx', title: 'X', zipBytes }),
+    ).rejects.toBeInstanceOf(TextValidationError);
+  });
+
+  it('rejects an empty ZIP', async () => {
+    await expect(
+      createChapterBookFromZip(OWNER, {
+        language: 'hi',
+        title: 'X',
+        zipBytes: new Uint8Array(0),
+      }),
+    ).rejects.toBeInstanceOf(TextValidationError);
+  });
+
+  it('rejects an oversize ZIP', async () => {
+    const tooBig = new ArrayBuffer(MAX_ZIP_BYTES + 1);
+    await expect(
+      createChapterBookFromZip(OWNER, {
+        language: 'hi',
+        title: 'X',
+        zipBytes: tooBig,
+      }),
+    ).rejects.toBeInstanceOf(TextValidationError);
+  });
+
+  it('surfaces parse failures (no top-level .txt files) as ZipParseError', async () => {
+    const zipBytes = await buildFixtureZip({ 'nested/inner.txt': 'Body.' });
+    await expect(
+      createChapterBookFromZip(OWNER, {
+        language: 'hi',
+        title: 'X',
+        zipBytes,
+      }),
+    ).rejects.toBeInstanceOf(ZipParseError);
+  });
+});
+
+// -----------------------------------------------------------------------
+// deleteText
+// -----------------------------------------------------------------------
+
+describe('deleteText', () => {
+  it('deletes when the actor owns the text', async () => {
+    stage([{ id: 'text-1', ownerId: OWNER.id }]); // pre-check select
+    await deleteText('text-1', { id: OWNER.id, role: 'user' });
+    expect(deleteCalls).toHaveLength(1);
+  });
+
+  it('deletes when the actor is an admin even if they do not own it', async () => {
+    stage([{ id: 'text-1', ownerId: 'someone-else' }]);
+    await deleteText(
+      'text-1',
+      { id: 'admin-id', role: 'admin' },
+    );
+    expect(deleteCalls).toHaveLength(1);
+  });
+
+  it('throws 404 when the text does not exist', async () => {
+    stage([]); // pre-check select returns no row
+    await expect(
+      deleteText('missing', { id: OWNER.id, role: 'user' }),
+    ).rejects.toMatchObject({
+      name: 'TextValidationError',
+      status: 404,
+    });
+    expect(deleteCalls).toHaveLength(0);
+  });
+
+  it('throws 404 (not 403) for a non-owner non-admin — no existence leak', async () => {
+    stage([{ id: 'text-1', ownerId: 'someone-else' }]);
+    await expect(
+      deleteText('text-1', { id: OWNER.id, role: 'user' }),
+    ).rejects.toMatchObject({
+      name: 'TextValidationError',
+      status: 404,
+    });
+    expect(deleteCalls).toHaveLength(0);
   });
 });
 

--- a/apps/web/src/lib/server/texts/upload.ts
+++ b/apps/web/src/lib/server/texts/upload.ts
@@ -29,17 +29,19 @@ import { eq } from 'drizzle-orm';
 
 import { db, schema } from '../db/index.js';
 import type { LanguageCode } from '@ciareader/shared-types';
-import { isSupportedLanguage } from '@ciareader/shared-types';
-import type { Text, TextChapter, User } from '../db/schema.js';
+import { isSupportedLanguage, LANGUAGES } from '@ciareader/shared-types';
+import type { Collection, Text, TextChapter, User } from '../db/schema.js';
 import {
   splitIntoChapters,
   estimateTokenCount,
   type ChapterDraft,
 } from './chunking.js';
 import { parseEpub, EpubParseError } from './epub.js';
+import { parseChapterZip, ZipParseError } from './zip.js';
 import { enqueueNlpJob } from './jobs.js';
+import { createChapterBookCollection } from '../collections.js';
 
-export { EpubParseError };
+export { EpubParseError, ZipParseError };
 
 export class TextValidationError extends Error {
   constructor(
@@ -48,6 +50,44 @@ export class TextValidationError extends Error {
   ) {
     super(message);
     this.name = 'TextValidationError';
+  }
+}
+
+/**
+ * Thrown when an EPUB's `<dc:language>` is one of our supported codes
+ * but doesn't match the language the user selected at upload time.
+ * The form/API layer surfaces the message so the user can fix the
+ * dropdown without re-picking the file.
+ */
+export class EpubLanguageMismatchError extends TextValidationError {
+  constructor(
+    public readonly declaredLanguage: LanguageCode,
+    public readonly selectedLanguage: string,
+  ) {
+    const declaredName = LANGUAGES[declaredLanguage].displayName;
+    const selectedName = LANGUAGES[selectedLanguage as LanguageCode]?.displayName
+      ?? selectedLanguage;
+    super(
+      `This EPUB declares its language as ${declaredName} (${declaredLanguage}),` +
+        ` but you selected ${selectedName}. Re-select the language or upload a different file.`,
+    );
+    this.name = 'EpubLanguageMismatchError';
+  }
+}
+
+/**
+ * Thrown when an EPUB's `<dc:language>` is set to something outside
+ * the supported set (Hindi / Marathi / Odia). MVP only handles three
+ * languages — an English / French / etc. EPUB would tokenize as
+ * garbage if we just trusted the user's dropdown.
+ */
+export class EpubLanguageUnsupportedError extends TextValidationError {
+  constructor(public readonly declaredLanguage: string) {
+    super(
+      `This EPUB is declared as language '${declaredLanguage}', which isn't supported yet ` +
+        `(only Hindi / Marathi / Odia are available).`,
+    );
+    this.name = 'EpubLanguageUnsupportedError';
   }
 }
 
@@ -68,12 +108,17 @@ export const MAX_TXT_BYTES = 10_000_000;
  * embedded video / audio that we can't use anyway. */
 export const MAX_EPUB_BYTES = 50_000_000;
 
+/** Hard cap on a chapter-book ZIP upload. Same envelope as EPUB —
+ * a few MB of `.txt` files compress trivially, but we don't want the
+ * surface area for someone to bury a multi-gig archive in the form. */
+export const MAX_ZIP_BYTES = 50_000_000;
+
 /** Hard cap on the visible title; the library card and `<title>` tag
  * both render this without truncation. */
 export const MAX_TITLE_LEN = 200;
 export const MIN_TITLE_LEN = 1;
 
-export type SourceType = 'paste' | 'txt' | 'epub';
+export type SourceType = 'paste' | 'txt' | 'epub' | 'zip';
 
 export type CreatePastedTextInput = {
   language: string;
@@ -257,32 +302,136 @@ export async function createTxtText(
   });
 }
 
-export type CreateEpubTextInput = {
+export type CreateChapterBookFromEpubInput = {
   language: string;
   title: string;
   /** Raw EPUB archive bytes. */
   epubBytes: ArrayBuffer | Uint8Array;
 };
 
+export type CreateChapterBookFromZipInput = {
+  language: string;
+  title: string;
+  /** Raw ZIP archive bytes. */
+  zipBytes: ArrayBuffer | Uint8Array;
+};
+
 /**
- * Create a text from an EPUB upload (T-4.3).
+ * Result of the EPUB/ZIP chapter-book creators. Two shapes because
+ * the single-chapter case falls back to a plain `texts` row (a 1-item
+ * collection is awkward UX — the reader page goes straight there).
  *
- * EPUB chapter structure is authored — the spine is the canonical
- * order, each spine item is a chapter — so we feed the parsed
- * chapters straight into `text_chapters` without going through the
- * paragraph auto-splitter. The chunker WOULD fire only if a single
- * EPUB chapter is itself enormous (>50k tokens), which essentially
- * never happens in real publishing.
- *
- * Per-chapter NFC normalization happens here rather than in the
- * parser so the parser stays a pure XML/HTML utility usable elsewhere
- * (e.g. an admin re-import path later).
+ * Callers branch on `kind` to redirect the user to either
+ * `/reader/<id>` (plain text) or `/collections/<id>` (chapter book).
  */
-export async function createEpubText(
+export type ChapterBookResult =
+  | { kind: 'text'; text: Text; chapter: TextChapter; chapters: TextChapter[] }
+  | {
+      kind: 'collection';
+      collection: Collection;
+      texts: Text[];
+    };
+
+/**
+ * A `ChapterDraft` extended with the parent-section heading from
+ * the source nav doc. Carried through `buildChapterDrafts` into
+ * `createChapterBookCollection`, which writes it to the
+ * `collection_items.section_title` column for grouped rendering on
+ * the collection detail page.
+ */
+export type ChapterDraftWithSection = ChapterDraft & {
+  section: string | null;
+};
+
+/**
+ * Run each parsed chapter through the auto-splitter and produce
+ * contiguous `ChapterDraft`s. A short chapter passes through as one
+ * draft; an enormous chapter (>50k tokens — basically never in
+ * real publishing) gets split at paragraph boundaries with the title
+ * suffixed `"(cont. N)"` so the order remains obvious in the reader.
+ *
+ * Shared by the EPUB and ZIP paths; the only thing that differs
+ * between them is where the per-chapter title/body pairs come from.
+ * The optional `section` per input chapter — only set by the EPUB
+ * path when the nav doc nests this chapter under a parent heading —
+ * propagates onto every sub-chunk so a "(cont. 1)" split inherits
+ * its parent's part membership.
+ */
+function buildChapterDrafts(
+  chapters: Array<{ title: string | null; body: string; section?: string | null }>,
+): ChapterDraftWithSection[] {
+  const drafts: ChapterDraftWithSection[] = [];
+  let nextIdx = 0;
+  for (const c of chapters) {
+    const body = c.body.normalize('NFC').replace(/\r\n?/g, '\n');
+    const subChapters = splitIntoChapters(body);
+    const section = c.section ?? null;
+    for (let i = 0; i < subChapters.length; i += 1) {
+      const sub = subChapters[i]!;
+      // First sub-chapter inherits the source's title; further sub-
+      // splits get a derived "(cont. N)" suffix or fall back to the
+      // chunker's title.
+      let derivedTitle: string | null;
+      if (i === 0) derivedTitle = c.title;
+      else if (c.title) derivedTitle = `${c.title} (cont. ${i})`;
+      else derivedTitle = sub.title;
+      drafts.push({
+        idx: nextIdx,
+        title: derivedTitle,
+        body: sub.body,
+        tokenCount: sub.tokenCount,
+        section,
+      });
+      nextIdx += 1;
+    }
+  }
+  return drafts;
+}
+
+/**
+ * Convert a single-chapter `ChapterDraft` into a plain pasted text.
+ * Used by the EPUB/ZIP fallback when only one chapter came out of
+ * the file — there's no point spinning up a 1-item collection just
+ * to wrap a single text.
+ */
+async function createSingleChapterFallback(
   owner: Pick<User, 'id'>,
-  input: CreateEpubTextInput,
-  now: Date = new Date(),
+  args: {
+    sourceType: 'epub' | 'zip';
+    language: LanguageCode;
+    title: string;
+    draft: ChapterDraft;
+    now: Date;
+  },
 ): Promise<CreatedText> {
+  return insertTextWithChapters(owner, {
+    sourceType: args.sourceType,
+    language: args.language,
+    title: args.title,
+    chapters: [args.draft],
+    now: args.now,
+  });
+}
+
+/**
+ * Create a chapter-book collection from an EPUB.
+ *
+ * Each spine chapter becomes its own `texts` row (so each gets its
+ * own status, NLP job, progress %, audio binding) inside a
+ * `collections` row of kind `chapter_book`. If the EPUB declares
+ * `<dc:language>` and it disagrees with the user's selection, the
+ * upload is rejected so we don't tokenize a Marathi book under the
+ * Hindi pipeline.
+ *
+ * When only one readable chapter exists after parsing + chunking,
+ * the result is a single `texts` row (kind `text`) — callers
+ * redirect to `/reader/<id>` rather than a 1-item collection page.
+ */
+export async function createChapterBookFromEpub(
+  owner: Pick<User, 'id'>,
+  input: CreateChapterBookFromEpubInput,
+  now: Date = new Date(),
+): Promise<ChapterBookResult> {
   if (!isSupportedLanguage(input.language)) {
     throw new TextValidationError(
       `Unsupported language '${input.language}' (expected one of: hi, mr, or)`,
@@ -296,10 +445,7 @@ export async function createEpubText(
   if (title.length > MAX_TITLE_LEN) {
     throw new TextValidationError(`title exceeds ${MAX_TITLE_LEN} characters`);
   }
-  const byteLength =
-    input.epubBytes instanceof Uint8Array
-      ? input.epubBytes.byteLength
-      : input.epubBytes.byteLength;
+  const byteLength = input.epubBytes.byteLength;
   if (byteLength > MAX_EPUB_BYTES) {
     throw new TextValidationError(
       `EPUB exceeds ${MAX_EPUB_BYTES.toLocaleString()} bytes`,
@@ -311,44 +457,129 @@ export async function createEpubText(
 
   const parsed = await parseEpub(input.epubBytes);
 
-  // For each parsed chapter, run it through the chunker — short
-  // chapters stay one row, freakishly long ones get split. We then
-  // re-number `idx` across the flattened result so the order is
-  // contiguous regardless of any per-chapter sub-splits.
-  const drafts: ChapterDraft[] = [];
-  let nextIdx = 0;
-  for (const c of parsed) {
-    const body = c.body.normalize('NFC').replace(/\r\n?/g, '\n');
-    const subChapters = splitIntoChapters(body);
-    for (let i = 0; i < subChapters.length; i += 1) {
-      const sub = subChapters[i]!;
-      // The first sub-chapter inherits the EPUB chapter's title; any
-      // additional splits within that chapter get a derived title or
-      // fall back to "{title} (cont.)".
-      let derivedTitle: string | null;
-      if (i === 0) derivedTitle = c.title;
-      else if (c.title) derivedTitle = `${c.title} (cont. ${i})`;
-      else derivedTitle = sub.title;
-      drafts.push({
-        idx: nextIdx,
-        title: derivedTitle,
-        body: sub.body,
-        tokenCount: sub.tokenCount,
-      });
-      nextIdx += 1;
+  // Language verification (T-EPUB language gate). Only fires when the
+  // EPUB actually declares its language — most authoring tools do, but
+  // we don't penalize files that don't.
+  if (parsed.language !== null && parsed.language !== language) {
+    if (isSupportedLanguage(parsed.language)) {
+      throw new EpubLanguageMismatchError(
+        parsed.language as LanguageCode,
+        input.language,
+      );
     }
+    throw new EpubLanguageUnsupportedError(parsed.language);
   }
+
+  const drafts = buildChapterDrafts(parsed.chapters);
   if (drafts.length === 0) {
     throw new TextValidationError('EPUB has no readable chapters');
   }
 
-  return insertTextWithChapters(owner, {
-    sourceType: 'epub',
+  if (drafts.length === 1) {
+    const single = await createSingleChapterFallback(owner, {
+      sourceType: 'epub',
+      language,
+      title,
+      draft: drafts[0]!,
+      now,
+    });
+    return {
+      kind: 'text',
+      text: single.text,
+      chapter: single.chapter,
+      chapters: single.chapters,
+    };
+  }
+
+  const created = await createChapterBookCollection({
+    ownerId: owner.id,
     language,
     title,
+    sourceType: 'epub',
     chapters: drafts,
     now,
   });
+  return {
+    kind: 'collection',
+    collection: created.collection,
+    texts: created.texts,
+  };
+}
+
+/**
+ * Create a chapter-book collection from a ZIP of `.txt` files.
+ *
+ * Layout convention is "flat top-level `.txt` files, lexicographic
+ * order" — see `parseChapterZip` for the spec. Filename minus the
+ * `.txt` extension is the chapter title. Unlike EPUB there's no
+ * declared language tag; we trust the user's dropdown selection.
+ *
+ * Single-chapter fallback matches the EPUB path: one `.txt` file
+ * lands as a plain `texts` row, not a 1-item collection.
+ */
+export async function createChapterBookFromZip(
+  owner: Pick<User, 'id'>,
+  input: CreateChapterBookFromZipInput,
+  now: Date = new Date(),
+): Promise<ChapterBookResult> {
+  if (!isSupportedLanguage(input.language)) {
+    throw new TextValidationError(
+      `Unsupported language '${input.language}' (expected one of: hi, mr, or)`,
+    );
+  }
+  const language = input.language as LanguageCode;
+  const title = normalizeTitle(input.title ?? '');
+  if (title.length < MIN_TITLE_LEN) {
+    throw new TextValidationError('title is required');
+  }
+  if (title.length > MAX_TITLE_LEN) {
+    throw new TextValidationError(`title exceeds ${MAX_TITLE_LEN} characters`);
+  }
+  const byteLength = input.zipBytes.byteLength;
+  if (byteLength > MAX_ZIP_BYTES) {
+    throw new TextValidationError(
+      `ZIP exceeds ${MAX_ZIP_BYTES.toLocaleString()} bytes`,
+    );
+  }
+  if (byteLength === 0) {
+    throw new TextValidationError('ZIP file is empty');
+  }
+
+  const parsed = await parseChapterZip(input.zipBytes);
+  const drafts = buildChapterDrafts(parsed);
+  if (drafts.length === 0) {
+    throw new TextValidationError('ZIP has no readable chapters');
+  }
+
+  if (drafts.length === 1) {
+    const single = await createSingleChapterFallback(owner, {
+      sourceType: 'zip',
+      language,
+      title,
+      draft: drafts[0]!,
+      now,
+    });
+    return {
+      kind: 'text',
+      text: single.text,
+      chapter: single.chapter,
+      chapters: single.chapters,
+    };
+  }
+
+  const created = await createChapterBookCollection({
+    ownerId: owner.id,
+    language,
+    title,
+    sourceType: 'zip',
+    chapters: drafts,
+    now,
+  });
+  return {
+    kind: 'collection',
+    collection: created.collection,
+    texts: created.texts,
+  };
 }
 
 /**
@@ -389,3 +620,32 @@ export async function getReadableText(
  * @deprecated Use `getReadableText` directly.
  */
 export const getOwnedText = getReadableText;
+
+/**
+ * Delete a text. Owner-or-admin only; matches the policy on the
+ * collection delete endpoint. Cascades through `text_chapters`,
+ * `text_tokens`, `nlp_jobs`, `text_shares`, `text_group_shares`,
+ * `user_text_progress`, `collection_items`, and `audio_files` —
+ * every dependent table declares `onDelete: 'cascade'` on its
+ * `text_id` FK, so a single DELETE on `texts` clears the lot.
+ *
+ * Throws `TextValidationError(404)` for a missing text, or for a
+ * non-owner non-admin actor — same status code in both cases so we
+ * don't leak existence to a viewer who isn't allowed to delete.
+ */
+export async function deleteText(
+  textId: string,
+  actor: Pick<User, 'id' | 'role'>,
+): Promise<void> {
+  const [row] = (await db
+    .select({ id: schema.texts.id, ownerId: schema.texts.ownerId })
+    .from(schema.texts)
+    .where(eq(schema.texts.id, textId))
+    .limit(1)) as Array<{ id: string; ownerId: string | null }>;
+  if (!row) throw new TextValidationError('Text not found', 404);
+  const isOwner = row.ownerId !== null && row.ownerId === actor.id;
+  if (!isOwner && actor.role !== 'admin') {
+    throw new TextValidationError('Text not found', 404);
+  }
+  await db.delete(schema.texts).where(eq(schema.texts.id, textId));
+}

--- a/apps/web/src/lib/server/texts/upload.ts
+++ b/apps/web/src/lib/server/texts/upload.ts
@@ -34,6 +34,7 @@ import type { Collection, Text, TextChapter, User } from '../db/schema.js';
 import {
   splitIntoChapters,
   estimateTokenCount,
+  prependTitleToBody,
   type ChapterDraft,
 } from './chunking.js';
 import { parseEpub, EpubParseError } from './epub.js';
@@ -393,6 +394,14 @@ function buildChapterDrafts(
  * Used by the EPUB/ZIP fallback when only one chapter came out of
  * the file — there's no point spinning up a 1-item collection just
  * to wrap a single text.
+ *
+ * The chapter title is prepended to the body so its words are
+ * tokenized + lookupable — same contract as multi-chapter
+ * chapter-book chapters created via `createChapterBookCollection`.
+ * Without this, single-file ZIP / one-spine EPUB titles render as
+ * reader chrome only and aren't clickable. `prependTitleToBody` is
+ * idempotent, so EPUBs whose `htmlToText` output already starts
+ * with the title don't get a duplicated heading.
  */
 async function createSingleChapterFallback(
   owner: Pick<User, 'id'>,
@@ -404,11 +413,20 @@ async function createSingleChapterFallback(
     now: Date;
   },
 ): Promise<CreatedText> {
+  // Prepend the chapter's own title when present, falling back to
+  // the text title (book / file name) — that's what the reader
+  // renders in the `<header>` chrome, and matching it lets the
+  // `titleInBody` detector suppress the duplicate display.
+  const titleForPrefix = args.draft.title?.trim() || args.title;
+  const { body, tokenCount } = prependTitleToBody(
+    titleForPrefix,
+    args.draft.body,
+  );
   return insertTextWithChapters(owner, {
     sourceType: args.sourceType,
     language: args.language,
     title: args.title,
-    chapters: [args.draft],
+    chapters: [{ ...args.draft, body, tokenCount }],
     now: args.now,
   });
 }

--- a/apps/web/src/lib/server/texts/zip.test.ts
+++ b/apps/web/src/lib/server/texts/zip.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+import JSZip from 'jszip';
+
+import { parseChapterZip, ZipParseError } from './zip.js';
+
+/**
+ * Build a ZIP with the given entries on the fly so the tests don't
+ * carry a checked-in binary fixture. Each entry is `name → utf8 body`
+ * unless the caller passes a Uint8Array for binary content.
+ */
+async function buildZip(
+  entries: Record<string, string | Uint8Array>,
+): Promise<Uint8Array> {
+  const zip = new JSZip();
+  for (const [name, body] of Object.entries(entries)) {
+    zip.file(name, body);
+  }
+  return zip.generateAsync({ type: 'uint8array' });
+}
+
+describe('parseChapterZip — happy path', () => {
+  it('returns one chapter per .txt file, ordered by filename', async () => {
+    const bytes = await buildZip({
+      '02-body.txt': 'Body of chapter two.',
+      '01-intro.txt': 'Intro chapter.',
+      '03-end.txt': 'Ending chapter.',
+    });
+    const chapters = await parseChapterZip(bytes);
+    expect(chapters).toHaveLength(3);
+    expect(chapters[0]!.title).toBe('01-intro');
+    expect(chapters[0]!.body).toBe('Intro chapter.');
+    expect(chapters[1]!.title).toBe('02-body');
+    expect(chapters[2]!.title).toBe('03-end');
+  });
+
+  it('strips a UTF-8 BOM from the start of a chapter', async () => {
+    const withBom = '﻿' + 'Body after BOM.';
+    const bytes = await buildZip({ 'a.txt': withBom });
+    const chapters = await parseChapterZip(bytes);
+    expect(chapters[0]!.body).toBe('Body after BOM.');
+  });
+
+  it('promotes single newlines to paragraph breaks so each line renders separately', async () => {
+    // CRLF and lone CR are normalized to LF first, then every newline
+    // becomes a paragraph break — the reader only treats `\n\n+` as a
+    // boundary, so without this every chapter would render as a wall
+    // of text.
+    const bytes = await buildZip({
+      'a.txt': 'Line one.\r\nLine two.\rLine three.',
+    });
+    const chapters = await parseChapterZip(bytes);
+    expect(chapters[0]!.body).toBe(
+      'Line one.\n\nLine two.\n\nLine three.',
+    );
+  });
+
+  it('leaves already-paragraphed content alone (no doubled blank lines)', async () => {
+    const bytes = await buildZip({
+      'a.txt': 'Para one.\n\nPara two.\n\nPara three.',
+    });
+    const chapters = await parseChapterZip(bytes);
+    expect(chapters[0]!.body).toBe(
+      'Para one.\n\nPara two.\n\nPara three.',
+    );
+  });
+
+  it('returns a single chapter when only one .txt file is present', async () => {
+    const bytes = await buildZip({ 'only.txt': 'Solo chapter.' });
+    const chapters = await parseChapterZip(bytes);
+    expect(chapters).toHaveLength(1);
+    expect(chapters[0]!.title).toBe('only');
+  });
+});
+
+describe('parseChapterZip — what gets ignored', () => {
+  it('ignores non-.txt files at the top level', async () => {
+    const bytes = await buildZip({
+      'a.txt': 'Real chapter.',
+      'cover.jpg': new Uint8Array([0xff, 0xd8, 0xff]),
+      'README.md': '# not a chapter',
+    });
+    const chapters = await parseChapterZip(bytes);
+    expect(chapters).toHaveLength(1);
+    expect(chapters[0]!.title).toBe('a');
+  });
+
+  it('ignores .txt files inside subdirectories', async () => {
+    const bytes = await buildZip({
+      'top.txt': 'Top-level chapter.',
+      'nested/inner.txt': 'Should be skipped.',
+      'deep/deeper/deepest.txt': 'Also skipped.',
+    });
+    const chapters = await parseChapterZip(bytes);
+    expect(chapters).toHaveLength(1);
+    expect(chapters[0]!.title).toBe('top');
+  });
+
+  it('skips .txt files that are empty or whitespace-only', async () => {
+    const bytes = await buildZip({
+      '01-blank.txt': '   \n\n   ',
+      '02-real.txt': 'Has content.',
+    });
+    const chapters = await parseChapterZip(bytes);
+    expect(chapters).toHaveLength(1);
+    expect(chapters[0]!.title).toBe('02-real');
+  });
+
+  it('is case-insensitive for the .txt suffix', async () => {
+    const bytes = await buildZip({ 'STORY.TXT': 'Yelling.' });
+    const chapters = await parseChapterZip(bytes);
+    expect(chapters).toHaveLength(1);
+    expect(chapters[0]!.title).toBe('STORY');
+  });
+});
+
+describe('parseChapterZip — error paths', () => {
+  it('rejects a non-zip blob with a ZipParseError', async () => {
+    await expect(
+      parseChapterZip(new Uint8Array([1, 2, 3, 4])),
+    ).rejects.toBeInstanceOf(ZipParseError);
+  });
+
+  it('rejects an empty zip', async () => {
+    const bytes = await buildZip({});
+    await expect(parseChapterZip(bytes)).rejects.toBeInstanceOf(ZipParseError);
+  });
+
+  it('rejects a zip with no top-level .txt files', async () => {
+    const bytes = await buildZip({
+      'nested/inner.txt': 'Should not save the upload.',
+      'cover.jpg': new Uint8Array([0xff, 0xd8, 0xff]),
+    });
+    await expect(parseChapterZip(bytes)).rejects.toBeInstanceOf(ZipParseError);
+  });
+
+  it('rejects a .txt file that is not valid UTF-8', async () => {
+    // 0xC3 0x28 is an invalid UTF-8 sequence (continuation byte
+    // missing). Strict decoder throws, the parser surfaces a
+    // ZipParseError naming the offending file.
+    const bytes = await buildZip({ 'broken.txt': new Uint8Array([0xc3, 0x28]) });
+    const err = await parseChapterZip(bytes).catch((e) => e);
+    expect(err).toBeInstanceOf(ZipParseError);
+    expect((err as ZipParseError).message).toContain('broken.txt');
+  });
+});

--- a/apps/web/src/lib/server/texts/zip.ts
+++ b/apps/web/src/lib/server/texts/zip.ts
@@ -1,0 +1,128 @@
+/**
+ * ZIP-of-text-files parser for chapter-book uploads.
+ *
+ * EPUBs are great when the source has them, but they're also annoying
+ * to author. This parser takes a plain ZIP whose top level holds a few
+ * `.txt` files and returns one chapter per file, ordered by filename.
+ * The chapter title comes from the filename minus extension; the body
+ * is the UTF-8 decoded contents with BOM stripped and CRLF normalized.
+ *
+ * Convention (intentionally narrow for v1):
+ *
+ *   - Top-level `.txt` files only — anything in a subdirectory is
+ *     ignored. (We don't want filesystem-zip viewers to silently
+ *     bundle metadata folders.)
+ *   - Order is lexicographic by filename. Users prefix
+ *     `01-intro.txt`, `02-chapter-one.txt`, etc. — same trick that
+ *     gets ePub authors to ordered spines.
+ *   - One `.txt` file → caller's job to fall back to a plain text
+ *     instead of a 1-item collection. This parser still returns the
+ *     single chapter so the caller can branch.
+ *
+ * Future v2 might support a `manifest.json` for explicit titles and
+ * order — left out for now per the implementation plan.
+ */
+import JSZip from 'jszip';
+
+export class ZipParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ZipParseError';
+  }
+}
+
+export type ZipChapter = {
+  title: string | null;
+  body: string;
+};
+
+/**
+ * UTF-8 with strict decoding so a binary or mis-encoded file bubbles
+ * up as a parse error rather than silently producing replacement
+ * characters in the reader.
+ */
+const STRICT_UTF8 = new TextDecoder('utf-8', { fatal: true });
+/** UTF-8 BOM, removed if present at the start of a chapter file. */
+const BOM = '﻿';
+
+/**
+ * Parse a ZIP archive into ordered chapters. See file header for the
+ * accepted layout.
+ *
+ * Throws `ZipParseError` for any user-actionable problem (bad zip,
+ * no `.txt` entries, undecodable file) — callers map it to a 400.
+ */
+export async function parseChapterZip(
+  zipBytes: ArrayBuffer | Uint8Array,
+): Promise<ZipChapter[]> {
+  let zip: JSZip;
+  try {
+    zip = await JSZip.loadAsync(zipBytes);
+  } catch (e) {
+    throw new ZipParseError(
+      `Could not open ZIP archive: ${(e as Error).message}`,
+    );
+  }
+
+  // JSZip exposes both files and directory entries through `files`.
+  // We want top-level `.txt` files only — `name` containing a `/`
+  // means the entry is inside a folder, which we deliberately ignore.
+  const entries = Object.values(zip.files).filter((f) => {
+    if (f.dir) return false;
+    if (f.name.includes('/')) return false;
+    if (!f.name.toLowerCase().endsWith('.txt')) return false;
+    return true;
+  });
+
+  if (entries.length === 0) {
+    throw new ZipParseError(
+      'ZIP contains no top-level .txt files (chapters must sit at the root)',
+    );
+  }
+
+  // Lexicographic sort on filename. Locale-aware Intl.Collator would
+  // surprise users who expect `01-foo.txt` to sort before `10-foo.txt`
+  // — that's exactly what `string.localeCompare` with default locale
+  // does, but we keep it simple with a plain compare since the
+  // documented contract is "lexicographic." Users who want different
+  // ordering rename their files; the v2 manifest path will replace
+  // this entirely.
+  entries.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+
+  const chapters: ZipChapter[] = [];
+  for (const entry of entries) {
+    let body: string;
+    try {
+      const bytes = (await entry.async('uint8array')) as Uint8Array;
+      body = STRICT_UTF8.decode(bytes);
+    } catch (e) {
+      throw new ZipParseError(
+        `'${entry.name}' is not valid UTF-8 text: ${(e as Error).message}`,
+      );
+    }
+    if (body.startsWith(BOM)) body = body.slice(BOM.length);
+    body = body.replace(/\r\n?/g, '\n');
+    // Plain-text chapter files typically use one paragraph per line,
+    // not the "blank line between paragraphs" convention pasted
+    // content uses. The reader (and the chunker) only treat `\n\n+`
+    // as a paragraph boundary — single `\n` collapses to whitespace —
+    // so a file with line-per-paragraph would render as one wall of
+    // text. Promote every newline to a paragraph break, then collapse
+    // any runs we just created back down to exactly one blank line.
+    // Files that already have `\n\n` separators end up unchanged.
+    body = body.replace(/\n/g, '\n\n').replace(/\n{3,}/g, '\n\n');
+    // Skip empty / whitespace-only files — matches the EPUB parser's
+    // "nav landmark" skip so an accidental blank chapter doesn't
+    // create a useless reader stub.
+    if (body.trim().length === 0) continue;
+    const title = entry.name.replace(/\.txt$/i, '').trim() || null;
+    chapters.push({ title, body });
+  }
+
+  if (chapters.length === 0) {
+    throw new ZipParseError(
+      'ZIP contains no readable chapters (every .txt file was empty)',
+    );
+  }
+  return chapters;
+}

--- a/apps/web/src/lib/styles/tokens.css
+++ b/apps/web/src/lib/styles/tokens.css
@@ -189,7 +189,12 @@
 
   --accent: oklch(0.78 0.13 70);
   --accent-soft: oklch(0.78 0.13 70 / 0.18);
-  --accent-ink: oklch(0.86 0.11 70);
+  /* Ink that sits ON the accent fill. Must be DARK in dark mode so it
+     contrasts the bright saffron (a near-equal-lightness ink made the
+     "Reprocess all chapters" button unreadable). Keeps a slight
+     saffron tint to harmonize. Approx contrast vs --accent: 6.8:1
+     (WCAG AAA for normal text). */
+  --accent-ink: oklch(0.2 0.04 70);
 
   --w-l1-bg: oklch(0.3 0.05 70);
   --w-l2-bg: oklch(0.38 0.08 68);

--- a/apps/web/src/routes/api/v1/collections/[id]/reprocess/+server.ts
+++ b/apps/web/src/routes/api/v1/collections/[id]/reprocess/+server.ts
@@ -1,0 +1,90 @@
+/**
+ * POST /api/v1/collections/:id/reprocess
+ *
+ * Re-dispatch the NLP pipeline against member texts. Owner or admin
+ * only — matches the rest of the collection management surface.
+ *
+ * Body (optional):
+ *   { "all": true }  → reprocess every member text regardless of
+ *                       status. Useful after a dictionary import
+ *                       when the chapters are already 'ready' but
+ *                       would benefit from a fresh tokenization.
+ *   omitted / false  → only reprocess texts currently `pending` or
+ *                       `failed` (the typical "unstick" case).
+ *
+ * Fire-and-forget per text. Returns the count + ids dispatched so
+ * the caller can surface "dispatched N chapters" without waiting for
+ * the actual work to finish; the polling status badge tracks each
+ * text from there.
+ */
+import { and, inArray } from 'drizzle-orm';
+import { error, json } from '@sveltejs/kit';
+
+import { requireUser } from '$lib/server/auth/require-user.js';
+import { isAdmin } from '$lib/server/dictionary/permissions.js';
+import { db, schema } from '$lib/server/db/index.js';
+import { loadCollectionDetail } from '$lib/server/collections.js';
+import { processTextNow } from '$lib/server/texts/in-process-dispatcher.js';
+import type { Text } from '$lib/server/db/schema.js';
+import type { RequestHandler } from './$types';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const STUCK_STATUSES: Array<Text['status']> = ['pending', 'failed'];
+
+export const POST: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  const id = event.params.id;
+  if (!id || !UUID_RE.test(id)) throw error(400, 'Invalid collection id');
+
+  // Optional body. We don't reject a missing/empty body — the common
+  // case (rescue pending/failed chapters) doesn't need any payload.
+  let all = false;
+  try {
+    const text = await event.request.text();
+    if (text.trim().length > 0) {
+      const parsed = JSON.parse(text) as { all?: unknown };
+      all = parsed.all === true;
+    }
+  } catch {
+    throw error(400, 'Invalid JSON body');
+  }
+
+  const detail = await loadCollectionDetail(id);
+  if (!detail) throw error(404, 'Collection not found');
+
+  const isOwner = detail.collection.ownerId === user.id;
+  if (!isOwner && !isAdmin({ role: user.role })) {
+    throw error(404, 'Collection not found');
+  }
+
+  if (detail.items.length === 0) {
+    return json({ matched: 0, dispatched: 0, textIds: [] });
+  }
+
+  // Re-query the live status rather than trusting
+  // `detail.items[].text.status` — there's a window between the page
+  // load and this POST where the worker could have flipped a row.
+  const memberIds = detail.items.map((i) => i.text.id);
+  const conditions = [inArray(schema.texts.id, memberIds)];
+  if (!all) conditions.push(inArray(schema.texts.status, STUCK_STATUSES));
+  const rows = (await db
+    .select({ id: schema.texts.id })
+    .from(schema.texts)
+    .where(and(...conditions))) as Array<{ id: string }>;
+
+  const textIds = rows.map((r) => r.id);
+  // Fire-and-forget per text — same pattern as bulkReprocessTexts.
+  // The dispatcher writes status flips back to the texts row, which
+  // the polling endpoint surfaces to the UI.
+  for (const tid of textIds) {
+    void processTextNow(tid).catch((err) => {
+      console.error(
+        `collection ${id} reprocess: text ${tid} failed:`,
+        err,
+      );
+    });
+  }
+
+  return json({ matched: textIds.length, dispatched: textIds.length, textIds });
+};

--- a/apps/web/src/routes/api/v1/texts/[id]/+server.ts
+++ b/apps/web/src/routes/api/v1/texts/[id]/+server.ts
@@ -1,0 +1,28 @@
+/**
+ * DELETE /api/v1/texts/:id
+ *
+ * Owner-or-admin only. Removes the text and cascades through every
+ * dependent table (chapters, tokens, NLP jobs, shares, progress,
+ * collection items, audio). Non-admins who don't own the row get the
+ * same 404 as if it didn't exist so we don't leak existence.
+ */
+import { error, json } from '@sveltejs/kit';
+
+import { requireUser } from '$lib/server/auth/require-user.js';
+import { deleteText, TextValidationError } from '$lib/server/texts/upload.js';
+import type { RequestHandler } from './$types';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const DELETE: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  const id = event.params.id;
+  if (!id || !UUID_RE.test(id)) throw error(400, 'Invalid text id');
+  try {
+    await deleteText(id, { id: user.id, role: user.role });
+    return json({ ok: true });
+  } catch (e) {
+    if (e instanceof TextValidationError) throw error(e.status, e.message);
+    throw e;
+  }
+};

--- a/apps/web/src/routes/api/v1/texts/[id]/id-server.test.ts
+++ b/apps/web/src/routes/api/v1/texts/[id]/id-server.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const deleteText = vi.fn();
+const requireUser = vi.fn();
+
+vi.mock('$lib/server/texts/upload.js', async () => {
+  const actual = await vi.importActual<
+    typeof import('$lib/server/texts/upload.js')
+  >('$lib/server/texts/upload.js');
+  return {
+    ...actual,
+    deleteText: (...a: unknown[]) => deleteText(...a),
+  };
+});
+
+vi.mock('$lib/server/auth/require-user.js', () => ({
+  requireUser: (...a: unknown[]) => requireUser(...a),
+  requireVerifiedUser: (...a: unknown[]) => requireUser(...a),
+}));
+
+type DeleteFn = (typeof import('./+server.js'))['DELETE'];
+
+const USER = { id: 'user-1', role: 'user' as const };
+const VALID_ID = '11111111-1111-1111-1111-111111111111';
+
+async function callDelete(
+  id: string = VALID_ID,
+  user: typeof USER | null = USER,
+) {
+  if (user) {
+    requireUser.mockResolvedValueOnce(user);
+  } else {
+    requireUser.mockImplementationOnce(() => {
+      throw { status: 401 };
+    });
+  }
+  const { DELETE } = await import('./+server.js');
+  const event = {
+    params: { id },
+    request: new Request(`http://x/api/v1/texts/${id}`, { method: 'DELETE' }),
+  } as unknown as Parameters<DeleteFn>[0];
+  try {
+    return await DELETE(event);
+  } catch (e) {
+    return e as { status: number };
+  }
+}
+
+beforeEach(() => {
+  deleteText.mockReset();
+  requireUser.mockReset();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('DELETE /api/v1/texts/:id', () => {
+  it('returns 200 ok on a happy-path delete', async () => {
+    deleteText.mockResolvedValueOnce(undefined);
+    const res = (await callDelete()) as Response;
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(deleteText).toHaveBeenCalledWith(VALID_ID, {
+      id: USER.id,
+      role: USER.role,
+    });
+  });
+
+  it('rejects an invalid uuid with 400', async () => {
+    const res = (await callDelete('not-a-uuid')) as { status: number };
+    expect(res.status).toBe(400);
+    expect(deleteText).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const res = (await callDelete(VALID_ID, null)) as { status: number };
+    expect(res.status).toBe(401);
+    expect(deleteText).not.toHaveBeenCalled();
+  });
+
+  it('maps TextValidationError(404) to a 404', async () => {
+    const { TextValidationError } = await import(
+      '$lib/server/texts/upload.js'
+    );
+    deleteText.mockRejectedValueOnce(
+      new TextValidationError('Text not found', 404),
+    );
+    const res = (await callDelete()) as { status: number };
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/web/src/routes/api/v1/texts/epub/+server.ts
+++ b/apps/web/src/routes/api/v1/texts/epub/+server.ts
@@ -1,5 +1,5 @@
 /**
- * POST /api/v1/texts/epub (T-4.3).
+ * POST /api/v1/texts/epub (T-4.3, extended for chapter-book upload).
  *
  * Multipart endpoint for EPUB uploads. The request body is form-data
  * with three fields:
@@ -14,9 +14,16 @@
  * primitive — every browser <input type="file"> form action posts it
  * natively.
  *
- * Response shape mirrors POST /api/v1/texts (T-4.1/T-4.2): 201 with
- * the new text metadata + `chapterCount` so the redirect target can
- * surface "uploaded N chapters" in M5.
+ * Response shape:
+ *
+ *   - Multi-chapter EPUB → 201 with `{ kind: 'collection',
+ *     collection, textCount }`. Each spine chapter becomes its own
+ *     `texts` row inside a `collections` row of kind `chapter_book`.
+ *   - Single-chapter EPUB → 201 with `{ kind: 'text', text,
+ *     chapterCount: 1 }` (1-item collections are awkward UX).
+ *
+ * Clients branch on `kind` to redirect to `/collections/<id>` or
+ * `/reader/<id>`.
  */
 import { error, json } from '@sveltejs/kit';
 
@@ -27,7 +34,7 @@ import {
   RequestRateLimitError,
 } from '$lib/server/auth/rate-limits.js';
 import {
-  createEpubText,
+  createChapterBookFromEpub,
   EpubParseError,
   TextValidationError,
   MAX_EPUB_BYTES,
@@ -91,7 +98,7 @@ export const POST: RequestHandler = async (event) => {
       limit: EPUB_UPLOADS_PER_DAY,
       windowMs: UPLOAD_WINDOW_MS,
     });
-    const created = await createEpubText(
+    const created = await createChapterBookFromEpub(
       { id: user.id },
       {
         language,
@@ -99,20 +106,40 @@ export const POST: RequestHandler = async (event) => {
         epubBytes,
       },
     );
-    const { text } = created;
+    if (created.kind === 'text') {
+      const { text } = created;
+      return json(
+        {
+          kind: 'text' as const,
+          text: {
+            id: text.id,
+            ownerId: text.ownerId,
+            language: text.language,
+            title: text.title,
+            sourceType: text.sourceType,
+            status: text.status,
+            visibility: text.visibility,
+            createdAt: text.createdAt,
+          },
+          chapterCount: 1,
+        },
+        { status: 201, headers: rateLimitHeaders(requestLimit) },
+      );
+    }
+    const { collection } = created;
     return json(
       {
-        text: {
-          id: text.id,
-          ownerId: text.ownerId,
-          language: text.language,
-          title: text.title,
-          sourceType: text.sourceType,
-          status: text.status,
-          visibility: text.visibility,
-          createdAt: text.createdAt,
+        kind: 'collection' as const,
+        collection: {
+          id: collection.id,
+          ownerId: collection.ownerId,
+          language: collection.language,
+          title: collection.title,
+          kind: collection.kind,
+          visibility: collection.visibility,
+          createdAt: collection.createdAt,
         },
-        chapterCount: created.chapters.length,
+        textCount: created.texts.length,
       },
       { status: 201, headers: rateLimitHeaders(requestLimit) },
     );

--- a/apps/web/src/routes/api/v1/texts/epub/epub-server.test.ts
+++ b/apps/web/src/routes/api/v1/texts/epub/epub-server.test.ts
@@ -4,7 +4,7 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const createEpubText = vi.fn();
+const createChapterBookFromEpub = vi.fn();
 const requireUser = vi.fn();
 const consumeRateLimit = vi.fn();
 
@@ -14,7 +14,8 @@ vi.mock('$lib/server/texts/upload.js', async () => {
   );
   return {
     ...actual,
-    createEpubText: (...a: unknown[]) => createEpubText(...a),
+    createChapterBookFromEpub: (...a: unknown[]) =>
+      createChapterBookFromEpub(...a),
   };
 });
 
@@ -73,7 +74,7 @@ async function callPost(
 }
 
 beforeEach(() => {
-  createEpubText.mockReset();
+  createChapterBookFromEpub.mockReset();
   requireUser.mockReset();
   consumeRateLimit.mockReset();
   consumeRateLimit.mockResolvedValue({
@@ -88,20 +89,23 @@ afterEach(() => {
 });
 
 describe('POST /api/v1/texts/epub', () => {
-  it('returns 201 with chapterCount on a happy path', async () => {
-    createEpubText.mockResolvedValueOnce({
-      text: {
-        id: 'text-1',
+  it('returns 201 with the new collection on a multi-chapter EPUB', async () => {
+    createChapterBookFromEpub.mockResolvedValueOnce({
+      kind: 'collection',
+      collection: {
+        id: 'col-1',
         ownerId: USER.id,
         language: 'hi',
         title: 'My novel',
-        sourceType: 'epub',
-        status: 'pending',
+        kind: 'chapter_book',
         visibility: 'private',
         createdAt: new Date('2026-04-27T00:00:00Z'),
       },
-      chapter: { id: 'c0' },
-      chapters: [{ id: 'c0' }, { id: 'c1' }, { id: 'c2' }],
+      texts: [
+        { id: 'text-1' },
+        { id: 'text-2' },
+        { id: 'text-3' },
+      ],
     });
     const res = (await callPost({
       language: 'hi',
@@ -110,12 +114,43 @@ describe('POST /api/v1/texts/epub', () => {
     })) as Response;
     expect(res.status).toBe(201);
     const json = await res.json();
+    expect(json.kind).toBe('collection');
+    expect(json.collection.id).toBe('col-1');
+    expect(json.collection.kind).toBe('chapter_book');
+    expect(json.textCount).toBe(3);
+  });
+
+  it('returns 201 with a plain text on a single-chapter EPUB (fallback)', async () => {
+    createChapterBookFromEpub.mockResolvedValueOnce({
+      kind: 'text',
+      text: {
+        id: 'text-1',
+        ownerId: USER.id,
+        language: 'hi',
+        title: 'Solo',
+        sourceType: 'epub',
+        status: 'pending',
+        visibility: 'private',
+        createdAt: new Date('2026-04-27T00:00:00Z'),
+      },
+      chapter: { id: 'c0' },
+      chapters: [{ id: 'c0' }],
+    });
+    const res = (await callPost({
+      language: 'hi',
+      title: 'Solo',
+      file: buildEpubFile(),
+    })) as Response;
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.kind).toBe('text');
     expect(json.text.sourceType).toBe('epub');
-    expect(json.chapterCount).toBe(3);
+    expect(json.chapterCount).toBe(1);
   });
 
   it('falls back to the filename when no title is supplied', async () => {
-    createEpubText.mockResolvedValueOnce({
+    createChapterBookFromEpub.mockResolvedValueOnce({
+      kind: 'text',
       text: {
         id: 'text-1',
         ownerId: USER.id,
@@ -133,7 +168,7 @@ describe('POST /api/v1/texts/epub', () => {
       language: 'hi',
       file: buildEpubFile(undefined, 'A Hindi Novel.epub'),
     });
-    expect(createEpubText).toHaveBeenCalledWith(
+    expect(createChapterBookFromEpub).toHaveBeenCalledWith(
       { id: USER.id },
       expect.objectContaining({ title: 'A Hindi Novel' }),
     );
@@ -146,7 +181,7 @@ describe('POST /api/v1/texts/epub', () => {
       file: buildEpubFile(),
     })) as { status: number };
     expect(res.status).toBe(400);
-    expect(createEpubText).not.toHaveBeenCalled();
+    expect(createChapterBookFromEpub).not.toHaveBeenCalled();
   });
 
   it('rejects a missing file with 400', async () => {
@@ -167,7 +202,7 @@ describe('POST /api/v1/texts/epub', () => {
 
   it('maps EpubParseError to 400', async () => {
     const { EpubParseError } = await import('$lib/server/texts/upload.js');
-    createEpubText.mockRejectedValueOnce(new EpubParseError('bad zip'));
+    createChapterBookFromEpub.mockRejectedValueOnce(new EpubParseError('bad zip'));
     const res = (await callPost({
       language: 'hi',
       title: 'X',
@@ -182,6 +217,6 @@ describe('POST /api/v1/texts/epub', () => {
       null,
     )) as { status: number };
     expect(res.status).toBe(401);
-    expect(createEpubText).not.toHaveBeenCalled();
+    expect(createChapterBookFromEpub).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/routes/collections/[id]/+page.server.ts
+++ b/apps/web/src/routes/collections/[id]/+page.server.ts
@@ -91,18 +91,35 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 
   return {
     collection: detail.collection,
-    items: detail.items.map((i) => ({
-      position: i.position,
-      text: {
-        id: i.text.id,
-        title: i.text.title,
-        status: i.text.status,
-        sourceType: i.text.sourceType,
-      },
-      pctRead: progressByTextId[i.text.id]?.pctRead ?? 0,
-      lastChapterIdx:
-        progressByTextId[i.text.id]?.lastChapterIdx ?? 0,
-    })),
+    // Each item is one of two kinds:
+    //  - 'chapter' — a leaf chapter the user reads. Carries its parent
+    //    section name for grouped rendering.
+    //  - 'sectionAnchor' — a top-level Part-intro page that the
+    //    publisher's TOC nests over a group of chapters (item has
+    //    no section of its own, AND the next item's section equals
+    //    this item's title). Rendered as the group's clickable
+    //    section header instead of a duplicate chapter card.
+    items: detail.items.map((i, idx, arr) => {
+      const nextSection = arr[idx + 1]?.sectionTitle ?? null;
+      const isSectionAnchor =
+        i.sectionTitle === null &&
+        nextSection !== null &&
+        nextSection === i.text.title;
+      return {
+        position: i.position,
+        sectionTitle: i.sectionTitle,
+        isSectionAnchor,
+        text: {
+          id: i.text.id,
+          title: i.text.title,
+          status: i.text.status,
+          sourceType: i.text.sourceType,
+        },
+        pctRead: progressByTextId[i.text.id]?.pctRead ?? 0,
+        lastChapterIdx:
+          progressByTextId[i.text.id]?.lastChapterIdx ?? 0,
+      };
+    }),
     aggregatedPctRead,
     // T-8.6: completion stats badge — number of finished texts on
     // course-kind collections. Counts pctRead >= 100.

--- a/apps/web/src/routes/collections/[id]/+page.svelte
+++ b/apps/web/src/routes/collections/[id]/+page.svelte
@@ -1,10 +1,49 @@
 <script lang="ts">
   import { invalidateAll, goto } from '$app/navigation';
+  import Modal from '$lib/components/overlay/Modal.svelte';
   import type { PageData } from './$types';
 
   let { data }: { data: PageData } = $props();
 
   import { untrack } from 'svelte';
+
+  // Single shared confirmation modal — used in place of the native
+  // `window.confirm()` so the dialog matches the rest of the app's
+  // visual language (and so we can support styled bodies, focus
+  // trapping, etc.). Each caller fills in title/body/confirmLabel
+  // and an async handler.
+  let confirmState = $state<{
+    title: string;
+    body: string;
+    confirmLabel: string;
+    danger?: boolean;
+    onConfirm: () => Promise<void> | void;
+  } | null>(null);
+  let confirmRunning = $state(false);
+
+  function openConfirm(opts: {
+    title: string;
+    body: string;
+    confirmLabel: string;
+    danger?: boolean;
+    onConfirm: () => Promise<void> | void;
+  }) {
+    confirmState = opts;
+  }
+  function closeConfirm() {
+    if (confirmRunning) return;
+    confirmState = null;
+  }
+  async function runConfirm() {
+    if (!confirmState || confirmRunning) return;
+    confirmRunning = true;
+    try {
+      await confirmState.onConfirm();
+    } finally {
+      confirmRunning = false;
+      confirmState = null;
+    }
+  }
   // Drag-and-drop reorder. The dragged element's index is captured
   // on dragstart; on drop we splice the items array client-side
   // and POST the new order. Mouse only — keyboard reorder is a
@@ -83,13 +122,76 @@
     }
   }
 
-  async function removeItem(textId: string) {
-    if (!window.confirm('Remove this text from the collection?')) return;
-    const res = await fetch(
-      `/api/v1/collections/${data.collection.id}/items/${textId}`,
-      { method: 'DELETE' },
-    );
-    if (res.ok) await invalidateAll();
+  function removeItem(textId: string) {
+    const item = data.items.find((i) => i.text.id === textId);
+    openConfirm({
+      title: 'Remove from collection',
+      body: item
+        ? `Remove “${item.text.title}” from this collection? The text itself isn't deleted.`
+        : 'Remove this text from the collection?',
+      confirmLabel: 'Remove',
+      danger: true,
+      onConfirm: async () => {
+        const res = await fetch(
+          `/api/v1/collections/${data.collection.id}/items/${textId}`,
+          { method: 'DELETE' },
+        );
+        if (res.ok) await invalidateAll();
+      },
+    });
+  }
+
+  // Re-dispatch NLP processing for member texts. Two modes:
+  //  - stuck rescue: when any chapter is `pending` or `failed`, the
+  //    button targets just those (POST without body, server default).
+  //  - full re-run: when everything is `ready`, the button targets
+  //    every chapter (POST `{all: true}`) — useful after a
+  //    dictionary import where the existing tokenizations are stale.
+  const stuckCount = $derived(
+    data.items.filter(
+      (it) => it.text.status === 'pending' || it.text.status === 'failed',
+    ).length,
+  );
+  const reprocessLabel = 'Reprocess All';
+  let reprocessing = $state(false);
+  let reprocessMessage = $state<string | null>(null);
+  function reprocessAll() {
+    if (data.items.length === 0) return;
+    const all = stuckCount === 0;
+    const target = all ? data.items.length : stuckCount;
+    openConfirm({
+      title: 'Reprocess chapters',
+      body: all
+        ? `Re-run NLP processing on all ${target} ${target === 1 ? 'chapter' : 'chapters'} in this collection? Existing tokens will be replaced.`
+        : `Reprocess ${target} stuck ${target === 1 ? 'chapter' : 'chapters'}? Already-ready chapters won't be touched.`,
+      confirmLabel: 'Reprocess',
+      onConfirm: async () => {
+        reprocessing = true;
+        reprocessMessage = null;
+        try {
+          const res = await fetch(
+            `/api/v1/collections/${data.collection.id}/reprocess`,
+            {
+              method: 'POST',
+              headers: all ? { 'content-type': 'application/json' } : {},
+              body: all ? JSON.stringify({ all: true }) : undefined,
+            },
+          );
+          if (!res.ok) {
+            reprocessMessage =
+              (await res.text().catch(() => '')) || `HTTP ${res.status}`;
+            return;
+          }
+          const body = (await res.json()) as { dispatched: number };
+          reprocessMessage = `Dispatched ${body.dispatched} ${
+            body.dispatched === 1 ? 'chapter' : 'chapters'
+          } — refresh in a few seconds to see status updates.`;
+          await invalidateAll();
+        } finally {
+          reprocessing = false;
+        }
+      },
+    });
   }
 
   // T-8.4 — manage sharing. Owner enters a recipient email; the API
@@ -147,7 +249,20 @@
       <span class="cd-pill">{data.collection.language}</span>
       <span class="cd-pill">{data.collection.visibility}</span>
       <span class="cd-pill">{data.items.length} {data.items.length === 1 ? 'text' : 'texts'}</span>
+      {#if data.isOwner && data.items.length > 0}
+        <button
+          type="button"
+          class="cd-pill-btn"
+          onclick={reprocessAll}
+          disabled={reprocessing}
+        >
+          {reprocessing ? 'Dispatching…' : reprocessLabel}
+        </button>
+      {/if}
     </p>
+    {#if data.isOwner && reprocessMessage}
+      <p class="cd-muted" role="status">{reprocessMessage}</p>
+    {/if}
     {#if data.collection.description}
       <p class="cd-desc">{data.collection.description}</p>
     {/if}
@@ -170,36 +285,51 @@
     {/if}
   </header>
 
-  <ol class="cd-list">
+  <div class="cd-list" role="list">
     {#each data.items as item, i (item.text.id)}
-      <li
-        class="cd-item"
-        draggable={data.isOwner}
-        ondragstart={onDragStart(i)}
-        ondragover={onDragOver}
-        ondrop={() => onDrop(i)}
-      >
-        <span class="cd-pos">{i + 1}</span>
-        <a class="cd-link" href={`/reader/${item.text.id}`}>{item.text.title}</a>
-        <span class="cd-status">{item.text.status}</span>
-        {#if item.pctRead > 0}
-          <span class="cd-pct">{Math.round(item.pctRead)}%</span>
+      {#if item.isSectionAnchor}
+        <!-- This spine item is the part-intro page that the publisher's
+             TOC nests over the next group of chapters. Render it as
+             the section header instead of a duplicate chapter card.
+             Link the header to its own reader page so the intro
+             content stays reachable. -->
+        <a class="cd-section cd-section-link" href={`/reader/${item.text.id}`}>
+          {item.text.title}
+        </a>
+      {:else}
+        {#if item.sectionTitle && (i === 0 || data.items[i - 1]?.sectionTitle !== item.sectionTitle) && !(data.items[i - 1]?.isSectionAnchor && data.items[i - 1]?.text.title === item.sectionTitle)}
+          <h3 class="cd-section">{item.sectionTitle}</h3>
         {/if}
-        {#if data.isOwner}
-          <button
-            type="button"
-            class="cd-remove"
-            aria-label="Remove from collection"
-            onclick={() => removeItem(item.text.id)}
-          >×</button>
-        {/if}
-      </li>
+        <div
+          class="cd-item"
+          role="listitem"
+          draggable={data.isOwner}
+          ondragstart={onDragStart(i)}
+          ondragover={onDragOver}
+          ondrop={() => onDrop(i)}
+        >
+          <span class="cd-pos">{i + 1}</span>
+          <a class="cd-link" href={`/reader/${item.text.id}`}>{item.text.title}</a>
+          <span class="cd-status">{item.text.status}</span>
+          {#if item.pctRead > 0}
+            <span class="cd-pct">{Math.round(item.pctRead)}%</span>
+          {/if}
+          {#if data.isOwner}
+            <button
+              type="button"
+              class="cd-remove"
+              aria-label="Remove from collection"
+              onclick={() => removeItem(item.text.id)}
+            >×</button>
+          {/if}
+        </div>
+      {/if}
     {:else}
-      <li class="cd-empty">
+      <p class="cd-empty">
         No texts in this collection yet.
-      </li>
+      </p>
     {/each}
-  </ol>
+  </div>
 
   {#if savingOrder}
     <p class="cd-muted">Saving new order…</p>
@@ -281,6 +411,35 @@
   {/if}
 </div>
 
+<Modal
+  open={confirmState !== null}
+  onClose={closeConfirm}
+  title={confirmState?.title ?? ''}
+  width={420}
+>
+  {#if confirmState}
+    <p class="confirm-body">{confirmState.body}</p>
+  {/if}
+  {#snippet footer()}
+    <button
+      type="button"
+      class="confirm-cancel"
+      onclick={closeConfirm}
+      disabled={confirmRunning}
+    >
+      Cancel
+    </button>
+    <button
+      type="button"
+      class={confirmState?.danger ? 'confirm-danger' : 'confirm-go'}
+      onclick={runConfirm}
+      disabled={confirmRunning}
+    >
+      {confirmRunning ? 'Working…' : (confirmState?.confirmLabel ?? 'Confirm')}
+    </button>
+  {/snippet}
+</Modal>
+
 <style>
   .cd {
     max-width: 48rem;
@@ -359,6 +518,40 @@
     display: flex;
     flex-direction: column;
     gap: 0.4rem;
+  }
+  /* Section heading rendered between groups of chapters that share
+     the same `section_title` (e.g. "Part 1: Make It Obvious").
+     Slightly heavier weight than the body but smaller than the
+     collection title so the hierarchy reads: collection → section
+     → chapter. Extra top margin separates each group. */
+  .cd-section {
+    margin: 0.9rem 0 0;
+    font-family: var(--font-serif, var(--font-ui));
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--ink, var(--color-fg));
+    letter-spacing: 0.01em;
+  }
+  /* First section header shouldn't add extra space above (the list's
+     own top margin already provides it). */
+  .cd-list > .cd-section:first-child {
+    margin-top: 0;
+  }
+  /* Section header that's also a link to the part-intro page. Same
+     typography as a plain section header; the underline + color
+     reveal that it's clickable. */
+  .cd-section-link {
+    display: block;
+    text-decoration: none;
+    color: var(--ink, var(--color-fg));
+  }
+  .cd-section-link:hover {
+    color: var(--accent, var(--color-accent));
+  }
+  .cd-section-link:focus-visible {
+    outline: 2px solid var(--accent, var(--color-accent));
+    outline-offset: 2px;
+    border-radius: 4px;
   }
   .cd-item {
     display: grid;
@@ -452,6 +645,82 @@
     cursor: pointer;
   }
   .cd-add-form button:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+  /* Pill-sized action button that lives alongside .cd-pill chips in
+     the meta row. Same height + radius as the pills. Filled accent +
+     paired ink for WCAG AA contrast (accent-on-transparent fails on
+     this surface). `margin-left: auto` pushes it to the far right of
+     the flex row, separating action from metadata. */
+  .cd-pill-btn {
+    margin-left: auto;
+    background: var(--accent, var(--color-accent));
+    color: var(--accent-ink, var(--color-bg));
+    border: 1px solid var(--accent, var(--color-accent));
+    border-radius: 999px;
+    padding: 0.18rem 0.7rem;
+    /* Label is slightly larger than the surrounding pills for
+       readability; tighter line-height keeps the overall box height
+       matched (pills inherit body line-height 1.5 at font-size
+       0.62rem ≈ 0.93rem leading; 0.75 * 1.24 ≈ 0.93rem). */
+    font-size: 0.75rem;
+    line-height: 1.24;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    font-weight: 600;
+    font-family: inherit;
+    cursor: pointer;
+  }
+  .cd-pill-btn:hover:not(:disabled) {
+    /* Darken the accent slightly so the hover state is detectable
+       without dropping contrast. */
+    background: color-mix(
+      in oklch,
+      var(--accent, var(--color-accent)) 85%,
+      var(--ink, var(--color-fg))
+    );
+  }
+  .cd-pill-btn:focus-visible {
+    outline: 2px solid var(--accent, var(--color-accent));
+    outline-offset: 2px;
+  }
+  .cd-pill-btn:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+  .confirm-body {
+    margin: 0;
+    color: var(--ink, var(--color-fg));
+    line-height: 1.4;
+  }
+  .confirm-cancel,
+  .confirm-go,
+  .confirm-danger {
+    min-height: 38px;
+    padding: 0 0.85rem;
+    border-radius: 6px;
+    font: inherit;
+    cursor: pointer;
+  }
+  .confirm-cancel {
+    background: transparent;
+    border: 1px solid var(--rule, var(--color-border));
+    color: var(--ink, var(--color-fg));
+  }
+  .confirm-go {
+    background: var(--accent, var(--color-accent));
+    color: var(--accent-ink, var(--color-bg));
+    border: 0;
+  }
+  .confirm-danger {
+    background: var(--err, #b94545);
+    color: #fff;
+    border: 0;
+  }
+  .confirm-cancel:disabled,
+  .confirm-go:disabled,
+  .confirm-danger:disabled {
     opacity: 0.55;
     cursor: not-allowed;
   }

--- a/apps/web/src/routes/library/+page.server.ts
+++ b/apps/web/src/routes/library/+page.server.ts
@@ -86,7 +86,7 @@ export const load: PageServerLoad = async ({ url, locals }) => {
     limit,
     offset,
   };
-  let collections: Array<{
+  type CollectionCard = {
     id: string;
     title: string;
     kind: string;
@@ -95,7 +95,14 @@ export const load: PageServerLoad = async ({ url, locals }) => {
     coverUrl: string | null;
     textCount: number;
     estimatedComprehensionPct: number | null;
-  }> = [];
+  };
+  let collections: CollectionCard[] = [];
+  // Chapter-book collections surfaced inline on the 'your' / 'official'
+  // tabs alongside texts — each book is one library card, never one
+  // card per chapter. The full collections catalog still lives on the
+  // dedicated Collections tab; this is just so users see their
+  // imported books in the place they expect them.
+  let chapterBookCards: CollectionCard[] = [];
   let collectionsPage = {
     totalCount: 0,
     limit,
@@ -111,6 +118,29 @@ export const load: PageServerLoad = async ({ url, locals }) => {
       { id: locals.user!.id },
       { limit, offset, language: language ?? undefined },
     );
+    // Surface chapter-book collections as library cards. We don't
+    // paginate these — a learner has at most a handful of imported
+    // books — they sit above the paginated texts.
+    const ownedCollections = await listCollectionsForUser(locals.user!.id);
+    const filtered = ownedCollections.filter(
+      (row) =>
+        row.collection.kind === 'chapter_book' &&
+        (!language || row.collection.language === language),
+    );
+    const compMap = await estimatedComprehensionForCollections(
+      locals.user!.id,
+      filtered.map((m) => m.collection.id),
+    );
+    chapterBookCards = filtered.map((row) => ({
+      id: row.collection.id,
+      title: row.collection.title,
+      kind: row.collection.kind,
+      language: row.collection.language,
+      visibility: row.collection.visibility,
+      coverUrl: row.collection.coverUrl,
+      textCount: row.textCount,
+      estimatedComprehensionPct: compMap.get(row.collection.id) ?? null,
+    }));
   } else if (tab === 'shared') {
     page = await listSharedTexts({ id: locals.user!.id }, { limit, offset });
   } else if (tab === 'collections') {
@@ -163,6 +193,31 @@ export const load: PageServerLoad = async ({ url, locals }) => {
       offset,
       language: language ?? undefined,
     });
+    // Same treatment for the official tab — official chapter-book
+    // collections surface as cards alongside standalone official
+    // texts. Anonymous viewers see no comprehension badge.
+    const officialCollections = await listOfficialCollections(
+      language ?? undefined,
+    );
+    const filtered = officialCollections.filter(
+      (row) => row.collection.kind === 'chapter_book',
+    );
+    const compMap = locals.user
+      ? await estimatedComprehensionForCollections(
+          locals.user.id,
+          filtered.map((m) => m.collection.id),
+        )
+      : new Map<string, number | null>();
+    chapterBookCards = filtered.map((row) => ({
+      id: row.collection.id,
+      title: row.collection.title,
+      kind: row.collection.kind,
+      language: row.collection.language,
+      visibility: row.collection.visibility,
+      coverUrl: row.collection.coverUrl,
+      textCount: row.textCount,
+      estimatedComprehensionPct: compMap.get(row.collection.id) ?? null,
+    }));
   }
 
   // T-10.2 text-card badge — same flow for the your / shared /
@@ -180,6 +235,7 @@ export const load: PageServerLoad = async ({ url, locals }) => {
     page,
     textComprehension: Object.fromEntries(textComprehension),
     collections,
+    chapterBookCards,
     collectionsPage,
     language,
     languages: Object.values(LANGUAGES).map((d) => ({

--- a/apps/web/src/routes/library/+page.svelte
+++ b/apps/web/src/routes/library/+page.svelte
@@ -9,10 +9,59 @@
   and a leading "Add a text" tile on the Your tab.
 -->
 <script lang="ts">
+  import { invalidateAll } from '$app/navigation';
   import { coverForId } from '$lib/components/library/cover.js';
+  import Modal from '$lib/components/overlay/Modal.svelte';
   import type { PageData } from './$types';
 
   let { data }: { data: PageData } = $props();
+
+  // Shared confirm-delete modal — used for both text cards and
+  // chapter-book collection cards. Native browser confirm() doesn't
+  // match the rest of the app's visual language (see
+  // feedback_ui_contrast: filled accent surfaces, focus traps, etc.).
+  let pendingDelete = $state<{
+    kind: 'text' | 'collection';
+    id: string;
+    title: string;
+  } | null>(null);
+  let deleting = $state(false);
+  let deleteError = $state<string | null>(null);
+
+  function askDeleteText(id: string, title: string) {
+    pendingDelete = { kind: 'text', id, title };
+    deleteError = null;
+  }
+  function askDeleteCollection(id: string, title: string) {
+    pendingDelete = { kind: 'collection', id, title };
+    deleteError = null;
+  }
+  function closeDelete() {
+    if (deleting) return;
+    pendingDelete = null;
+    deleteError = null;
+  }
+  async function confirmDelete() {
+    if (!pendingDelete || deleting) return;
+    deleting = true;
+    deleteError = null;
+    try {
+      const url =
+        pendingDelete.kind === 'text'
+          ? `/api/v1/texts/${pendingDelete.id}`
+          : `/api/v1/collections/${pendingDelete.id}`;
+      const res = await fetch(url, { method: 'DELETE' });
+      if (!res.ok) {
+        deleteError =
+          (await res.text().catch(() => '')) || `HTTP ${res.status}`;
+        return;
+      }
+      pendingDelete = null;
+      await invalidateAll();
+    } finally {
+      deleting = false;
+    }
+  }
 
   const activePage = $derived(
     data.tab === 'collections' ? data.collectionsPage : data.page,
@@ -146,36 +195,83 @@
         </a>
       {/each}
     {:else}
+      {#each data.chapterBookCards as col (col.id)}
+        <div class="lib-card-wrap">
+          <a class="card lib-card" href={`/collections/${col.id}`}>
+            <div class={`lib-cover cover-${coverForId(col.id)}`}>
+              <div class="cover-title">{col.title}</div>
+              <div class="cover-chips">
+                <span class="chip">chapter book</span>
+                {#if col.visibility !== 'private'}
+                  <span class="chip">{col.visibility}</span>
+                {/if}
+                {#if col.estimatedComprehensionPct !== null}
+                  <span class="chip chip-pct" title="Estimated comprehension">
+                    {col.estimatedComprehensionPct}% known
+                  </span>
+                {/if}
+              </div>
+            </div>
+            <div class="body">
+              <div class="kind-row">
+                <span class="kind-tag">book</span>
+                <span class="kind-meta">{col.textCount} {col.textCount === 1 ? 'chapter' : 'chapters'}</span>
+              </div>
+              <div class="title-dev">{col.title}</div>
+            </div>
+          </a>
+          {#if data.tab === 'your'}
+            <button
+              type="button"
+              class="lib-card-del"
+              aria-label="Delete {col.title}"
+              title="Delete"
+              onclick={() => askDeleteCollection(col.id, col.title)}
+            >×</button>
+          {/if}
+        </div>
+      {/each}
       {#each data.page.cards as card (card.id)}
         {@const pct = data.textComprehension?.[card.id] ?? null}
-        <a class="card lib-card" href={`/reader/${card.id}`}>
-          <div class={`lib-cover cover-${coverForId(card.id)}`}>
-            <div class="cover-title">{card.title}</div>
-            <div class="cover-chips">
-              <span class="chip status-{card.status}">{card.status}</span>
-              {#if card.visibility !== 'private'}
-                <span class="chip">{card.visibility}</span>
-              {/if}
-              {#if pct !== null}
-                <span class="chip chip-pct" title="Estimated comprehension">
-                  {pct}% known
-                </span>
-              {/if}
+        <div class="lib-card-wrap">
+          <a class="card lib-card" href={`/reader/${card.id}`}>
+            <div class={`lib-cover cover-${coverForId(card.id)}`}>
+              <div class="cover-title">{card.title}</div>
+              <div class="cover-chips">
+                <span class="chip status-{card.status}">{card.status}</span>
+                {#if card.visibility !== 'private'}
+                  <span class="chip">{card.visibility}</span>
+                {/if}
+                {#if pct !== null}
+                  <span class="chip chip-pct" title="Estimated comprehension">
+                    {pct}% known
+                  </span>
+                {/if}
+              </div>
             </div>
-          </div>
-          <div class="body">
-            <div class="kind-row">
-              <span class="kind-tag">{card.sourceType}</span>
-              <span class="kind-meta">{card.language}</span>
+            <div class="body">
+              <div class="kind-row">
+                <span class="kind-tag">{card.sourceType}</span>
+                <span class="kind-meta">{card.language}</span>
+              </div>
+              <div class="title-dev">{card.title}</div>
             </div>
-            <div class="title-dev">{card.title}</div>
-          </div>
-        </a>
+          </a>
+          {#if data.tab === 'your'}
+            <button
+              type="button"
+              class="lib-card-del"
+              aria-label="Delete {card.title}"
+              title="Delete"
+              onclick={() => askDeleteText(card.id, card.title)}
+            >×</button>
+          {/if}
+        </div>
       {/each}
     {/if}
   </div>
 
-  {#if data.tab === 'collections' ? data.collections.length === 0 : data.page.cards.length === 0}
+  {#if data.tab === 'collections' ? data.collections.length === 0 : data.page.cards.length === 0 && data.chapterBookCards.length === 0}
     <p class="empty">
       {#if data.tab === 'your'}
         You haven't uploaded any texts yet — try the
@@ -212,6 +308,47 @@
     </nav>
   {/if}
 </section>
+
+<Modal
+  open={pendingDelete !== null}
+  onClose={closeDelete}
+  title={pendingDelete?.kind === 'collection' ? 'Delete chapter book' : 'Delete text'}
+  width={420}
+>
+  {#if pendingDelete}
+    <p class="del-body">
+      Delete <strong>“{pendingDelete.title}”</strong>?
+      {#if pendingDelete.kind === 'collection'}
+        Every chapter, its tokens, audio, and progress goes with it.
+      {:else}
+        This removes the text, its chapters, tokens, audio, and
+        progress.
+      {/if}
+      It can't be undone.
+    </p>
+    {#if deleteError}
+      <p class="del-err" role="alert">{deleteError}</p>
+    {/if}
+  {/if}
+  {#snippet footer()}
+    <button
+      type="button"
+      class="del-cancel"
+      onclick={closeDelete}
+      disabled={deleting}
+    >
+      Cancel
+    </button>
+    <button
+      type="button"
+      class="del-confirm"
+      onclick={confirmDelete}
+      disabled={deleting}
+    >
+      {deleting ? 'Deleting…' : 'Delete'}
+    </button>
+  {/snippet}
+</Modal>
 
 <style>
   .content {
@@ -319,6 +456,94 @@
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
     gap: 1rem;
+  }
+
+  /* A wrapper so we can stack a delete affordance over the card link
+     without nesting a <button> inside an <a>. The wrapper itself has
+     no visual chrome — the card link still owns the card box. */
+  .lib-card-wrap {
+    position: relative;
+    display: flex;
+  }
+  .lib-card-wrap > .lib-card {
+    flex: 1;
+  }
+  .lib-card-del {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    z-index: 2;
+    width: 28px;
+    height: 28px;
+    border-radius: 999px;
+    border: 1px solid var(--card-edge, var(--color-border));
+    background: var(--paper, var(--color-bg));
+    color: var(--ink, var(--color-fg));
+    font-size: 1.2rem;
+    line-height: 1;
+    display: grid;
+    place-items: center;
+    cursor: pointer;
+    opacity: 0;
+    transition:
+      opacity 150ms ease,
+      background-color 150ms ease,
+      color 150ms ease;
+  }
+  .lib-card-wrap:hover .lib-card-del,
+  .lib-card-del:focus-visible {
+    opacity: 1;
+  }
+  .lib-card-del:hover,
+  .lib-card-del:focus-visible {
+    background: var(--err, #b94545);
+    color: #fff;
+    border-color: var(--err, #b94545);
+  }
+  .lib-card-del:focus-visible {
+    outline: 2px solid var(--accent, var(--color-accent));
+    outline-offset: 2px;
+  }
+  /* Touch / coarse-pointer devices have no hover state — keep the
+     delete affordance always visible so phone users can reach it. */
+  @media (hover: none) {
+    .lib-card-del {
+      opacity: 1;
+    }
+  }
+
+  .del-body {
+    margin: 0;
+    color: var(--ink, var(--color-fg));
+    line-height: 1.4;
+  }
+  .del-err {
+    margin: 0.6rem 0 0;
+    color: var(--err, #b94545);
+    font-size: 0.85rem;
+  }
+  .del-cancel,
+  .del-confirm {
+    min-height: 38px;
+    padding: 0 0.85rem;
+    border-radius: 6px;
+    font: inherit;
+    cursor: pointer;
+  }
+  .del-cancel {
+    background: transparent;
+    border: 1px solid var(--rule, var(--color-border));
+    color: var(--ink, var(--color-fg));
+  }
+  .del-confirm {
+    background: var(--err, #b94545);
+    color: #fff;
+    border: 0;
+  }
+  .del-cancel:disabled,
+  .del-confirm:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
   }
 
   .card {

--- a/apps/web/src/routes/reader/[textId]/+page.server.ts
+++ b/apps/web/src/routes/reader/[textId]/+page.server.ts
@@ -79,16 +79,26 @@ export const load: PageServerLoad = async ({ params, locals, url }) => {
   if (locals.user) {
     savedProgress = await getTextProgress(locals.user.id, params.textId);
   }
+  // `?endOfChapter=1` is the cross-text "prev" handoff: when a
+  // reader on page 1 of chapter N hits prev, they advance into the
+  // previous text's LAST page (last page of the last internal
+  // chapter). We treat this as a URL anchor so saved progress
+  // doesn't override it.
+  const endOfChapter = url.searchParams.get('endOfChapter') === '1';
   const hasUrlAnchor =
-    url.searchParams.has('chapter') || url.searchParams.has('token');
+    url.searchParams.has('chapter') ||
+    url.searchParams.has('token') ||
+    endOfChapter;
 
   // Clamp anchor params to valid ranges. A bad `?chapter=999` URL
   // shouldn't 500 — it should land on the first chapter.
-  const requestedChapter = readInt(
-    url,
-    'chapter',
-    !hasUrlAnchor && savedProgress ? savedProgress.lastChapterIdx : 0,
-  );
+  const requestedChapter = endOfChapter
+    ? result.chapters.length - 1
+    : readInt(
+        url,
+        'chapter',
+        !hasUrlAnchor && savedProgress ? savedProgress.lastChapterIdx : 0,
+      );
   const chapterIdx = Math.max(
     0,
     Math.min(requestedChapter, result.chapters.length - 1),
@@ -222,6 +232,7 @@ export const load: PageServerLoad = async ({ params, locals, url }) => {
     anchor: {
       chapterIdx,
       tokenIdx,
+      endOfChapter,
     },
     mode,
     showRomanization,

--- a/apps/web/src/routes/reader/[textId]/+page.svelte
+++ b/apps/web/src/routes/reader/[textId]/+page.svelte
@@ -85,7 +85,7 @@
       const body = (await res.json()) as { tokensWritten: number };
       reprocessFeedback = {
         kind: 'ok',
-        text: `Reprocessed — ${body.tokensWritten} tokens written.`,
+        text: `Reprocessed — ${body.tokensWritten} words written.`,
       };
       // Refresh the page-data so the new tokens render in place
       // without a full reload.
@@ -351,7 +351,10 @@
             {data.collectionContext.collectionTitle}
           </a>
           <span class="reader-coll-pos">
-            {data.collectionContext.position + 1}/{data.collectionContext.totalCount}
+            Chapter {data.collectionContext.position + 1} of {data.collectionContext.totalCount}
+            <span class="reader-coll-tokens">
+              · {data.chapters[data.anchor.chapterIdx]?.tokenCount?.toLocaleString() ?? 0} words
+            </span>
           </span>
           <span class="reader-coll-nav">
             {#if data.collectionContext.prevTextId}
@@ -488,6 +491,11 @@
       lineSpacing={readerSettings.lineSpacing}
       fontFamily={readerSettings.fontFamily}
       readingWidth={readerSettings.readingWidth}
+      prevTextId={data.collectionContext?.prevTextId ?? null}
+      nextTextId={data.collectionContext?.nextTextId ?? null}
+      collectionPosition={data.collectionContext?.position ?? null}
+      collectionTotal={data.collectionContext?.totalCount ?? null}
+      startAtEndOfChapter={data.anchor.endOfChapter ?? false}
     />
   {:else if data.mode === 'paged_scroll'}
     <ReaderScroll
@@ -629,6 +637,9 @@
   .reader-coll-pos {
     font-family: var(--font-mono-display, var(--font-mono));
     font-feature-settings: 'tnum';
+  }
+  .reader-coll-tokens {
+    color: var(--ink-3, var(--color-fg-muted));
   }
   .reader-coll-nav {
     display: flex;

--- a/apps/web/src/routes/reader/[textId]/page-server.test.ts
+++ b/apps/web/src/routes/reader/[textId]/page-server.test.ts
@@ -174,7 +174,11 @@ describe('/reader/[textId] loader', () => {
       mode: string;
       isOwner: boolean;
     };
-    expect(data.anchor).toEqual({ chapterIdx: 0, tokenIdx: 0 });
+    expect(data.anchor).toEqual({
+      chapterIdx: 0,
+      tokenIdx: 0,
+      endOfChapter: false,
+    });
     // Default reader_layout_mode is 'page' (matches the user_languages
     // column default — T-5.1b's loader reads through to that default).
     expect(data.mode).toBe('page');
@@ -185,8 +189,27 @@ describe('/reader/[textId] loader', () => {
     getReadableText.mockResolvedValueOnce(ownedTextWithChapters(5));
     const data = (await callLoad(
       `http://x/reader/${VALID_ID}?chapter=2&token=10`,
-    )) as { anchor: { chapterIdx: number; tokenIdx: number } };
-    expect(data.anchor).toEqual({ chapterIdx: 2, tokenIdx: 10 });
+    )) as { anchor: { chapterIdx: number; tokenIdx: number; endOfChapter: boolean } };
+    expect(data.anchor).toEqual({
+      chapterIdx: 2,
+      tokenIdx: 10,
+      endOfChapter: false,
+    });
+  });
+
+  it('honors ?endOfChapter=1 by landing on the last chapter', async () => {
+    getReadableText.mockResolvedValueOnce(ownedTextWithChapters(5));
+    const data = (await callLoad(
+      `http://x/reader/${VALID_ID}?endOfChapter=1`,
+    )) as { anchor: { chapterIdx: number; tokenIdx: number; endOfChapter: boolean } };
+    // 5 chapters → last index is 4. The reader component then
+    // jumps to the last *page* of that chapter via its own
+    // `pendingJumpToLast` effect.
+    expect(data.anchor).toEqual({
+      chapterIdx: 4,
+      tokenIdx: 0,
+      endOfChapter: true,
+    });
   });
 
   it('clamps a chapter param above the chapter count to the last chapter', async () => {

--- a/apps/web/src/routes/upload/+page.server.ts
+++ b/apps/web/src/routes/upload/+page.server.ts
@@ -17,15 +17,18 @@ import { fail, redirect } from '@sveltejs/kit';
 import { z } from 'zod';
 
 import {
-  createEpubText,
+  createChapterBookFromEpub,
+  createChapterBookFromZip,
   createPastedText,
   createTxtText,
   EpubParseError,
   TextValidationError,
+  ZipParseError,
   MAX_EPUB_BYTES,
   MAX_PASTE_BYTES,
   MAX_TXT_BYTES,
   MAX_TITLE_LEN,
+  MAX_ZIP_BYTES,
   MIN_TITLE_LEN,
 } from '$lib/server/texts/upload.js';
 import { LANGUAGES, SUPPORTED_LANGUAGE_CODES } from '@ciareader/shared-types';
@@ -70,6 +73,7 @@ export const load: PageServerLoad = async ({ locals, url }) => {
       maxPasteBytes: MAX_PASTE_BYTES,
       maxTxtBytes: MAX_TXT_BYTES,
       maxEpubBytes: MAX_EPUB_BYTES,
+      maxZipBytes: MAX_ZIP_BYTES,
     },
   };
 };
@@ -91,6 +95,15 @@ export const actions: Actions = {
       title: fd.get('title')?.toString() ?? '',
       body: fd.get('body')?.toString() ?? '',
     };
+    if (!locals.user.emailVerifiedAt) {
+      return fail(403, {
+        ok: false,
+        message:
+          'Please verify your email before uploading. Check your inbox for the verification link.',
+        // Echo values so the user keeps their paste on resubmit.
+        values: raw,
+      });
+    }
     const parsed = formSchema.safeParse(raw);
     if (!parsed.success) {
       return fail(400, {
@@ -138,6 +151,14 @@ export const actions: Actions = {
   epub: async ({ request, locals }) => {
     if (!locals.user) {
       throw redirect(303, '/login?next=/upload');
+    }
+    if (!locals.user.emailVerifiedAt) {
+      return fail(403, {
+        ok: false,
+        section: 'epub',
+        message:
+          'Please verify your email before uploading. Check your inbox for the verification link.',
+      });
     }
     const fd = await request.formData();
     const language = fd.get('language')?.toString() ?? '';
@@ -193,11 +214,14 @@ export const actions: Actions = {
     }
     const epubBytes = new Uint8Array(await file.arrayBuffer());
     try {
-      const created = await createEpubText(
+      const created = await createChapterBookFromEpub(
         { id: locals.user.id },
         { language, title, epubBytes },
       );
-      throw redirect(303, `/reader/${created.text.id}`);
+      if (created.kind === 'text') {
+        throw redirect(303, `/reader/${created.text.id}`);
+      }
+      throw redirect(303, `/collections/${created.collection.id}`);
     } catch (err) {
       if (err instanceof TextValidationError) {
         return fail(err.status, {
@@ -210,6 +234,95 @@ export const actions: Actions = {
         return fail(400, {
           ok: false,
           section: 'epub',
+          message: err.message,
+        });
+      }
+      throw err;
+    }
+  },
+
+  zip: async ({ request, locals }) => {
+    if (!locals.user) {
+      throw redirect(303, '/login?next=/upload');
+    }
+    if (!locals.user.emailVerifiedAt) {
+      return fail(403, {
+        ok: false,
+        section: 'zip',
+        message:
+          'Please verify your email before uploading. Check your inbox for the verification link.',
+      });
+    }
+    const fd = await request.formData();
+    const language = fd.get('language')?.toString() ?? '';
+    const titleRaw = fd.get('title')?.toString() ?? '';
+    const file = fd.get('file');
+    if (language !== 'hi' && language !== 'mr' && language !== 'or') {
+      return fail(400, {
+        ok: false,
+        section: 'zip',
+        message: `Unsupported language '${language}'`,
+      });
+    }
+    if (!(file instanceof File)) {
+      return fail(400, {
+        ok: false,
+        section: 'zip',
+        message: 'Please select a .zip file to upload',
+      });
+    }
+    if (file.size === 0) {
+      return fail(400, {
+        ok: false,
+        section: 'zip',
+        message: 'ZIP file is empty',
+      });
+    }
+    if (file.size > MAX_ZIP_BYTES) {
+      return fail(400, {
+        ok: false,
+        section: 'zip',
+        message: `ZIP exceeds ${MAX_ZIP_BYTES.toLocaleString()} bytes`,
+      });
+    }
+    let title = titleRaw.trim();
+    if (title.length === 0) title = file.name.replace(/\.zip$/i, '').trim();
+    if (title.length < MIN_TITLE_LEN) {
+      return fail(400, {
+        ok: false,
+        section: 'zip',
+        message: 'title is required',
+      });
+    }
+    if (title.length > MAX_TITLE_LEN) {
+      return fail(400, {
+        ok: false,
+        section: 'zip',
+        message: `title exceeds ${MAX_TITLE_LEN} characters`,
+      });
+    }
+    const zipBytes = new Uint8Array(await file.arrayBuffer());
+    try {
+      const created = await createChapterBookFromZip(
+        { id: locals.user.id },
+        { language, title, zipBytes },
+      );
+      if (created.kind === 'text') {
+        throw redirect(303, `/reader/${created.text.id}`);
+      }
+      throw redirect(303, `/collections/${created.collection.id}`);
+    } catch (err) {
+      if (err instanceof TextValidationError) {
+        return fail(err.status, {
+          ok: false,
+          section: 'zip',
+          message: err.message,
+        });
+      }
+      if (err instanceof ZipParseError) {
+        return fail(400, {
+          ok: false,
+          section: 'zip',
           message: err.message,
         });
       }

--- a/apps/web/src/routes/upload/+page.svelte
+++ b/apps/web/src/routes/upload/+page.svelte
@@ -8,130 +8,231 @@
     form,
   }: { data: PageData; form: ActionData } = $props();
 
-  // Initial form state, prefilled from the last failed submission's
-  // echoed values so the user doesn't have to re-type their paste. We
-  // wrap the prop reads in `untrack` so Svelte 5 doesn't flag them as
-  // a reactivity mistake — we deliberately want a one-time snapshot,
-  // not a binding to the prop.
+  // Initial state seeded from any failed-submit echo (paste-action
+  // values), so the user keeps their work after a validation bounce.
   let language = $state(
     untrack(() => form?.values?.language ?? data.languages[0]!.code),
   );
   let title = $state(untrack(() => form?.values?.title ?? ''));
   let body = $state(untrack(() => form?.values?.body ?? ''));
-  // Tracks whether the body originated from a file drop; controls
-  // which byte cap applies and gets posted to the form action so the
-  // server picks the right service (createTxtText vs createPastedText).
-  // Echoed back on a failed submit so the user keeps their state.
-  let sourceType = $state<'paste' | 'txt'>(
+
+  // The active "mode" picks which form action runs and which fields
+  // get submitted. Drag/drop or file-pick flips it; the user can flip
+  // back manually too.
+  //
+  // 'paste' + 'txt' both submit to ?/paste — the difference is the
+  // byte cap (10MB vs 1MB) and the hidden sourceType marker.
+  // 'epub' submits to ?/epub. 'zip' submits to ?/zip.
+  let mode = $state<'paste' | 'txt' | 'epub' | 'zip'>(
     untrack(() => (form?.values?.sourceType === 'txt' ? 'txt' : 'paste')),
   );
+  let pickedFileName = $state<string | null>(null);
+  let pickedFileSize = $state(0);
   let dropMessage = $state<string | null>(null);
+  // The actual File object the user dropped or picked. Held separately
+  // so drag-and-drop (which can't directly mutate the <input>'s
+  // FileList) and the file picker behave identically — `use:enhance`'s
+  // submit callback below copies this into FormData before submission.
+  let pickedFile = $state<File | null>(null);
 
-  // The applicable byte cap depends on the source type — paste paths
-  // are tighter than .txt paths.
-  const maxBodyBytes = $derived(
-    sourceType === 'txt' ? data.limits.maxTxtBytes : data.limits.maxPasteBytes,
+  // The action attribute changes with mode so a single <form> can
+  // dispatch to three different handlers.
+  const formAction = $derived(
+    mode === 'epub'
+      ? '?/epub'
+      : mode === 'zip'
+        ? '?/zip'
+        : '?/paste',
   );
 
-  // Cheap UTF-8 byte count for the live counter — `TextEncoder` exists
-  // in every browser we care about. Match the server's caps so we can
-  // disable submit before hitting the wire.
+  const isTextMode = $derived(mode === 'paste' || mode === 'txt');
+  const isFileMode = $derived(mode === 'epub' || mode === 'zip');
+
+  const maxBodyBytes = $derived(
+    mode === 'txt' ? data.limits.maxTxtBytes : data.limits.maxPasteBytes,
+  );
   const byteCount = $derived(new TextEncoder().encode(body).byteLength);
   const overLimit = $derived(byteCount > maxBodyBytes);
 
-  async function handleFileDrop(file: File) {
+  // True from the moment the form is submitted until the server's
+  // response lands (or a redirect-navigation completes). Locks the
+  // submit button so a double-click can't fire two uploads and a
+  // big EPUB doesn't look frozen. Declared up here so the derivation
+  // below can see it.
+  let uploading = $state(false);
+
+  const submitDisabled = $derived(
+    uploading || (isTextMode ? overLimit : !pickedFileName),
+  );
+
+  // Used to force-remount the <input type="file"> when we reset back
+  // to paste — clears any FileList the input was carrying so a stale
+  // EPUB doesn't ride along with a subsequent paste submission.
+  let filePickerKey = $state(0);
+
+  async function handleFile(file: File) {
     const lower = file.name.toLowerCase();
     if (lower.endsWith('.epub')) {
-      dropMessage =
-        `EPUB '${file.name}' selected — upload it via the EPUB section below.`;
+      mode = 'epub';
+      pickedFile = file;
+      pickedFileName = file.name;
+      pickedFileSize = file.size;
+      if (!title) title = file.name.replace(/\.epub$/i, '');
+      dropMessage = null;
       return;
     }
-    if (!lower.endsWith('.txt')) {
-      dropMessage = `Unsupported file type: ${file.name}`;
+    if (lower.endsWith('.zip')) {
+      mode = 'zip';
+      pickedFile = file;
+      pickedFileName = file.name;
+      pickedFileSize = file.size;
+      if (!title) title = file.name.replace(/\.zip$/i, '');
+      dropMessage = null;
       return;
     }
-    if (file.size > data.limits.maxTxtBytes) {
-      dropMessage = `File is too large (max ${(
-        data.limits.maxTxtBytes / 1_000_000
-      ).toLocaleString()} MB).`;
+    if (lower.endsWith('.txt')) {
+      if (file.size > data.limits.maxTxtBytes) {
+        dropMessage = `File is too large (max ${(
+          data.limits.maxTxtBytes / 1_000_000
+        ).toLocaleString()} MB).`;
+        return;
+      }
+      try {
+        body = await file.text();
+        mode = 'txt';
+        pickedFile = null;
+        pickedFileName = null;
+        pickedFileSize = 0;
+        if (!title) title = file.name.replace(/\.txt$/i, '');
+        dropMessage = `Loaded ${file.name} (${(file.size / 1000).toFixed(1)} KB).`;
+      } catch {
+        dropMessage = `Failed to read ${file.name}.`;
+      }
       return;
     }
-    try {
-      const text = await file.text();
-      body = text;
-      sourceType = 'txt';
-      if (!title) title = file.name.replace(/\.txt$/i, '');
-      dropMessage = `Loaded ${file.name} (${(file.size / 1000).toFixed(1)} KB).`;
-    } catch {
-      dropMessage = `Failed to read ${file.name}.`;
-    }
+    dropMessage = `Unsupported file type: ${file.name}`;
   }
 
-  // The EPUB upload uses its own form action (multipart) rather than
-  // re-using the JSON paste/txt path. This separation keeps the JSON
-  // validator schema strict and avoids dragging EPUB-specific concerns
-  // (file picker, multipart, parser-driven errors) into the paste UI.
-  let epubLanguage = $state(
-    untrack(() => form?.values?.language ?? data.languages[0]!.code),
-  );
-  let epubTitle = $state('');
-  let epubFileName = $state<string | null>(null);
-  let epubFileSize = $state(0);
-
-  function onEpubPick(event: Event) {
-    const input = event.currentTarget as HTMLInputElement;
-    const file = input.files?.[0];
-    if (!file) {
-      epubFileName = null;
-      epubFileSize = 0;
-      return;
+  // use:enhance contract: the outer callback fires before the
+  // request goes out; the inner callback fires once the response is
+  // back. We:
+  //   - Copy the dropped/picked File into FormData (drag-and-drop
+  //     never touches the underlying <input>'s FileList, so without
+  //     this the server sees an empty file slot).
+  //   - Flip `uploading` true before send, false after the response.
+  //     On a 303-redirect success, `update()` runs SvelteKit's
+  //     navigation, which mounts a fresh page where this state no
+  //     longer matters.
+  function onSubmit({ formData }: { formData: FormData }) {
+    if (isFileMode && pickedFile) {
+      formData.set('file', pickedFile, pickedFile.name);
     }
-    epubFileName = file.name;
-    epubFileSize = file.size;
-    if (!epubTitle) epubTitle = file.name.replace(/\.epub$/i, '');
+    uploading = true;
+    return async ({ update }: { update: () => Promise<void> }) => {
+      try {
+        await update();
+      } finally {
+        uploading = false;
+      }
+    };
   }
 
-  const epubMessage = $derived(
-    form && 'section' in form && form.section === 'epub' && !form.ok
-      ? form.message
-      : null,
-  );
+  // Active drag-target highlight. Counts enter/leave events so that
+  // hovering over child elements (the file-pick label, the inner
+  // <p>) doesn't flicker the highlight off and on.
+  let dragDepth = $state(0);
+  const dragActive = $derived(dragDepth > 0);
 
-  function onDragOver(event: DragEvent) {
+  function onDragEnter(event: DragEvent) {
+    if (!event.dataTransfer?.types.includes('Files')) return;
     event.preventDefault();
+    dragDepth += 1;
+  }
+  function onDragLeave(event: DragEvent) {
+    if (!event.dataTransfer?.types.includes('Files')) return;
+    event.preventDefault();
+    dragDepth = Math.max(0, dragDepth - 1);
+  }
+  function onDragOver(event: DragEvent) {
+    if (!event.dataTransfer?.types.includes('Files')) return;
+    event.preventDefault();
+    // Hint to the browser that this is a copy gesture so the cursor
+    // updates appropriately.
+    event.dataTransfer.dropEffect = 'copy';
   }
 
   function onDrop(event: DragEvent) {
+    if (!event.dataTransfer?.types.includes('Files')) return;
     event.preventDefault();
+    dragDepth = 0;
     const file = event.dataTransfer?.files?.[0];
-    if (file) void handleFileDrop(file);
+    if (file) void handleFile(file);
   }
 
   function onFilePick(event: Event) {
     const target = event.currentTarget as HTMLInputElement;
     const file = target.files?.[0];
-    if (file) void handleFileDrop(file);
+    if (file) void handleFile(file);
   }
+
+  function resetToPaste() {
+    mode = 'paste';
+    pickedFile = null;
+    pickedFileName = null;
+    pickedFileSize = 0;
+    dropMessage = null;
+    // Remount the file input to drop any FileList it was carrying.
+    filePickerKey += 1;
+  }
+
+  const errorMessage = $derived(form && !form.ok ? form.message : null);
+
+  const submitLabel = $derived(
+    uploading
+      ? mode === 'epub'
+        ? 'Uploading EPUB…'
+        : mode === 'zip'
+          ? 'Uploading ZIP…'
+          : 'Uploading…'
+      : mode === 'epub'
+        ? 'Upload EPUB'
+        : mode === 'zip'
+          ? 'Upload ZIP'
+          : 'Upload text',
+  );
 </script>
 
 <svelte:head>
-  <title>Upload text — CIA Reader</title>
+  <title>Upload — CIA Reader</title>
 </svelte:head>
 
 <div class="page">
   <header>
     <h1>Upload a text</h1>
     <p class="sub">
-      Paste a passage or drop a <code>.txt</code> file. Texts are private to
-      your account by default — sharing options come later.
+      Paste a passage, drop a <code>.txt</code> file, or upload an
+      <code>.epub</code> or a <code>.zip</code> of
+      <code>.txt</code> files to import as a chapter-book collection.
+      Texts are private to your account by default.
     </p>
   </header>
 
-  {#if form && !form.ok}
-    <p class="err" role="alert">{form.message}</p>
+  {#if errorMessage}
+    <p class="err" role="alert">{errorMessage}</p>
   {/if}
 
-  <form method="post" action="?/paste" use:enhance class="stack">
+  <form
+    method="post"
+    action={formAction}
+    enctype="multipart/form-data"
+    use:enhance={onSubmit}
+    class="stack"
+    class:drag-active={dragActive}
+    ondragenter={onDragEnter}
+    ondragleave={onDragLeave}
+    ondragover={onDragOver}
+    ondrop={onDrop}
+  >
     <label>
       Language
       <select name="language" bind:value={language} required>
@@ -144,27 +245,36 @@
     </label>
 
     <label>
-      Title
+      Title {#if isFileMode}<span class="hint">(optional)</span>{/if}
       <input
         name="title"
         bind:value={title}
         maxlength={data.limits.maxTitleLength}
-        required
-        placeholder="e.g. Chapter 1 — A short story"
+        required={isTextMode}
+        placeholder={isFileMode
+          ? 'Defaults to the filename'
+          : 'e.g. Chapter 1 — A short story'}
       />
     </label>
 
     <div
       class="dropzone"
-      ondragover={onDragOver}
-      ondrop={onDrop}
+      class:active={dragActive}
       role="region"
       aria-label="File drop zone"
     >
       <p>
-        Drag &amp; drop a <code>.txt</code> file here, or
+        Drag &amp; drop a <code>.txt</code>, <code>.epub</code>, or
+        <code>.zip</code> file, or
         <label class="file-pick">
-          <input type="file" accept=".txt,.epub" onchange={onFilePick} />
+          {#key filePickerKey}
+            <input
+              type="file"
+              name="file"
+              accept=".txt,.epub,.zip"
+              onchange={onFilePick}
+            />
+          {/key}
           choose a file
         </label>
         .
@@ -172,104 +282,54 @@
       {#if dropMessage}
         <p class="drop-msg">{dropMessage}</p>
       {/if}
-    </div>
-
-    <input type="hidden" name="sourceType" value={sourceType} />
-
-    <label>
-      Body
-      <textarea
-        name="body"
-        bind:value={body}
-        rows="14"
-        required
-        placeholder="Paste your text here in the language's native script."
-      ></textarea>
-      <span class="counter" class:over={overLimit}>
-        {byteCount.toLocaleString()} / {maxBodyBytes.toLocaleString()} bytes
-        <span class="src">· {sourceType === 'txt' ? '.txt upload' : 'paste'}</span>
-        {#if sourceType === 'txt'}
-          <button
-            type="button"
-            class="reset"
-            onclick={() => {
-              sourceType = 'paste';
-              dropMessage = null;
-            }}
-          >
-            Treat as paste
-          </button>
-        {/if}
-      </span>
-    </label>
-
-    <button type="submit" disabled={overLimit}>Upload</button>
-  </form>
-
-  <hr class="divider" />
-
-  <section class="epub-section">
-    <h2>Upload an EPUB</h2>
-    <p class="sub">
-      Chapters are imported as authored — the EPUB's own table of
-      contents drives the chapter list. Up to {(
-        data.limits.maxEpubBytes / 1_000_000
-      ).toLocaleString()} MB.
-    </p>
-
-    {#if epubMessage}
-      <p class="err" role="alert">{epubMessage}</p>
-    {/if}
-
-    <form
-      method="post"
-      action="?/epub"
-      enctype="multipart/form-data"
-      use:enhance
-      class="stack"
-    >
-      <label>
-        Language
-        <select name="language" bind:value={epubLanguage} required>
-          {#each data.languages as lang (lang.code)}
-            <option value={lang.code}>
-              {lang.displayName} ({lang.nativeName})
-            </option>
-          {/each}
-        </select>
-      </label>
-
-      <label>
-        Title (optional — defaults to the filename)
-        <input
-          name="title"
-          bind:value={epubTitle}
-          maxlength={data.limits.maxTitleLength}
-          placeholder="e.g. The Far Pavilions"
-        />
-      </label>
-
-      <label>
-        EPUB file
-        <input
-          type="file"
-          name="file"
-          accept=".epub,application/epub+zip"
-          required
-          onchange={onEpubPick}
-        />
-      </label>
-
-      {#if epubFileName}
+      {#if isFileMode && pickedFileName}
         <p class="muted">
-          Selected: <code>{epubFileName}</code>
-          ({(epubFileSize / 1000).toFixed(1)} KB)
+          Selected: <code>{pickedFileName}</code>
+          ({(pickedFileSize / 1000).toFixed(1)} KB) — will be imported
+          as {mode === 'epub' ? 'an EPUB chapter book' : 'a ZIP chapter book'}.
+          <button type="button" class="reset" onclick={resetToPaste}>
+            Switch to paste
+          </button>
         </p>
       {/if}
+    </div>
 
-      <button type="submit" disabled={!epubFileName}>Upload EPUB</button>
-    </form>
-  </section>
+    {#if isTextMode}
+      <input type="hidden" name="sourceType" value={mode} />
+      <label>
+        Body
+        <textarea
+          name="body"
+          bind:value={body}
+          rows="14"
+          required
+          placeholder="Paste your text here in the language's native script."
+        ></textarea>
+        <span class="counter" class:over={overLimit}>
+          {byteCount.toLocaleString()} / {maxBodyBytes.toLocaleString()} bytes
+          <span class="src">· {mode === 'txt' ? '.txt upload' : 'paste'}</span>
+          {#if mode === 'txt'}
+            <button
+              type="button"
+              class="reset"
+              onclick={() => {
+                mode = 'paste';
+                dropMessage = null;
+              }}
+            >
+              Treat as paste
+            </button>
+          {/if}
+        </span>
+      </label>
+    {/if}
+
+    <button
+      type="submit"
+      disabled={submitDisabled}
+      aria-busy={uploading}
+    >{submitLabel}</button>
+  </form>
 </div>
 
 <style>
@@ -336,6 +396,37 @@
     color: var(--color-fg-muted);
     font-size: 0.9rem;
     margin-bottom: 0.75rem;
+    transition:
+      border-color 120ms ease,
+      background-color 120ms ease,
+      color 120ms ease;
+  }
+  /* Active drag-target state — fires when a file is being dragged
+     anywhere over the form (the form is the drop target so the
+     textarea also accepts files). Solid accent border + a very
+     light tint so users see exactly where to release, but text
+     keeps full WCAG AA contrast against the (mostly unchanged)
+     page-surface background. `--accent-ink` is paired with a solid
+     accent FILL only — never use it on a tinted-on-page surface
+     where the background is essentially the page color. */
+  .dropzone.active {
+    border-color: var(--accent, var(--color-accent));
+    border-style: solid;
+    background: color-mix(
+      in oklch,
+      var(--accent, var(--color-accent)) 6%,
+      transparent
+    );
+    color: var(--ink, var(--color-fg));
+  }
+  .dropzone.active code {
+    color: var(--ink, var(--color-fg));
+  }
+  /* Mirror the highlight on the textarea: just the accent border,
+     no bg tint. Tinting the textarea bg even slightly makes the
+     ink-on-paper contrast harder to hit in dark mode. */
+  form.drag-active textarea {
+    border-color: var(--accent, var(--color-accent));
   }
   .dropzone p {
     margin: 0.25rem 0;
@@ -366,7 +457,8 @@
     margin-left: 0.25rem;
     color: var(--color-fg-muted);
   }
-  .counter .reset {
+  .counter .reset,
+  .muted .reset {
     margin-left: 0.5rem;
     background: transparent;
     border: 1px solid var(--color-border);
@@ -385,18 +477,14 @@
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 0.85em;
   }
-  .divider {
-    border: 0;
-    border-top: 1px solid var(--color-border);
-    margin: 2rem 0 1.25rem;
-  }
-  .epub-section h2 {
-    margin: 0 0 0.4rem;
-    font-size: 1.2rem;
-  }
   .muted {
     color: var(--color-fg-muted);
     font-size: 0.85rem;
-    margin: 0 0 0.5rem;
+    margin: 0.5rem 0 0;
+  }
+  .hint {
+    color: var(--color-fg-muted);
+    font-weight: normal;
+    font-size: 0.85em;
   }
 </style>

--- a/apps/web/src/routes/upload/page-server.test.ts
+++ b/apps/web/src/routes/upload/page-server.test.ts
@@ -6,7 +6,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const createPastedText = vi.fn();
 const createTxtText = vi.fn();
-const createEpubText = vi.fn();
+const createChapterBookFromEpub = vi.fn();
+const createChapterBookFromZip = vi.fn();
 
 vi.mock('$lib/server/texts/upload.js', async () => {
   const actual = await vi.importActual<typeof import('$lib/server/texts/upload.js')>(
@@ -16,13 +17,23 @@ vi.mock('$lib/server/texts/upload.js', async () => {
     ...actual,
     createPastedText: (...a: unknown[]) => createPastedText(...a),
     createTxtText: (...a: unknown[]) => createTxtText(...a),
-    createEpubText: (...a: unknown[]) => createEpubText(...a),
+    createChapterBookFromEpub: (...a: unknown[]) =>
+      createChapterBookFromEpub(...a),
+    createChapterBookFromZip: (...a: unknown[]) =>
+      createChapterBookFromZip(...a),
   };
 });
 
 type Mod = typeof import('./+page.server.js');
 
-const USER = { id: 'user-1', role: 'user' as const };
+// Verified-by-default in tests — the upload actions gate on
+// emailVerifiedAt, so an unverified-user test sets this to null
+// explicitly.
+const USER = {
+  id: 'user-1',
+  role: 'user' as const,
+  emailVerifiedAt: new Date('2026-01-01T00:00:00Z'),
+};
 
 async function callLoad(user: typeof USER | null) {
   const { load } = (await import('./+page.server.js')) as Mod;
@@ -58,7 +69,8 @@ async function callAction(
 beforeEach(() => {
   createPastedText.mockReset();
   createTxtText.mockReset();
-  createEpubText.mockReset();
+  createChapterBookFromEpub.mockReset();
+  createChapterBookFromZip.mockReset();
 });
 
 async function callEpubAction(
@@ -76,6 +88,26 @@ async function callEpubAction(
   } as unknown as Parameters<Mod['actions']['epub']>[0];
   try {
     return await actions.epub!(event);
+  } catch (e) {
+    return e as { status: number; location?: string };
+  }
+}
+
+async function callZipAction(
+  fields: { language?: string; title?: string; file?: File | null },
+  user: typeof USER | null = USER,
+) {
+  const { actions } = (await import('./+page.server.js')) as Mod;
+  const fd = new FormData();
+  if (fields.language !== undefined) fd.append('language', fields.language);
+  if (fields.title !== undefined) fd.append('title', fields.title);
+  if (fields.file) fd.append('file', fields.file);
+  const event = {
+    locals: { user },
+    request: { formData: () => Promise.resolve(fd) } as unknown as Request,
+  } as unknown as Parameters<Mod['actions']['zip']>[0];
+  try {
+    return await actions.zip!(event);
   } catch (e) {
     return e as { status: number; location?: string };
   }
@@ -190,6 +222,19 @@ describe('/upload paste action', () => {
     expect(res.status).toBe(303);
     expect(res.location).toContain('/login');
   });
+
+  it('rejects unverified users with a 403 verification message', async () => {
+    const result = (await callAction(
+      { language: 'hi', title: 'X', body: 'hello' },
+      { ...USER, emailVerifiedAt: null } as unknown as typeof USER,
+    )) as {
+      status: number;
+      data: { ok: boolean; message: string };
+    };
+    expect(result.status).toBe(403);
+    expect(result.data.message).toMatch(/verify your email/i);
+    expect(createPastedText).not.toHaveBeenCalled();
+  });
 });
 
 describe('/upload epub action', () => {
@@ -198,11 +243,11 @@ describe('/upload epub action', () => {
     return new File([bytes], name, { type: 'application/epub+zip' });
   }
 
-  it('creates an EPUB-sourced text and 303s to it', async () => {
-    createEpubText.mockResolvedValueOnce({
-      text: { id: 'text-3', ownerId: USER.id },
-      chapter: { id: 'c0' },
-      chapters: [{ id: 'c0' }, { id: 'c1' }],
+  it('redirects to the new collection for a multi-chapter EPUB', async () => {
+    createChapterBookFromEpub.mockResolvedValueOnce({
+      kind: 'collection',
+      collection: { id: 'col-1', ownerId: USER.id },
+      texts: [{ id: 'text-a' }, { id: 'text-b' }],
     });
     const res = (await callEpubAction({
       language: 'hi',
@@ -210,15 +255,32 @@ describe('/upload epub action', () => {
       file: fakeFile(),
     })) as { status: number; location: string };
     expect(res.status).toBe(303);
-    expect(res.location).toBe('/reader/text-3');
-    expect(createEpubText).toHaveBeenCalledWith(
+    expect(res.location).toBe('/collections/col-1');
+    expect(createChapterBookFromEpub).toHaveBeenCalledWith(
       { id: USER.id },
       expect.objectContaining({ language: 'hi', title: 'My EPUB' }),
     );
   });
 
+  it('redirects to the reader for a single-chapter EPUB (fallback)', async () => {
+    createChapterBookFromEpub.mockResolvedValueOnce({
+      kind: 'text',
+      text: { id: 'text-3', ownerId: USER.id },
+      chapter: { id: 'c0' },
+      chapters: [{ id: 'c0' }],
+    });
+    const res = (await callEpubAction({
+      language: 'hi',
+      title: 'Solo',
+      file: fakeFile(),
+    })) as { status: number; location: string };
+    expect(res.status).toBe(303);
+    expect(res.location).toBe('/reader/text-3');
+  });
+
   it('falls back to filename when no title is given', async () => {
-    createEpubText.mockResolvedValueOnce({
+    createChapterBookFromEpub.mockResolvedValueOnce({
+      kind: 'text',
       text: { id: 'text-3', ownerId: USER.id },
       chapter: { id: 'c0' },
       chapters: [{ id: 'c0' }],
@@ -227,7 +289,7 @@ describe('/upload epub action', () => {
       language: 'hi',
       file: fakeFile(100, 'A Hindi Novel.epub'),
     });
-    expect(createEpubText).toHaveBeenCalledWith(
+    expect(createChapterBookFromEpub).toHaveBeenCalledWith(
       { id: USER.id },
       expect.objectContaining({ title: 'A Hindi Novel' }),
     );
@@ -244,7 +306,7 @@ describe('/upload epub action', () => {
     };
     expect(result.status).toBe(400);
     expect(result.data.section).toBe('epub');
-    expect(createEpubText).not.toHaveBeenCalled();
+    expect(createChapterBookFromEpub).not.toHaveBeenCalled();
   });
 
   it('rejects a missing file', async () => {
@@ -273,7 +335,7 @@ describe('/upload epub action', () => {
 
   it('surfaces an EpubParseError as a section=epub fail', async () => {
     const { EpubParseError } = await import('$lib/server/texts/upload.js');
-    createEpubText.mockRejectedValueOnce(new EpubParseError('bad zip'));
+    createChapterBookFromEpub.mockRejectedValueOnce(new EpubParseError('bad zip'));
     const result = (await callEpubAction({
       language: 'hi',
       title: 'X',
@@ -286,6 +348,26 @@ describe('/upload epub action', () => {
     expect(result.data.message).toMatch(/bad zip/);
   });
 
+  it('surfaces a language-mismatch as a section=epub fail with a clear message', async () => {
+    const { EpubLanguageMismatchError } = await import(
+      '$lib/server/texts/upload.js'
+    );
+    createChapterBookFromEpub.mockRejectedValueOnce(
+      new EpubLanguageMismatchError('mr', 'hi'),
+    );
+    const result = (await callEpubAction({
+      language: 'hi',
+      title: 'X',
+      file: fakeFile(),
+    })) as {
+      status: number;
+      data: { ok: boolean; section: string; message: string };
+    };
+    expect(result.status).toBe(400);
+    expect(result.data.section).toBe('epub');
+    expect(result.data.message).toMatch(/Marathi/);
+  });
+
   it('redirects unauthenticated EPUB submissions to /login', async () => {
     const res = (await callEpubAction(
       { language: 'hi', title: 'X', file: fakeFile() },
@@ -293,5 +375,121 @@ describe('/upload epub action', () => {
     )) as { status: number; location: string };
     expect(res.status).toBe(303);
     expect(res.location).toContain('/login');
+  });
+
+  it('rejects unverified users with a 403 verification message', async () => {
+    const result = (await callEpubAction(
+      { language: 'hi', title: 'X', file: fakeFile() },
+      { ...USER, emailVerifiedAt: null } as unknown as typeof USER,
+    )) as {
+      status: number;
+      data: { ok: boolean; section: string; message: string };
+    };
+    expect(result.status).toBe(403);
+    expect(result.data.section).toBe('epub');
+    expect(result.data.message).toMatch(/verify your email/i);
+    expect(createChapterBookFromEpub).not.toHaveBeenCalled();
+  });
+});
+
+describe('/upload zip action', () => {
+  function fakeFile(size = 100, name = 'book.zip') {
+    const bytes = new Uint8Array(size);
+    return new File([bytes], name, { type: 'application/zip' });
+  }
+
+  it('redirects to the new collection for a multi-file ZIP', async () => {
+    createChapterBookFromZip.mockResolvedValueOnce({
+      kind: 'collection',
+      collection: { id: 'col-9', ownerId: USER.id },
+      texts: [{ id: 't1' }, { id: 't2' }],
+    });
+    const res = (await callZipAction({
+      language: 'hi',
+      title: 'My ZIP',
+      file: fakeFile(),
+    })) as { status: number; location: string };
+    expect(res.status).toBe(303);
+    expect(res.location).toBe('/collections/col-9');
+    expect(createChapterBookFromZip).toHaveBeenCalledWith(
+      { id: USER.id },
+      expect.objectContaining({ language: 'hi', title: 'My ZIP' }),
+    );
+  });
+
+  it('redirects to the reader for a single-file ZIP (fallback)', async () => {
+    createChapterBookFromZip.mockResolvedValueOnce({
+      kind: 'text',
+      text: { id: 'text-zip', ownerId: USER.id },
+      chapter: { id: 'c0' },
+      chapters: [{ id: 'c0' }],
+    });
+    const res = (await callZipAction({
+      language: 'hi',
+      title: 'Solo',
+      file: fakeFile(),
+    })) as { status: number; location: string };
+    expect(res.status).toBe(303);
+    expect(res.location).toBe('/reader/text-zip');
+  });
+
+  it('falls back to filename when no title is given', async () => {
+    createChapterBookFromZip.mockResolvedValueOnce({
+      kind: 'text',
+      text: { id: 'text-zip', ownerId: USER.id },
+      chapter: { id: 'c0' },
+      chapters: [{ id: 'c0' }],
+    });
+    await callZipAction({
+      language: 'hi',
+      file: fakeFile(100, 'A Hindi Anthology.zip'),
+    });
+    expect(createChapterBookFromZip).toHaveBeenCalledWith(
+      { id: USER.id },
+      expect.objectContaining({ title: 'A Hindi Anthology' }),
+    );
+  });
+
+  it('rejects a missing file with a section=zip fail', async () => {
+    const result = (await callZipAction({
+      language: 'hi',
+      title: 'X',
+    })) as {
+      status: number;
+      data: { ok: boolean; section: string; message: string };
+    };
+    expect(result.status).toBe(400);
+    expect(result.data.section).toBe('zip');
+  });
+
+  it('surfaces a ZipParseError as a section=zip fail', async () => {
+    const { ZipParseError } = await import('$lib/server/texts/upload.js');
+    createChapterBookFromZip.mockRejectedValueOnce(
+      new ZipParseError('no top-level .txt'),
+    );
+    const result = (await callZipAction({
+      language: 'hi',
+      title: 'X',
+      file: fakeFile(),
+    })) as {
+      status: number;
+      data: { ok: boolean; section: string; message: string };
+    };
+    expect(result.status).toBe(400);
+    expect(result.data.section).toBe('zip');
+    expect(result.data.message).toMatch(/top-level/);
+  });
+
+  it('rejects unverified users with a 403 verification message', async () => {
+    const result = (await callZipAction(
+      { language: 'hi', title: 'X', file: fakeFile() },
+      { ...USER, emailVerifiedAt: null } as unknown as typeof USER,
+    )) as {
+      status: number;
+      data: { ok: boolean; section: string; message: string };
+    };
+    expect(result.status).toBe(403);
+    expect(result.data.section).toBe('zip');
+    expect(result.data.message).toMatch(/verify your email/i);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
         specifier: ^3.23.8
         version: 3.25.76
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@sveltejs/adapter-node':
         specifier: ^5.2.6
         version: 5.5.4(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.55.4(@typescript-eslint/types@8.59.0))(vite@5.4.21(@types/node@22.19.17)))(svelte@5.55.4(@typescript-eslint/types@8.59.0))(typescript@5.9.3)(vite@5.4.21(@types/node@22.19.17)))
@@ -939,6 +942,11 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
@@ -1777,6 +1785,11 @@ packages:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2114,6 +2127,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss-load-config@3.1.4:
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
@@ -3095,6 +3118,10 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
+
   '@polka/url@1.0.0-next.29': {}
 
   '@rollup/plugin-commonjs@29.0.2(rollup@4.60.2)':
@@ -3929,6 +3956,9 @@ snapshots:
       hasown: 2.0.3
       mime-types: 2.1.35
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -4260,6 +4290,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-load-config@3.1.4(postcss@8.5.10):
     dependencies:


### PR DESCRIPTION
## Summary

- EPUB and ZIP uploads now create a `chapter_book` collection with one `texts` row per chapter (linked via `collection_items`), so every chapter has its own status, progress, audio binding, and NLP job. Single-chapter files still land as a plain `texts` row.
- Reader page-mode prev/next walks into sibling texts at chapter boundaries; stepping prev from page 1 lands on the **last** page of the prior chapter via a `?endOfChapter=1` URL handoff. Chapter-step buttons get an open-book SVG glyph + an updated aria label.
- Word-based progress: each page advances the bar by `(words on that page / chapter total)`. Library cards for chapter books appear once; chapters are hidden from the standalone text list. Delete affordance added on both texts and chapter-book collections.
- Adds Playwright e2e infrastructure with auth + reader specs covering cross-text navigation, page counter, progress percentage, progress bar widths, and edge cases (sparse vs dense pages).

## What's in the box

**Uploads**

- Single consolidated upload form (paste / .txt / .epub / .zip). Drag-and-drop on the textarea or the dropzone; submit locks the button + shows in-flight state.
- EPUB: parses the publisher's nav doc (EPUB3 `nav.xhtml` or EPUB2 `toc.ncx`) for authoritative chapter titles + hierarchy. Part headings render as group dividers on the collection page; part-intro pages get merged into the section header. `dc:language` is verified against the dropdown and rejected on mismatch. Calibre auto-IDs and page-marker anchors fall back to "Untitled".
- ZIP: top-level `.txt` files, lexicographic order, filename minus `.txt` becomes the chapter title. Single-newline → paragraph break so per-line text files render correctly.
- Chapter titles are prepended to the body at creation time so the NLP pipeline tokenizes the title alongside the body — words in the title are clickable and tracked just like the rest.
- Email-verification gate added to `/upload` form actions to match the existing API endpoint behavior.

**Reader**

- Page-mode prev/next buttons honor sibling-text navigation at chapter boundaries. Different SVG glyph (book + chevron) + aria label when the click crosses a chapter.
- Chapter counter + footer percentages use the collection-level position for one-chapter chapter-book members (no more "Ch. 1 / 1").
- Word-based progress with per-page word counts from the DOM index. Sparse pages move the bar a little, dense pages move it a lot.

**Library + collection detail**

- Chapter-book collections render as a single card on the Yours and Official tabs (the chapters are hidden from the standalone text list). The Collections tab is unchanged.
- "Reprocess all" pill on the collection page reruns NLP for pending / failed / all chapters via the new `POST /api/v1/collections/:id/reprocess` endpoint.
- Red × delete affordance on Yours-tab cards (texts and chapter-book collections). Deleting a `chapter_book` cascades to its member texts in a single transaction.
- Modal-based confirm dialogs replace `window.confirm` on delete + reprocess flows.

**Schema (migrations 0040 + 0041)**

- `text_source_type` enum gains `'zip'`.
- `collection_items.section_title` (nullable text) — parent-section label from the publisher's TOC.

**API**

- `DELETE /api/v1/texts/:id` — owner-or-admin.
- `POST /api/v1/collections/:id/reprocess` — owner-or-admin; optional `{ all: true }` body to re-run NLP on already-ready chapters.
- `POST /api/v1/texts/epub` response shape changes: now `{ kind: 'collection', collection, textCount }` for multi-chapter EPUBs, `{ kind: 'text', text, chapterCount: 1 }` for single-chapter fallback.

**UI / accessibility**

- Dark-theme `--accent-ink` fixed from `oklch(0.86)` to `oklch(0.20)` so accent-filled buttons clear WCAG AA contrast. New `feedback_ui_contrast` memory documents the rule.
- Drag-and-drop on the upload form: solid accent border, faint accent-tinted background, full-contrast text. Drops anywhere on the form (including the textarea) are accepted.
- "tokens" → "words" everywhere user-facing in the reader (API docs + moderation surfaces left as "tokens").

## Test plan

- [x] Vitest: 1449 / 1449 passing. New coverage for ZIP parsing, EPUB nav + `dc:language`, junk-title detection, chapter-book collection helper, text delete, library filter, reprocess endpoint, and the new reader behaviors.
- [x] `pnpm typecheck` clean.
- [x] Playwright: `pnpm test:e2e` runs auth setup + reader specs. Covers cross-text navigation (prev lands on last page, next returns to page 1), page counter, progress bar widths, percentage range, and the dense-vs-sparse-page edge case.
- [ ] Manual smoke: upload a fresh EPUB and ZIP; confirm chapter-book collection appears on the Yours tab; click into a chapter; verify per-chapter NLP status, progress bar, and prev/next navigation. Verify drag-and-drop on the upload form. Verify the delete confirm modal.