### PR TITLE
Give NLP container 3 CPUs + match BLAS threads to the cgroup quota

### DIFF
--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -74,9 +74,16 @@ services:
       context: ..
       dockerfile: services/nlp/Dockerfile
     restart: always
-    # Override the Dockerfile's dev-style `--reload` CMD with a
-    # production worker pool. Two workers fits CX32 / CCX13 headroom
-    # and keeps Stanza models pinned per process.
+    # Single uvicorn worker with all of the container's CPU budget.
+    # We previously ran two workers on 1.5 cpus, but that meant two
+    # full Stanza model loads in RAM and two PyTorch BLAS pools
+    # contending for the cgroup CPU quota — Hindi chapters took
+    # 10–30+ minutes wall-clock, hit the undici headers timeout, and
+    # surfaced as `UND_ERR_HEADERS_TIMEOUT` failures in the texts
+    # table. One worker × N threads is faster end-to-end and uses
+    # roughly half the RAM. Stanza loads each language's pipeline
+    # lazily on first request, so a single process per container
+    # still serves all three.
     command:
       - uvicorn
       - app.main:app
@@ -85,16 +92,29 @@ services:
       - --port
       - "8000"
       - --workers
-      - "2"
+      - "1"
     networks:
       - internal
     environment:
       PYTHONPATH: /opt/shared-types:/srv/nlp
+      # Pin PyTorch / NumPy / Stanza's BLAS thread count to the
+      # cgroup CPU quota. Without these, the libraries try to use
+      # every host core they can see, then Docker throttles them —
+      # which on Hindi depparse can mean 5–10× slower than just
+      # matching the quota up front. Keep these in lockstep with
+      # `deploy.resources.limits.cpus` below if you retune.
+      OMP_NUM_THREADS: "3"
+      MKL_NUM_THREADS: "3"
+      OPENBLAS_NUM_THREADS: "3"
     deploy:
       resources:
         limits:
-          memory: 2500m
-          cpus: "1.5"
+          # 4-vCPU / 8-GB host: NLP takes 3 cpus, web keeps 1; the
+          # host has ~1 cpu of headroom for postgres/redis/caddy
+          # bursts. Bump in lockstep with the *_NUM_THREADS env vars
+          # above if you move to a bigger box.
+          memory: 3000m
+          cpus: "3.0"
     logging:
       driver: json-file
       options:


### PR DESCRIPTION
## Summary

EPUB chapters were processing **5–10× slower in prod than locally** because the NLP container was running two uvicorn workers on a 1.5-cpu cgroup quota, with no PyTorch/BLAS thread limit set. The slowness surfaced as `UND_ERR_HEADERS_TIMEOUT` failures in the texts table even after #428's heap-limit fix.

This is probably the actual fix for "processing fails most of the time" — #429 (longer fetch timeout) is belt-and-braces; this PR makes the NLP service fast enough that long chapters finish in minutes rather than tens of minutes.

## Diagnosis

Local: no cgroup, Stanza/PyTorch see all 8 host cores → chapters finish in seconds.

Prod (before this PR):

```yaml
nlp:
  command: [..., --workers, "2"]
  deploy:
    resources:
      limits:
        memory: 2500m
        cpus: "1.5"
  # no OMP_NUM_THREADS / MKL_NUM_THREADS / OPENBLAS_NUM_THREADS
```

- **Two workers** = two full Stanza Hindi model loads in RAM + two PyTorch BLAS pools competing for the same 1.5-cpu cgroup quota.
- **No thread cap** = each PyTorch instance starts threads for "all host cores" (4) → Docker throttles them back to 1.5 → worst-case oversubscription, lots of context-switch overhead.

User reported the host is **4 vCPU / 8 GB / 160 GB**.

## Fix

```yaml
nlp:
  command: [..., --workers, "1"]
  deploy:
    resources:
      limits:
        memory: 3000m
        cpus: "3.0"
  environment:
    OMP_NUM_THREADS:      "3"
    MKL_NUM_THREADS:      "3"
    OPENBLAS_NUM_THREADS: "3"
```

- **One worker** holds one set of Stanza models in RAM and uses the full 3-cpu cgroup with 3 BLAS threads — no contention, no throttling.
- Memory bumped 2500m → 3000m (one model copy needs less than two; headroom is cheap on an 8 GB host).
- Web stays on its existing 1 cpu / 3000m — it only dispatches.
- Stanza loads each language's pipeline lazily on first request, so one worker still serves Hindi, Marathi, and Odia.

Capacity map after this PR on the 4-vCPU / 8-GB host:

| Service | cpus | memory |
| --- | ---: | ---: |
| web | 1.0 | 3000m |
| nlp | 3.0 | 3000m |
| postgres / redis / caddy | (no explicit limit) | … |
| **headroom** | 0.0 | ~2000m |

If we move to a bigger box, bump `cpus` and the three `*_NUM_THREADS` env vars in lockstep — they're commented to call this out.

## Test plan

- [ ] Merge + `./scripts/deploy.sh` (rebuild not strictly needed — compose-only change — `scripts/deploy.sh` auto-detects)
- [ ] Confirm the new env vars are live: `docker compose exec nlp sh -c 'echo "$OMP_NUM_THREADS $MKL_NUM_THREADS $OPENBLAS_NUM_THREADS"'` → `3 3 3`
- [ ] Reset the orphaned `processing`/`failed` rows so they re-dispatch:
      ```sql
      update texts set status='pending', status_error=NULL, updated_at=now()
       where status in ('processing','failed');
      ```
- [ ] Trigger reprocess on one long chapter; observe wall-clock with `docker compose logs -f nlp` — Stanza emits per-stage progress
- [ ] Confirm `select count(*) filter (where status='failed') from texts;` → 0 (or close to)