### PR TITLE
feat(reader): admin overlay to flag words with no definition yet

### DIFF
--- a/apps/web/src/lib/components/reader/ReaderSettings.svelte
+++ b/apps/web/src/lib/components/reader/ReaderSettings.svelte
@@ -44,6 +44,15 @@
      *  reads of an official text) we still live-preview but skip the
      *  network call. */
     canPersist?: boolean;
+    /** #435: when true, the popover shows an admin-only section with
+     *  the "flag undefined words" overlay toggle. */
+    isAdmin?: boolean;
+    /** #435: current state of the admin overlay. Owned by the reader
+     *  page (persisted to localStorage there, not via the per-language
+     *  settings API), so it lives outside `settings`. */
+    flagUndefined?: boolean;
+    /** #435: called when the admin flips the overlay toggle. */
+    onFlagUndefinedChange?: (on: boolean) => void;
     /** Override hook for tests. Real callers omit this. */
     fetcher?: typeof fetch;
   }
@@ -55,6 +64,9 @@
     settings,
     onChange,
     canPersist = true,
+    isAdmin = false,
+    flagUndefined = false,
+    onFlagUndefinedChange,
     fetcher = fetch,
   }: Props = $props();
 
@@ -308,6 +320,36 @@
     </section>
     {/if}
 
