### PR TITLE
fix(dictionary): skip Kaikki romanization forms so they don't pollute lemma_forms

### DIFF
--- a/apps/web/scripts/cleanup-yiddish-romanization-forms.sql
+++ b/apps/web/scripts/cleanup-yiddish-romanization-forms.sql
@@ -1,0 +1,66 @@
+-- One-time cleanup: delete Latin-script romanization junk from
+-- `lemma_forms` for Yiddish lemmas.
+--
+-- WHY THIS IS A SCRIPT, NOT A DRIZZLE MIGRATION
+-- ---------------------------------------------
+-- The bug: the generic Kaikki importer treated a Wiktionary
+-- `romanization`-tagged *form* (`{ "form": "bemeshekh",
+-- "tags": ["romanization"] }`) as a native-script inflected surface,
+-- because the Latin string differs from the Hebrew-script headword and
+-- slipped past the `surface !== headword` guard. For Yiddish this wrote
+-- 31,339 Latin junk surfaces (`bemeshekh`, `zuntikn`, `religyes`, ...).
+-- `kaikkiToImportEntry()` now skips romanization/transliteration forms,
+-- so nothing new is written — but `insertForm` is append-only, so rows
+-- written before the fix survive a re-import and must be cleaned once.
+--
+-- This is intentionally NOT a numbered drizzle migration. Yiddish ('yi')
+-- support — the `language` enum value, the `kaikki-yiddish` source, and
+-- the import that produced the junk — lives on a separate feature branch
+-- whose merge order relative to this importer fix is not fixed. A
+-- numbered migration here would (a) break `drizzle-kit migrate` on any
+-- database whose `language` enum does not yet contain 'yi', and (b) run
+-- exactly once, in migration order, with no guarantee of running *after*
+-- the Yiddish import. So this is a manual, idempotent, run-once-after-
+-- deploy operation instead.
+--
+-- The earlier quarantine pass (drizzle/0038_quarantine_lemma_form_junk.sql)
+-- neutralised the same class of Latin junk for hi/mr/or, but predates
+-- Yiddish, so 'yi' never got that treatment. Here we DELETE rather than
+-- quarantine: a Hebrew-script language has no legitimate Latin-script
+-- surface, and these rows are pure transliterations whose curated value
+-- (if ever wanted) belongs in `lemma_forms.romanization`, not `surface`.
+--
+-- Safe to run more than once (a second run matches 0 rows). Curator-
+-- authored rows (`created_by = 'curator'`) are never touched. The
+-- pg_enum guard makes the script a no-op on databases that do not have
+-- Yiddish, so it is safe to run anywhere.
+--
+-- Run with:
+--   psql "$DATABASE_URL" -f apps/web/scripts/cleanup-yiddish-romanization-forms.sql
+-- Verify (expect 0):
+--   select count(*) from lemma_forms lf join lemmas l on l.id = lf.lemma_id
+--   where l.language = 'yi' and lf.surface ~ '^[a-zA-Z]';
+
+DO $$
+DECLARE
+  deleted_count bigint;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_enum e
+    JOIN pg_type t ON t.oid = e.enumtypid
+    WHERE t.typname = 'language' AND e.enumlabel = 'yi'
+  ) THEN
+    RAISE NOTICE 'language enum has no ''yi'' value — nothing to clean up; skipping.';
+    RETURN;
+  END IF;
+
+  DELETE FROM lemma_forms lf
+  USING lemmas l
+  WHERE l.id = lf.lemma_id
+    AND l.language = 'yi'
+    AND lf.created_by <> 'curator'
+    AND lf.surface ~ '[A-Za-z]';
+
+  GET DIAGNOSTICS deleted_count = ROW_COUNT;
+  RAISE NOTICE 'Deleted % Latin-script lemma_forms surface row(s) for Yiddish.', deleted_count;
+END $$;

--- a/apps/web/src/lib/server/dictionary/sources/kaikki.test.ts
+++ b/apps/web/src/lib/server/dictionary/sources/kaikki.test.ts
@@ -214,6 +214,32 @@ describe('kaikkiToImportEntry', () => {
     expect(r!.forms![0]!.features).toEqual({});
   });
 
