### PR TITLE
Raise adapter-node BODY_SIZE_LIMIT to 100 MB for prod uploads

### DIFF
--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -132,6 +132,14 @@ services:
       # adapter-node defaults to PORT=3000; we standardize on 5173
       # across dev + prod so EXPOSE / healthcheck / Caddy all line up.
       PORT: "5173"
+      # adapter-node's `get_raw_body` defaults to a 512 KB cap, which
+      # rejected EPUB uploads (up to MAX_EPUB_BYTES = 50 MB) and
+      # audio uploads (up to MAX_AUDIO_BYTES = 80 MB) with a
+      # confusing low-level 500 before the route's own validator
+      # could surface a friendlier 413. 100 MB clears the largest
+      # app-side limit plus multipart boundary overhead, leaving the
+      # per-route MAX_*_BYTES checks as the source of truth.
+      BODY_SIZE_LIMIT: "100000000"
     volumes:
       - audio-data:/srv/audio
     networks:


### PR DESCRIPTION
## Summary

Production EPUB upload was failing with:

```
[500] POST /upload
Error: Content-length of 4890950 exceeds limit of 524288 bytes.
    at Object.start (.../build/handler.js:1019:19)
    at get_raw_body (.../build/handler.js:1008:9)
```

The 524288-byte (512 KB) cap is SvelteKit `adapter-node`'s default `BODY_SIZE_LIMIT`. It rejects anything bigger inside the adapter's `get_raw_body`, **before** the upload route's own size validator runs — so the user sees a generic 500 instead of the friendly 413 the app would otherwise return.

## Fix

Set `BODY_SIZE_LIMIT=100000000` (100 MB) on the `web` container in `infra/docker-compose.prod.yml`. That clears every app-side upload cap by a comfortable margin:

| Upload kind | App-side cap | Source |
| --- | --- | --- |
| Audio | 80 MB | `MAX_AUDIO_BYTES` ([audio/storage.ts](apps/web/src/lib/server/audio/storage.ts)) |
| EPUB | 50 MB | `MAX_EPUB_BYTES` ([texts/upload.ts](apps/web/src/lib/server/texts/upload.ts)) |
| TXT | 10 MB | `MAX_TXT_BYTES` (same file) |
| Paste | 1 MB | `MAX_PASTE_BYTES` (same file) |

100 MB also covers multipart-form-data boundary overhead, so the per-route `MAX_*_BYTES` checks remain the single source of truth and continue to return 413 with their own error message.

Caddy's `reverse_proxy` directive doesn't impose a body limit on its own, so no Caddyfile change is needed.

## Test plan

- [ ] Redeploy with the new compose file
- [ ] Confirm `docker compose exec web env | grep BODY_SIZE_LIMIT` shows `100000000`
- [ ] Upload a multi-MB EPUB — succeeds (or fails with the app's own 413 if it really is over 50 MB)
- [ ] Upload an audio file under 80 MB — succeeds
- [ ] Upload an audio file over 80 MB — gets the app's friendly 413 instead of the adapter's 500