+    <!-- #435: admin-only overlay that tints words whose lemma has no
+         definition yet, so curators can spot dictionary gaps while
+         reading. Outside the per-language settings persistence — the
+         reader page owns this flag and stores it in localStorage. -->
+    {#if isAdmin}
+    <section data-testid="rs-admin">
+      <h3>Admin</h3>
+      <div class="rs-row">
+        <span class="rs-l">Undefined words</span>
+        <div class="rs-seg" role="group" aria-label="Highlight words with no definition">
+          <button
+            type="button"
+            data-testid="rs-flag-undefined-on"
+            data-active={flagUndefined ? '1' : '0'}
+            aria-pressed={flagUndefined}
+            onclick={() => onFlagUndefinedChange?.(true)}
+          >Flag</button>
+          <button
+            type="button"
+            data-testid="rs-flag-undefined-off"
+            data-active={flagUndefined ? '0' : '1'}
+            aria-pressed={!flagUndefined}
+            onclick={() => onFlagUndefinedChange?.(false)}
+          >Off</button>
+        </div>
+      </div>
+      <p class="rs-hint">Tints words with no definition yet so you can spot gaps.</p>
+    </section>
+    {/if}
+
     <footer class="rs-foot">
       <button type="button" class="rs-reset" onclick={reset}>Reset to defaults</button>
       {#if saveError}
@@ -411,5 +453,11 @@
     margin: 0;
     color: var(--err, #b94545);
     font-size: 0.78rem;
+  }
+  .rs-hint {
+    margin: 0;
+    color: var(--ink-3, var(--color-fg-muted));
+    font-size: 0.72rem;
+    line-height: 1.4;
   }
 </style>

--- a/apps/web/src/lib/components/reader/ReaderSettings.test.ts
+++ b/apps/web/src/lib/components/reader/ReaderSettings.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/svelte';
+
+import ReaderSettings from './ReaderSettings.svelte';
+import { DEFAULT_READER_SETTINGS } from './reader-settings.js';
+
+function renderPopover(props: Record<string, unknown> = {}) {
+  return render(ReaderSettings, {
+    open: true,
+    onClose: () => {},
+    language: 'hi',
+    settings: DEFAULT_READER_SETTINGS,
+    onChange: () => {},
+    // Skip the per-language PATCH network path in these tests.
+    canPersist: false,
+    ...props,
+  });
+}
+
+afterEach(() => cleanup());
+
+describe('ReaderSettings — admin undefined-words overlay (#435)', () => {
+  it('hides the admin section for non-admins', () => {
+    renderPopover({ isAdmin: false });
+    expect(screen.queryByTestId('rs-admin')).toBeNull();
+  });
+
+  it('shows the admin section for admins', () => {
+    renderPopover({ isAdmin: true });
+    expect(screen.getByTestId('rs-admin')).not.toBeNull();
+    expect(screen.getByTestId('rs-flag-undefined-on')).not.toBeNull();
+    expect(screen.getByTestId('rs-flag-undefined-off')).not.toBeNull();
+  });
+
+  it('marks "Off" active when the overlay is disabled', () => {
+    renderPopover({ isAdmin: true, flagUndefined: false });
+    expect(
+      screen.getByTestId('rs-flag-undefined-off').getAttribute('data-active'),
+    ).toBe('1');
+    expect(
+      screen.getByTestId('rs-flag-undefined-on').getAttribute('data-active'),
+    ).toBe('0');
+  });
+
+  it('marks "Flag" active when the overlay is enabled', () => {
+    renderPopover({ isAdmin: true, flagUndefined: true });
+    expect(
+      screen.getByTestId('rs-flag-undefined-on').getAttribute('data-active'),
+    ).toBe('1');
+    expect(
+      screen.getByTestId('rs-flag-undefined-on').getAttribute('aria-pressed'),
+    ).toBe('true');
+  });
+
+  it('fires onFlagUndefinedChange(true) when "Flag" is clicked', async () => {
+    const onFlagUndefinedChange = vi.fn();
+    renderPopover({ isAdmin: true, flagUndefined: false, onFlagUndefinedChange });
+    await fireEvent.click(screen.getByTestId('rs-flag-undefined-on'));
+    expect(onFlagUndefinedChange).toHaveBeenCalledWith(true);
+  });
+
+  it('fires onFlagUndefinedChange(false) when "Off" is clicked', async () => {
+    const onFlagUndefinedChange = vi.fn();
+    renderPopover({ isAdmin: true, flagUndefined: true, onFlagUndefinedChange });
+    await fireEvent.click(screen.getByTestId('rs-flag-undefined-off'));
+    expect(onFlagUndefinedChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/apps/web/src/lib/components/reader/TokenSpan.svelte
+++ b/apps/web/src/lib/components/reader/TokenSpan.svelte
@@ -39,6 +39,12 @@
     if (token.isOov) classes.push('oov');
     if (token.isAmbiguous) classes.push('ambiguous');
     if (isAnchor) classes.push('anchor');
+    // #435: tag words whose lemma has no definition yet. The class is
+    // inert until an admin flips `data-flag-undefined` on <html> from
+    // the reader settings popover, so non-admins never see it. We only
+    // mark when the loader said `false` outright — absent (client
+    // fallback / synthetic tokens) means "unknown", so we don't flag.
+    if (token.hasDefinition === false) classes.push('no-definition');
     return classes.join(' ');
   });
 

--- a/apps/web/src/lib/components/reader/TokenSpan.test.ts
+++ b/apps/web/src/lib/components/reader/TokenSpan.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render } from '@testing-library/svelte';
+
+import TokenSpan from './TokenSpan.svelte';
+import type { ServerToken } from './types.js';
+
+function makeToken(overrides: Partial<ServerToken> = {}): ServerToken {
+  return {
+    id: 't1',
+    idx: 0,
+    surface: 'पानी',
+    isWord: true,
+    isAmbiguous: false,
+    isOov: false,
+    lemmaId: 'lem-1',
+    romanization: null,
+    glossDefault: 'water',
+    personalGloss: null,
+    candidates: [],
+    features: {},
+    numberForms: null,
+    status: 'unknown',
+    hasDefinition: true,
+    ...overrides,
+  };
+}
+
+afterEach(() => cleanup());
+
+describe('TokenSpan — no-definition class (#435)', () => {
+  it('tags a word as .no-definition when hasDefinition is false', () => {
+    const { container } = render(TokenSpan, {
+      token: makeToken({ hasDefinition: false }),
+    });
+    const word = container.querySelector('.word');
+    expect(word).not.toBeNull();
+    expect(word!.classList.contains('no-definition')).toBe(true);
+  });
+
+  it('does not tag a defined word', () => {
+    const { container } = render(TokenSpan, {
+      token: makeToken({ hasDefinition: true }),
+    });
+    expect(
+      container.querySelector('.word')!.classList.contains('no-definition'),
+    ).toBe(false);
+  });
+
+  it('does not tag when hasDefinition is absent (client-fallback tokens)', () => {
+    const token = makeToken();
+    delete token.hasDefinition;
+    const { container } = render(TokenSpan, { token });
+    expect(
+      container.querySelector('.word')!.classList.contains('no-definition'),
+    ).toBe(false);
+  });
+
+  it('tags an undefined OOV word alongside the .oov class', () => {
+    const { container } = render(TokenSpan, {
+      token: makeToken({ isOov: true, lemmaId: null, hasDefinition: false }),
+    });
+    const word = container.querySelector('.word')!;
+    expect(word.classList.contains('oov')).toBe(true);
+    expect(word.classList.contains('no-definition')).toBe(true);
+  });
+
+  it('never tags whitespace / non-word tokens', () => {
+    const { container } = render(TokenSpan, {
+      token: makeToken({
+        isWord: false,
+        surface: ' ',
+        hasDefinition: false,
+      }),
+    });
+    // Non-word tokens render as bare text, no .word span at all.
+    expect(container.querySelector('.no-definition')).toBeNull();
+  });
+
+  it('tags the undefined word in <ruby> render mode too', () => {
+    const { container } = render(TokenSpan, {
+      token: makeToken({ hasDefinition: false, romanization: 'pānī' }),
+      showRomanization: true,
+    });
+    const ruby = container.querySelector('ruby.word');
+    expect(ruby).not.toBeNull();
+    expect(ruby!.classList.contains('no-definition')).toBe(true);
+  });
+});

--- a/apps/web/src/lib/components/reader/types.ts
+++ b/apps/web/src/lib/components/reader/types.ts
@@ -139,6 +139,14 @@ export type ServerToken = {
    *  lemma/translation block with the three written-out renderings. */
   numberForms: ServerNumberForms | null;
   status: 'known' | 'learning' | 'ignored' | 'unknown';
+  /** #435: true when the lemma has a canonical gloss (the dictionary
+   *  defines it), false when it has none yet (OOV words, or lemmas
+   *  awaiting a definition). Optional because client-tokenized
+   *  fallback tokens and synthetic phrase tokens can't know it — the
+   *  admin "flag undefined words" overlay only marks a token when this
+   *  is explicitly `false`, so an absent value is treated as "unknown,
+   *  don't flag." */
+  hasDefinition?: boolean;
 };
 
 /**

--- a/apps/web/src/lib/components/reader/undefined-highlight.test.ts
+++ b/apps/web/src/lib/components/reader/undefined-highlight.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  FLAG_UNDEFINED_ATTR,
+  FLAG_UNDEFINED_STORAGE_KEY,
+  isFlagUndefinedAttributeSet,
+  readPersistedFlagUndefined,
+  setFlagUndefinedAttribute,
+  writePersistedFlagUndefined,
+} from './undefined-highlight.js';
+
+// The CI/node env's global `localStorage` (Web Storage shim) isn't a
+// dependable jsdom Storage — `.clear()` may be missing. Stub a plain
+// in-memory fake, the same pattern WordPopup.test.ts uses.
+function fakeStorage(seed: Record<string, string> = {}) {
+  const store = new Map<string, string>(Object.entries(seed));
+  return {
+    store,
+    api: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, v),
+      removeItem: (k: string) => void store.delete(k),
+      clear: () => store.clear(),
+      key: () => null,
+      length: 0,
+    },
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  document.documentElement.removeAttribute(FLAG_UNDEFINED_ATTR);
+});
+
+describe('undefined-highlight — localStorage helpers', () => {
+  it('readPersistedFlagUndefined returns false when nothing is stored', () => {
+    vi.stubGlobal('localStorage', fakeStorage().api);
+    expect(readPersistedFlagUndefined()).toBe(false);
+  });
+
+  it('readPersistedFlagUndefined returns true when the flag is stored', () => {
+    vi.stubGlobal(
+      'localStorage',
+      fakeStorage({ [FLAG_UNDEFINED_STORAGE_KEY]: '1' }).api,
+    );
+    expect(readPersistedFlagUndefined()).toBe(true);
+  });
+
+  it('writePersistedFlagUndefined(true) writes the flag', () => {
+    const storage = fakeStorage();
+    vi.stubGlobal('localStorage', storage.api);
+    writePersistedFlagUndefined(true);
+    expect(storage.store.get(FLAG_UNDEFINED_STORAGE_KEY)).toBe('1');
+  });
+
+  it('writePersistedFlagUndefined(false) removes the flag (default reverts to off)', () => {
+    const storage = fakeStorage({ [FLAG_UNDEFINED_STORAGE_KEY]: '1' });
+    vi.stubGlobal('localStorage', storage.api);
+    writePersistedFlagUndefined(false);
+    expect(storage.store.has(FLAG_UNDEFINED_STORAGE_KEY)).toBe(false);
+  });
+
+  it('treats non-"1" values as off', () => {
+    const storage = fakeStorage({ [FLAG_UNDEFINED_STORAGE_KEY]: 'true' });
+    vi.stubGlobal('localStorage', storage.api);
+    expect(readPersistedFlagUndefined()).toBe(false);
+    storage.store.set(FLAG_UNDEFINED_STORAGE_KEY, '0');
+    expect(readPersistedFlagUndefined()).toBe(false);
+  });
+
+  it('persists across a write/read round trip', () => {
+    vi.stubGlobal('localStorage', fakeStorage().api);
+    writePersistedFlagUndefined(true);
+    expect(readPersistedFlagUndefined()).toBe(true);
+    writePersistedFlagUndefined(false);
+    expect(readPersistedFlagUndefined()).toBe(false);
+  });
+
+  it('returns false (never throws) when localStorage is unavailable', () => {
+    vi.stubGlobal('localStorage', undefined);
+    expect(readPersistedFlagUndefined()).toBe(false);
+    // Writing is a silent no-op rather than a crash.
+    expect(() => writePersistedFlagUndefined(true)).not.toThrow();
+  });
+});
+
+describe('undefined-highlight — DOM attribute helpers', () => {
+  beforeEach(() => {
+    document.documentElement.removeAttribute(FLAG_UNDEFINED_ATTR);
+  });
+
+  it('setFlagUndefinedAttribute(true) puts the flag on <html>', () => {
+    setFlagUndefinedAttribute(true);
+    expect(document.documentElement.getAttribute(FLAG_UNDEFINED_ATTR)).toBe('1');
+    expect(isFlagUndefinedAttributeSet()).toBe(true);
+  });
+
+  it('setFlagUndefinedAttribute(false) clears the flag', () => {
+    setFlagUndefinedAttribute(true);
+    setFlagUndefinedAttribute(false);
+    expect(document.documentElement.hasAttribute(FLAG_UNDEFINED_ATTR)).toBe(false);
+    expect(isFlagUndefinedAttributeSet()).toBe(false);
+  });
+
+  it('isFlagUndefinedAttributeSet reflects only the exact "1" value', () => {
+    document.documentElement.setAttribute(FLAG_UNDEFINED_ATTR, '0');
+    expect(isFlagUndefinedAttributeSet()).toBe(false);
+  });
+});

--- a/apps/web/src/lib/components/reader/undefined-highlight.ts
+++ b/apps/web/src/lib/components/reader/undefined-highlight.ts
@@ -1,0 +1,58 @@
+/**
+ * Admin "flag undefined words" reader overlay (#435).
+ *
+ * Admins can toggle a reader overlay that tints every word whose
+ * lemma has no canonical definition yet, so dictionary gaps are easy
+ * to spot while reading. The reader page sets
+ * `data-flag-undefined="1"` on `<html>`; `tokens.css` only paints
+ * `.word.no-definition` while that attribute is present, so the class
+ * TokenSpan always emits stays inert for everyone else.
+ *
+ * Unlike immersive mode (sessionStorage, fresh each visit), the
+ * preference lives in `localStorage`: an admin doing a
+ * definition-coverage pass keeps the overlay on across visits until
+ * they switch it off.
+ *
+ * The helpers are pure DOM/storage so they're testable under jsdom
+ * without rendering a Svelte component.
+ */
+
+export const FLAG_UNDEFINED_ATTR = 'data-flag-undefined';
+export const FLAG_UNDEFINED_STORAGE_KEY = 'cia_reader_flag_undefined';
+
+/** Read the persisted overlay preference. Returns false in
+ *  non-browser environments (SSR) or when storage is unavailable. */
+export function readPersistedFlagUndefined(): boolean {
+  if (typeof localStorage === 'undefined') return false;
+  try {
+    return localStorage.getItem(FLAG_UNDEFINED_STORAGE_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+/** Persist the overlay preference. */
+export function writePersistedFlagUndefined(on: boolean): void {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    if (on) localStorage.setItem(FLAG_UNDEFINED_STORAGE_KEY, '1');
+    else localStorage.removeItem(FLAG_UNDEFINED_STORAGE_KEY);
+  } catch {
+    // Storage may be unavailable (private browsing on Safari, etc.) —
+    // fall through silently. The attribute on <html> is still the
+    // active source of truth for the current page paint.
+  }
+}
+
+/** Apply the overlay flag to `<html>` so the token CSS responds. */
+export function setFlagUndefinedAttribute(on: boolean): void {
+  if (typeof document === 'undefined') return;
+  if (on) document.documentElement.setAttribute(FLAG_UNDEFINED_ATTR, '1');
+  else document.documentElement.removeAttribute(FLAG_UNDEFINED_ATTR);
+}
+
+/** Read the current attribute state. */
+export function isFlagUndefinedAttributeSet(): boolean {
+  if (typeof document === 'undefined') return false;
+  return document.documentElement.getAttribute(FLAG_UNDEFINED_ATTR) === '1';
+}

--- a/apps/web/src/lib/server/texts/tokens.test.ts
+++ b/apps/web/src/lib/server/texts/tokens.test.ts
@@ -182,6 +182,49 @@ describe('loadChapterTokens', () => {
     expect(result![2]).toMatchObject({ id: 't3', glossDefault: null });
   });
 
+  it('sets hasDefinition from the effective gloss for the admin overlay (#435)', async () => {
+    stage([
+      tokenRow({ id: 't1', idx: 0, lemmaId: 'lem-a' }),
+      tokenRow({ id: 't2', idx: 1, lemmaId: 'lem-b' }),
+      // OOV word: no lemma id at all → no definition.
+      tokenRow({ id: 't3', idx: 2, lemmaId: null, isOov: true }),
+    ]);
+    stage([]); // token_corrections
+    stage([]); // user_known_lemmas
+    stage([
+      { id: 'lem-a', language: 'hi', headword: 'पानी', glossDefault: 'water' },
+      { id: 'lem-b', language: 'hi', headword: 'rare', glossDefault: null },
+    ]);
+    stage([]); // personal translations
+    stage([]); // sibling fallback — no rows for lem-b
+    const result = await loadChapterTokens('chap-1', 'user-1');
+    // Lemma with a gloss → defined.
+    expect(result![0]).toMatchObject({ id: 't1', hasDefinition: true });
+    // Lemma exists but gloss is null and no sibling → undefined.
+    expect(result![1]).toMatchObject({ id: 't2', hasDefinition: false });
+    // OOV word (no lemma) → undefined.
+    expect(result![2]).toMatchObject({ id: 't3', hasDefinition: false });
+  });
+
+  it('hasDefinition follows the T-3.14 sibling-gloss fallback (#435)', async () => {
+    stage([tokenRow({ id: 't1', idx: 0, lemmaId: 'lem-propn' })]);
+    stage([]); // token_corrections
+    stage([]); // user_known_lemmas
+    stage([
+      { id: 'lem-propn', language: 'hi', headword: 'पार्क', glossDefault: null },
+    ]);
+    stage([]); // personal translations
+    stage([{ language: 'hi', headword: 'पार्क', glossDefault: 'park' }]);
+    const result = await loadChapterTokens('chap-1', 'user-1');
+    // The linked lemma had no gloss, but a same-headword sibling does —
+    // the overlay must agree with the tooltip and treat it as defined.
+    expect(result![0]).toMatchObject({
+      id: 't1',
+      glossDefault: 'park',
+      hasDefinition: true,
+    });
+  });
+
   it('falls back to a sibling lemma\'s gloss when the linked lemma has none (T-3.14)', async () => {
     // Common case: NLP tagged "पार्क" as PROPN with no gloss; the
     // dictionary entry is under "पार्क/NOUN" with the actual gloss.

--- a/apps/web/src/lib/server/texts/tokens.ts
+++ b/apps/web/src/lib/server/texts/tokens.ts
@@ -109,6 +109,15 @@ export type RenderedToken = {
    *  form + romanization. Null on every other token. */
   numberForms: RenderedNumberForms | null;
   status: 'known' | 'learning' | 'ignored' | 'unknown';
+  /** #435: true when this word's lemma (or a same-headword sibling)
+   *  carries a canonical short gloss — i.e. the dictionary has a
+   *  definition for it. False for OOV words and for lemmas with no
+   *  gloss on file yet. Drives the admin-only "flag undefined words"
+   *  reader overlay so curators can spot dictionary gaps while
+   *  reading. Derived from the same `glossDefault` (incl. the T-3.14
+   *  sibling fallback) the hover tooltip uses, so the overlay agrees
+   *  with what a reader actually sees on hover. */
+  hasDefinition: boolean;
 };
 
 /**
@@ -407,6 +416,13 @@ export async function loadChapterTokens(
     }
     candidates.sort((a, b) => b.score - a.score);
 
+    // #435: resolve the effective gloss once so both the tooltip
+    // payload and the `hasDefinition` flag read the same value (incl.
+    // the sibling fallback applied to `glossByLemma` above).
+    const effectiveGloss = effectiveLemmaId
+      ? glossByLemma.get(effectiveLemmaId) ?? null
+      : null;
+
     const nf = t.numberForms;
     const renderedNumberForms: RenderedNumberForms | null = nf
       ? {
@@ -437,9 +453,7 @@ export async function loadChapterTokens(
       isOov: isMarkedNonWord ? false : t.isOov,
       lemmaId: effectiveLemmaId,
       romanization: t.romanization,
-      glossDefault: effectiveLemmaId
-        ? glossByLemma.get(effectiveLemmaId) ?? null
-        : null,
+      glossDefault: effectiveGloss,
       personalGloss: effectiveLemmaId
         ? personalGlossByLemma.get(effectiveLemmaId) ?? null
         : null,
@@ -447,6 +461,7 @@ export async function loadChapterTokens(
       features: t.features,
       numberForms: renderedNumberForms,
       status,
+      hasDefinition: effectiveGloss != null,
     };
   });
 }

--- a/apps/web/src/lib/styles/tokens.css
+++ b/apps/web/src/lib/styles/tokens.css
@@ -88,6 +88,12 @@
   --w-known-bg: transparent;
   --w-ignored-bg: transparent;
   --w-ignored-ink: var(--ink-4);
+  /* #435: admin "no definition yet" overlay. A magenta hue (≈330)
+   * deliberately apart from the saffron status palette so flagged
+   * words never read as a learning state. Ink is dark enough on the
+   * pale tint to clear WCAG AA at body size. */
+  --w-undefined-bg: oklch(0.9 0.06 330);
+  --w-undefined-ink: oklch(0.36 0.14 330);
 
   --shadow-1:
     0 1px 0 rgba(255, 255, 255, 0.5) inset, 0 1px 2px rgba(67, 47, 14, 0.06);
@@ -141,6 +147,9 @@
   --w-l1-bg: oklch(0.84 0.08 75);
   --w-l2-bg: oklch(0.76 0.12 70);
   --w-l3-bg: oklch(0.68 0.13 65);
+  /* #435: tuned for the warmer sepia paper. */
+  --w-undefined-bg: oklch(0.82 0.07 330);
+  --w-undefined-ink: oklch(0.32 0.14 330);
 }
 
 [data-theme='dark'] {
@@ -199,6 +208,10 @@
   --w-l1-bg: oklch(0.3 0.05 70);
   --w-l2-bg: oklch(0.38 0.08 68);
   --w-l3-bg: oklch(0.46 0.11 65);
+  /* #435: dark tint with a near-white violet ink so flagged words
+   * stay legible on the dark paper. */
+  --w-undefined-bg: oklch(0.4 0.1 330);
+  --w-undefined-ink: oklch(0.95 0.05 330);
 
   --shadow-1:
     0 1px 0 rgba(255, 255, 255, 0.04) inset, 0 1px 2px rgba(0, 0, 0, 0.4);
@@ -404,4 +417,21 @@ html[data-hl='colored_text'] .word[data-s='5'] {
   text-decoration: line-through;
   text-decoration-color: var(--ink-4);
   text-decoration-thickness: 0.5px;
+}
+
+/* —— Admin overlay: flag words with no definition yet (#435) ————————
+ * Admins toggle `data-flag-undefined` on <html> from the reader
+ * settings popover. While it's set, every word whose lemma carries no
+ * canonical gloss (TokenSpan tags it `.no-definition`) gets a distinct
+ * magenta tint that overrides whatever highlight mode is active, so
+ * dictionary gaps are obvious while reading. Declared after every
+ * `data-hl` rule above so it wins at equal specificity in all three
+ * modes; `box-shadow`/`color` are reset so the status tint can't bleed
+ * through. The class is inert without the attribute, so non-admins
+ * (and any reader who never flips the toggle) see nothing. */
+html[data-flag-undefined='1'] .word.no-definition {
+  background: var(--w-undefined-bg);
+  color: var(--w-undefined-ink);
+  box-shadow: none;
+  border-radius: 3px;
 }

--- a/apps/web/src/routes/reader/[textId]/+page.svelte
+++ b/apps/web/src/routes/reader/[textId]/+page.svelte
@@ -17,6 +17,11 @@
     writePersistedImmersive,
   } from '$lib/components/reader/immersive.js';
   import {
+    readPersistedFlagUndefined,
+    setFlagUndefinedAttribute,
+    writePersistedFlagUndefined,
+  } from '$lib/components/reader/undefined-highlight.js';
+  import {
     READING_WIDTH_REM,
     type ReaderSettings as ReaderSettingsT,
   } from '$lib/components/reader/reader-settings.js';
@@ -57,6 +62,18 @@
     readerSettings = data.readerSettings;
   });
   let settingsOpen = $state(false);
+
+  // #435: admin-only overlay that tints words whose lemma has no
+  // definition yet. The flag is hydrated from localStorage on mount
+  // (admins only) and mirrored onto <html> by the effect below; the
+  // reader settings popover flips it. Persisting outside the
+  // per-language settings keeps it a personal diagnostic preference
+  // rather than a shared reading setting.
+  let flagUndefined = $state(false);
+  function setFlagUndefined(on: boolean) {
+    flagUndefined = on;
+    writePersistedFlagUndefined(on);
+  }
 
   // T-2.8: admin-only "Reprocess this text" affordance. Re-runs the
   // NLP pipeline (POSTs `/api/v1/admin/texts/:id/reprocess`) and
@@ -133,6 +150,15 @@
       if (previous == null) html.removeAttribute('data-hl');
       else html.setAttribute('data-hl', previous);
     };
+  });
+
+  // #435: mirror the admin overlay flag onto <html> so tokens.css
+  // paints `.word.no-definition`. Only admins can turn it on; clearing
+  // on unmount keeps the attribute scoped to the reader route.
+  $effect(() => {
+    if (typeof document === 'undefined') return;
+    setFlagUndefinedAttribute(data.isAdmin && flagUndefined);
+    return () => setFlagUndefinedAttribute(false);
   });
 
   function shouldPoll(s: typeof data.text.status): boolean {
@@ -232,6 +258,11 @@
 
   onMount(() => {
     liveStatus = data.text.status;
+
+    // #435: restore the admin's overlay preference. Read after mount
+    // (not during SSR) so the localStorage access is browser-only; the
+    // effect above syncs it onto <html> once the state lands.
+    if (data.isAdmin) flagUndefined = readPersistedFlagUndefined();
 
     // Reading is immersive: hide the app-shell rail / bottom nav so the
     // text owns the screen. The × button (→ library) and Esc are the ways
@@ -551,6 +582,9 @@
     readerSettings = next;
   }}
   canPersist={data.canPersistSettings}
+  isAdmin={data.isAdmin}
+  {flagUndefined}
+  onFlagUndefinedChange={setFlagUndefined}
 />
 
 <style>


### PR DESCRIPTION
## What

Adds an admin-only reader overlay that tints every word whose lemma has **no definition yet**, so curators can spot dictionary gaps while reading.

Closes #435

## How it works

- **Server** — `loadChapterTokens` ([tokens.ts](apps/web/src/lib/server/texts/tokens.ts)) now sets a per-token `hasDefinition`, derived from the effective `glossDefault` (including the existing T-3.14 sibling-gloss fallback) so the overlay agrees with what a reader already sees on hover. It rides the existing token payload — no extra queries, and the lazy sibling-chapter endpoint picks it up for free.
- **Rendering** — `TokenSpan` tags undefined words with `.no-definition`. `tokens.css` only paints that class while `html[data-flag-undefined='1']` is set (per-theme light/sepia/dark colours, WCAG-AA contrast), so the class is completely inert for non-admins.
- **Toggle** — a new "Admin → Undefined words" section in the reader settings popover, gated on the `isAdmin` flag the reader load already exposes. State lives on the reader page and persists in `localStorage` via a small helper (`undefined-highlight.ts`, modelled on `immersive.ts`) — kept out of the synced per-language settings since it's a personal diagnostic, not a reading preference.

## Notable decisions

- **`glossDefault`, not a `translations` query** for the presence signal — the loader's gloss fallback is explicitly designed to stay in sync with the popup, so it's the right zero-cost proxy for "has a definition."
- **`hasDefinition` is optional on the client `ServerToken`** — only an explicit `false` flags a word, so client-fallback and synthetic phrase tokens (which can't know) are never wrongly tinted, and no existing fixtures broke.

## Tests

New: `undefined-highlight.test.ts` (storage round-trip + DOM attribute), `TokenSpan.test.ts` (`.no-definition` class logic incl. OOV / ruby / non-word), `ReaderSettings.test.ts` (admin section visibility + toggle callbacks), plus `hasDefinition` cases (gloss / null / OOV / sibling fallback) in `tokens.test.ts`.

Full web suite green (1730 tests); `svelte-check` 0 errors; eslint clean; coverage 81.9% (floor 80).

## Verified in the running app

Loaded the reader as the owning admin — the served page carries `hasDefinition` on all tokens and renders the `.no-definition` class on undefined words; flipping the toggle paints them.
