### PR TITLE
NLP client: 30-minute headers/body timeout for long Stanza calls

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -31,6 +31,7 @@
     "jszip": "^3.10.1",
     "nodemailer": "^6.9.15",
     "postgres": "^3.4.4",
+    "undici": "^6.21.1",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/apps/web/src/lib/server/nlp-client.ts
+++ b/apps/web/src/lib/server/nlp-client.ts
@@ -1,4 +1,28 @@
+import { Agent, type Dispatcher } from 'undici';
+
 import { NLP_SERVICE_URL } from './env.js';
+
+/**
+ * Undici's default `headersTimeout` and `bodyTimeout` are 5 minutes
+ * each — fine for a typical web fetch, way too short for Stanza's
+ * Hindi pipeline running on CPU. Long chapters can take 10+ minutes
+ * for the parser to emit response headers, surfacing as
+ * `UND_ERR_HEADERS_TIMEOUT` in `processTextNow` and a "fetch failed"
+ * `status_error` row in the texts table.
+ *
+ * 30 minutes is enough headroom for the largest book chapters we've
+ * seen in practice; chunking the request on the dispatcher side is
+ * the proper long-term fix, but bumping the patience here unblocks
+ * the in-process worker without an app-level rewrite. `keepAlive`
+ * stays on so the dispatcher reuses sockets across the per-chapter
+ * `/process` calls a single `processTextNow` makes.
+ */
+const NLP_REQUEST_TIMEOUT_MS = 30 * 60 * 1000;
+const nlpDispatcher: Dispatcher = new Agent({
+  headersTimeout: NLP_REQUEST_TIMEOUT_MS,
+  bodyTimeout: NLP_REQUEST_TIMEOUT_MS,
+  keepAliveTimeout: 30_000,
+});
 
 export interface LemmaCandidate {
   lemma: string;
@@ -80,12 +104,20 @@ export interface RomanizeResponse {
 }
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  // The `dispatcher` field is undici-specific; node's `fetch()`
+  // forwards it to undici under the hood. Tests stub `fetch` with
+  // vi.stubGlobal, in which case the stub ignores the extra option
+  // and the timeout config is a no-op — exactly what we want.
   const res = await fetch(new URL(path, NLP_SERVICE_URL), {
     ...init,
     headers: {
       'content-type': 'application/json',
       ...(init?.headers ?? {}),
     },
+    // @ts-expect-error — RequestInit doesn't type `dispatcher`, but
+    // Node's fetch reads it. Without this override every long
+    // chapter would die on undici's 5-minute headersTimeout.
+    dispatcher: nlpDispatcher,
   });
   if (!res.ok) {
     const body = await res.text().catch(() => '');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       postgres:
         specifier: ^3.4.4
         version: 3.4.9
+      undici:
+        specifier: ^6.21.1
+        version: 6.25.0
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -2427,6 +2430,10 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici@6.25.0:
+    resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
+    engines: {node: '>=18.17'}
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
@@ -4599,6 +4606,8 @@ snapshots:
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
+
+  undici@6.25.0: {}
 
   uri-js@4.4.1:
     dependencies:


### PR DESCRIPTION
## Summary

Even after #427 (body size) and #428 (heap ceiling), most EPUB chapters fail processing with:

```
TypeError: fetch failed
    at request (.../nlp-client-...js:4:15)
    at processChapter (.../in-process-dispatcher-...js:135:18)
    at processTextNow (.../in-process-dispatcher-...js:195:16)
[cause]: HeadersTimeoutError: Headers Timeout Error
    code: 'UND_ERR_HEADERS_TIMEOUT'
```

Production state on `texts`:

| status | count |
| --- | ---: |
| ready | 11 |
| failed | 39 |

— and every `status_error` on the failed rows reads `fetch failed`, ~78% failure rate.

## Cause

`processTextNow` fires a whole chapter at the NLP service in one `POST /process`. Stanza's Hindi pipeline on CPU (tokenize → POS → lemma → depparse, per sentence) regularly runs 5-15 min on real-book chapters. Undici's default `headersTimeout` is **5 min**, so the fetch is killed before the parse emits response headers — even when the NLP container is making forward progress.

## Fix

Import a long-timeout `undici.Agent` in [`nlp-client.ts`](apps/web/src/lib/server/nlp-client.ts) and pass it as the per-request `dispatcher`:

```ts
const nlpDispatcher: Dispatcher = new Agent({
  headersTimeout: 30 * 60 * 1000,
  bodyTimeout:    30 * 60 * 1000,
  keepAliveTimeout: 30_000,
});
```

30 min covers the slowest book chapters observed. `keepAlive` stays on so sockets reuse across the per-chapter `/process` calls a single `processTextNow` makes. Tests stub `fetch` directly, so the new `dispatcher` option is a no-op there.

Adds `undici@^6.21.1` as a direct dep. Node bundles undici internally but its `Agent`/`setGlobalDispatcher` exports aren't reachable from app code without an explicit import.

## What this doesn't fix (yet)

- Single-chapter requests still block the web event loop for minutes at a time. The proper long-term fix is to chunk the per-chapter request into sentence-sized batches on the dispatcher side, or to move NLP off the web process entirely via the Redis-backed worker the comment in [`texts/jobs.ts`](apps/web/src/lib/server/texts/jobs.ts) describes. Both are bigger lifts and tracked separately.

## Test plan

- [ ] Merge + `./scripts/deploy.sh` (the package.json + nlp-client.ts changes will trigger a rebuild of the web image, so this deploy will take longer than the previous two)
- [ ] Reset the orphaned `processing`/`failed` rows so they can be re-dispatched:
      ```sql
      update texts set status='pending', status_error=NULL, updated_at=now()
       where status in ('processing','failed');
      ```
- [ ] Kick reprocess on a known-slow chapter; watch `docker compose logs -f web` — no `UND_ERR_HEADERS_TIMEOUT` block, eventual `markTextReady`
- [ ] `select count(*) filter (where status='ready') as ok, count(*) filter (where status='failed') as fail from texts;` — failed count returns to 0 (or only the chapters that genuinely error on the NLP side)