+  it('skips transliteration forms so romanizations never become surfaces', () => {
+    // Kaikki attaches a word's romanization as a form object whose Latin
+    // string differs from the native headword; left in, it pollutes
+    // lemma_forms.surface (regression: 31k Latin junk rows for Yiddish).
+    const r = kaikkiToImportEntry(
+      {
+        word: 'במשך',
+        pos: 'noun',
+        senses: [{ glosses: ['during'] }],
+        forms: [
+          { form: 'bemeshekh', tags: ['romanization'] },
+          { form: 'bʼmšḵ', tags: ['transliteration'] },
+          { form: 'bemeshech', tags: ['Romanisation'] },
+          { form: 'במשכן', tags: ['plural'] },
+        ],
+      },
+      { script: 'Hebr', sourceIdPrefix: 'kaikki:yi' },
+    );
+    // Only the genuine native-script inflected form survives.
+    expect(r!.forms).toHaveLength(1);
+    expect(r!.forms![0]!.surface).toBe('במשכן');
+    const surfaces = r!.forms!.map((f) => f.surface);
+    expect(surfaces).not.toContain('bemeshekh');
+    expect(surfaces.some((s) => /[a-zA-Z]/.test(s))).toBe(false);
+  });
+
   it('NFC-normalizes the headword', () => {
     const r = kaikkiToImportEntry(
       { word: 'क़', pos: 'noun', senses: [{ glosses: ['letter qa'] }] },

--- a/apps/web/src/lib/server/dictionary/sources/kaikki.ts
+++ b/apps/web/src/lib/server/dictionary/sources/kaikki.ts
@@ -87,6 +87,26 @@ function glossesOf(sense: KaikkiSense): string[] {
   return sense.glosses ?? sense.raw_glosses ?? sense.english ?? [];
 }
 
+/**
+ * Kaikki carries a word's transliteration as a *form* object, e.g.
+ * `{ "form": "bemeshekh", "tags": ["romanization"] }`. Those Latin
+ * strings are not native-script inflected surfaces — left in, they
+ * pollute `lemma_forms.surface` (31k Latin junk rows for Yiddish
+ * alone). We drop any form carrying a transliteration tag here; the
+ * curated romanization belongs in `lemma_forms.romanization`, not the
+ * surface column. Spelling variants (`-zation` / `-sation`) are both
+ * matched, case-insensitively.
+ */
+const ROMANIZATION_FORM_TAGS = new Set([
+  'romanization',
+  'romanisation',
+  'transliteration',
+]);
+
+function isRomanizationForm(form: { tags?: string[] }): boolean {
+  return (form.tags ?? []).some((t) => ROMANIZATION_FORM_TAGS.has(t.toLowerCase()));
+}
+
 function hashGlosses(senses: KaikkiSense[]): string {
   const joined = senses
     .flatMap(glossesOf)
@@ -155,6 +175,7 @@ export function kaikkiToImportEntry(
   // discoverable in fallback lookups but leave `features` empty.
   const forms = (raw.forms ?? [])
     .filter((f) => typeof f.form === 'string' && f.form.length > 0)
+    .filter((f) => !isRomanizationForm(f))
     .map((f) => f.form.normalize('NFC'))
     .filter((surface) => surface !== headword)
     .map((surface) => ({ surface, features: {} as Record<string, string> }));


### PR DESCRIPTION
## Problem

The generic Kaikki importer (`kaikkiToImportEntry()`) built `lemma_forms` surfaces from every `raw.forms` entry, filtering only on non-empty and `surface !== headword`. Kaikki stores a word's transliteration as a *form* object:

```json
{ "form": "bemeshekh", "tags": ["romanization"] }
```

Because the Latin string differs from the native-script headword, it slipped past `surface !== headword` and was stored as if it were a native inflected surface form. For Yiddish alone this produced **31,339** Latin-script junk rows (`bemeshekh`, `zuntikn`, `religyes`, ...), and the same class of junk affects Hindi/Marathi/Odia imports.

## Fix

`apps/web/src/lib/server/dictionary/sources/kaikki.ts` — added an `isRomanizationForm()` guard and a `.filter()` step in the `forms` build that drops any form tagged `romanization` / `romanisation` / `transliteration` (case-insensitive) before the surface is extracted. The existing non-empty and `surface !== headword` filters are unchanged. The fix is language-agnostic, so it stops the pollution for every Kaikki import.

## Cleaning up existing rows

`insertForm` is append-only, so rows written before the fix survive a re-import. This is shipped as a one-time, idempotent, enum-guarded script — `apps/web/scripts/cleanup-yiddish-romanization-forms.sql` — **not** a numbered drizzle migration, because:

- `'yi'` is not in this branch's `language` enum (it lands on the unmerged Yiddish feature branch), so a migration with `WHERE language='yi'` would break `drizzle-kit migrate` on a fresh/CI database; and
- a migration runs exactly once, in order, with no guarantee of running *after* the cross-branch Yiddish import that produced the junk.

The script is a no-op where `'yi'` isn't a language, never touches `created_by = 'curator'` rows, and is safe to re-run. The earlier `drizzle/0038_quarantine_lemma_form_junk.sql` already neutralised this Latin junk for hi/mr/or (via quarantine); Yiddish postdates it, hence the dedicated cleanup.

Run with:
```
psql "$DATABASE_URL" -f apps/web/scripts/cleanup-yiddish-romanization-forms.sql
```

## Verification

- **New unit test** in `kaikki.test.ts` asserts a romanization-tagged form is not emitted as a surface (covers `romanization`, `transliteration`, British-spelling `Romanisation`), while a genuine native-script inflected form still survives.
- `pnpm test src/lib/server/dictionary/sources/` → **41/41 pass**; eslint clean; `pnpm check` → 0 errors, 0 warnings.
- Ran the cleanup against the dev DB: 31,339 → **0** Latin surfaces for `yi`; second run deletes 0 (idempotent); 12,179 `yi` lemmas and 58,714 legitimate Hebrew-script forms untouched.

The verify query now returns 0:
```sql
select count(*) from lemma_forms lf join lemmas l on l.id = lf.lemma_id
where l.language = 'yi' and lf.surface ~ '^[a-zA-Z]';
```

## Out of scope

The future enhancement to capture the curated romanization into `lemma_forms.romanization` for loshn-koydesh loans (mirroring the NLP-side override) is intentionally left for a follow-up — this PR is scoped to stopping the pollution.