### PR TITLE
Curator paradigm editor — admin /moderation/paradigms

### DIFF
--- a/apps/web/src/lib/components/toast/Toast.svelte
+++ b/apps/web/src/lib/components/toast/Toast.svelte
@@ -1,0 +1,115 @@
+<!--
+  Single toast row. Rendered by `ToastHost`; not meant to be used
+  directly elsewhere — pass through `pushToast()` instead so the
+  store stays the single source of truth.
+
+  The component owns its own auto-dismiss timer keyed off the
+  toast's `duration`. A `duration` of `null` makes the toast sticky;
+  the user can still close it via the × button.
+-->
+<script lang="ts">
+  import type { Toast as ToastType } from './toast-store.js';
+  import { dismissToast } from './toast-store.js';
+
+  let { toast }: { toast: ToastType } = $props();
+
+  // Auto-dismiss after `duration` ms. We re-arm the timer if the
+  // toast object identity changes (defensive — `ToastHost` keys
+  // children by id so this shouldn't normally happen, but the
+  // teardown still cleans up correctly).
+  $effect(() => {
+    if (toast.duration == null) return;
+    const t = window.setTimeout(() => dismissToast(toast.id), toast.duration);
+    return () => window.clearTimeout(t);
+  });
+</script>
+
+<div
+  class="toast"
+  class:success={toast.kind === 'success'}
+  class:error={toast.kind === 'error'}
+  class:info={toast.kind === 'info'}
+  role={toast.kind === 'error' ? 'alert' : 'status'}
+  aria-live={toast.kind === 'error' ? 'assertive' : 'polite'}
+>
+  <span class="msg">{toast.message}</span>
+  <button
+    type="button"
+    class="close"
+    aria-label="Dismiss notification"
+    onclick={() => dismissToast(toast.id)}
+  >
+    ×
+  </button>
+</div>
+
+<style>
+  /*
+   * Surface + stripe design.
+   *
+   * Solid `--color-surface-1` background and `--color-fg` text — both
+   * read from the active theme so the toast is legible on light,
+   * sepia, and dark with WCAG AA contrast (no accent-on-transparent
+   * for text — see the project's UI contrast rule). The toast's
+   * "kind" is signalled by a 4px left stripe coloured with the
+   * semantic token for that kind; the message itself never sits on a
+   * tinted background, so contrast is always toast-bg-vs-fg.
+   */
+  .toast {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    min-width: 16rem;
+    max-width: 28rem;
+    padding: 0.65rem 0.85rem;
+    border-radius: 8px;
+    background: var(--color-surface-1);
+    color: var(--color-fg);
+    border: 1px solid var(--color-border);
+    border-left: 4px solid var(--color-fg-subtle);
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.15);
+    font-size: 0.9rem;
+    line-height: 1.4;
+    animation: toast-in 180ms ease-out;
+  }
+  .toast.success {
+    border-left-color: var(--color-success);
+  }
+  .toast.error {
+    border-left-color: var(--color-danger);
+  }
+  .toast.info {
+    border-left-color: var(--color-accent);
+  }
+  .msg {
+    flex: 1;
+  }
+  .close {
+    flex: 0 0 auto;
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: currentColor;
+    border-radius: 4px;
+    font-size: 1.2rem;
+    line-height: 1;
+    cursor: pointer;
+    opacity: 0.65;
+  }
+  .close:hover {
+    opacity: 1;
+    background: rgba(0, 0, 0, 0.06);
+  }
+  @keyframes toast-in {
+    from {
+      opacity: 0;
+      transform: translateY(8px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+</style>

--- a/apps/web/src/lib/components/toast/ToastHost.svelte
+++ b/apps/web/src/lib/components/toast/ToastHost.svelte
@@ -1,0 +1,47 @@
+<!--
+  Fixed-position stack that renders every active toast from the
+  `toasts` store. Mount this once in the root layout — `pushToast()`
+  from anywhere in the app routes through here.
+-->
+<script lang="ts">
+  import { toasts } from './toast-store.js';
+  import Toast from './Toast.svelte';
+</script>
+
+<div class="toast-host" aria-label="Notifications">
+  {#each $toasts as t (t.id)}
+    <Toast toast={t} />
+  {/each}
+</div>
+
+<style>
+  /* The host itself is non-blocking; each toast turns pointer-events
+     back on for its own clickable surface. That way an empty host
+     never intercepts a click on the page underneath. */
+  .toast-host {
+    position: fixed;
+    bottom: 1rem;
+    right: 1rem;
+    z-index: 100;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    pointer-events: none;
+  }
+  .toast-host > :global(.toast) {
+    pointer-events: auto;
+  }
+
+  /* On narrow viewports center the toasts horizontally — sitting in
+     a corner makes them hard to dismiss with thumb-reach. */
+  @media (max-width: 30rem) {
+    .toast-host {
+      left: 1rem;
+      right: 1rem;
+      align-items: center;
+    }
+    .toast-host > :global(.toast) {
+      width: 100%;
+    }
+  }
+</style>

--- a/apps/web/src/lib/components/toast/__fixtures__/RegenEffectFixture.svelte
+++ b/apps/web/src/lib/components/toast/__fixtures__/RegenEffectFixture.svelte
@@ -1,0 +1,36 @@
+<!--
+  Test fixture mirroring the regen-result → toast pattern used in
+  `/moderation/paradigms/[id]/+page.svelte`. The fixture exists as a
+  regression pin: the original bug ("$state-wrapped reference no
+  longer === source object") manifested here as Svelte aborting with
+  `effect_update_depth_exceeded` after toasts began stacking up.
+
+  The pattern below uses a **plain `let`** for `toastedInput`, NOT a
+  `$state` rune. Svelte 5 deeply proxies objects assigned into a
+  `$state` slot, so `someObject === toastedInput` is permanently
+  false after the assignment, the effect's guard fails, the effect
+  re-fires (because `toastedInput` is tracked), and the loop pushes
+  a fresh toast every tick.
+
+  If a future refactor "tidies up" by switching this back to $state,
+  the test in `regen-effect.test.ts` will fail loudly. Keep it as
+  plain `let`.
+-->
+<script lang="ts">
+  import { pushToast } from '../toast-store.js';
+
+  type Input = { ok: true; lemmasProcessed: number; removed: number; inserted: number };
+  let { input }: { input: Input | null } = $props();
+
+  let toastedInput: unknown = null;
+  $effect(() => {
+    if (!input || input === toastedInput) return;
+    toastedInput = input;
+    pushToast({
+      kind: 'success',
+      message: `Regenerated ${input.lemmasProcessed} · removed ${input.removed} · inserted ${input.inserted}`,
+    });
+  });
+</script>
+
+<div data-testid="fixture"></div>

--- a/apps/web/src/lib/components/toast/regen-effect.test.ts
+++ b/apps/web/src/lib/components/toast/regen-effect.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+/**
+ * Reproduces the "Regenerating… toast spammed dozens of times" bug
+ * reported against /moderation/paradigms/[id].
+ *
+ * Why this test exists: in Svelte 5, `let foo = $state(null); foo =
+ * someObject;` wraps `someObject` in a Proxy — so `someObject === foo`
+ * is `false` thereafter. The page's guard
+ *     if (!regenResult || regenResult === toastedRegenResult) return;
+ * uses reference-equality against a `$state`-typed slot, which fails
+ * permanently the moment the slot is assigned. The effect then fires
+ * on every reactive tick and pushes a fresh toast each time.
+ *
+ * The fixture mirrors the page's pattern in two lines so the bug can
+ * be exercised in jsdom under a few ms instead of a full Playwright
+ * boot. Once the page swaps the `$state` guard for a non-reactive
+ * `let`, this test pins it to exactly one toast.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import { get } from 'svelte/store';
+
+import { clearToasts, toasts } from './toast-store.js';
+import RegenEffectFixture from './__fixtures__/RegenEffectFixture.svelte';
+
+afterEach(() => {
+  cleanup();
+  clearToasts();
+});
+
+describe('regen-result → toast effect (reproduction)', () => {
+  it('pushes exactly one toast for a stable input prop', async () => {
+    const input = {
+      ok: true as const,
+      lemmasProcessed: 1,
+      removed: 36,
+      inserted: 36,
+    };
+    render(RegenEffectFixture, { input });
+    // Drain the microtask queue so $effect runs to completion +
+    // any re-entrant re-runs settle. If the bug is present, the
+    // guard fails on the second tick, the assignment re-fires the
+    // effect, and the loop pushes a fresh toast on every tick.
+    await tick();
+    await tick();
+    await tick();
+    expect(get(toasts)).toHaveLength(1);
+  });
+
+  it('pushes a second toast only when the prop reference changes', async () => {
+    const inputA = {
+      ok: true as const,
+      lemmasProcessed: 1,
+      removed: 36,
+      inserted: 36,
+    };
+    const inputB = {
+      ok: true as const,
+      lemmasProcessed: 2,
+      removed: 70,
+      inserted: 72,
+    };
+    const { rerender } = render(RegenEffectFixture, { input: inputA });
+    await tick();
+    expect(get(toasts)).toHaveLength(1);
+
+    // Same content, different reference → should fire again. This
+    // matches what SvelteKit's `form` prop does after a fresh
+    // action submission: the curator clicks Regenerate again and a
+    // new response arrives, even if the numbers happen to match.
+    await rerender({ input: { ...inputA } });
+    await tick();
+    expect(get(toasts)).toHaveLength(2);
+
+    // Different content, different reference → still one new toast.
+    await rerender({ input: inputB });
+    await tick();
+    expect(get(toasts)).toHaveLength(3);
+  });
+
+  it('does not push when the prop is null', async () => {
+    render(RegenEffectFixture, { input: null });
+    await tick();
+    await tick();
+    expect(get(toasts)).toHaveLength(0);
+  });
+});

--- a/apps/web/src/lib/components/toast/toast-store.test.ts
+++ b/apps/web/src/lib/components/toast/toast-store.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment node
+/**
+ * Unit tests for the toast store.
+ *
+ * The store is a thin wrapper around `svelte/store#writable` exposing
+ * a push/dismiss/clear API. We exercise the subscribe contract +
+ * defaulting rules without mounting any Svelte component — the
+ * visual behaviour is component territory and tested via the Svelte
+ * UI in browser e2e if it ever becomes flaky.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { get } from 'svelte/store';
+
+import {
+  clearToasts,
+  dismissToast,
+  pushToast,
+  toasts,
+} from './toast-store.js';
+
+afterEach(() => {
+  clearToasts();
+});
+
+describe('pushToast', () => {
+  it('appends a toast with the supplied fields and returns the id', () => {
+    const id = pushToast({ kind: 'success', message: 'Saved' });
+    const list = get(toasts);
+    expect(list).toHaveLength(1);
+    expect(list[0]!.id).toBe(id);
+    expect(list[0]!.kind).toBe('success');
+    expect(list[0]!.message).toBe('Saved');
+    expect(list[0]!.duration).toBe(5000);
+  });
+
+  it('defaults `kind` to "info" when omitted', () => {
+    pushToast({ message: 'Heads up' });
+    expect(get(toasts)[0]!.kind).toBe('info');
+  });
+
+  it('honors a custom `duration`', () => {
+    pushToast({ message: 'quick', duration: 1500 });
+    expect(get(toasts)[0]!.duration).toBe(1500);
+  });
+
+  it('keeps the toast sticky when `duration` is null', () => {
+    pushToast({ message: 'sticky', duration: null });
+    expect(get(toasts)[0]!.duration).toBeNull();
+  });
+
+  it('returns unique ids across rapid calls', () => {
+    const a = pushToast({ message: 'a' });
+    const b = pushToast({ message: 'b' });
+    const c = pushToast({ message: 'c' });
+    expect(new Set([a, b, c]).size).toBe(3);
+    expect(get(toasts)).toHaveLength(3);
+  });
+});
+
+describe('dismissToast', () => {
+  it('removes the targeted toast and leaves the rest', () => {
+    const a = pushToast({ message: 'a' });
+    const b = pushToast({ message: 'b' });
+    dismissToast(a);
+    const list = get(toasts);
+    expect(list).toHaveLength(1);
+    expect(list[0]!.id).toBe(b);
+  });
+
+  it('is a no-op when the id is unknown', () => {
+    pushToast({ message: 'still here' });
+    dismissToast('does-not-exist');
+    expect(get(toasts)).toHaveLength(1);
+  });
+});
+
+describe('clearToasts', () => {
+  it('empties the store', () => {
+    pushToast({ message: 'a' });
+    pushToast({ message: 'b' });
+    clearToasts();
+    expect(get(toasts)).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/components/toast/toast-store.ts
+++ b/apps/web/src/lib/components/toast/toast-store.ts
@@ -1,0 +1,71 @@
+/**
+ * App-wide toast store.
+ *
+ * Anything that wants to surface a transient notification calls
+ * `pushToast({ kind, message, duration? })`. A single `<ToastHost />`
+ * in the root layout subscribes to this store and renders the active
+ * stack — callers never need to mount anything component-side.
+ *
+ * The store is a plain Svelte `writable` so it works equally well
+ * inside `.svelte` components (`$store` syntax) and `.ts` modules
+ * (the imperative API below). Toasts auto-dismiss after `duration`
+ * ms; pass `duration: null` for a sticky toast the user has to
+ * close by hand.
+ */
+import { writable, type Readable } from 'svelte/store';
+
+export type ToastKind = 'success' | 'error' | 'info';
+
+export type Toast = {
+  /** Stable id for keying + programmatic dismiss. */
+  id: string;
+  kind: ToastKind;
+  message: string;
+  /** ms before auto-dismiss; `null` means sticky. */
+  duration: number | null;
+};
+
+const inner = writable<Toast[]>([]);
+
+/**
+ * Read-only view of the active toasts. Public consumers shouldn't
+ * mutate the list directly — they go through the helpers below so the
+ * store stays the single mutation point.
+ */
+export const toasts: Readable<Toast[]> = { subscribe: inner.subscribe };
+
+let counter = 0;
+
+export type PushToastInput = {
+  kind?: ToastKind;
+  message: string;
+  /** Defaults to 5000ms. Pass `null` to make the toast sticky. */
+  duration?: number | null;
+};
+
+/**
+ * Append a toast to the stack and return its id. The id can be
+ * passed to `dismissToast` to remove it programmatically (useful
+ * when a long-running operation wants to clear a "loading…" toast
+ * once it succeeds).
+ */
+export function pushToast(input: PushToastInput): string {
+  counter += 1;
+  const id = `toast-${counter}-${Date.now()}`;
+  const toast: Toast = {
+    id,
+    kind: input.kind ?? 'info',
+    message: input.message,
+    duration: input.duration === undefined ? 5000 : input.duration,
+  };
+  inner.update((list) => [...list, toast]);
+  return id;
+}
+
+export function dismissToast(id: string): void {
+  inner.update((list) => list.filter((t) => t.id !== id));
+}
+
+export function clearToasts(): void {
+  inner.set([]);
+}

--- a/apps/web/src/lib/server/dictionary/lemma-forms-repo.test.ts
+++ b/apps/web/src/lib/server/dictionary/lemma-forms-repo.test.ts
@@ -1,0 +1,325 @@
+// @vitest-environment node
+/**
+ * Unit tests for the simple lemma_forms repository helpers in
+ * lemma-forms.ts. The list / create / update / delete / search /
+ * setLemmaParadigm / loadSurfaceToLemmaMap helpers all accept a
+ * `dbHandle: DbLike = db` parameter, so we can hand in a fake DB
+ * instead of mocking the module.
+ *
+ * `regenerateForms` (and its umbrella `regenerateAllForParadigm`)
+ * own their own tests + transaction handling; this file covers the
+ * lighter-weight repository surface.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createForm,
+  deleteForm,
+  listFormsForLemma,
+  loadSurfaceToLemmaMap,
+  searchFormsByPrefix,
+  setLemmaParadigm,
+  updateForm,
+} from './lemma-forms.js';
+
+type Call =
+  | { kind: 'select' }
+  | { kind: 'update'; set?: unknown }
+  | { kind: 'insert'; values?: unknown }
+  | { kind: 'delete' }
+  | { kind: 'execute'; sql?: unknown };
+const calls: Call[] = [];
+const staged: Array<unknown> = [];
+function stage(rows: unknown) {
+  staged.push(rows);
+}
+function nextStaged(): unknown {
+  if (staged.length === 0) throw new Error('Test bug: no staged result');
+  return staged.shift();
+}
+
+function makeSelectChain() {
+  const chain: Record<string, unknown> = {};
+  chain.from = vi.fn(() => chain);
+  chain.leftJoin = vi.fn(() => chain);
+  chain.innerJoin = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.orderBy = vi.fn(() => chain);
+  chain.limit = vi.fn(() => chain);
+  chain.then = (resolve: (v: unknown) => unknown) => resolve(nextStaged());
+  return chain;
+}
+
+function makeUpdateChain() {
+  const entry: Call = { kind: 'update' };
+  calls.push(entry);
+  const chain: Record<string, unknown> = {};
+  chain.set = vi.fn((v: unknown) => {
+    entry.set = v;
+    return chain;
+  });
+  chain.where = vi.fn(() => chain);
+  chain.returning = vi.fn(() => nextStaged());
+  return chain;
+}
+
+function makeInsertChain() {
+  const entry: Call = { kind: 'insert' };
+  calls.push(entry);
+  const chain: Record<string, unknown> = {};
+  chain.values = vi.fn((v: unknown) => {
+    entry.values = v;
+    return chain;
+  });
+  chain.returning = vi.fn(() => nextStaged());
+  return chain;
+}
+
+function makeDeleteChain() {
+  calls.push({ kind: 'delete' });
+  const chain: Record<string, unknown> = {};
+  chain.where = vi.fn(() => chain);
+  chain.then = (resolve: (v: unknown) => unknown) => resolve(undefined);
+  return chain;
+}
+
+const fakeDb = {
+  select: () => {
+    calls.push({ kind: 'select' });
+    return makeSelectChain();
+  },
+  update: () => makeUpdateChain(),
+  insert: () => makeInsertChain(),
+  delete: () => makeDeleteChain(),
+  execute: vi.fn((sql: unknown) => {
+    calls.push({ kind: 'execute', sql });
+    return nextStaged();
+  }),
+} as unknown as Parameters<typeof createForm>[1];
+
+beforeEach(() => {
+  calls.length = 0;
+  staged.length = 0;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('listFormsForLemma', () => {
+  it('shapes each joined row into a LemmaFormRow', async () => {
+    stage([
+      {
+        id: 'f-1',
+        surface: 'ରହିବା',
+        features: { VerbForm: 'Inf' },
+        romanization: 'rahibā',
+        createdBy: 'curator',
+        paradigmSlotId: 's-1',
+        paradigmSlotKey: 'inf',
+        paradigmSlotSort: 10,
+        quarantinedAt: null,
+        quarantineReason: null,
+      },
+    ]);
+    const rows = await listFormsForLemma('l-1', fakeDb);
+    expect(rows).toEqual([
+      {
+        id: 'f-1',
+        surface: 'ରହିବା',
+        features: { VerbForm: 'Inf' },
+        romanization: 'rahibā',
+        createdBy: 'curator',
+        paradigmSlotId: 's-1',
+        paradigmSlotKey: 'inf',
+        quarantinedAt: null,
+        quarantineReason: null,
+      },
+    ]);
+  });
+});
+
+describe('createForm', () => {
+  it('NFC-normalises surface and defaults features + romanization + createdBy', async () => {
+    stage([
+      {
+        id: 'f-new',
+        lemmaId: 'l-1',
+        surface: 'ବୋଲ',
+        features: {},
+        romanization: null,
+        createdBy: 'curator',
+      },
+    ]);
+    const row = await createForm(
+      {
+        lemmaId: 'l-1',
+        // explicitly decomposed input — verifies the NFC normalize path
+        surface: 'ବୋଲ',
+      },
+      fakeDb,
+    );
+    expect(row.id).toBe('f-new');
+    const insert = calls.find((c) => c.kind === 'insert')!;
+    expect(insert.values).toMatchObject({
+      lemmaId: 'l-1',
+      features: {},
+      romanization: null,
+      createdBy: 'curator',
+    });
+  });
+
+  it('respects an explicit createdBy override', async () => {
+    stage([{ id: 'f', createdBy: 'generator' }]);
+    await createForm(
+      {
+        lemmaId: 'l-1',
+        surface: 'x',
+        createdBy: 'generator',
+      },
+      fakeDb,
+    );
+    const insert = calls.find((c) => c.kind === 'insert')!;
+    expect((insert.values as { createdBy: string }).createdBy).toBe('generator');
+  });
+});
+
+describe('updateForm', () => {
+  it('promotes the row to curator and persists patch fields', async () => {
+    stage([{ id: 'f-1', createdBy: 'curator' }]);
+    const row = await updateForm(
+      'f-1',
+      {
+        surface: 'newsurface',
+        features: { Tense: 'Past' },
+        romanization: 'rom',
+      },
+      fakeDb,
+    );
+    expect(row).not.toBeNull();
+    const update = calls.find((c) => c.kind === 'update')!;
+    const set = update.set as Record<string, unknown>;
+    expect(set.createdBy).toBe('curator');
+    expect(set.surface).toBe('newsurface');
+    expect(set.features).toEqual({ Tense: 'Past' });
+    expect(set.romanization).toBe('rom');
+  });
+
+  it('returns null when the row id no longer exists', async () => {
+    stage([]);
+    const out = await updateForm('f-missing', { surface: 'x' }, fakeDb);
+    expect(out).toBeNull();
+  });
+
+  it('forwards quarantine fields when supplied', async () => {
+    stage([{ id: 'f-1' }]);
+    const at = new Date('2026-05-12');
+    await updateForm(
+      'f-1',
+      { quarantinedAt: at, quarantineReason: 'junk' },
+      fakeDb,
+    );
+    const update = calls.find((c) => c.kind === 'update')!;
+    expect(update.set).toMatchObject({
+      quarantinedAt: at,
+      quarantineReason: 'junk',
+    });
+  });
+});
+
+describe('deleteForm', () => {
+  it('issues a DELETE keyed by form id', async () => {
+    await deleteForm('f-1', fakeDb);
+    expect(calls.some((c) => c.kind === 'delete')).toBe(true);
+  });
+});
+
+describe('setLemmaParadigm', () => {
+  it('updates paradigm_id + stem on the lemma row', async () => {
+    stage([{ id: 'l-1', paradigmId: 'p-1', stem: 'बोल' }]);
+    const out = await setLemmaParadigm(
+      'l-1',
+      { paradigmId: 'p-1', stem: 'बोल' },
+      fakeDb,
+    );
+    expect(out!.paradigmId).toBe('p-1');
+    const update = calls.find((c) => c.kind === 'update')!;
+    expect(update.set).toMatchObject({ paradigmId: 'p-1', stem: 'बोल' });
+  });
+
+  it('returns null when no lemma matches', async () => {
+    stage([]);
+    const out = await setLemmaParadigm(
+      'l-missing',
+      { paradigmId: null, stem: null },
+      fakeDb,
+    );
+    expect(out).toBeNull();
+  });
+});
+
+describe('searchFormsByPrefix', () => {
+  it('returns an empty list for whitespace queries (no SQL fires)', async () => {
+    const out = await searchFormsByPrefix('hi', '   ', {}, fakeDb);
+    expect(out).toEqual([]);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('clamps the limit into [1, 100] and maps result rows', async () => {
+    stage({
+      rows: [
+        {
+          lemma_id: 'l-1',
+          headword: 'बोलना',
+          pos: 'VERB',
+          language: 'hi',
+          matched_surface: 'बोलते',
+        },
+      ],
+    });
+    const hits = await searchFormsByPrefix(
+      'hi',
+      'बोल',
+      { limit: 9999 },
+      fakeDb,
+    );
+    expect(hits).toEqual([
+      {
+        lemmaId: 'l-1',
+        headword: 'बोलना',
+        pos: 'VERB',
+        language: 'hi',
+        matchedSurface: 'बोलते',
+      },
+    ]);
+  });
+
+  it('handles a bare array shape (drizzle returns rows directly in some cases)', async () => {
+    stage([
+      {
+        lemma_id: 'l-2',
+        headword: 'पीना',
+        pos: 'VERB',
+        language: 'hi',
+        matched_surface: null,
+      },
+    ]);
+    const hits = await searchFormsByPrefix('hi', 'पी', {}, fakeDb);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.matchedSurface).toBeNull();
+  });
+});
+
+describe('loadSurfaceToLemmaMap', () => {
+  it('keeps the first lemmaId for each surface', async () => {
+    stage([
+      { surface: 'बोल', lemmaId: 'l-1' },
+      { surface: 'बोल', lemmaId: 'l-collision' },
+      { surface: 'पी', lemmaId: 'l-2' },
+    ]);
+    const map = await loadSurfaceToLemmaMap('hi', fakeDb);
+    expect(map.get('बोल')).toBe('l-1');
+    expect(map.get('पी')).toBe('l-2');
+    expect(map.size).toBe(2);
+  });
+});

--- a/apps/web/src/lib/server/dictionary/lemma-forms.ts
+++ b/apps/web/src/lib/server/dictionary/lemma-forms.ts
@@ -31,7 +31,7 @@ import { nlpClient } from '../nlp-client.js';
 import type { LanguageCode } from '@ciareader/shared-types';
 import type { Lemma, LemmaForm } from '../db/schema.js';
 
-import { generateForms, loadParadigm } from './paradigms.js';
+import { generateForms, listLemmasUsingParadigm, loadParadigm } from './paradigms.js';
 
 export type DbLike = typeof db;
 
@@ -354,6 +354,57 @@ export async function regenerateForms(
     }
     return { removed, inserted: generated.length };
   });
+}
+
+export type ParadigmRegenSummary = {
+  lemmasProcessed: number;
+  lemmasFailed: number;
+  removed: number;
+  inserted: number;
+  failures: Array<{ lemmaId: string; headword: string; error: string }>;
+};
+
+/**
+ * Regenerate forms for every lemma that opts into a given paradigm.
+ *
+ * Driven by the paradigm editor's "Regenerate forms" prompt — when
+ * the curator saves a slot edit (suffix, features, key), the
+ * generator-emitted rows on every affected lemma are now stale
+ * w.r.t. the paradigm. This helper walks the lemma list and calls
+ * `regenerateForms` on each, swallowing per-lemma failures so one
+ * bad row doesn't block the rest.
+ *
+ * Each lemma's regen is its own transaction (see `regenerateForms`),
+ * so the cumulative state is consistent: even if half the loop fails
+ * the successful half's rows are committed.
+ */
+export async function regenerateAllForParadigm(
+  paradigmId: string,
+): Promise<ParadigmRegenSummary> {
+  const lemmas = await listLemmasUsingParadigm(paradigmId);
+  const summary: ParadigmRegenSummary = {
+    lemmasProcessed: 0,
+    lemmasFailed: 0,
+    removed: 0,
+    inserted: 0,
+    failures: [],
+  };
+  for (const lemma of lemmas) {
+    try {
+      const result = await regenerateForms(lemma.id);
+      summary.removed += result.removed;
+      summary.inserted += result.inserted;
+      summary.lemmasProcessed += 1;
+    } catch (e) {
+      summary.lemmasFailed += 1;
+      summary.failures.push({
+        lemmaId: lemma.id,
+        headword: lemma.headword,
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
+  return summary;
 }
 
 /**

--- a/apps/web/src/lib/server/dictionary/lemma-forms.ts
+++ b/apps/web/src/lib/server/dictionary/lemma-forms.ts
@@ -377,11 +377,22 @@ export type ParadigmRegenSummary = {
  * Each lemma's regen is its own transaction (see `regenerateForms`),
  * so the cumulative state is consistent: even if half the loop fails
  * the successful half's rows are committed.
+ *
+ * The `lookupLemmas` + `regenerateLemma` parameters exist purely as
+ * test seams: same-module bindings can't be swapped via `vi.spyOn`,
+ * so unit tests pass mocked collaborators directly. Production
+ * callers leave them on their defaults.
  */
 export async function regenerateAllForParadigm(
   paradigmId: string,
+  deps: {
+    lookupLemmas?: typeof listLemmasUsingParadigm;
+    regenerateLemma?: (lemmaId: string) => Promise<RegenerateResult>;
+  } = {},
 ): Promise<ParadigmRegenSummary> {
-  const lemmas = await listLemmasUsingParadigm(paradigmId);
+  const lookup = deps.lookupLemmas ?? listLemmasUsingParadigm;
+  const regenLemma = deps.regenerateLemma ?? regenerateForms;
+  const lemmas = await lookup(paradigmId);
   const summary: ParadigmRegenSummary = {
     lemmasProcessed: 0,
     lemmasFailed: 0,
@@ -391,7 +402,7 @@ export async function regenerateAllForParadigm(
   };
   for (const lemma of lemmas) {
     try {
-      const result = await regenerateForms(lemma.id);
+      const result = await regenLemma(lemma.id);
       summary.removed += result.removed;
       summary.inserted += result.inserted;
       summary.lemmasProcessed += 1;

--- a/apps/web/src/lib/server/dictionary/paradigms.crud.test.ts
+++ b/apps/web/src/lib/server/dictionary/paradigms.crud.test.ts
@@ -1,0 +1,770 @@
+// @vitest-environment node
+/**
+ * Unit tests for the paradigm-editor service (curator-paradigm
+ * follow-up). The admin page at /moderation/paradigms calls these
+ * helpers; the page tests mock them, so the only place the actual
+ * query logic + validation rules are exercised is here.
+ *
+ * Pattern (matches curator.test.ts): we stage SELECT result rows in
+ * order, log every write payload, and pass a swapped-in `db` mock
+ * with chainable methods. `db.transaction` invokes the callback with
+ * the same mock so saveAllParadigmChanges can be exercised end-to-end
+ * without a real Postgres.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Call =
+  | { kind: 'select' }
+  | { kind: 'update'; set?: unknown }
+  | { kind: 'insert'; values?: unknown }
+  | { kind: 'delete' };
+const calls: Call[] = [];
+
+const staged: Array<unknown[]> = [];
+function stage(rows: unknown[]) {
+  staged.push(rows);
+}
+function nextStaged(): unknown[] {
+  const v = staged.shift();
+  if (!v) throw new Error('Test bug: no staged result available');
+  return v;
+}
+
+let insertFailure: Error | null = null;
+
+function makeSelectChain() {
+  const chain: Record<string, unknown> = {};
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.limit = vi.fn(() => chain);
+  chain.orderBy = vi.fn(() => chain);
+  chain.then = (resolve: (v: unknown) => unknown) => resolve(nextStaged());
+  return chain;
+}
+
+function makeUpdateChain() {
+  const entry: Call = { kind: 'update' };
+  calls.push(entry);
+  const chain: Record<string, unknown> = {};
+  chain.set = vi.fn((v: unknown) => {
+    entry.set = v;
+    return chain;
+  });
+  chain.where = vi.fn(() => chain);
+  chain.returning = vi.fn(() => nextStaged());
+  chain.then = (resolve: (v: unknown) => unknown) => resolve(undefined);
+  return chain;
+}
+
+function makeInsertChain() {
+  const entry: Call = { kind: 'insert' };
+  calls.push(entry);
+  const chain: Record<string, unknown> = {};
+  chain.values = vi.fn((v: unknown) => {
+    entry.values = v;
+    return chain;
+  });
+  chain.returning = vi.fn(() => {
+    if (insertFailure) {
+      const err = insertFailure;
+      insertFailure = null;
+      throw err;
+    }
+    return nextStaged();
+  });
+  chain.then = (resolve: (v: unknown) => unknown) => resolve(undefined);
+  return chain;
+}
+
+function makeDeleteChain() {
+  calls.push({ kind: 'delete' });
+  const chain: Record<string, unknown> = {};
+  chain.where = vi.fn(() => chain);
+  chain.returning = vi.fn(() => nextStaged());
+  chain.then = (resolve: (v: unknown) => unknown) => resolve(undefined);
+  return chain;
+}
+
+const dbMock = {
+  select: () => {
+    calls.push({ kind: 'select' });
+    return makeSelectChain();
+  },
+  update: () => makeUpdateChain(),
+  insert: () => makeInsertChain(),
+  delete: () => makeDeleteChain(),
+  transaction: async <T>(cb: (tx: unknown) => Promise<T>): Promise<T> => cb(dbMock),
+};
+
+vi.mock('../db/index.js', () => ({
+  db: dbMock,
+  schema: {
+    paradigms: {
+      id: 'paradigms.id',
+      language: 'paradigms.language',
+      pos: 'paradigms.pos',
+      name: 'paradigms.name',
+      description: 'paradigms.description',
+      updatedAt: 'paradigms.updated_at',
+    },
+    paradigmSlots: {
+      id: 'paradigm_slots.id',
+      paradigmId: 'paradigm_slots.paradigm_id',
+      slotKey: 'paradigm_slots.slot_key',
+      features: 'paradigm_slots.features',
+      suffix: 'paradigm_slots.suffix',
+      sortOrder: 'paradigm_slots.sort_order',
+    },
+    lemmas: {
+      id: 'lemmas.id',
+      headword: 'lemmas.headword',
+      pos: 'lemmas.pos',
+      language: 'lemmas.language',
+      paradigmId: 'lemmas.paradigm_id',
+      stem: 'lemmas.stem',
+    },
+  },
+}));
+
+const {
+  ParadigmValidationError,
+  countLemmasUsingParadigm,
+  createParadigm,
+  createSlot,
+  deleteParadigm,
+  deleteSlot,
+  listLemmasUsingParadigm,
+  listParadigms,
+  saveAllParadigmChanges,
+  updateParadigm,
+  updateSlot,
+} = await import('./paradigms.js');
+
+beforeEach(() => {
+  calls.length = 0;
+  staged.length = 0;
+  insertFailure = null;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function paradigmRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'p-1',
+    language: 'or',
+    pos: 'VERB',
+    name: 'Odia regular verb',
+    description: 'desc',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function slotRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 's-1',
+    paradigmId: 'p-1',
+    slotKey: 'inf',
+    features: { VerbForm: 'Inf' },
+    suffix: 'ିବା',
+    sortOrder: 10,
+    ...overrides,
+  };
+}
+
+describe('loadParadigm', () => {
+  it('returns the paradigm and its slots ordered by sortOrder', async () => {
+    stage([paradigmRow()]); // paradigm row
+    stage([slotRow(), slotRow({ id: 's-2', slotKey: 'past', sortOrder: 20 })]);
+    const loaded = await (
+      await import('./paradigms.js')
+    ).loadParadigm('p-1');
+    expect(loaded).not.toBeNull();
+    expect(loaded!.paradigm.id).toBe('p-1');
+    expect(loaded!.slots).toHaveLength(2);
+  });
+
+  it('returns null when the paradigm is unknown', async () => {
+    stage([]); // empty
+    const loaded = await (await import('./paradigms.js')).loadParadigm('p-x');
+    expect(loaded).toBeNull();
+  });
+});
+
+describe('listParadigmsForLemma', () => {
+  it('queries by language + pos', async () => {
+    stage([
+      paradigmRow({ language: 'hi', pos: 'NOUN' }),
+      paradigmRow({ id: 'p-2', language: 'hi', pos: 'NOUN', name: 'Another' }),
+    ]);
+    const rows = await (
+      await import('./paradigms.js')
+    ).listParadigmsForLemma('hi', 'NOUN');
+    expect(rows).toHaveLength(2);
+  });
+});
+
+describe('listParadigms', () => {
+  it('returns every paradigm when no filter is supplied', async () => {
+    stage([paradigmRow(), paradigmRow({ id: 'p-2', name: 'Other' })]);
+    const rows = await listParadigms();
+    expect(rows).toHaveLength(2);
+  });
+
+  it('filters by language', async () => {
+    stage([paradigmRow({ language: 'hi' })]);
+    const rows = await listParadigms({ language: 'hi' });
+    expect(rows[0]!.language).toBe('hi');
+  });
+
+  it('filters by pos (trimming whitespace)', async () => {
+    stage([paradigmRow()]);
+    const rows = await listParadigms({ pos: '  VERB  ' });
+    expect(rows).toHaveLength(1);
+  });
+
+  it('ignores an empty `pos` filter', async () => {
+    stage([paradigmRow()]);
+    await listParadigms({ pos: '' });
+    // Just verifying we don't crash on the trim-and-skip path.
+    expect(calls.filter((c) => c.kind === 'select')).toHaveLength(1);
+  });
+});
+
+describe('createParadigm', () => {
+  it('inserts a validated paradigm and returns the row', async () => {
+    stage([paradigmRow({ id: 'p-new' })]);
+    const row = await createParadigm({
+      language: 'or',
+      pos: 'VERB',
+      name: '  Odia regular verb  ',
+      description: '  trim me  ',
+    });
+    expect(row.id).toBe('p-new');
+    const insert = calls.find((c) => c.kind === 'insert')!;
+    expect(insert.values).toMatchObject({
+      language: 'or',
+      pos: 'VERB',
+      name: 'Odia regular verb',
+      description: 'trim me',
+    });
+  });
+
+  it('coerces an empty / whitespace description to null', async () => {
+    stage([paradigmRow()]);
+    await createParadigm({
+      language: 'or',
+      pos: 'VERB',
+      name: 'x',
+      description: '   ',
+    });
+    const insert = calls.find((c) => c.kind === 'insert')!;
+    expect((insert.values as { description: unknown }).description).toBeNull();
+  });
+
+  it('rejects an unsupported language', async () => {
+    await expect(
+      createParadigm({ language: 'xx', pos: 'VERB', name: 'x' }),
+    ).rejects.toBeInstanceOf(ParadigmValidationError);
+  });
+
+  it('rejects an empty pos', async () => {
+    await expect(
+      createParadigm({ language: 'or', pos: '   ', name: 'x' }),
+    ).rejects.toThrowError(/pos is required/);
+  });
+
+  it('rejects an over-long pos', async () => {
+    await expect(
+      createParadigm({ language: 'or', pos: 'X'.repeat(33), name: 'x' }),
+    ).rejects.toThrowError(/pos is too long/);
+  });
+
+  it('rejects an empty name', async () => {
+    await expect(
+      createParadigm({ language: 'or', pos: 'VERB', name: '   ' }),
+    ).rejects.toThrowError(/name is required/);
+  });
+
+  it('rejects an over-long name', async () => {
+    await expect(
+      createParadigm({ language: 'or', pos: 'VERB', name: 'x'.repeat(129) }),
+    ).rejects.toThrowError(/name is too long/);
+  });
+
+  it('throws 500 when the insert returns no row', async () => {
+    stage([]);
+    await expect(
+      createParadigm({ language: 'or', pos: 'VERB', name: 'x' }),
+    ).rejects.toMatchObject({ status: 500 });
+  });
+});
+
+describe('updateParadigm', () => {
+  it('loads the current row, merges the patch, and writes the update', async () => {
+    stage([paradigmRow()]); // load
+    stage([paradigmRow({ name: 'new name' })]); // return from update
+    const row = await updateParadigm('p-1', { name: 'new name' });
+    expect(row.name).toBe('new name');
+    const update = calls.find((c) => c.kind === 'update')!;
+    expect((update.set as { name: string }).name).toBe('new name');
+  });
+
+  it('preserves the original description when the patch omits it', async () => {
+    stage([paradigmRow({ description: 'keep me' })]);
+    stage([paradigmRow({ description: 'keep me' })]);
+    await updateParadigm('p-1', { name: 'x' });
+    const update = calls.find((c) => c.kind === 'update')!;
+    expect((update.set as { description: unknown }).description).toBe('keep me');
+  });
+
+  it('clears the description when given empty string', async () => {
+    stage([paradigmRow({ description: 'old' })]);
+    stage([paradigmRow({ description: null })]);
+    await updateParadigm('p-1', { description: '   ' });
+    const update = calls.find((c) => c.kind === 'update')!;
+    expect((update.set as { description: unknown }).description).toBeNull();
+  });
+
+  it('clears the description when given null', async () => {
+    stage([paradigmRow({ description: 'old' })]);
+    stage([paradigmRow({ description: null })]);
+    await updateParadigm('p-1', { description: null });
+    const update = calls.find((c) => c.kind === 'update')!;
+    expect((update.set as { description: unknown }).description).toBeNull();
+  });
+
+  it('writes a trimmed non-empty description', async () => {
+    stage([paradigmRow({ description: 'old' })]);
+    stage([paradigmRow({ description: 'fresh' })]);
+    await updateParadigm('p-1', { description: '  fresh  ' });
+    const update = calls.find((c) => c.kind === 'update')!;
+    expect((update.set as { description: string }).description).toBe('fresh');
+  });
+
+  it('throws 404 when the paradigm does not exist', async () => {
+    stage([]); // load returns nothing
+    await expect(
+      updateParadigm('p-missing', { name: 'x' }),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('throws 404 when the returning row is empty', async () => {
+    stage([paradigmRow()]); // load
+    stage([]); // update returning empty (concurrent delete)
+    await expect(
+      updateParadigm('p-1', { name: 'x' }),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+});
+
+describe('deleteParadigm', () => {
+  it('returns void on success', async () => {
+    stage([{ id: 'p-1' }]); // delete returning
+    await expect(deleteParadigm('p-1')).resolves.toBeUndefined();
+  });
+
+  it('throws 404 when nothing was deleted', async () => {
+    stage([]);
+    await expect(deleteParadigm('p-missing')).rejects.toMatchObject({ status: 404 });
+  });
+});
+
+describe('listLemmasUsingParadigm + countLemmasUsingParadigm', () => {
+  it('returns the lemmas with a stem set', async () => {
+    stage([
+      { id: 'l-1', headword: 'बोलना', pos: 'VERB', language: 'hi', stem: 'बोल' },
+    ]);
+    const list = await listLemmasUsingParadigm('p-1');
+    expect(list).toHaveLength(1);
+    expect(list[0]!.headword).toBe('बोलना');
+  });
+
+  it('countLemmasUsingParadigm derives from the list', async () => {
+    stage([
+      { id: 'l-1', headword: 'a', pos: 'VERB', language: 'hi', stem: 'a' },
+      { id: 'l-2', headword: 'b', pos: 'VERB', language: 'hi', stem: 'b' },
+    ]);
+    expect(await countLemmasUsingParadigm('p-1')).toBe(2);
+  });
+});
+
+describe('createSlot', () => {
+  it('verifies the paradigm exists and inserts the slot', async () => {
+    stage([{ id: 'p-1' }]); // paradigm-exists check
+    stage([slotRow({ id: 's-new' })]); // returning
+    const row = await createSlot({
+      paradigmId: 'p-1',
+      slotKey: 'pres_hab_1sg',
+      features: { Tense: 'Pres' },
+      suffix: 'े',
+      sortOrder: 20,
+    });
+    expect(row.id).toBe('s-new');
+    const insert = calls.find((c) => c.kind === 'insert')!;
+    expect(insert.values).toMatchObject({
+      paradigmId: 'p-1',
+      slotKey: 'pres_hab_1sg',
+      sortOrder: 20,
+    });
+  });
+
+  it('rejects a slot_key that violates the [a-z0-9_] shape', async () => {
+    stage([{ id: 'p-1' }]);
+    await expect(
+      createSlot({
+        paradigmId: 'p-1',
+        slotKey: 'Bad-Key',
+        features: {},
+        suffix: '',
+        sortOrder: 10,
+      }),
+    ).rejects.toThrowError(/slot_key must contain/);
+  });
+
+  it('rejects an empty slot_key', async () => {
+    stage([{ id: 'p-1' }]);
+    await expect(
+      createSlot({
+        paradigmId: 'p-1',
+        slotKey: '   ',
+        features: {},
+        suffix: '',
+        sortOrder: 10,
+      }),
+    ).rejects.toThrowError(/slot_key is required/);
+  });
+
+  it('rejects an over-long slot_key', async () => {
+    stage([{ id: 'p-1' }]);
+    await expect(
+      createSlot({
+        paradigmId: 'p-1',
+        slotKey: 'a'.repeat(65),
+        features: {},
+        suffix: '',
+        sortOrder: 10,
+      }),
+    ).rejects.toThrowError(/slot_key is too long/);
+  });
+
+  it('rejects an over-long suffix', async () => {
+    stage([{ id: 'p-1' }]);
+    await expect(
+      createSlot({
+        paradigmId: 'p-1',
+        slotKey: 'ok',
+        features: {},
+        suffix: 'a'.repeat(65),
+        sortOrder: 10,
+      }),
+    ).rejects.toThrowError(/suffix is too long/);
+  });
+
+  it('rejects an empty feature key or value', async () => {
+    stage([{ id: 'p-1' }]);
+    await expect(
+      createSlot({
+        paradigmId: 'p-1',
+        slotKey: 'ok',
+        features: { '': 'x' },
+        suffix: '',
+        sortOrder: 10,
+      }),
+    ).rejects.toThrowError(/non-empty keys/);
+  });
+
+  it('rejects a non-integer sortOrder', async () => {
+    stage([{ id: 'p-1' }]);
+    await expect(
+      createSlot({
+        paradigmId: 'p-1',
+        slotKey: 'ok',
+        features: {},
+        suffix: '',
+        sortOrder: 1.5,
+      }),
+    ).rejects.toThrowError(/integer/);
+  });
+
+  it('throws 404 when the parent paradigm does not exist', async () => {
+    stage([]); // paradigm check
+    await expect(
+      createSlot({
+        paradigmId: 'p-missing',
+        slotKey: 'inf',
+        features: {},
+        suffix: '',
+        sortOrder: 10,
+      }),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('translates a Postgres unique-violation into 409', async () => {
+    stage([{ id: 'p-1' }]); // paradigm check
+    insertFailure = Object.assign(new Error('duplicate'), { code: '23505' });
+    await expect(
+      createSlot({
+        paradigmId: 'p-1',
+        slotKey: 'inf',
+        features: {},
+        suffix: '',
+        sortOrder: 10,
+      }),
+    ).rejects.toMatchObject({ status: 409 });
+  });
+
+  it('rethrows non-unique-violation insert errors', async () => {
+    stage([{ id: 'p-1' }]);
+    insertFailure = Object.assign(new Error('boom'), { code: '99999' });
+    await expect(
+      createSlot({
+        paradigmId: 'p-1',
+        slotKey: 'inf',
+        features: {},
+        suffix: '',
+        sortOrder: 10,
+      }),
+    ).rejects.toThrowError(/boom/);
+  });
+});
+
+describe('updateSlot', () => {
+  it('loads, merges, and writes the slot', async () => {
+    stage([slotRow()]); // load
+    stage([slotRow({ slotKey: 'inf2' })]); // returning
+    const row = await updateSlot('s-1', { slotKey: 'inf2' });
+    expect(row.slotKey).toBe('inf2');
+  });
+
+  it('preserves untouched fields by merging with current values', async () => {
+    stage([slotRow({ suffix: 'ିବା' })]);
+    stage([slotRow({ suffix: 'ିବା' })]);
+    await updateSlot('s-1', { sortOrder: 99 });
+    const update = calls.find((c) => c.kind === 'update')!;
+    expect((update.set as { suffix: string; sortOrder: number }).suffix).toBe('ିବା');
+    expect((update.set as { sortOrder: number }).sortOrder).toBe(99);
+  });
+
+  it('throws 404 when the slot does not exist', async () => {
+    stage([]);
+    await expect(updateSlot('s-missing', {})).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+
+  it('translates a Postgres unique-violation into 409', async () => {
+    stage([slotRow()]); // load
+    const origUpdate = dbMock.update;
+    dbMock.update = () => {
+      const chain = origUpdate();
+      chain.returning = vi.fn(() => {
+        throw Object.assign(new Error('dup'), { code: '23505' });
+      });
+      return chain;
+    };
+    try {
+      await expect(
+        updateSlot('s-1', { slotKey: 'dup' }),
+      ).rejects.toMatchObject({ status: 409 });
+    } finally {
+      dbMock.update = origUpdate;
+    }
+  });
+
+  it('rethrows non-unique-violation update errors', async () => {
+    stage([slotRow()]);
+    const origUpdate = dbMock.update;
+    dbMock.update = () => {
+      const chain = origUpdate();
+      chain.returning = vi.fn(() => {
+        throw Object.assign(new Error('boom'), { code: '99999' });
+      });
+      return chain;
+    };
+    try {
+      await expect(updateSlot('s-1', { slotKey: 'x' })).rejects.toThrowError(
+        /boom/,
+      );
+    } finally {
+      dbMock.update = origUpdate;
+    }
+  });
+
+  it('throws 404 when the returning is empty after a successful set', async () => {
+    stage([slotRow()]); // load
+    stage([]); // returning empty
+    await expect(updateSlot('s-1', { slotKey: 'x' })).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+});
+
+describe('deleteSlot', () => {
+  it('succeeds when a row was deleted', async () => {
+    stage([{ id: 's-1' }]);
+    await expect(deleteSlot('s-1')).resolves.toBeUndefined();
+  });
+
+  it('throws 404 when nothing was deleted', async () => {
+    stage([]);
+    await expect(deleteSlot('s-missing')).rejects.toMatchObject({ status: 404 });
+  });
+});
+
+describe('saveAllParadigmChanges', () => {
+  it('updates paradigm fields + every slot in one transaction', async () => {
+    // exists check on paradigm
+    stage([{ id: 'p-1' }]);
+    // exists check on slot ids
+    stage([
+      { id: 's-1', paradigmId: 'p-1' },
+      { id: 's-2', paradigmId: 'p-1' },
+    ]);
+    await saveAllParadigmChanges('p-1', {
+      paradigm: {
+        language: 'or',
+        pos: 'VERB',
+        name: 'Odia regular verb',
+        description: 'updated',
+      },
+      slots: [
+        { id: 's-1', slotKey: 'inf', features: { VerbForm: 'Inf' }, suffix: 'ିବା' },
+        { id: 's-2', slotKey: 'past', features: {}, suffix: 'ିଲା' },
+      ],
+    });
+    // paradigm update + one update per slot = 3 update calls
+    expect(calls.filter((c) => c.kind === 'update')).toHaveLength(3);
+    const slotUpdates = calls.filter((c) => c.kind === 'update').slice(1);
+    expect((slotUpdates[0]!.set as { sortOrder: number }).sortOrder).toBe(10);
+    expect((slotUpdates[1]!.set as { sortOrder: number }).sortOrder).toBe(20);
+  });
+
+  it('throws 404 when the paradigm is gone', async () => {
+    stage([]); // paradigm exists check empty
+    await expect(
+      saveAllParadigmChanges('p-missing', {
+        paradigm: { language: 'or', pos: 'VERB', name: 'x', description: null },
+        slots: [],
+      }),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('throws 404 when a slot id does not exist', async () => {
+    stage([{ id: 'p-1' }]);
+    stage([{ id: 's-1', paradigmId: 'p-1' }]); // only one of the two
+    await expect(
+      saveAllParadigmChanges('p-1', {
+        paradigm: { language: 'or', pos: 'VERB', name: 'x', description: null },
+        slots: [
+          { id: 's-1', slotKey: 'a', features: {}, suffix: '', },
+          { id: 's-2', slotKey: 'b', features: {}, suffix: '' },
+        ],
+      }),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('throws 400 when a slot belongs to a different paradigm', async () => {
+    stage([{ id: 'p-1' }]);
+    stage([{ id: 's-x', paradigmId: 'other-paradigm' }]);
+    await expect(
+      saveAllParadigmChanges('p-1', {
+        paradigm: { language: 'or', pos: 'VERB', name: 'x', description: null },
+        slots: [{ id: 's-x', slotKey: 'a', features: {}, suffix: '' }],
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('rolls validation errors out before touching the DB', async () => {
+    await expect(
+      saveAllParadigmChanges('p-1', {
+        paradigm: { language: 'xx', pos: 'VERB', name: 'x', description: null },
+        slots: [],
+      }),
+    ).rejects.toBeInstanceOf(ParadigmValidationError);
+    expect(calls.filter((c) => c.kind === 'update')).toHaveLength(0);
+  });
+
+  it('normalises a null description', async () => {
+    stage([{ id: 'p-1' }]);
+    await saveAllParadigmChanges('p-1', {
+      paradigm: { language: 'or', pos: 'VERB', name: 'x', description: null },
+      slots: [],
+    });
+    const update = calls.find((c) => c.kind === 'update')!;
+    expect((update.set as { description: unknown }).description).toBeNull();
+  });
+
+  it('rethrows non-unique slot-update errors verbatim', async () => {
+    stage([{ id: 'p-1' }]);
+    stage([{ id: 's-1', paradigmId: 'p-1' }]);
+    const origUpdate = dbMock.update;
+    let firstCall = true;
+    dbMock.update = () => {
+      const chain = origUpdate();
+      if (firstCall) {
+        firstCall = false;
+        return chain;
+      }
+      chain.where = vi.fn(() => {
+        throw Object.assign(new Error('boom'), { code: '99999' });
+      });
+      return chain;
+    };
+    try {
+      await expect(
+        saveAllParadigmChanges('p-1', {
+          paradigm: {
+            language: 'or',
+            pos: 'VERB',
+            name: 'x',
+            description: null,
+          },
+          slots: [{ id: 's-1', slotKey: 'a', features: {}, suffix: '' }],
+        }),
+      ).rejects.toThrowError(/boom/);
+    } finally {
+      dbMock.update = origUpdate;
+    }
+  });
+
+  it('throws 409 when a slot update hits a unique-violation', async () => {
+    stage([{ id: 'p-1' }]);
+    stage([{ id: 's-1', paradigmId: 'p-1' }]);
+    // Intercept the slot UPDATE chain to throw a unique violation.
+    const origUpdate = dbMock.update;
+    let firstCall = true;
+    dbMock.update = () => {
+      const chain = origUpdate();
+      if (firstCall) {
+        firstCall = false; // first update is the paradigm, let it pass
+        return chain;
+      }
+      chain.where = vi.fn(() => {
+        const err = Object.assign(new Error('dup'), { code: '23505' });
+        throw err;
+      });
+      return chain;
+    };
+    try {
+      await expect(
+        saveAllParadigmChanges('p-1', {
+          paradigm: {
+            language: 'or',
+            pos: 'VERB',
+            name: 'x',
+            description: null,
+          },
+          slots: [
+            { id: 's-1', slotKey: 'dup', features: {}, suffix: '' },
+          ],
+        }),
+      ).rejects.toMatchObject({ status: 409 });
+    } finally {
+      dbMock.update = origUpdate;
+    }
+  });
+});

--- a/apps/web/src/lib/server/dictionary/paradigms.ts
+++ b/apps/web/src/lib/server/dictionary/paradigms.ts
@@ -15,11 +15,20 @@
  * morpheme boundaries) the combine step is the right place to teach
  * — for now the seam is `combine(stem, suffix) = stem + suffix`.
  */
-import { and, asc, eq } from 'drizzle-orm';
+import { and, asc, eq, inArray, isNotNull } from 'drizzle-orm';
 
 import { db, schema } from '../db/index.js';
-import type { LanguageCode } from '@ciareader/shared-types';
-import type { Paradigm, ParadigmSlot } from '../db/schema.js';
+import { isSupportedLanguage, type LanguageCode } from '@ciareader/shared-types';
+import type { Lemma, Paradigm, ParadigmSlot } from '../db/schema.js';
+
+export class ParadigmValidationError extends Error {
+  readonly status: number;
+  constructor(message: string, status = 400) {
+    super(message);
+    this.name = 'ParadigmValidationError';
+    this.status = status;
+  }
+}
 
 export type GeneratedForm = {
   /** Stable handle from the slot. Lets callers and tests address a
@@ -101,4 +110,495 @@ export async function listParadigmsForLemma(
       ),
     )
     .orderBy(asc(schema.paradigms.name))) as Paradigm[];
+}
+
+// ─── Curator-facing CRUD ─────────────────────────────────────────────
+// The paradigm-editor admin page reads/writes through these helpers.
+// All writes assume the caller has already proven admin via the
+// route's load() / action guard — the helpers don't re-check the
+// role, so callers must not expose them on a public-facing surface.
+
+export type ParadigmListFilter = {
+  language?: LanguageCode | null;
+  pos?: string | null;
+};
+
+/**
+ * List every paradigm, optionally narrowed by language and/or POS.
+ * Ordered (language, pos, name) so the admin list groups naturally.
+ */
+export async function listParadigms(
+  filter: ParadigmListFilter = {},
+): Promise<Paradigm[]> {
+  const conds = [] as ReturnType<typeof eq>[];
+  if (filter.language) conds.push(eq(schema.paradigms.language, filter.language));
+  if (filter.pos && filter.pos.trim().length > 0) {
+    conds.push(eq(schema.paradigms.pos, filter.pos.trim()));
+  }
+  const where = conds.length === 0 ? undefined : and(...conds);
+  return (await db
+    .select()
+    .from(schema.paradigms)
+    .where(where)
+    .orderBy(
+      asc(schema.paradigms.language),
+      asc(schema.paradigms.pos),
+      asc(schema.paradigms.name),
+    )) as Paradigm[];
+}
+
+export type CreateParadigmInput = {
+  language: string;
+  pos: string;
+  name: string;
+  description?: string | null;
+};
+
+function validateParadigmCore(input: {
+  language: string;
+  pos: string;
+  name: string;
+}): { language: LanguageCode; pos: string; name: string } {
+  const language = input.language.trim();
+  const pos = input.pos.trim();
+  const name = input.name.trim();
+  if (!isSupportedLanguage(language)) {
+    throw new ParadigmValidationError(`Unsupported language: ${input.language}`);
+  }
+  if (pos.length === 0) {
+    throw new ParadigmValidationError('pos is required');
+  }
+  if (pos.length > 32) {
+    throw new ParadigmValidationError('pos is too long (max 32 chars)');
+  }
+  if (name.length === 0) {
+    throw new ParadigmValidationError('name is required');
+  }
+  if (name.length > 128) {
+    throw new ParadigmValidationError('name is too long (max 128 chars)');
+  }
+  return { language: language as LanguageCode, pos, name };
+}
+
+export async function createParadigm(input: CreateParadigmInput): Promise<Paradigm> {
+  const core = validateParadigmCore(input);
+  const description =
+    input.description == null || input.description.trim().length === 0
+      ? null
+      : input.description.trim();
+  const [row] = await db
+    .insert(schema.paradigms)
+    .values({
+      language: core.language,
+      pos: core.pos,
+      name: core.name,
+      description,
+    })
+    .returning();
+  if (!row) throw new ParadigmValidationError('Failed to create paradigm', 500);
+  return row as Paradigm;
+}
+
+export type UpdateParadigmInput = {
+  language?: string;
+  pos?: string;
+  name?: string;
+  description?: string | null;
+};
+
+export async function updateParadigm(
+  paradigmId: string,
+  patch: UpdateParadigmInput,
+): Promise<Paradigm> {
+  const existing = await db
+    .select()
+    .from(schema.paradigms)
+    .where(eq(schema.paradigms.id, paradigmId))
+    .limit(1);
+  const current = existing[0];
+  if (!current) throw new ParadigmValidationError('Paradigm not found', 404);
+  const next = {
+    language: patch.language ?? current.language,
+    pos: patch.pos ?? current.pos,
+    name: patch.name ?? current.name,
+  };
+  const core = validateParadigmCore(next);
+  const description =
+    patch.description === undefined
+      ? current.description
+      : patch.description == null || patch.description.trim().length === 0
+        ? null
+        : patch.description.trim();
+  const [row] = await db
+    .update(schema.paradigms)
+    .set({
+      language: core.language,
+      pos: core.pos,
+      name: core.name,
+      description,
+      updatedAt: new Date(),
+    })
+    .where(eq(schema.paradigms.id, paradigmId))
+    .returning();
+  if (!row) throw new ParadigmValidationError('Paradigm not found', 404);
+  return row as Paradigm;
+}
+
+/**
+ * Delete a paradigm. Lemmas referencing it via `paradigm_id` are
+ * untouched at the row level — the FK is `ON DELETE SET NULL`, so
+ * affected lemmas keep their stem but lose the paradigm pointer.
+ * Generator-created `lemma_forms` rows that still point at this
+ * paradigm's slots will have their `paradigm_slot_id` set to NULL
+ * via the cascading slot delete (slots are also SET NULL on the
+ * forms side). Curators can clean up orphaned generator rows from
+ * the per-lemma editor afterward.
+ */
+export async function deleteParadigm(paradigmId: string): Promise<void> {
+  const [row] = await db
+    .delete(schema.paradigms)
+    .where(eq(schema.paradigms.id, paradigmId))
+    .returning({ id: schema.paradigms.id });
+  if (!row) throw new ParadigmValidationError('Paradigm not found', 404);
+}
+
+const SLOT_KEY_RE = /^[a-z0-9_]+$/;
+
+function validateSlotCore(input: {
+  slotKey: string;
+  suffix: string;
+  features: Record<string, string>;
+  sortOrder: number;
+}): {
+  slotKey: string;
+  suffix: string;
+  features: Record<string, string>;
+  sortOrder: number;
+} {
+  const slotKey = input.slotKey.trim();
+  if (slotKey.length === 0) {
+    throw new ParadigmValidationError('slot_key is required');
+  }
+  if (slotKey.length > 64) {
+    throw new ParadigmValidationError('slot_key is too long (max 64 chars)');
+  }
+  if (!SLOT_KEY_RE.test(slotKey)) {
+    throw new ParadigmValidationError(
+      'slot_key must contain only lowercase letters, digits, and underscores',
+    );
+  }
+  // Suffix may be empty — the seed has "pres_hab_2pl" with suffix ''.
+  if (input.suffix.length > 64) {
+    throw new ParadigmValidationError('suffix is too long (max 64 chars)');
+  }
+  for (const [k, v] of Object.entries(input.features)) {
+    if (k.length === 0 || v.length === 0) {
+      throw new ParadigmValidationError('features must have non-empty keys + values');
+    }
+  }
+  if (!Number.isInteger(input.sortOrder)) {
+    throw new ParadigmValidationError('sort_order must be an integer');
+  }
+  return {
+    slotKey,
+    suffix: input.suffix.normalize('NFC'),
+    features: input.features,
+    sortOrder: input.sortOrder,
+  };
+}
+
+export type CreateSlotInput = {
+  paradigmId: string;
+  slotKey: string;
+  features: Record<string, string>;
+  suffix: string;
+  sortOrder: number;
+};
+
+export async function createSlot(input: CreateSlotInput): Promise<ParadigmSlot> {
+  const core = validateSlotCore(input);
+  const [paradigm] = await db
+    .select({ id: schema.paradigms.id })
+    .from(schema.paradigms)
+    .where(eq(schema.paradigms.id, input.paradigmId))
+    .limit(1);
+  if (!paradigm) throw new ParadigmValidationError('Paradigm not found', 404);
+  try {
+    const [row] = await db
+      .insert(schema.paradigmSlots)
+      .values({
+        paradigmId: input.paradigmId,
+        slotKey: core.slotKey,
+        features: core.features,
+        suffix: core.suffix,
+        sortOrder: core.sortOrder,
+      })
+      .returning();
+    if (!row) throw new ParadigmValidationError('Failed to create slot', 500);
+    return row as ParadigmSlot;
+  } catch (e) {
+    if (isUniqueViolation(e)) {
+      throw new ParadigmValidationError(
+        `slot_key "${core.slotKey}" already exists in this paradigm`,
+        409,
+      );
+    }
+    throw e;
+  }
+}
+
+export type UpdateSlotInput = {
+  slotKey?: string;
+  features?: Record<string, string>;
+  suffix?: string;
+  sortOrder?: number;
+};
+
+export async function updateSlot(
+  slotId: string,
+  patch: UpdateSlotInput,
+): Promise<ParadigmSlot> {
+  const [current] = await db
+    .select()
+    .from(schema.paradigmSlots)
+    .where(eq(schema.paradigmSlots.id, slotId))
+    .limit(1);
+  if (!current) throw new ParadigmValidationError('Slot not found', 404);
+  const core = validateSlotCore({
+    slotKey: patch.slotKey ?? current.slotKey,
+    suffix: patch.suffix ?? current.suffix,
+    features: patch.features ?? current.features,
+    sortOrder: patch.sortOrder ?? current.sortOrder,
+  });
+  try {
+    const [row] = await db
+      .update(schema.paradigmSlots)
+      .set({
+        slotKey: core.slotKey,
+        features: core.features,
+        suffix: core.suffix,
+        sortOrder: core.sortOrder,
+      })
+      .where(eq(schema.paradigmSlots.id, slotId))
+      .returning();
+    if (!row) throw new ParadigmValidationError('Slot not found', 404);
+    return row as ParadigmSlot;
+  } catch (e) {
+    if (isUniqueViolation(e)) {
+      throw new ParadigmValidationError(
+        `slot_key "${core.slotKey}" already exists in this paradigm`,
+        409,
+      );
+    }
+    throw e;
+  }
+}
+
+export async function deleteSlot(slotId: string): Promise<void> {
+  const [row] = await db
+    .delete(schema.paradigmSlots)
+    .where(eq(schema.paradigmSlots.id, slotId))
+    .returning({ id: schema.paradigmSlots.id });
+  if (!row) throw new ParadigmValidationError('Slot not found', 404);
+}
+
+/**
+ * Rewrite the `sort_order` column for a list of slots. The caller
+ * passes the canonical order — each slot's new position is its index
+ * in the list times 10 (so future inline inserts have room without
+ * a full re-ordering pass). All listed ids must belong to the same
+ * paradigm.
+ */
+export async function reorderSlots(
+  paradigmId: string,
+  orderedSlotIds: string[],
+): Promise<void> {
+  if (orderedSlotIds.length === 0) return;
+  const rows = await db
+    .select({ id: schema.paradigmSlots.id, paradigmId: schema.paradigmSlots.paradigmId })
+    .from(schema.paradigmSlots)
+    .where(inArray(schema.paradigmSlots.id, orderedSlotIds));
+  if (rows.length !== orderedSlotIds.length) {
+    throw new ParadigmValidationError('One or more slot ids do not exist', 404);
+  }
+  for (const row of rows) {
+    if (row.paradigmId !== paradigmId) {
+      throw new ParadigmValidationError('Slot does not belong to this paradigm', 400);
+    }
+  }
+  await db.transaction(async (tx) => {
+    for (const [i, id] of orderedSlotIds.entries()) {
+      await tx
+        .update(schema.paradigmSlots)
+        .set({ sortOrder: (i + 1) * 10 })
+        .where(eq(schema.paradigmSlots.id, id));
+    }
+  });
+}
+
+/**
+ * Lemmas that opt into this paradigm and have a stem set — i.e. the
+ * subset of consumers whose generated `lemma_forms` rows reflect the
+ * current slot definitions. Lemmas without a stem aren't regenerated
+ * (the form-generator no-ops on a null stem) so they're omitted here.
+ *
+ * Returned ordered by headword so the regen summary surface lists
+ * them deterministically.
+ */
+export async function listLemmasUsingParadigm(
+  paradigmId: string,
+): Promise<Array<Pick<Lemma, 'id' | 'headword' | 'pos' | 'language' | 'stem'>>> {
+  return (await db
+    .select({
+      id: schema.lemmas.id,
+      headword: schema.lemmas.headword,
+      pos: schema.lemmas.pos,
+      language: schema.lemmas.language,
+      stem: schema.lemmas.stem,
+    })
+    .from(schema.lemmas)
+    .where(
+      and(
+        eq(schema.lemmas.paradigmId, paradigmId),
+        isNotNull(schema.lemmas.stem),
+      ),
+    )
+    .orderBy(asc(schema.lemmas.headword))) as Array<
+    Pick<Lemma, 'id' | 'headword' | 'pos' | 'language' | 'stem'>
+  >;
+}
+
+export async function countLemmasUsingParadigm(
+  paradigmId: string,
+): Promise<number> {
+  // Reuses the list query to keep the "what counts" rule single-
+  // sourced. The list is at most ~hundreds of rows in practice (one
+  // paradigm covers a single language+pos cohort) so the extra
+  // serialization cost over a SELECT count(*) is negligible.
+  const rows = await listLemmasUsingParadigm(paradigmId);
+  return rows.length;
+}
+
+function isUniqueViolation(e: unknown): boolean {
+  return (
+    typeof e === 'object' &&
+    e !== null &&
+    'code' in e &&
+    (e as { code?: string }).code === '23505'
+  );
+}
+
+/**
+ * Bulk save the entire paradigm editor state in one transaction —
+ * paradigm metadata, per-slot field edits, and slot order, applied
+ * atomically. Drives the editor's single "Save changes" button.
+ *
+ * Slots are addressed by id; the caller passes every slot it knows
+ * about IN THE ORDER they should appear, and the server derives
+ * each slot's `sort_order` from its index in the payload (i.e.
+ * `(i + 1) * 10` so future inline inserts have room). That makes the
+ * drag-and-drop ordering in the UI the single source of truth — the
+ * curator never sees or edits sort_order directly.
+ *
+ * We don't add or remove slots here — those still go through
+ * `createSlot` / `deleteSlot` as immediate actions because they have
+ * their own confirmation flows in the UI.
+ */
+export type SaveAllInput = {
+  paradigm: {
+    language: string;
+    pos: string;
+    name: string;
+    description: string | null;
+  };
+  slots: Array<{
+    id: string;
+    slotKey: string;
+    features: Record<string, string>;
+    suffix: string;
+  }>;
+};
+
+export async function saveAllParadigmChanges(
+  paradigmId: string,
+  input: SaveAllInput,
+): Promise<void> {
+  // Validate everything up-front so a bad slot doesn't half-apply.
+  // The placeholder sortOrder fed into `validateSlotCore` is throwaway
+  // — the real sortOrder gets stamped from the slot's array index in
+  // the write below.
+  const paradigmCore = validateParadigmCore(input.paradigm);
+  const slotCores = input.slots.map((s, i) => ({
+    id: s.id,
+    ...validateSlotCore({
+      slotKey: s.slotKey,
+      suffix: s.suffix,
+      features: s.features,
+      sortOrder: (i + 1) * 10,
+    }),
+  }));
+  const description =
+    input.paradigm.description == null || input.paradigm.description.trim().length === 0
+      ? null
+      : input.paradigm.description.trim();
+
+  await db.transaction(async (tx) => {
+    const [pRow] = await tx
+      .select({ id: schema.paradigms.id })
+      .from(schema.paradigms)
+      .where(eq(schema.paradigms.id, paradigmId))
+      .limit(1);
+    if (!pRow) throw new ParadigmValidationError('Paradigm not found', 404);
+
+    if (slotCores.length > 0) {
+      const ids = slotCores.map((s) => s.id);
+      const existing = await tx
+        .select({ id: schema.paradigmSlots.id, paradigmId: schema.paradigmSlots.paradigmId })
+        .from(schema.paradigmSlots)
+        .where(inArray(schema.paradigmSlots.id, ids));
+      if (existing.length !== ids.length) {
+        throw new ParadigmValidationError('One or more slot ids do not exist', 404);
+      }
+      for (const row of existing) {
+        if (row.paradigmId !== paradigmId) {
+          throw new ParadigmValidationError('Slot does not belong to this paradigm', 400);
+        }
+      }
+    }
+
+    await tx
+      .update(schema.paradigms)
+      .set({
+        language: paradigmCore.language,
+        pos: paradigmCore.pos,
+        name: paradigmCore.name,
+        description,
+        updatedAt: new Date(),
+      })
+      .where(eq(schema.paradigms.id, paradigmId));
+
+    // Single write per slot — fields + the position-derived sort_order
+    // land together.
+    for (const s of slotCores) {
+      try {
+        await tx
+          .update(schema.paradigmSlots)
+          .set({
+            slotKey: s.slotKey,
+            features: s.features,
+            suffix: s.suffix,
+            sortOrder: s.sortOrder,
+          })
+          .where(eq(schema.paradigmSlots.id, s.id));
+      } catch (e) {
+        if (isUniqueViolation(e)) {
+          throw new ParadigmValidationError(
+            `slot_key "${s.slotKey}" already exists in this paradigm`,
+            409,
+          );
+        }
+        throw e;
+      }
+    }
+  });
 }

--- a/apps/web/src/lib/server/dictionary/paradigms.ts
+++ b/apps/web/src/lib/server/dictionary/paradigms.ts
@@ -403,40 +403,6 @@ export async function deleteSlot(slotId: string): Promise<void> {
 }
 
 /**
- * Rewrite the `sort_order` column for a list of slots. The caller
- * passes the canonical order — each slot's new position is its index
- * in the list times 10 (so future inline inserts have room without
- * a full re-ordering pass). All listed ids must belong to the same
- * paradigm.
- */
-export async function reorderSlots(
-  paradigmId: string,
-  orderedSlotIds: string[],
-): Promise<void> {
-  if (orderedSlotIds.length === 0) return;
-  const rows = await db
-    .select({ id: schema.paradigmSlots.id, paradigmId: schema.paradigmSlots.paradigmId })
-    .from(schema.paradigmSlots)
-    .where(inArray(schema.paradigmSlots.id, orderedSlotIds));
-  if (rows.length !== orderedSlotIds.length) {
-    throw new ParadigmValidationError('One or more slot ids do not exist', 404);
-  }
-  for (const row of rows) {
-    if (row.paradigmId !== paradigmId) {
-      throw new ParadigmValidationError('Slot does not belong to this paradigm', 400);
-    }
-  }
-  await db.transaction(async (tx) => {
-    for (const [i, id] of orderedSlotIds.entries()) {
-      await tx
-        .update(schema.paradigmSlots)
-        .set({ sortOrder: (i + 1) * 10 })
-        .where(eq(schema.paradigmSlots.id, id));
-    }
-  });
-}
-
-/**
  * Lemmas that opt into this paradigm and have a stem set — i.e. the
  * subset of consumers whose generated `lemma_forms` rows reflect the
  * current slot definitions. Lemmas without a stem aren't regenerated

--- a/apps/web/src/lib/server/dictionary/regenerate-all.test.ts
+++ b/apps/web/src/lib/server/dictionary/regenerate-all.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment node
+/**
+ * Unit test for `regenerateAllForParadigm` (curator-paradigm
+ * follow-up). The function loops over every lemma opted into a
+ * paradigm and runs the existing `regenerateForms` per lemma; this
+ * suite verifies the aggregation + per-lemma error containment.
+ *
+ * Same-module bindings make it awkward to mock `regenerateForms`
+ * via `vi.spyOn`, so the function accepts injected collaborators
+ * (`lookupLemmas`, `regenerateLemma`) for testing. Production callers
+ * leave the defaults in place.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { regenerateAllForParadigm } from './lemma-forms.js';
+
+const lookupLemmas = vi.fn();
+const regenerateLemma = vi.fn();
+
+beforeEach(() => {
+  lookupLemmas.mockReset();
+  regenerateLemma.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('regenerateAllForParadigm', () => {
+  it('returns a zero summary when no lemma opts into the paradigm', async () => {
+    lookupLemmas.mockResolvedValueOnce([]);
+    const out = await regenerateAllForParadigm('p-1', {
+      lookupLemmas,
+      regenerateLemma,
+    });
+    expect(out).toEqual({
+      lemmasProcessed: 0,
+      lemmasFailed: 0,
+      removed: 0,
+      inserted: 0,
+      failures: [],
+    });
+    expect(regenerateLemma).not.toHaveBeenCalled();
+  });
+
+  it('walks every lemma and aggregates removed + inserted counts', async () => {
+    lookupLemmas.mockResolvedValueOnce([
+      { id: 'l-1', headword: 'a', pos: 'VERB', language: 'hi', stem: 'a' },
+      { id: 'l-2', headword: 'b', pos: 'VERB', language: 'hi', stem: 'b' },
+      { id: 'l-3', headword: 'c', pos: 'VERB', language: 'hi', stem: 'c' },
+    ]);
+    regenerateLemma
+      .mockResolvedValueOnce({ removed: 5, inserted: 6 })
+      .mockResolvedValueOnce({ removed: 7, inserted: 8 })
+      .mockResolvedValueOnce({ removed: 1, inserted: 1 });
+    const out = await regenerateAllForParadigm('p-1', {
+      lookupLemmas,
+      regenerateLemma,
+    });
+    expect(out.lemmasProcessed).toBe(3);
+    expect(out.lemmasFailed).toBe(0);
+    expect(out.removed).toBe(13);
+    expect(out.inserted).toBe(15);
+    expect(out.failures).toEqual([]);
+    expect(regenerateLemma).toHaveBeenCalledTimes(3);
+  });
+
+  it('keeps going when one lemma fails and records the failure', async () => {
+    lookupLemmas.mockResolvedValueOnce([
+      { id: 'l-1', headword: 'good', pos: 'VERB', language: 'hi', stem: 's' },
+      { id: 'l-2', headword: 'बोलना', pos: 'VERB', language: 'hi', stem: 's' },
+    ]);
+    regenerateLemma
+      .mockResolvedValueOnce({ removed: 4, inserted: 4 })
+      .mockRejectedValueOnce(new Error('nlp down'));
+    const out = await regenerateAllForParadigm('p-1', {
+      lookupLemmas,
+      regenerateLemma,
+    });
+    expect(out.lemmasProcessed).toBe(1);
+    expect(out.lemmasFailed).toBe(1);
+    expect(out.removed).toBe(4);
+    expect(out.inserted).toBe(4);
+    expect(out.failures).toEqual([
+      { lemmaId: 'l-2', headword: 'बोलना', error: 'nlp down' },
+    ]);
+  });
+
+  it('coerces non-Error throws into a string error message', async () => {
+    lookupLemmas.mockResolvedValueOnce([
+      { id: 'l-1', headword: 'h', pos: 'VERB', language: 'hi', stem: 's' },
+    ]);
+    regenerateLemma.mockRejectedValueOnce('weird-string-throw');
+    const out = await regenerateAllForParadigm('p-1', {
+      lookupLemmas,
+      regenerateLemma,
+    });
+    expect(out.failures[0]!.error).toBe('weird-string-throw');
+  });
+});

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -2,6 +2,7 @@
   import '$lib/styles/tokens.css';
   import AppShell from '$lib/components/shell/AppShell.svelte';
   import VerifyEmailBanner from '$lib/components/auth/VerifyEmailBanner.svelte';
+  import ToastHost from '$lib/components/toast/ToastHost.svelte';
   import type { LayoutData } from './$types';
 
   let { data, children }: { data: LayoutData; children: import('svelte').Snippet } = $props();
@@ -19,3 +20,8 @@
 >
   {@render children()}
 </AppShell>
+
+<!-- App-wide toast host. Anything that calls `pushToast()` from
+     `$lib/components/toast/toast-store.js` lands here. Rendered
+     once at the root so toasts persist across route transitions. -->
+<ToastHost />

--- a/apps/web/src/routes/moderation/dictionary/+page.svelte
+++ b/apps/web/src/routes/moderation/dictionary/+page.svelte
@@ -41,6 +41,7 @@
       {#if data.isAdmin}
         <a href="/moderation/dictionary/bulk">Bulk tools →</a>
         <a href="/moderation/dictionary/sources">Sources →</a>
+        <a href="/moderation/paradigms">Paradigms →</a>
       {/if}
     </nav>
   </header>

--- a/apps/web/src/routes/moderation/dictionary/sources/+page.svelte
+++ b/apps/web/src/routes/moderation/dictionary/sources/+page.svelte
@@ -103,6 +103,7 @@
     <nav class="mod-nav" aria-label="Moderation sections">
       <a href="/moderation/dictionary">← Dictionary moderation</a>
       <a href="/moderation/dictionary/bulk">Bulk tools</a>
+      <a href="/moderation/paradigms">Paradigms</a>
     </nav>
   </header>
 

--- a/apps/web/src/routes/moderation/paradigms/+page.server.ts
+++ b/apps/web/src/routes/moderation/paradigms/+page.server.ts
@@ -1,0 +1,118 @@
+/**
+ * Admin paradigm registry (curator-paradigm follow-up).
+ *
+ * Lists every paradigm row with optional (language, pos) filters and
+ * exposes a create-paradigm action. Per-paradigm slot editing lives in
+ * the `[id]/+page.server.ts` sibling. The page is admin-only at the
+ * loader and the action level — a curator without admin role lands on
+ * a 403 instead of a half-rendered "you can't change anything" view.
+ *
+ * Naming alongside the existing `paradigms.ts` service keeps every
+ * paradigm write inside one module so a future audit-row helper can
+ * be added in one place.
+ */
+import { error, fail, redirect } from '@sveltejs/kit';
+import { z } from 'zod';
+
+import {
+  createParadigm,
+  listParadigms,
+  ParadigmValidationError,
+} from '$lib/server/dictionary/paradigms.js';
+import { isAdmin } from '$lib/server/dictionary/permissions.js';
+import { LANGUAGES, isSupportedLanguage } from '@ciareader/shared-types';
+import type { LanguageCode } from '@ciareader/shared-types';
+import type { Actions, PageServerLoad } from './$types';
+
+type CreateResult =
+  | { ok: true; section: 'create'; paradigmId: string }
+  | { ok: false; section: 'create'; message: string };
+
+function mapError(e: unknown): { status: number; message: string } {
+  if (e instanceof ParadigmValidationError) {
+    return { status: e.status, message: e.message };
+  }
+  return { status: 500, message: 'Unexpected error' };
+}
+
+export const load: PageServerLoad = async ({ locals, url }) => {
+  if (!locals.user) {
+    throw redirect(303, `/login?next=${encodeURIComponent(url.pathname + url.search)}`);
+  }
+  if (!isAdmin({ role: locals.user.role })) {
+    throw error(403, 'Paradigm editor requires admin role');
+  }
+
+  const langParam = url.searchParams.get('language');
+  const posParam = url.searchParams.get('pos');
+  const language: LanguageCode | null =
+    langParam && isSupportedLanguage(langParam) ? (langParam as LanguageCode) : null;
+  const pos = posParam && posParam.trim().length > 0 ? posParam.trim() : null;
+
+  const paradigms = await listParadigms({
+    language,
+    pos,
+  });
+
+  return {
+    paradigms,
+    languages: Object.values(LANGUAGES).map((d) => ({
+      code: d.code,
+      displayName: d.displayName,
+      nativeName: d.nativeName,
+    })),
+    filter: { language, pos },
+  };
+};
+
+const createSchema = z.object({
+  language: z.string().min(1),
+  pos: z.string().min(1).max(32),
+  name: z.string().min(1).max(128),
+  description: z
+    .string()
+    .max(1000)
+    .optional()
+    .transform((s) => (s && s.trim().length > 0 ? s : null)),
+});
+
+export const actions: Actions = {
+  create: async ({ request, locals }) => {
+    if (!locals.user || !isAdmin({ role: locals.user.role })) {
+      return fail(403, {
+        ok: false,
+        section: 'create',
+        message: 'Admin role required',
+      } satisfies CreateResult);
+    }
+    const form = Object.fromEntries(await request.formData());
+    const parsed = createSchema.safeParse(form);
+    if (!parsed.success) {
+      return fail(400, {
+        ok: false,
+        section: 'create',
+        message: parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; '),
+      } satisfies CreateResult);
+    }
+    try {
+      const row = await createParadigm({
+        language: parsed.data.language,
+        pos: parsed.data.pos,
+        name: parsed.data.name,
+        description: parsed.data.description,
+      });
+      return {
+        ok: true,
+        section: 'create',
+        paradigmId: row.id,
+      } satisfies CreateResult;
+    } catch (e) {
+      const mapped = mapError(e);
+      return fail(mapped.status, {
+        ok: false,
+        section: 'create',
+        message: mapped.message,
+      } satisfies CreateResult);
+    }
+  },
+};

--- a/apps/web/src/routes/moderation/paradigms/+page.svelte
+++ b/apps/web/src/routes/moderation/paradigms/+page.svelte
@@ -1,0 +1,301 @@
+<script lang="ts">
+  import { enhance } from '$app/forms';
+  import type { ActionData, PageData } from './$types';
+
+  let {
+    data,
+    form,
+  }: { data: PageData; form: ActionData } = $props();
+
+  const createResult = $derived(form?.section === 'create' ? form : null);
+
+  function hrefWith(params: { language?: string | null; pos?: string | null }): string {
+    const sp = new URLSearchParams();
+    if (params.language) sp.set('language', params.language);
+    if (params.pos) sp.set('pos', params.pos);
+    const qs = sp.toString();
+    return qs ? `?${qs}` : '';
+  }
+</script>
+
+<svelte:head>
+  <title>Paradigms — CIA Reader</title>
+  <meta name="robots" content="noindex" />
+</svelte:head>
+
+<div class="page">
+  <p class="crumb">
+    <a href="/moderation/dictionary">← Back to dictionary</a>
+  </p>
+
+  <header>
+    <h1>Paradigms</h1>
+    <p class="sub">
+      Admin-only. A paradigm is a conjugation/declension pattern (e.g. "Odia
+      regular verb"); each row pairs a (language, pos) scope with a list of
+      slot suffixes the form generator appends to a lemma's <code>stem</code>.
+    </p>
+  </header>
+
+  <section>
+    <h2>Filter</h2>
+    <form method="get" class="filter">
+      <label>
+        Language
+        <select name="language">
+          <option value="">All languages</option>
+          {#each data.languages as l (l.code)}
+            <option value={l.code} selected={data.filter.language === l.code}>
+              {l.displayName} ({l.nativeName})
+            </option>
+          {/each}
+        </select>
+      </label>
+      <label>
+        POS
+        <input
+          name="pos"
+          value={data.filter.pos ?? ''}
+          placeholder="e.g. VERB"
+        />
+      </label>
+      <div class="filter-actions">
+        <button type="submit">Apply</button>
+        {#if data.filter.language || data.filter.pos}
+          <a class="reset" href={hrefWith({})}>Reset</a>
+        {/if}
+      </div>
+    </form>
+  </section>
+
+  <section>
+    <h2>Paradigms ({data.paradigms.length})</h2>
+    {#if data.paradigms.length === 0}
+      <p class="empty">No paradigms match the current filter.</p>
+    {:else}
+      <ul class="paradigm-list">
+        {#each data.paradigms as p (p.id)}
+          <li>
+            <a class="row" href={`/moderation/paradigms/${p.id}`}>
+              <span class="lang-badge">{p.language}</span>
+              <span class="pos-badge">{p.pos}</span>
+              <span class="name">{p.name}</span>
+            </a>
+            {#if p.description}
+              <div class="desc">{p.description}</div>
+            {/if}
+          </li>
+        {/each}
+      </ul>
+    {/if}
+  </section>
+
+  <section>
+    <h2>Create a paradigm</h2>
+    <p class="sub">
+      The new paradigm starts with no slots. Open the detail page after
+      creating it to add infinitive, person/number, tense slots etc.
+    </p>
+
+    {#if createResult}
+      {#if createResult.ok}
+        <p class="ok">
+          Created. <a href={`/moderation/paradigms/${createResult.paradigmId}`}
+            >Open editor →</a
+          >
+        </p>
+      {:else}
+        <p class="err">{createResult.message}</p>
+      {/if}
+    {/if}
+
+    <form method="post" action="?/create" use:enhance class="stack">
+      <label>
+        Language
+        <select name="language" required>
+          {#each data.languages as l (l.code)}
+            <option value={l.code}>{l.displayName} ({l.nativeName})</option>
+          {/each}
+        </select>
+      </label>
+      <label>
+        POS
+        <input name="pos" placeholder="VERB" required maxlength="32" />
+      </label>
+      <label>
+        Name
+        <input
+          name="name"
+          placeholder="e.g. Hindi regular verb"
+          required
+          maxlength="128"
+        />
+      </label>
+      <label>
+        Description (optional)
+        <textarea name="description" rows="3" maxlength="1000"></textarea>
+      </label>
+      <button type="submit">Create paradigm</button>
+    </form>
+  </section>
+</div>
+
+<style>
+  .page {
+    max-width: 48rem;
+    margin: 0 auto;
+    padding: 1.5rem 1.25rem 3rem;
+  }
+  .crumb {
+    margin: 0 0 1rem;
+    font-size: 0.9rem;
+  }
+  .crumb a {
+    color: var(--color-accent);
+  }
+  header h1 {
+    margin: 0 0 0.25rem;
+    font-size: 1.6rem;
+  }
+  .sub {
+    margin: 0 0 0.75rem;
+    color: var(--color-fg-muted);
+    font-size: 0.9rem;
+  }
+  section {
+    margin: 1.75rem 0;
+    padding: 1rem 1.25rem;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+  }
+  section h2 {
+    margin: 0 0 0.5rem;
+    font-size: 1.1rem;
+  }
+  .filter {
+    display: grid;
+    gap: 0.75rem;
+    grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+    align-items: end;
+  }
+  .filter label {
+    display: block;
+    font-size: 0.85rem;
+  }
+  .filter input,
+  .filter select {
+    display: block;
+    width: 100%;
+    margin-top: 0.25rem;
+    padding: 0.5rem 0.6rem;
+    font: inherit;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    background: var(--color-bg);
+    color: var(--color-fg);
+    min-height: 44px;
+  }
+  .filter-actions {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+  }
+  .filter-actions button {
+    min-height: 44px;
+    padding: 0 1rem;
+    background: var(--color-accent);
+    color: var(--color-accent-fg, #fff);
+    border: 0;
+    border-radius: 6px;
+    cursor: pointer;
+  }
+  .reset {
+    font-size: 0.85rem;
+    color: var(--color-fg-muted);
+  }
+  .paradigm-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+  .paradigm-list li {
+    padding: 0.6rem 0;
+    border-bottom: 1px solid var(--color-border);
+  }
+  .row {
+    display: flex;
+    align-items: baseline;
+    gap: 0.6rem;
+    text-decoration: none;
+    color: var(--color-fg);
+  }
+  .row:hover .name {
+    text-decoration: underline;
+  }
+  .lang-badge,
+  .pos-badge {
+    font-size: 0.7rem;
+    padding: 0.05rem 0.4rem;
+    border-radius: 999px;
+    background: var(--color-border);
+    color: var(--color-fg-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .name {
+    font-weight: 500;
+  }
+  .desc {
+    margin-top: 0.25rem;
+    color: var(--color-fg-muted);
+    font-size: 0.85rem;
+  }
+  .empty {
+    margin: 0.5rem 0;
+    color: var(--color-fg-muted);
+  }
+  form.stack > * {
+    margin-bottom: 0.75rem;
+  }
+  form label {
+    display: block;
+    font-size: 0.9rem;
+  }
+  form input,
+  form textarea,
+  form select {
+    display: block;
+    width: 100%;
+    margin-top: 0.25rem;
+    padding: 0.5rem 0.6rem;
+    font: inherit;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    background: var(--color-bg);
+    color: var(--color-fg);
+    min-height: 44px;
+  }
+  form textarea {
+    min-height: 5rem;
+    resize: vertical;
+  }
+  form button {
+    min-height: 44px;
+    padding: 0 1rem;
+    background: var(--color-accent);
+    color: var(--color-accent-fg, #fff);
+    border: 0;
+    border-radius: 6px;
+    cursor: pointer;
+  }
+  .ok {
+    color: #197a2f;
+  }
+  .err {
+    color: #b03131;
+  }
+  code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.85em;
+  }
+</style>

--- a/apps/web/src/routes/moderation/paradigms/[id]/+page.server.ts
+++ b/apps/web/src/routes/moderation/paradigms/[id]/+page.server.ts
@@ -1,0 +1,379 @@
+/**
+ * Admin paradigm detail editor (curator-paradigm follow-up).
+ *
+ * One paradigm + its slots on a single page. The slots are addressable
+ * by stable handle (`slot_key`) so a future migration / test can refer
+ * to them without round-tripping through a UUID — same convention as
+ * the seed SQL the page replaces.
+ *
+ * Features are entered as a comma-separated `Key=Value` list, mirroring
+ * the parser the lemma form editor already ships (`Tense=Past, Person=1`).
+ * Reusing the wire shape means a curator who's already learned to edit
+ * a form's features doesn't have to learn a second syntax for slots.
+ *
+ * The editor uses three immediate actions — `addSlot`, `removeSlot`,
+ * `deleteParadigm` — each gated by an inline confirmation in the UI.
+ * Every other edit (paradigm metadata, per-slot field changes, slot
+ * reorder) is staged client-side and shipped atomically by the
+ * `saveAll` action so a curator's "Save changes" press is one
+ * transaction, not five.
+ */
+import { error, fail, redirect } from '@sveltejs/kit';
+import { z } from 'zod';
+
+import {
+  ParadigmValidationError,
+  countLemmasUsingParadigm,
+  createSlot,
+  deleteParadigm,
+  deleteSlot,
+  loadParadigm,
+  saveAllParadigmChanges,
+} from '$lib/server/dictionary/paradigms.js';
+import { regenerateAllForParadigm } from '$lib/server/dictionary/lemma-forms.js';
+import { isAdmin } from '$lib/server/dictionary/permissions.js';
+import { LANGUAGES, isSupportedLanguage } from '@ciareader/shared-types';
+import type { Actions, PageServerLoad } from './$types';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function mapError(e: unknown): { status: number; message: string } {
+  if (e instanceof ParadigmValidationError) {
+    return { status: e.status, message: e.message };
+  }
+  return { status: 500, message: 'Unexpected error' };
+}
+
+type SaveAllResult =
+  | {
+      ok: true;
+      section: 'saveAll';
+      /** Number of lemmas opted into this paradigm with a stem set —
+       *  the cohort whose generated forms may now be stale and that
+       *  the UI should prompt to regenerate. Zero means the prompt
+       *  is suppressed. */
+      affectedLemmaCount: number;
+    }
+  | { ok: false; section: 'saveAll'; message: string };
+type SlotFormResult =
+  | { ok: true; section: 'slot'; action: 'add' | 'remove' }
+  | {
+      ok: false;
+      section: 'slot';
+      action: 'add' | 'remove';
+      message: string;
+    };
+type RegenerateResult =
+  | {
+      ok: true;
+      section: 'regenerate';
+      lemmasProcessed: number;
+      lemmasFailed: number;
+      removed: number;
+      inserted: number;
+      failures: Array<{ lemmaId: string; headword: string; error: string }>;
+    }
+  | { ok: false; section: 'regenerate'; message: string };
+type DeleteParadigmResult = { ok: false; section: 'delete'; message: string };
+
+export const load: PageServerLoad = async ({ locals, params, url }) => {
+  if (!locals.user) {
+    throw redirect(303, `/login?next=${encodeURIComponent(url.pathname)}`);
+  }
+  if (!isAdmin({ role: locals.user.role })) {
+    throw error(403, 'Paradigm editor requires admin role');
+  }
+  if (!UUID_RE.test(params.id)) throw error(400, 'Invalid paradigm id');
+
+  const loaded = await loadParadigm(params.id);
+  if (!loaded) throw error(404, 'Paradigm not found');
+
+  return {
+    paradigm: loaded.paradigm,
+    slots: loaded.slots,
+    languages: Object.values(LANGUAGES).map((d) => ({
+      code: d.code,
+      displayName: d.displayName,
+      nativeName: d.nativeName,
+    })),
+  };
+};
+
+/**
+ * `Tense=Past, Person=1, Number=Sing` → { Tense: 'Past', Person: '1', Number: 'Sing' }.
+ * Same shape the form-editor uses (`parseFeatureString` in dictionary/[id]/+page.server.ts).
+ * Duplicated rather than imported because both pages will probably evolve
+ * their feature-validation independently — the dictionary editor accepts
+ * unknown keys silently, this page is admin-only and may want stricter
+ * checks later.
+ */
+const FEAT_SEP = /\s*,\s*/;
+function parseFeatureString(raw: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const piece of raw.split(FEAT_SEP)) {
+    if (!piece) continue;
+    const eq = piece.indexOf('=');
+    if (eq <= 0) continue;
+    const k = piece.slice(0, eq).trim();
+    const v = piece.slice(eq + 1).trim();
+    if (k && v) out[k] = v;
+  }
+  return out;
+}
+
+const slotCreateSchema = z.object({
+  slotKey: z.string().min(1).max(64),
+  features: z.string().max(1024).optional().default(''),
+  suffix: z.string().max(64).optional().default(''),
+  sortOrder: z
+    .string()
+    .optional()
+    .transform((s) => (s && s.trim().length > 0 ? Number.parseInt(s, 10) : null))
+    .refine((v) => v === null || (Number.isInteger(v) && v >= 0), {
+      message: 'sortOrder must be a non-negative integer',
+    }),
+});
+
+const slotDeleteSchema = z.object({
+  slotId: z.string().regex(UUID_RE),
+});
+
+/**
+ * Wire schema for `?/saveAll`. The Svelte side stringifies the editor's
+ * client-side state into a single `payload` form field, server-side we
+ * parse + validate it as JSON before handing the structured object to
+ * the service. The features for each slot arrive as a key-value object
+ * (already parsed in the browser) rather than a comma-separated string
+ * — the service rejects empty keys / values either way.
+ */
+const saveAllSchema = z.object({
+  paradigm: z.object({
+    language: z.string().min(1).refine((v) => isSupportedLanguage(v), {
+      message: 'unsupported language',
+    }),
+    pos: z.string().min(1).max(32),
+    name: z.string().min(1).max(128),
+    description: z
+      .string()
+      .max(1000)
+      .nullable()
+      .optional()
+      .transform((s) => (s == null || s.trim().length === 0 ? null : s)),
+  }),
+  // `sortOrder` is intentionally NOT accepted from the client — the
+  // server derives it from each slot's index in this array. That makes
+  // the drag-and-drop order the single source of truth and forecloses
+  // the "what if the curator's typed sort_order conflicts with their
+  // drag order?" question.
+  slots: z.array(
+    z.object({
+      id: z.string().regex(UUID_RE),
+      slotKey: z.string().min(1).max(64),
+      features: z.record(z.string(), z.string()),
+      suffix: z.string().max(64),
+    }),
+  ),
+});
+
+export const actions: Actions = {
+  saveAll: async ({ params, request, locals }) => {
+    if (!locals.user || !isAdmin({ role: locals.user.role })) {
+      return fail(403, {
+        ok: false,
+        section: 'saveAll',
+        message: 'Admin role required',
+      } satisfies SaveAllResult);
+    }
+    const form = await request.formData();
+    const rawPayload = form.get('payload');
+    if (typeof rawPayload !== 'string') {
+      return fail(400, {
+        ok: false,
+        section: 'saveAll',
+        message: 'Missing payload',
+      } satisfies SaveAllResult);
+    }
+    let parsedJson: unknown;
+    try {
+      parsedJson = JSON.parse(rawPayload);
+    } catch {
+      return fail(400, {
+        ok: false,
+        section: 'saveAll',
+        message: 'Malformed JSON payload',
+      } satisfies SaveAllResult);
+    }
+    const parsed = saveAllSchema.safeParse(parsedJson);
+    if (!parsed.success) {
+      return fail(400, {
+        ok: false,
+        section: 'saveAll',
+        message: parsed.error.issues
+          .map((i) => `${i.path.join('.')}: ${i.message}`)
+          .join('; '),
+      } satisfies SaveAllResult);
+    }
+    try {
+      await saveAllParadigmChanges(params.id, parsed.data);
+      // Hand the UI the count of lemmas opted into this paradigm so
+      // it can offer to regenerate their `lemma_forms` rows — slot
+      // edits change the surfaces the generator would emit, so the
+      // generator-created rows on those lemmas are now stale.
+      const affectedLemmaCount = await countLemmasUsingParadigm(params.id);
+      return {
+        ok: true,
+        section: 'saveAll',
+        affectedLemmaCount,
+      } satisfies SaveAllResult;
+    } catch (e) {
+      const mapped = mapError(e);
+      return fail(mapped.status, {
+        ok: false,
+        section: 'saveAll',
+        message: mapped.message,
+      } satisfies SaveAllResult);
+    }
+  },
+
+  /**
+   * Walk every lemma opted into this paradigm and rebuild its
+   * generator-created forms. Returns a summary the UI surfaces in a
+   * banner so the curator sees what just happened. Per-lemma errors
+   * don't abort the run; they're collected and reported.
+   */
+  regenerateAffected: async ({ params, locals }) => {
+    if (!locals.user || !isAdmin({ role: locals.user.role })) {
+      return fail(403, {
+        ok: false,
+        section: 'regenerate',
+        message: 'Admin role required',
+      } satisfies RegenerateResult);
+    }
+    try {
+      const summary = await regenerateAllForParadigm(params.id);
+      return {
+        ok: true,
+        section: 'regenerate',
+        ...summary,
+      } satisfies RegenerateResult;
+    } catch (e) {
+      const mapped = mapError(e);
+      return fail(mapped.status, {
+        ok: false,
+        section: 'regenerate',
+        message: mapped.message,
+      } satisfies RegenerateResult);
+    }
+  },
+
+  deleteParadigm: async ({ params, locals }) => {
+    if (!locals.user || !isAdmin({ role: locals.user.role })) {
+      return fail(403, {
+        ok: false,
+        section: 'delete',
+        message: 'Admin role required',
+      } satisfies DeleteParadigmResult);
+    }
+    try {
+      await deleteParadigm(params.id);
+    } catch (e) {
+      const mapped = mapError(e);
+      return fail(mapped.status, {
+        ok: false,
+        section: 'delete',
+        message: mapped.message,
+      } satisfies DeleteParadigmResult);
+    }
+    throw redirect(303, '/moderation/paradigms');
+  },
+
+  addSlot: async ({ params, request, locals }) => {
+    if (!locals.user || !isAdmin({ role: locals.user.role })) {
+      return fail(403, {
+        ok: false,
+        section: 'slot',
+        action: 'add',
+        message: 'Admin role required',
+      } satisfies SlotFormResult);
+    }
+    const form = Object.fromEntries(await request.formData());
+    const parsed = slotCreateSchema.safeParse(form);
+    if (!parsed.success) {
+      return fail(400, {
+        ok: false,
+        section: 'slot',
+        action: 'add',
+        message: parsed.error.issues
+          .map((i) => `${i.path.join('.')}: ${i.message}`)
+          .join('; '),
+      } satisfies SlotFormResult);
+    }
+    // Default sort order: append to the end. Re-read the slot list so
+    // we can compute (max + 10); using the in-loader value would race
+    // with concurrent adds.
+    const existing = await loadParadigm(params.id);
+    if (!existing) {
+      return fail(404, {
+        ok: false,
+        section: 'slot',
+        action: 'add',
+        message: 'Paradigm not found',
+      } satisfies SlotFormResult);
+    }
+    const maxSort = existing.slots.reduce((m, s) => Math.max(m, s.sortOrder), 0);
+    const sortOrder = parsed.data.sortOrder ?? maxSort + 10;
+    try {
+      await createSlot({
+        paradigmId: params.id,
+        slotKey: parsed.data.slotKey,
+        features: parseFeatureString(parsed.data.features),
+        suffix: parsed.data.suffix,
+        sortOrder,
+      });
+      return { ok: true, section: 'slot', action: 'add' } satisfies SlotFormResult;
+    } catch (e) {
+      const mapped = mapError(e);
+      return fail(mapped.status, {
+        ok: false,
+        section: 'slot',
+        action: 'add',
+        message: mapped.message,
+      } satisfies SlotFormResult);
+    }
+  },
+
+  removeSlot: async ({ request, locals }) => {
+    if (!locals.user || !isAdmin({ role: locals.user.role })) {
+      return fail(403, {
+        ok: false,
+        section: 'slot',
+        action: 'remove',
+        message: 'Admin role required',
+      } satisfies SlotFormResult);
+    }
+    const form = Object.fromEntries(await request.formData());
+    const parsed = slotDeleteSchema.safeParse(form);
+    if (!parsed.success) {
+      return fail(400, {
+        ok: false,
+        section: 'slot',
+        action: 'remove',
+        message: parsed.error.issues
+          .map((i) => `${i.path.join('.')}: ${i.message}`)
+          .join('; '),
+      } satisfies SlotFormResult);
+    }
+    try {
+      await deleteSlot(parsed.data.slotId);
+      return { ok: true, section: 'slot', action: 'remove' } satisfies SlotFormResult;
+    } catch (e) {
+      const mapped = mapError(e);
+      return fail(mapped.status, {
+        ok: false,
+        section: 'slot',
+        action: 'remove',
+        message: mapped.message,
+      } satisfies SlotFormResult);
+    }
+  },
+};

--- a/apps/web/src/routes/moderation/paradigms/[id]/+page.svelte
+++ b/apps/web/src/routes/moderation/paradigms/[id]/+page.svelte
@@ -1,0 +1,1134 @@
+<script lang="ts">
+  import { enhance } from '$app/forms';
+  import { dismissToast, pushToast } from '$lib/components/toast/toast-store.js';
+  import type { ActionData, PageData } from './$types';
+
+  let {
+    data,
+    form,
+  }: { data: PageData; form: ActionData } = $props();
+
+  const saveResult = $derived(form?.section === 'saveAll' ? form : null);
+  const slotResult = $derived(form?.section === 'slot' ? form : null);
+  const deleteResult = $derived(form?.section === 'delete' ? form : null);
+  const regenResult = $derived(form?.section === 'regenerate' ? form : null);
+
+  function featuresToString(feats: Record<string, string>): string {
+    return Object.entries(feats)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(', ');
+  }
+
+  const FEAT_SEP = /\s*,\s*/;
+  function parseFeatureString(raw: string): Record<string, string> {
+    const out: Record<string, string> = {};
+    for (const piece of raw.split(FEAT_SEP)) {
+      if (!piece) continue;
+      const eq = piece.indexOf('=');
+      if (eq <= 0) continue;
+      const k = piece.slice(0, eq).trim();
+      const v = piece.slice(eq + 1).trim();
+      if (k && v) out[k] = v;
+    }
+    return out;
+  }
+
+  // ─── Editable state ─────────────────────────────────────────────────
+  // Every field the curator can edit lives in `$state`. We diff against
+  // `data.paradigm` / `data.slots` (the server's last-known truth) to
+  // compute `dirty`. After a successful save the loader re-runs and
+  // `data` changes; the $effect below resets the local copy so the
+  // save bar de-activates.
+
+  type EditableSlot = {
+    id: string;
+    slotKey: string;
+    features: string;
+    suffix: string;
+  };
+
+  // `sort_order` is intentionally absent — it's derived server-side
+  // from the slot's index in the saveAll payload, so the curator
+  // never touches it directly. Drag handle = source of truth.
+  function toEditable(slots: typeof data.slots): EditableSlot[] {
+    return slots.map((s) => ({
+      id: s.id,
+      slotKey: s.slotKey,
+      features: featuresToString(s.features),
+      suffix: s.suffix,
+    }));
+  }
+
+  // Seed the editable copies from the loader's data on first render so
+  // SSR + hydration produces correctly-filled inputs (no empty flash,
+  // no chance of submitting an empty `pos` / `name`). The `data` access
+  // here is intentional — we want the snapshot at mount, not a live
+  // reference; subsequent reloads are picked up by the $effect below.
+  // The function wrapper keeps svelte-check from misreading this as a
+  // bare prop reference that should be a $derived.
+  function snapshotParadigm() {
+    return {
+      language: data.paradigm.language,
+      pos: data.paradigm.pos,
+      name: data.paradigm.name,
+      description: data.paradigm.description ?? '',
+    };
+  }
+  function snapshotSlots() {
+    return toEditable(data.slots);
+  }
+  function snapshotKey() {
+    // Slot order itself is the only "order" signal — sortOrder isn't
+    // part of the key because it's an implementation detail the
+    // server derives from index.
+    return [
+      data.paradigm.id,
+      data.paradigm.language,
+      data.paradigm.pos,
+      data.paradigm.name,
+      data.paradigm.description ?? '',
+      ...data.slots.map(
+        (s) => `${s.id}|${s.slotKey}|${s.suffix}|${featuresToString(s.features)}`,
+      ),
+    ].join('::');
+  }
+
+  let paradigmDraft = $state(snapshotParadigm());
+  let slotDrafts = $state<EditableSlot[]>(snapshotSlots());
+
+  // Re-seed the local copies whenever the loader returns a different
+  // server state (after add / remove / save). Without this the saved
+  // values would persist as "dirty" after a successful reload, and a
+  // fresh add wouldn't appear in the slot list.
+  const serverKey = $derived(snapshotKey());
+  let lastSeenServerKey = $state(snapshotKey());
+  $effect(() => {
+    if (serverKey !== lastSeenServerKey) {
+      paradigmDraft = snapshotParadigm();
+      slotDrafts = snapshotSlots();
+      lastSeenServerKey = serverKey;
+    }
+  });
+
+  // ─── Dirty detection ────────────────────────────────────────────────
+
+  const paradigmDirty = $derived(
+    paradigmDraft.language !== data.paradigm.language ||
+      paradigmDraft.pos !== data.paradigm.pos ||
+      paradigmDraft.name !== data.paradigm.name ||
+      paradigmDraft.description !== (data.paradigm.description ?? ''),
+  );
+  const slotsDirty = $derived(
+    slotDrafts.length !== data.slots.length ||
+      slotDrafts.some((d, i) => {
+        const original = data.slots[i];
+        if (!original) return true;
+        // Comparing by index detects reorder (server's sort_order
+        // derives from index) — no need to compare sort_order itself.
+        return (
+          d.id !== original.id ||
+          d.slotKey !== original.slotKey ||
+          d.suffix !== original.suffix ||
+          d.features !== featuresToString(original.features)
+        );
+      }),
+  );
+  const dirty = $derived(paradigmDirty || slotsDirty);
+
+  // ─── Reorder (drag + keyboard) ──────────────────────────────────────
+  // The drag handle is the only place a slot row can be picked up.
+  // Native HTML5 DnD: `dragstart` on the handle stamps the source
+  // index into dataTransfer, `dragover` on a row sets the visual
+  // indicator + signals the position the drop will land at, `drop`
+  // splices `slotDrafts` to the new order. Keyboard users focus the
+  // handle and press ArrowUp / ArrowDown — same swap as the legacy
+  // arrow buttons, just hung off the handle.
+
+  let draggingIdx = $state<number | null>(null);
+  // Indicates where a drop would land: the index of the row the
+  // dragged item would slot ABOVE. Used purely for the visual
+  // top-border indicator on the target row.
+  let dropTargetIdx = $state<number | null>(null);
+
+  function moveSlot(from: number, to: number) {
+    if (from === to) return;
+    if (from < 0 || from >= slotDrafts.length) return;
+    if (to < 0 || to > slotDrafts.length) return;
+    const next = slotDrafts.slice();
+    const [picked] = next.splice(from, 1);
+    if (!picked) return;
+    // When dragging downward, the target index shifts left by one
+    // after the splice removal.
+    const insertAt = from < to ? to - 1 : to;
+    next.splice(insertAt, 0, picked);
+    slotDrafts = next;
+  }
+
+  function onDragStart(e: DragEvent, i: number) {
+    if (!e.dataTransfer) return;
+    draggingIdx = i;
+    e.dataTransfer.effectAllowed = 'move';
+    // Some browsers require *some* data on the transfer for the drag
+    // to be allowed. Setting plain text with the source index keeps
+    // any external listener (which we don't have) sensible.
+    e.dataTransfer.setData('text/plain', String(i));
+  }
+
+  function onDragOver(e: DragEvent, i: number) {
+    if (draggingIdx === null) return;
+    e.preventDefault();
+    if (e.dataTransfer) e.dataTransfer.dropEffect = 'move';
+    // Decide whether the drop would land above or below this row,
+    // based on the pointer's position within the row. This makes the
+    // indicator follow the user instead of snapping to "above" only.
+    const target = e.currentTarget as HTMLElement;
+    const rect = target.getBoundingClientRect();
+    const below = e.clientY > rect.top + rect.height / 2;
+    dropTargetIdx = below ? i + 1 : i;
+  }
+
+  function onDragLeaveList(e: DragEvent) {
+    // The `dragleave` fires for every child boundary; only clear when
+    // the pointer actually leaves the list container.
+    const related = e.relatedTarget;
+    const current = e.currentTarget as HTMLElement;
+    if (
+      !related ||
+      !(related instanceof globalThis.Node) ||
+      !current.contains(related)
+    ) {
+      dropTargetIdx = null;
+    }
+  }
+
+  function onDrop(e: DragEvent) {
+    if (draggingIdx === null || dropTargetIdx === null) return;
+    e.preventDefault();
+    moveSlot(draggingIdx, dropTargetIdx);
+    draggingIdx = null;
+    dropTargetIdx = null;
+  }
+
+  function onDragEnd() {
+    draggingIdx = null;
+    dropTargetIdx = null;
+  }
+
+  function onHandleKeydown(e: KeyboardEvent, i: number) {
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      if (i > 0) {
+        moveSlot(i, i - 1);
+        // Keep keyboard focus on the now-moved row's handle so the
+        // user can repeat without re-tabbing.
+        window.requestAnimationFrame(() => {
+          const el = document.querySelector<HTMLElement>(
+            `[data-handle-idx="${i - 1}"]`,
+          );
+          el?.focus();
+        });
+      }
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      if (i < slotDrafts.length - 1) {
+        moveSlot(i, i + 2);
+        window.requestAnimationFrame(() => {
+          const el = document.querySelector<HTMLElement>(
+            `[data-handle-idx="${i + 1}"]`,
+          );
+          el?.focus();
+        });
+      }
+    }
+  }
+
+  // ─── Build save payload ─────────────────────────────────────────────
+
+  const savePayload = $derived(
+    JSON.stringify({
+      paradigm: {
+        language: paradigmDraft.language,
+        pos: paradigmDraft.pos,
+        name: paradigmDraft.name,
+        description:
+          paradigmDraft.description.trim().length === 0
+            ? null
+            : paradigmDraft.description,
+      },
+      slots: slotDrafts.map((s) => ({
+        id: s.id,
+        slotKey: s.slotKey,
+        features: parseFeatureString(s.features),
+        suffix: s.suffix,
+      })),
+    }),
+  );
+
+  // ─── Inline-confirm state ───────────────────────────────────────────
+  // One slot at a time can be in the "confirming delete" state, and
+  // separately the paradigm-delete confirmation has its own flag. The
+  // delete row replaces the icon button with Cancel / Delete buttons.
+
+  let confirmingSlotId = $state<string | null>(null);
+  let confirmingParadigmDelete = $state(false);
+
+  // ─── Regen prompt (modal) ───────────────────────────────────────────
+  // After a successful save, if any lemmas use this paradigm we open
+  // a confirmation modal. The dismissed flag is keyed off the
+  // action-result identity so it resets on every new save — we never
+  // want to silently suppress the prompt for a different save.
+  let regenDialog = $state<globalThis.HTMLDialogElement | null>(null);
+  let regenPending = $state(false);
+  // Plain `let` (not `$state`) — see the regen-result effect below
+  // for the proxy-equality rationale. Same trap: assigning `form`
+  // into a `$state` slot proxies it and breaks `=== form` checks.
+  let dismissedRegenForSave: unknown = null;
+  /** Id of the sticky "Regenerating…" toast we show while the request
+   *  is in flight, so the result handler below can dismiss it the
+   *  moment the response lands. */
+  let regenProgressToastId = $state<string | null>(null);
+  // Re-evaluating the derived needs *some* reactive trigger for
+  // dismissal — we bump this counter when the curator dismisses, and
+  // read it inside the derived so Svelte knows to recompute.
+  let dismissBump = $state(0);
+  const regenPromptVisible = $derived(
+    !!(
+      saveResult &&
+      saveResult.ok &&
+      saveResult.affectedLemmaCount > 0 &&
+      // Read the counter so the derived recomputes when dismiss
+      // fires; the actual identity check uses the non-reactive slot.
+      dismissBump >= 0 &&
+      dismissedRegenForSave !== form &&
+      !regenResult
+    ),
+  );
+
+  // Auto-open / auto-close the modal in response to `regenPromptVisible`.
+  // Tracking `dialog.open` keeps us idempotent — Svelte's $effect may
+  // re-run if any dep flips, but we only `showModal()` once per open.
+  $effect(() => {
+    if (!regenDialog) return;
+    if (regenPromptVisible && !regenDialog.open) {
+      regenDialog.showModal();
+    } else if (!regenPromptVisible && regenDialog.open) {
+      regenDialog.close();
+    }
+  });
+
+  function dismissRegenPrompt() {
+    dismissedRegenForSave = form; dismissBump += 1;
+    regenDialog?.close();
+  }
+
+  // ─── Regen result → toast ───────────────────────────────────────────
+  // When the regen action returns, surface the summary as a toast so
+  // the curator gets the confirmation without the save bar carrying
+  // long-lived result text. We key the "already toasted" check by the
+  // result identity so we don't re-fire the toast on incidental
+  // re-renders (e.g. a fresh `dirty` flip).
+  //
+  // IMPORTANT: this guard is a plain `let`, not `$state`. Svelte 5
+  // deeply proxies any object assigned to a `$state` slot — which
+  // would make `regenResult === toastedRegenResult` permanently
+  // false after the first assignment, re-firing the effect on every
+  // reactive tick and pushing a fresh toast each time (see
+  // regen-effect.test.ts for the repro). Plain `let` keeps the
+  // reference identical and stops the effect tracking writes here.
+  let toastedRegenResult: unknown = null;
+  $effect(() => {
+    if (!regenResult || regenResult === toastedRegenResult) return;
+    toastedRegenResult = regenResult;
+    // Dismiss the in-flight "Regenerating…" toast (if any) before the
+    // result toast goes up, so the two don't briefly stack.
+    if (regenProgressToastId) {
+      dismissToast(regenProgressToastId);
+      regenProgressToastId = null;
+    }
+    if (regenResult.ok) {
+      // Single toast captures the whole outcome — partial failures
+      // fold into the same line instead of stacking a second toast.
+      const { lemmasProcessed, lemmasFailed, removed, inserted, failures } =
+        regenResult;
+      const total = lemmasProcessed + lemmasFailed;
+      const lemmaWord = total === 1 ? 'lemma' : 'lemmas';
+      let message: string;
+      if (lemmasFailed === 0) {
+        message = `Regenerated ${lemmasProcessed} ${lemmaWord} · removed ${removed} · inserted ${inserted}`;
+      } else {
+        const failedNames = failures
+          .slice(0, 2)
+          .map((f) => f.headword)
+          .join(', ');
+        const more = lemmasFailed > 2 ? ` (+${lemmasFailed - 2})` : '';
+        message = `Regenerated ${lemmasProcessed} of ${total} ${lemmaWord} · ${lemmasFailed} failed: ${failedNames}${more}`;
+      }
+      // Use the error variant only when NOTHING succeeded; partial
+      // success is still a success worth confirming.
+      const kind = lemmasProcessed === 0 ? 'error' : 'success';
+      pushToast({ kind, message });
+    } else {
+      pushToast({
+        kind: 'error',
+        message: `Regenerate failed: ${regenResult.message}`,
+      });
+    }
+  });
+</script>
+
+<svelte:head>
+  <title>{data.paradigm.name} — Paradigms — CIA Reader</title>
+  <meta name="robots" content="noindex" />
+</svelte:head>
+
+<div class="page">
+  <p class="crumb">
+    <a href="/moderation/paradigms">← Back to paradigms</a>
+  </p>
+
+  <header>
+    <h1>{data.paradigm.name}</h1>
+    <p class="sub">
+      <span class="lang-badge">{data.paradigm.language}</span>
+      <span class="pos-badge">{data.paradigm.pos}</span>
+      · {data.slots.length} slot{data.slots.length === 1 ? '' : 's'}
+    </p>
+  </header>
+
+  <!-- 1. Paradigm metadata -------------------------------------------------- -->
+  <section>
+    <h2>Paradigm</h2>
+    <div class="stack">
+      <label>
+        Language
+        <select bind:value={paradigmDraft.language} required>
+          {#each data.languages as l (l.code)}
+            <option value={l.code}>{l.displayName} ({l.nativeName})</option>
+          {/each}
+        </select>
+      </label>
+      <label>
+        POS
+        <input bind:value={paradigmDraft.pos} required maxlength="32" />
+      </label>
+      <label>
+        Name
+        <input bind:value={paradigmDraft.name} required maxlength="128" />
+      </label>
+      <label>
+        Description
+        <textarea
+          bind:value={paradigmDraft.description}
+          rows="3"
+          maxlength="1000"
+        ></textarea>
+      </label>
+    </div>
+  </section>
+
+  <!-- 2. Slot table ------------------------------------------------------- -->
+  <section>
+    <h2>Slots</h2>
+    <p class="sub">
+      Each slot defines one cell in the conjugation/declension grid. The
+      generator appends <code>suffix</code> to a lemma's <code>stem</code> to
+      produce the surface form. Features are emitted onto the resulting
+      <code>lemma_forms.features</code> blob so the popup pills render
+      correctly. Drag the grip handle to reorder (or focus a handle and
+      press ↑ / ↓); delete to remove a slot entirely.
+    </p>
+
+    {#if slotResult}
+      {#if slotResult.ok}
+        <p class="ok">
+          {#if slotResult.action === 'add'}Slot added.
+          {:else if slotResult.action === 'remove'}Slot removed.
+          {/if}
+        </p>
+      {:else}
+        <p class="err">{slotResult.message}</p>
+      {/if}
+    {/if}
+
+    {#if slotDrafts.length === 0}
+      <p class="empty">No slots yet. Add one below.</p>
+    {:else}
+      <div class="slot-table" ondragleave={onDragLeaveList} role="list">
+        <div class="slot-row slot-header" aria-hidden="true">
+          <span class="col-handle"></span>
+          <span class="col-key">slot_key</span>
+          <span class="col-suffix">suffix</span>
+          <span class="col-features">features (Key=Value, comma-separated)</span>
+          <span class="col-actions"></span>
+        </div>
+        {#each slotDrafts as slot, i (slot.id)}
+          <div
+            class="slot-row"
+            role="listitem"
+            class:dragging={draggingIdx === i}
+            class:drop-above={dropTargetIdx === i && draggingIdx !== i}
+            class:drop-below={dropTargetIdx === i + 1 && draggingIdx !== i}
+            ondragover={(e) => onDragOver(e, i)}
+            ondrop={onDrop}
+          >
+            <span
+              class="col-handle drag-handle"
+              role="button"
+              tabindex="0"
+              draggable="true"
+              data-handle-idx={i}
+              title="Drag to reorder · ↑/↓ to nudge"
+              aria-label="Drag handle for slot {slot.slotKey}"
+              ondragstart={(e) => onDragStart(e, i)}
+              ondragend={onDragEnd}
+              onkeydown={(e) => onHandleKeydown(e, i)}
+            >
+              <svg
+                width="14"
+                height="20"
+                viewBox="0 0 14 20"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <circle cx="4" cy="4" r="1.5" />
+                <circle cx="10" cy="4" r="1.5" />
+                <circle cx="4" cy="10" r="1.5" />
+                <circle cx="10" cy="10" r="1.5" />
+                <circle cx="4" cy="16" r="1.5" />
+                <circle cx="10" cy="16" r="1.5" />
+              </svg>
+            </span>
+            <label class="col-key">
+              <span class="vh">slot_key</span>
+              <input
+                bind:value={slot.slotKey}
+                required
+                maxlength="64"
+                pattern="[a-z0-9_]+"
+                title="lowercase, digits, underscore"
+              />
+            </label>
+            <label class="col-suffix">
+              <span class="vh">suffix</span>
+              <input bind:value={slot.suffix} maxlength="64" />
+            </label>
+            <label class="col-features">
+              <span class="vh">features</span>
+              <input
+                bind:value={slot.features}
+                placeholder="Tense=Past, Person=1, Number=Sing"
+              />
+            </label>
+            <span class="col-actions">
+              {#if confirmingSlotId === slot.id}
+                <form
+                  method="post"
+                  action="?/removeSlot"
+                  use:enhance
+                  class="confirm-inline"
+                >
+                  <input type="hidden" name="slotId" value={slot.id} />
+                  <button
+                    type="button"
+                    class="iconbtn"
+                    title="Cancel"
+                    aria-label="Cancel delete"
+                    onclick={() => (confirmingSlotId = null)}
+                  >
+                    ✕
+                  </button>
+                  <button
+                    type="submit"
+                    class="iconbtn danger"
+                    title="Confirm delete"
+                    aria-label="Confirm delete slot"
+                  >
+                    ✓
+                  </button>
+                </form>
+              {:else}
+                <button
+                  type="button"
+                  class="iconbtn danger"
+                  title="Delete slot"
+                  aria-label="Delete slot"
+                  onclick={() => (confirmingSlotId = slot.id)}
+                >
+                  🗑
+                </button>
+              {/if}
+            </span>
+          </div>
+        {/each}
+      </div>
+    {/if}
+  </section>
+
+  <!-- 3. Add slot --------------------------------------------------------- -->
+  <section>
+    <h2>Add slot</h2>
+    <form method="post" action="?/addSlot" use:enhance class="add-slot-row">
+      <!-- Empty column so the form lines up under the grip column of
+           the slot table above. -->
+      <span class="col-handle" aria-hidden="true"></span>
+      <label class="col-key">
+        <span class="vh">slot_key</span>
+        <input
+          name="slotKey"
+          required
+          maxlength="64"
+          pattern="[a-z0-9_]+"
+          placeholder="slot_key"
+        />
+      </label>
+      <label class="col-suffix">
+        <span class="vh">suffix</span>
+        <input name="suffix" maxlength="64" placeholder="suffix" />
+      </label>
+      <label class="col-features">
+        <span class="vh">features</span>
+        <input
+          name="features"
+          placeholder="Tense=Pres, Aspect=Hab, Person=3, Number=Sing"
+        />
+      </label>
+      <span class="col-actions">
+        <button type="submit">Add</button>
+      </span>
+    </form>
+  </section>
+
+  <!-- 4. Delete paradigm --------------------------------------------------- -->
+  <section class="danger-zone">
+    <h2>Delete paradigm</h2>
+    <p class="sub">
+      Lemmas referencing this paradigm keep their <code>stem</code> but their
+      <code>paradigm_id</code> is reset to NULL. Generator-created form rows
+      lose their slot pointer and become orphans (curators can clean them
+      up from each lemma's form editor).
+    </p>
+
+    {#if deleteResult && !deleteResult.ok}
+      <p class="err">{deleteResult.message}</p>
+    {/if}
+
+    {#if confirmingParadigmDelete}
+      <form method="post" action="?/deleteParadigm" use:enhance class="confirm">
+        <p>
+          Really delete <strong>{data.paradigm.name}</strong>? This wipes
+          {data.slots.length} slot{data.slots.length === 1 ? '' : 's'}.
+        </p>
+        <div class="confirm-actions">
+          <button
+            type="button"
+            onclick={() => (confirmingParadigmDelete = false)}
+          >
+            Cancel
+          </button>
+          <button type="submit" class="danger">Yes, delete</button>
+        </div>
+      </form>
+    {:else}
+      <button
+        type="button"
+        class="danger"
+        onclick={() => (confirmingParadigmDelete = true)}
+      >
+        Delete paradigm
+      </button>
+    {/if}
+  </section>
+</div>
+
+<!-- Sticky save bar — only visible / active when there are unsaved
+     edits or a post-save confirmation. Regen results land in the
+     toast host, so the bar doesn't have to stay open for them. -->
+<div
+  class="save-bar"
+  class:hidden={!dirty && !saveResult}
+>
+  <div class="save-bar-inner">
+    <!-- Top row: save action + post-save status -->
+    <form
+      method="post"
+      action="?/saveAll"
+      use:enhance
+      class="save-row"
+    >
+      <input type="hidden" name="payload" value={savePayload} />
+      {#if saveResult}
+        {#if saveResult.ok}
+          <span class="ok">Saved.</span>
+        {:else}
+          <span class="err">{saveResult.message}</span>
+        {/if}
+      {/if}
+      <span class="spacer"></span>
+      <button type="submit" class="save" disabled={!dirty}>
+        {dirty ? 'Save changes' : 'No unsaved changes'}
+      </button>
+    </form>
+
+  </div>
+</div>
+
+<!-- Regen confirmation modal — opens automatically after a save that
+     reports lemmas using this paradigm. Uses native <dialog> for the
+     focus trap, ESC handling, and backdrop. -->
+<dialog
+  bind:this={regenDialog}
+  class="regen-dialog"
+  oncancel={dismissRegenPrompt}
+  onclose={() => {
+    if (regenPromptVisible) {
+      // The dialog was dismissed via ESC or close() not initiated
+      // by our own dismiss handler — mark it dismissed so the
+      // $effect doesn't re-open it on the next reactive tick.
+      dismissedRegenForSave = form; dismissBump += 1;
+    }
+  }}
+>
+  {#if saveResult?.ok && saveResult.affectedLemmaCount > 0}
+    <h3>Regenerate forms?</h3>
+    <p>
+      <strong>{saveResult.affectedLemmaCount}</strong>
+      {saveResult.affectedLemmaCount === 1 ? 'lemma uses' : 'lemmas use'}
+      this paradigm. Their generator-created
+      <code>lemma_forms</code> rows reflect the
+      <em>previous</em> slot definitions and are now stale.
+    </p>
+    <p class="dialog-sub">
+      Regenerating wipes every non-curator form row on each affected
+      lemma and rebuilds from the current slots. Curator-edited forms
+      are preserved.
+    </p>
+    <div class="dialog-actions">
+      <button
+        type="button"
+        class="dismiss"
+        disabled={regenPending}
+        onclick={dismissRegenPrompt}
+      >
+        Not now
+      </button>
+      <form
+        method="post"
+        action="?/regenerateAffected"
+        use:enhance={() => {
+          // Close the modal immediately and surface progress as a
+          // sticky toast. The regen loops over every affected lemma
+          // sequentially (each makes an NLP romanize call) so it
+          // can run for tens of seconds — leaving the modal open
+          // would render the page `inert` for that whole window
+          // and make the editor feel frozen.
+          regenPending = true;
+          regenProgressToastId = pushToast({
+            kind: 'info',
+            message: `Regenerating forms for ${saveResult?.ok ? saveResult.affectedLemmaCount : ''} lemmas…`.replace(
+              '  ',
+              ' ',
+            ),
+            duration: null,
+          });
+          dismissedRegenForSave = form; dismissBump += 1;
+          regenDialog?.close();
+          return async ({ update }) => {
+            try {
+              await update();
+            } finally {
+              // Reset even if update() threw — otherwise the next
+              // attempt would see stale state. The result-watching
+              // $effect handles dismissing the progress toast +
+              // pushing the success/error toast.
+              regenPending = false;
+            }
+          };
+        }}
+      >
+        <button type="submit" class="regen" disabled={regenPending}>
+          {regenPending ? 'Regenerating…' : 'Regenerate forms'}
+        </button>
+      </form>
+    </div>
+  {/if}
+</dialog>
+
+<style>
+  .page {
+    max-width: 64rem;
+    margin: 0 auto;
+    /* Reserve room at the bottom so the sticky save bar doesn't cover
+       the last section. */
+    padding: 1.5rem 1.25rem 6rem;
+  }
+  .crumb {
+    margin: 0 0 1rem;
+    font-size: 0.9rem;
+  }
+  .crumb a {
+    color: var(--color-accent);
+  }
+  header h1 {
+    margin: 0 0 0.25rem;
+    font-size: 1.6rem;
+  }
+  .sub {
+    margin: 0 0 0.75rem;
+    color: var(--color-fg-muted);
+    font-size: 0.9rem;
+  }
+  section {
+    margin: 1.75rem 0;
+    padding: 1rem 1.25rem;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+  }
+  section h2 {
+    margin: 0 0 0.5rem;
+    font-size: 1.1rem;
+  }
+  .lang-badge,
+  .pos-badge {
+    font-size: 0.7rem;
+    padding: 0.05rem 0.4rem;
+    border-radius: 999px;
+    background: var(--color-border);
+    color: var(--color-fg-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .stack > * {
+    margin-bottom: 0.75rem;
+  }
+  label {
+    display: block;
+    font-size: 0.9rem;
+  }
+  input,
+  textarea,
+  select {
+    display: block;
+    width: 100%;
+    margin-top: 0.25rem;
+    padding: 0.5rem 0.6rem;
+    font: inherit;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    background: var(--color-bg);
+    color: var(--color-fg);
+    min-height: 44px;
+  }
+  textarea {
+    min-height: 5rem;
+    resize: vertical;
+  }
+  button {
+    min-height: 44px;
+    padding: 0 1rem;
+    background: var(--color-accent);
+    color: var(--color-accent-fg, #fff);
+    border: 0;
+    border-radius: 6px;
+    cursor: pointer;
+  }
+  button[disabled] {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  button.danger {
+    background: #b03131;
+    color: #fff;
+  }
+
+  /* ── Slot grid ────────────────────────────────────────────────── */
+  .slot-table {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+  .slot-row {
+    /* Grip handle column is auto-width so it sticks to its 22px target
+       regardless of viewport size; everything else shares the
+       remaining space. */
+    display: grid;
+    grid-template-columns:
+      28px
+      minmax(7rem, 1fr)
+      minmax(4rem, 0.8fr)
+      minmax(10rem, 2.2fr)
+      auto;
+    gap: 0.4rem;
+    align-items: end;
+    padding: 0.35rem 0;
+    border-top: 2px solid transparent;
+    border-bottom: 1px solid var(--color-border);
+    transition: opacity 80ms ease;
+  }
+  .slot-row:last-child {
+    border-bottom: 0;
+  }
+  .slot-row.dragging {
+    opacity: 0.4;
+  }
+  /* Drop indicators: a thicker accent-colored top or bottom border on
+     the target row, so the user sees exactly where the dragged slot
+     will land. */
+  .slot-row.drop-above {
+    border-top-color: var(--color-accent);
+  }
+  .slot-row.drop-below {
+    border-bottom: 2px solid var(--color-accent);
+  }
+  .slot-header {
+    border-bottom: 0;
+    font-size: 0.75rem;
+    color: var(--color-fg-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding-bottom: 0;
+  }
+  .slot-header > span {
+    padding: 0 0.4rem;
+  }
+  .slot-row label {
+    margin: 0;
+  }
+  .slot-row input {
+    margin-top: 0;
+    min-height: 36px;
+    padding: 0.3rem 0.5rem;
+    font-size: 0.9rem;
+  }
+
+  /* Drag handle — 28px square, vertical "grip" of six dots in an
+     SVG. The whole element is focusable + draggable; the SVG is
+     pointer-events:none so child events don't get in the way. */
+  .col-handle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    align-self: stretch;
+  }
+  .drag-handle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 36px;
+    color: var(--color-fg-muted);
+    background: transparent;
+    border-radius: 6px;
+    cursor: grab;
+    user-select: none;
+    outline: none;
+  }
+  .drag-handle:hover,
+  .drag-handle:focus-visible {
+    background: var(--color-border);
+    color: var(--color-fg);
+  }
+  .drag-handle:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: -2px;
+  }
+  .drag-handle:active {
+    cursor: grabbing;
+  }
+  .drag-handle svg {
+    fill: currentColor;
+    pointer-events: none;
+  }
+  .col-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    justify-content: flex-end;
+  }
+  .iconbtn {
+    min-height: 32px;
+    min-width: 32px;
+    padding: 0 0.4rem;
+    background: var(--color-bg);
+    color: var(--color-fg);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    font-size: 0.9rem;
+    line-height: 1;
+    cursor: pointer;
+  }
+  .iconbtn.danger {
+    color: #b03131;
+    border-color: rgba(176, 49, 49, 0.4);
+    background: var(--color-bg);
+  }
+  .iconbtn.danger:hover:not([disabled]) {
+    background: rgba(176, 49, 49, 0.08);
+  }
+  .confirm-inline {
+    display: flex;
+    gap: 0.3rem;
+  }
+
+  /* Visually-hidden header text — the column header row above acts
+     as the visible label, but each input still carries a screen-
+     reader-only label for assistive tech. */
+  .vh {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  /* ── Add-slot row uses the same grid so columns line up ───────── */
+  .add-slot-row {
+    display: grid;
+    grid-template-columns:
+      28px
+      minmax(7rem, 1fr)
+      minmax(4rem, 0.8fr)
+      minmax(10rem, 2.2fr)
+      auto;
+    gap: 0.4rem;
+    align-items: end;
+  }
+  .add-slot-row input {
+    margin-top: 0;
+    min-height: 36px;
+    padding: 0.3rem 0.5rem;
+    font-size: 0.9rem;
+  }
+  .add-slot-row button {
+    min-height: 36px;
+    padding: 0 0.85rem;
+  }
+
+  /* ── Sticky save bar ──────────────────────────────────────────── */
+  .save-bar {
+    position: sticky;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    margin: 0;
+    background: var(--color-bg);
+    border-top: 1px solid var(--color-border);
+    padding: 0.6rem 1.25rem;
+    transition: transform 150ms ease;
+  }
+  .save-bar.hidden {
+    transform: translateY(120%);
+    pointer-events: none;
+  }
+  .save-bar-inner {
+    max-width: 64rem;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  .save-row {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+  .save-bar .spacer {
+    flex: 1;
+  }
+  .save-bar .save {
+    min-height: 40px;
+    padding: 0 1.2rem;
+  }
+
+  /* ── Regen confirmation dialog ─────────────────────────────────── */
+  .regen-dialog {
+    max-width: 30rem;
+    width: calc(100% - 2rem);
+    padding: 1.25rem 1.5rem;
+    border: 1px solid var(--color-border);
+    border-radius: 10px;
+    background: var(--color-bg);
+    color: var(--color-fg);
+    /* Browsers vary on default <dialog> centering; pin it explicitly
+       so the modal lands middle of the viewport on every engine. */
+    margin: auto;
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.2);
+  }
+  .regen-dialog::backdrop {
+    background: rgba(0, 0, 0, 0.45);
+  }
+  .regen-dialog h3 {
+    margin: 0 0 0.5rem;
+    font-size: 1.15rem;
+  }
+  .regen-dialog p {
+    margin: 0 0 0.6rem;
+    font-size: 0.95rem;
+    line-height: 1.5;
+  }
+  .regen-dialog .dialog-sub {
+    font-size: 0.85rem;
+    color: var(--color-fg-muted);
+  }
+  .dialog-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+    margin-top: 1rem;
+  }
+  .regen {
+    min-height: 40px;
+    padding: 0 1rem;
+    background: var(--color-accent);
+    color: var(--color-accent-fg, #fff);
+    border: 0;
+    border-radius: 6px;
+    cursor: pointer;
+  }
+  .regen[disabled] {
+    opacity: 0.6;
+    cursor: progress;
+  }
+  .dismiss {
+    min-height: 40px;
+    padding: 0 0.85rem;
+    background: transparent;
+    color: var(--color-fg);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    cursor: pointer;
+  }
+  .dismiss[disabled] {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+
+  .empty {
+    margin: 0.5rem 0;
+    color: var(--color-fg-muted);
+  }
+  .ok {
+    color: #197a2f;
+  }
+  .err {
+    color: #b03131;
+  }
+  .danger-zone {
+    border-color: rgba(176, 49, 49, 0.4);
+  }
+  .confirm {
+    margin-top: 0.75rem;
+  }
+  .confirm-actions {
+    display: flex;
+    gap: 0.5rem;
+  }
+  code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.85em;
+  }
+</style>

--- a/apps/web/src/routes/moderation/paradigms/[id]/page-server.test.ts
+++ b/apps/web/src/routes/moderation/paradigms/[id]/page-server.test.ts
@@ -1,0 +1,434 @@
+// @vitest-environment node
+/**
+ * Tests for /moderation/paradigms/[id] SSR loader + actions.
+ *
+ * The page is admin-only. The interesting wire-level decisions:
+ *   - the editor's "Save changes" button posts a JSON `payload` to
+ *     `?/saveAll` and that one action handles paradigm metadata +
+ *     per-slot edits + reorder atomically.
+ *   - add / remove / delete-paradigm fire immediately under their
+ *     own actions, each gated by an inline confirmation in the UI.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const loadParadigm = vi.fn();
+const saveAllParadigmChanges = vi.fn();
+const deleteParadigm = vi.fn();
+const createSlot = vi.fn();
+const deleteSlot = vi.fn();
+const countLemmasUsingParadigm = vi.fn();
+const regenerateAllForParadigm = vi.fn();
+
+vi.mock('$lib/server/dictionary/paradigms.js', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/dictionary/paradigms.js')>(
+    '$lib/server/dictionary/paradigms.js',
+  );
+  return {
+    ...actual,
+    loadParadigm: (...a: unknown[]) => loadParadigm(...a),
+    saveAllParadigmChanges: (...a: unknown[]) => saveAllParadigmChanges(...a),
+    deleteParadigm: (...a: unknown[]) => deleteParadigm(...a),
+    createSlot: (...a: unknown[]) => createSlot(...a),
+    deleteSlot: (...a: unknown[]) => deleteSlot(...a),
+    countLemmasUsingParadigm: (...a: unknown[]) => countLemmasUsingParadigm(...a),
+  };
+});
+
+vi.mock('$lib/server/dictionary/lemma-forms.js', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/dictionary/lemma-forms.js')>(
+    '$lib/server/dictionary/lemma-forms.js',
+  );
+  return {
+    ...actual,
+    regenerateAllForParadigm: (...a: unknown[]) => regenerateAllForParadigm(...a),
+  };
+});
+
+type Mod = typeof import('./+page.server.js');
+const PARADIGM_ID = '00000000-0000-0000-0000-0000000000a1';
+const SLOT_ID_1 = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const SLOT_ID_2 = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+const ADMIN = { id: 'admin-1', role: 'admin' as const };
+const CURATOR = { id: 'cur-1', role: 'curator' as const };
+
+async function callLoad(
+  user: { id: string; role: 'admin' | 'curator' | 'user' } | null,
+  paradigmId = PARADIGM_ID,
+) {
+  const { load } = (await import('./+page.server.js')) as Mod;
+  const event = {
+    locals: { user },
+    params: { id: paradigmId },
+    url: new URL(`http://x/moderation/paradigms/${paradigmId}`),
+  } as unknown as Parameters<Mod['load']>[0];
+  try {
+    return await load(event);
+  } catch (e) {
+    return e as { status?: number; location?: string };
+  }
+}
+
+async function callAction(
+  name:
+    | 'saveAll'
+    | 'deleteParadigm'
+    | 'addSlot'
+    | 'removeSlot'
+    | 'regenerateAffected',
+  fields: Record<string, string>,
+  user: { id: string; role: 'admin' | 'curator' | 'user' } | null = ADMIN,
+  paradigmId = PARADIGM_ID,
+) {
+  const { actions } = (await import('./+page.server.js')) as Mod;
+  const fd = new FormData();
+  for (const [k, v] of Object.entries(fields)) fd.append(k, v);
+  const event = {
+    locals: { user },
+    params: { id: paradigmId },
+    request: {
+      formData: () => Promise.resolve(fd),
+    } as unknown as Request,
+  } as unknown as Parameters<Mod['actions'][string]>[0];
+  return actions[name]!(event);
+}
+
+beforeEach(() => {
+  loadParadigm.mockReset();
+  saveAllParadigmChanges.mockReset();
+  deleteParadigm.mockReset();
+  createSlot.mockReset();
+  deleteSlot.mockReset();
+  countLemmasUsingParadigm.mockReset();
+  countLemmasUsingParadigm.mockResolvedValue(0);
+  regenerateAllForParadigm.mockReset();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('/moderation/paradigms/[id] loader', () => {
+  it('hydrates the paradigm + slots for an admin', async () => {
+    loadParadigm.mockResolvedValueOnce({
+      paradigm: { id: PARADIGM_ID, language: 'or', pos: 'VERB', name: 'Odia regular verb' },
+      slots: [
+        { id: SLOT_ID_1, slotKey: 'inf', features: { VerbForm: 'Inf' }, suffix: 'ିବା', sortOrder: 10 },
+      ],
+    });
+    const data = (await callLoad(ADMIN)) as {
+      paradigm: { name: string };
+      slots: { id: string }[];
+    };
+    expect(data.paradigm.name).toBe('Odia regular verb');
+    expect(data.slots).toHaveLength(1);
+    expect(data.slots[0]!.id).toBe(SLOT_ID_1);
+  });
+
+  it('404s when the paradigm is unknown', async () => {
+    loadParadigm.mockResolvedValueOnce(null);
+    const res = (await callLoad(ADMIN)) as { status: number };
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects a malformed paradigm id with 400', async () => {
+    const res = (await callLoad(ADMIN, 'not-a-uuid')) as { status: number };
+    expect(res.status).toBe(400);
+    expect(loadParadigm).not.toHaveBeenCalled();
+  });
+
+  it('forbids curators', async () => {
+    const res = (await callLoad(CURATOR)) as { status: number };
+    expect(res.status).toBe(403);
+    expect(loadParadigm).not.toHaveBeenCalled();
+  });
+
+  it('redirects an unauthenticated visitor', async () => {
+    const res = (await callLoad(null)) as { status: number; location: string };
+    expect(res.status).toBe(303);
+    expect(res.location).toContain('/login');
+  });
+});
+
+describe('?/saveAll action', () => {
+  function payload(over: Partial<{
+    paradigm: Record<string, unknown>;
+    slots: Array<Record<string, unknown>>;
+  }> = {}): string {
+    const paradigm = {
+      language: 'or',
+      pos: 'VERB',
+      name: 'Odia regular verb',
+      description: 'updated',
+      ...(over.paradigm ?? {}),
+    };
+    const slots = over.slots ?? [
+      {
+        id: SLOT_ID_1,
+        slotKey: 'inf',
+        features: { VerbForm: 'Inf' },
+        suffix: 'ିବା',
+      },
+    ];
+    return JSON.stringify({ paradigm, slots });
+  }
+
+  it('forwards the parsed JSON payload to the service', async () => {
+    saveAllParadigmChanges.mockResolvedValueOnce(undefined);
+    const result = (await callAction('saveAll', { payload: payload() })) as {
+      ok: boolean;
+      section: string;
+      affectedLemmaCount: number;
+    };
+    expect(result.ok).toBe(true);
+    expect(result.section).toBe('saveAll');
+    expect(saveAllParadigmChanges).toHaveBeenCalledWith(PARADIGM_ID, {
+      paradigm: {
+        language: 'or',
+        pos: 'VERB',
+        name: 'Odia regular verb',
+        description: 'updated',
+      },
+      slots: [
+        {
+          id: SLOT_ID_1,
+          slotKey: 'inf',
+          features: { VerbForm: 'Inf' },
+          suffix: 'ିବା',
+        },
+      ],
+    });
+    // Default mock returns 0 — verify the count is surfaced for the
+    // UI's regen prompt to decide whether to render itself.
+    expect(result.affectedLemmaCount).toBe(0);
+  });
+
+  it('returns the count of lemmas using this paradigm', async () => {
+    saveAllParadigmChanges.mockResolvedValueOnce(undefined);
+    countLemmasUsingParadigm.mockResolvedValueOnce(7);
+    const result = (await callAction('saveAll', { payload: payload() })) as {
+      ok: boolean;
+      affectedLemmaCount: number;
+    };
+    expect(result.ok).toBe(true);
+    expect(result.affectedLemmaCount).toBe(7);
+    expect(countLemmasUsingParadigm).toHaveBeenCalledWith(PARADIGM_ID);
+  });
+
+  it('accepts a null description and forwards it through', async () => {
+    saveAllParadigmChanges.mockResolvedValueOnce(undefined);
+    await callAction('saveAll', {
+      payload: payload({ paradigm: { description: null } }),
+    });
+    const args = saveAllParadigmChanges.mock.calls[0]![1] as {
+      paradigm: { description: unknown };
+    };
+    expect(args.paradigm.description).toBeNull();
+  });
+
+  it('returns 400 when the payload is missing', async () => {
+    const result = (await callAction('saveAll', {})) as {
+      status: number;
+      data: { section: string; message: string };
+    };
+    expect(result.status).toBe(400);
+    expect(result.data.section).toBe('saveAll');
+    expect(saveAllParadigmChanges).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when the payload is not valid JSON', async () => {
+    const result = (await callAction('saveAll', { payload: 'not-json' })) as {
+      status: number;
+      data: { message: string };
+    };
+    expect(result.status).toBe(400);
+    expect(result.data.message).toContain('Malformed');
+  });
+
+  it('rejects an unsupported language', async () => {
+    const result = (await callAction('saveAll', {
+      payload: payload({ paradigm: { language: 'xx' } }),
+    })) as { status: number; data: { ok: boolean } };
+    expect(result.status).toBe(400);
+    expect(result.data.ok).toBe(false);
+    expect(saveAllParadigmChanges).not.toHaveBeenCalled();
+  });
+
+  it('rejects a slot id that is not a UUID', async () => {
+    const result = (await callAction('saveAll', {
+      payload: payload({
+        slots: [
+          {
+            id: 'not-a-uuid',
+            slotKey: 'inf',
+            features: {},
+            suffix: '',
+          },
+        ],
+      }),
+    })) as { status: number };
+    expect(result.status).toBe(400);
+    expect(saveAllParadigmChanges).not.toHaveBeenCalled();
+  });
+
+  it('forbids non-admin', async () => {
+    const result = (await callAction(
+      'saveAll',
+      { payload: payload() },
+      CURATOR,
+    )) as { status: number };
+    expect(result.status).toBe(403);
+    expect(saveAllParadigmChanges).not.toHaveBeenCalled();
+  });
+});
+
+describe('?/addSlot action', () => {
+  beforeEach(() => {
+    loadParadigm.mockResolvedValue({
+      paradigm: { id: PARADIGM_ID, language: 'or', pos: 'VERB', name: 'P' },
+      slots: [
+        { id: SLOT_ID_1, slotKey: 'inf', features: {}, suffix: '', sortOrder: 10 },
+        { id: SLOT_ID_2, slotKey: 'past_3sg', features: {}, suffix: '', sortOrder: 40 },
+      ],
+    });
+  });
+
+  it('parses Key=Value features and appends past the max sort_order', async () => {
+    createSlot.mockResolvedValueOnce({ id: 'new-slot' });
+    const result = (await callAction('addSlot', {
+      slotKey: 'pres_hab_1sg',
+      suffix: 'े',
+      features: 'Tense=Pres, Aspect=Hab, Person=1, Number=Sing',
+    })) as { ok: boolean; action: string };
+    expect(result.ok).toBe(true);
+    expect(result.action).toBe('add');
+    expect(createSlot).toHaveBeenCalledWith({
+      paradigmId: PARADIGM_ID,
+      slotKey: 'pres_hab_1sg',
+      features: { Tense: 'Pres', Aspect: 'Hab', Person: '1', Number: 'Sing' },
+      suffix: 'े',
+      sortOrder: 50,
+    });
+  });
+
+  it('respects an explicit sort_order when provided', async () => {
+    createSlot.mockResolvedValueOnce({ id: 'new-slot' });
+    await callAction('addSlot', {
+      slotKey: 'mid',
+      suffix: '',
+      features: '',
+      sortOrder: '25',
+    });
+    expect(createSlot).toHaveBeenCalledWith(
+      expect.objectContaining({ sortOrder: 25 }),
+    );
+  });
+
+  it('rejects a missing slot_key via 400', async () => {
+    const result = (await callAction('addSlot', {
+      slotKey: '',
+      suffix: '',
+    })) as { status: number; data: { ok: boolean; section: string; action: string } };
+    expect(result.status).toBe(400);
+    expect(result.data.section).toBe('slot');
+    expect(result.data.action).toBe('add');
+    expect(createSlot).not.toHaveBeenCalled();
+  });
+});
+
+describe('?/removeSlot action', () => {
+  it('forwards the slot id', async () => {
+    deleteSlot.mockResolvedValueOnce(undefined);
+    const result = (await callAction('removeSlot', { slotId: SLOT_ID_1 })) as {
+      ok: boolean;
+      action: string;
+    };
+    expect(result.ok).toBe(true);
+    expect(result.action).toBe('remove');
+    expect(deleteSlot).toHaveBeenCalledWith(SLOT_ID_1);
+  });
+
+  it('rejects a non-uuid slot id with 400', async () => {
+    const result = (await callAction('removeSlot', { slotId: 'not-a-uuid' })) as {
+      status: number;
+    };
+    expect(result.status).toBe(400);
+    expect(deleteSlot).not.toHaveBeenCalled();
+  });
+});
+
+describe('?/regenerateAffected action', () => {
+  it('forwards to regenerateAllForParadigm and surfaces the summary', async () => {
+    regenerateAllForParadigm.mockResolvedValueOnce({
+      lemmasProcessed: 3,
+      lemmasFailed: 0,
+      removed: 27,
+      inserted: 30,
+      failures: [],
+    });
+    const result = (await callAction('regenerateAffected', {})) as {
+      ok: boolean;
+      section: string;
+      lemmasProcessed: number;
+      removed: number;
+      inserted: number;
+    };
+    expect(result.ok).toBe(true);
+    expect(result.section).toBe('regenerate');
+    expect(result.lemmasProcessed).toBe(3);
+    expect(result.removed).toBe(27);
+    expect(result.inserted).toBe(30);
+    expect(regenerateAllForParadigm).toHaveBeenCalledWith(PARADIGM_ID);
+  });
+
+  it('reports per-lemma failures without failing the action', async () => {
+    regenerateAllForParadigm.mockResolvedValueOnce({
+      lemmasProcessed: 2,
+      lemmasFailed: 1,
+      removed: 18,
+      inserted: 20,
+      failures: [{ lemmaId: 'l-99', headword: 'बोलना', error: 'nlp down' }],
+    });
+    const result = (await callAction('regenerateAffected', {})) as {
+      ok: boolean;
+      lemmasFailed: number;
+      failures: Array<{ headword: string }>;
+    };
+    expect(result.ok).toBe(true);
+    expect(result.lemmasFailed).toBe(1);
+    expect(result.failures[0]!.headword).toBe('बोलना');
+  });
+
+  it('forbids a curator', async () => {
+    const result = (await callAction(
+      'regenerateAffected',
+      {},
+      CURATOR,
+    )) as { status: number };
+    expect(result.status).toBe(403);
+    expect(regenerateAllForParadigm).not.toHaveBeenCalled();
+  });
+});
+
+describe('?/deleteParadigm action', () => {
+  it('redirects to the list after a successful delete', async () => {
+    deleteParadigm.mockResolvedValueOnce(undefined);
+    let thrown: unknown;
+    try {
+      await callAction('deleteParadigm', {});
+    } catch (e) {
+      thrown = e;
+    }
+    expect(deleteParadigm).toHaveBeenCalledWith(PARADIGM_ID);
+    const r = thrown as { status?: number; location?: string };
+    expect(r?.status).toBe(303);
+    expect(r?.location).toBe('/moderation/paradigms');
+  });
+
+  it('forbids a curator', async () => {
+    const result = (await callAction('deleteParadigm', {}, CURATOR)) as {
+      status: number;
+    };
+    expect(result.status).toBe(403);
+    expect(deleteParadigm).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/routes/moderation/paradigms/page-server.test.ts
+++ b/apps/web/src/routes/moderation/paradigms/page-server.test.ts
@@ -1,0 +1,145 @@
+// @vitest-environment node
+/**
+ * Tests for /moderation/paradigms SSR loader + create action.
+ *
+ * The page is admin-only; this suite verifies the gate and that the
+ * create action forwards a validated paradigm to the service, returning
+ * a discriminated `section: 'create'` result.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const listParadigms = vi.fn();
+const createParadigm = vi.fn();
+
+vi.mock('$lib/server/dictionary/paradigms.js', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/dictionary/paradigms.js')>(
+    '$lib/server/dictionary/paradigms.js',
+  );
+  return {
+    ...actual,
+    listParadigms: (...a: unknown[]) => listParadigms(...a),
+    createParadigm: (...a: unknown[]) => createParadigm(...a),
+  };
+});
+
+type Mod = typeof import('./+page.server.js');
+const ADMIN = { id: 'admin-1', role: 'admin' as const };
+const CURATOR = { id: 'cur-1', role: 'curator' as const };
+
+async function callLoad(
+  user: { id: string; role: 'admin' | 'curator' | 'user' } | null,
+  path = '/moderation/paradigms',
+) {
+  const { load } = (await import('./+page.server.js')) as Mod;
+  const event = {
+    locals: { user },
+    url: new URL(`http://x${path}`),
+  } as unknown as Parameters<Mod['load']>[0];
+  try {
+    return await load(event);
+  } catch (e) {
+    return e as { status?: number; location?: string };
+  }
+}
+
+async function callCreate(
+  fields: Record<string, string>,
+  user: { id: string; role: 'admin' | 'curator' | 'user' } | null = ADMIN,
+) {
+  const { actions } = (await import('./+page.server.js')) as Mod;
+  const fd = new FormData();
+  for (const [k, v] of Object.entries(fields)) fd.append(k, v);
+  const event = {
+    locals: { user },
+    request: {
+      formData: () => Promise.resolve(fd),
+    } as unknown as Request,
+  } as unknown as Parameters<Mod['actions'][string]>[0];
+  return actions.create!(event);
+}
+
+beforeEach(() => {
+  listParadigms.mockReset();
+  createParadigm.mockReset();
+  listParadigms.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('/moderation/paradigms loader', () => {
+  it('admins see the list', async () => {
+    listParadigms.mockResolvedValueOnce([
+      { id: 'p1', language: 'or', pos: 'VERB', name: 'Odia regular verb' },
+    ]);
+    const data = (await callLoad(ADMIN)) as { paradigms: { id: string }[] };
+    expect(data.paradigms).toHaveLength(1);
+    expect(data.paradigms[0]!.id).toBe('p1');
+    expect(listParadigms).toHaveBeenCalledWith({ language: null, pos: null });
+  });
+
+  it('passes language + pos filter through to the service', async () => {
+    await callLoad(ADMIN, '/moderation/paradigms?language=hi&pos=NOUN');
+    expect(listParadigms).toHaveBeenCalledWith({ language: 'hi', pos: 'NOUN' });
+  });
+
+  it('ignores an unsupported language code in the query', async () => {
+    await callLoad(ADMIN, '/moderation/paradigms?language=xx');
+    expect(listParadigms).toHaveBeenCalledWith({ language: null, pos: null });
+  });
+
+  it('curators get a 403', async () => {
+    const res = (await callLoad(CURATOR)) as { status: number };
+    expect(res.status).toBe(403);
+    expect(listParadigms).not.toHaveBeenCalled();
+  });
+
+  it('unauthenticated visitors are redirected to /login', async () => {
+    const res = (await callLoad(null)) as { status: number; location: string };
+    expect(res.status).toBe(303);
+    expect(res.location).toContain('/login');
+    expect(res.location).toContain('next=');
+  });
+});
+
+describe('?/create action', () => {
+  it('forwards a validated paradigm and returns its id', async () => {
+    createParadigm.mockResolvedValueOnce({ id: 'p99' });
+    const result = (await callCreate({
+      language: 'hi',
+      pos: 'VERB',
+      name: 'Hindi regular verb',
+      description: 'For -ना infinitive verbs',
+    })) as { ok: boolean; paradigmId: string };
+    expect(result.ok).toBe(true);
+    expect(result.paradigmId).toBe('p99');
+    expect(createParadigm).toHaveBeenCalledWith({
+      language: 'hi',
+      pos: 'VERB',
+      name: 'Hindi regular verb',
+      description: 'For -ना infinitive verbs',
+    });
+  });
+
+  it('returns a 400 fail when the name is missing', async () => {
+    const result = (await callCreate({
+      language: 'hi',
+      pos: 'VERB',
+    })) as { status: number; data: { ok: boolean; section: string } };
+    expect(result.status).toBe(400);
+    expect(result.data.section).toBe('create');
+    expect(result.data.ok).toBe(false);
+    expect(createParadigm).not.toHaveBeenCalled();
+  });
+
+  it('returns a 403 fail when a curator tries to create', async () => {
+    const result = (await callCreate(
+      { language: 'hi', pos: 'VERB', name: 'Test' },
+      CURATOR,
+    )) as { status: number; data: { ok: boolean; message: string } };
+    expect(result.status).toBe(403);
+    expect(result.data.ok).toBe(false);
+    expect(createParadigm).not.toHaveBeenCalled();
+  });
+});

--- a/docs/curator-paradigm-followups.md
+++ b/docs/curator-paradigm-followups.md
@@ -8,7 +8,7 @@ for its own PR.
 
 ## Curator UX gaps
 
-- [ ] **Paradigm editor UI.** Today paradigms are added via SQL
+- [x] **Paradigm editor UI.** Today paradigms are added via SQL
       migrations (`apps/web/drizzle/0037_seed_odia_regular_verb_paradigm.sql`
       is the template). A `/moderation/paradigms` page should
       list paradigms (filter by language + POS), let admins create


### PR DESCRIPTION
## Summary

- Ships the **Paradigm editor UI** scoped out of #422 ([docs/curator-paradigm-followups.md](docs/curator-paradigm-followups.md)): admins can list/filter paradigms, create/edit/delete them, manage slots with drag-to-reorder + key=value features.
- After a successful save the editor surfaces a modal prompt to regenerate forms on every lemma using that paradigm; confirming kicks off `regenerateAllForParadigm` and reports the outcome via a toast.
- Adds a reusable toast system (`$lib/components/toast/`) — `pushToast()` / `dismissToast()` public API, single `<ToastHost />` mounted from the root layout.

## Notable design choices

- **`sort_order` is server-derived.** The slot table has no editable sort field; the curator drags or uses ↑/↓ on a focused handle, and `saveAllParadigmChanges` rewrites `sort_order` from the slot's index in the payload. Drag is the single source of truth.
- **One atomic `saveAll`.** All paradigm-metadata + per-slot edits + reorder ship in one transactional action via a JSON payload. Add/remove slot + delete paradigm remain immediate (each with inline confirmation) because they have natural confirmation moments.
- **Regen runs synchronously, modal closes immediately.** The dialog used to block the page while the regen looped over every affected lemma (each calling NLP romanize). Now: click Regenerate → dialog closes, sticky "Regenerating…" toast pops up, page stays interactive. Result toast replaces the progress toast when the response arrives.
- **Toast styling uses solid surface tokens + a coloured left stripe.** No tinted backgrounds with dark-on-dark text. Reads in light, sepia, and dark themes at WCAG AA.

## Sharp edge pinned by a test

`let toastedRegenResult = $state(null); toastedRegenResult = obj;` wraps `obj` in a Proxy in Svelte 5 — so `obj === toastedRegenResult` is permanently false, the effect re-fires on every tick, and toasts spam until Svelte aborts with `effect_update_depth_exceeded`. The fix is a plain `let` for the "have I toasted this?" guard. [`regen-effect.test.ts`](apps/web/src/lib/components/toast/regen-effect.test.ts) + [`RegenEffectFixture.svelte`](apps/web/src/lib/components/toast/__fixtures__/RegenEffectFixture.svelte) reproduce the trap so a future refactor that switches back to `$state` trips the test.

## Test plan

- [ ] `pnpm test` — 1427 tests, including 31 paradigm route, 4 paradigm service, 8 toast store, 3 regen-effect regression
- [ ] `pnpm typecheck` — 0 errors, 0 warnings
- [ ] `pnpm lint`
- [ ] `pnpm build` succeeds
- [ ] Manual: load `/moderation/paradigms`, filter by language + POS, open an existing paradigm
- [ ] Manual: drag a slot handle to reorder; observe drop indicator; Save changes; reload and confirm new order persisted
- [ ] Manual: focus a slot handle, press ↑/↓, confirm focus follows the moved row
- [ ] Manual: edit a slot's `features` or `suffix`, save; if lemmas use the paradigm, confirm the regen modal opens and the result toast reports the right counts
- [ ] Manual: click trash on a slot → confirm × / ✓ inline → confirm removal
- [ ] Manual: delete-paradigm flow at the bottom → confirm redirect to list
- [ ] Manual: verify toasts read correctly in light, sepia, and dark theme

Refs #422.