### PR TITLE
Raise web container memory + cap V8 heap so EPUB processing finishes

### DIFF
--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -140,6 +140,16 @@ services:
       # app-side limit plus multipart boundary overhead, leaving the
       # per-route MAX_*_BYTES checks as the source of truth.
       BODY_SIZE_LIMIT: "100000000"
+      # Without an explicit `--max-old-space-size`, Node sizes V8's
+      # old generation against a conservative cgroup-memory heuristic
+      # (~50% of the limit) and `processTextNow` would OOM around
+      # 720 MB even on the 1500m limit — the trace is a chain of
+      # "Reached heap limit Allocation failed" / "Aborted (core
+      # dumped)" lines, with `restart: always` looping the container.
+      # 2600 MB leaves ~400 MB headroom under the 3000m container
+      # limit below for native heap, libuv buffers, and any other
+      # off-heap allocations.
+      NODE_OPTIONS: "--max-old-space-size=2600"
     volumes:
       - audio-data:/srv/audio
     networks:
@@ -147,7 +157,12 @@ services:
     deploy:
       resources:
         limits:
-          memory: 1500m
+          # Bumped from 1500m: EPUB processing pre-loads the language's
+          # full lemma index + tokenizes every chapter in-process, and
+          # 1500m wasn't enough headroom once the lemma table grew past
+          # MVP size. NODE_OPTIONS above caps V8's heap so this limit
+          # only has to cover heap + Node native + libuv overhead.
+          memory: 3000m
           cpus: "1.0"
     logging:
       driver: json-file


### PR DESCRIPTION
## Summary

EPUB upload now lands after #427, but the in-process dispatcher OOMs about three minutes in. Each affected text row sits in `processing` with **NULL** `status_error` because the `SIGABRT` skips the `try/catch` in `processTextNow` that would otherwise call `markTextFailed`. `restart: always` loops the container, migrations re-run, processing retries, OOMs again.

Production log excerpt (web service):

```
[20:0x3566f000]   196033 ms: Mark-Compact 721.6 (763.7) -> 718.4 (765.0) MB
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
Aborted (core dumped)
migrate-prod: applying migrations from apps/web/drizzle   # restart: always
...
FATAL ERROR: Reached heap limit ...
```

Postgres view confirms: three texts stuck in `processing`, `status_error IS NULL`, 1 chapter each, **0 tokens** written.

## Root cause

V8 capped its old generation around 720 MB even though the container has 1500 MB. Without `--max-old-space-size`, Node 22 uses a conservative cgroup-memory heuristic (~50% of the limit) for the old-gen ceiling. `processTextNow` ([in-process-dispatcher.ts:438](apps/web/src/lib/server/texts/in-process-dispatcher.ts)) pre-loads the entire lemma index for the text's language (three `Map`s keyed by headword / headword+POS / nukta-stripped) and tokenizes every chapter in-process, which pushes allocation past V8's self-imposed ceiling on a non-trivial Hindi book.

## Fix

Two compose-side knobs on the `web` service:

- `NODE_OPTIONS="--max-old-space-size=2600"` so V8 actually uses the headroom we want to give it.
- `memory` limit raised from `1500m` → `3000m` so a 2.6 GB heap fits with ~400 MB margin for native heap, libuv buffers, and other off-heap allocations.

No app-code change. The longer-term fix is the Redis-backed dispatcher hinted at in [`texts/jobs.ts`](apps/web/src/lib/server/texts/jobs.ts) — moving NLP processing onto an `arq` worker would take this load off the web process entirely. Tracked separately.

## Test plan

- [ ] Merge + `./scripts/deploy.sh` (only `infra/docker-compose.prod.yml` changed → smart-detect skips the rebuild, just recreates `web`)
- [ ] `docker compose exec web sh -c 'echo "$NODE_OPTIONS"'` shows `--max-old-space-size=2600`
- [ ] `docker compose -f infra/docker-compose.prod.yml stats web --no-stream` shows the new 3 GB limit
- [ ] Mark the orphaned `processing` rows as failed (so they can be re-dispatched) and retry the upload — processing completes, `status='ready'`, tokens written, no OOM in `docker compose logs web`