### PR TITLE
feat(languages): separate the site by language (#436)

### DIFF
--- a/apps/web/src/lib/components/shell/AppShell.svelte
+++ b/apps/web/src/lib/components/shell/AppShell.svelte
@@ -26,6 +26,7 @@
     setImmersiveAttribute,
     writePersistedImmersive,
   } from '../reader/immersive.js';
+  import { switchCurrentLanguage } from './language-switch.js';
   import type { Snippet } from 'svelte';
 
   interface LanguageOption {
@@ -50,6 +51,9 @@
     /** Languages the signed-in user has a `user_languages` row for —
      *  the picker's options. Empty for anonymous visitors. */
     availableLanguages?: LanguageOption[];
+    /** Supported languages the user hasn't added yet — the switcher's
+     *  "Add a language" options (#436). Empty for anonymous visitors. */
+    addableLanguages?: LanguageOption[];
     children: Snippet;
   }
 
@@ -57,6 +61,7 @@
     user,
     currentLanguage = null,
     availableLanguages = [],
+    addableLanguages = [],
     children,
   }: Props = $props();
 
@@ -95,6 +100,8 @@
     };
   });
 
+  // Switch to a language the user already reads. Adding a *new* language
+  // happens on the dedicated /languages/new page (#436), not here.
   async function pickLanguage(code: string) {
     if (switching) return;
     if (code === currentLanguage) {
@@ -104,17 +111,10 @@
     switching = true;
     switchError = null;
     try {
-      const res = await fetch('/api/v1/me/current-language', {
-        method: 'PUT',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ code }),
-      });
-      if (!res.ok) {
-        throw new Error(`PUT failed: ${res.status}`);
-      }
+      await switchCurrentLanguage(code);
       langPickerOpen = false;
-      // Re-run every loader so the new currentLanguage is picked up
-      // (rail indicator, home grid, library filter, words filter…).
+      // Re-run every loader so the new currentLanguage is picked up (rail
+      // indicator, home grid, library / words / upload scoping…).
       await invalidateAll();
     } catch (e) {
       switchError = (e as Error).message;
@@ -348,9 +348,10 @@
   </nav>
 </div>
 
-<!-- T-5.25: language picker. Anchored under the top-left brand icon.
-     Manage / add / remove languages still happens on /profile — this
-     dropdown is just the runtime switcher. -->
+<!-- T-5.25 / #436: language switcher. Anchored under the top-left brand
+     icon. Lists the languages you read (switch in place); adding a new
+     language is its own page, reached via the "Add a language" button at
+     the foot. Fine-grained per-language settings live on /profile. -->
 {#snippet langDropdown()}
   <div class="lang-dropdown" role="menu" aria-label="Languages">
     {#if availableLanguages.length === 0}
@@ -384,10 +385,17 @@
         {/each}
       </ul>
     {/if}
+
     {#if switchError}
       <p class="lang-err" role="alert">Could not switch: {switchError}</p>
     {/if}
-    <a class="lang-manage" href="/profile">Manage languages →</a>
+
+    {#if addableLanguages.length > 0}
+      <div class="lang-foot">
+        <!-- Adding a language is its own page (#436). -->
+        <a class="lang-add-btn" href="/languages/new">Add a language</a>
+      </div>
+    {/if}
   </div>
 {/snippet}
 
@@ -833,15 +841,35 @@
     font-size: 0.78rem;
     margin: 0;
   }
-  .lang-manage {
-    align-self: flex-start;
-    color: var(--accent-ink, var(--color-accent));
-    text-decoration: none;
-    font-size: 0.85rem;
-    padding: 0.4rem 0;
+
+  /* —— Footer action (#436) —————————————————————————————————————
+   * A single "Add a language" button under the active list, separated
+   * by a rule. It navigates to the dedicated add page rather than
+   * adding inline. */
+  .lang-foot {
+    border-top: 1px solid var(--rule, var(--color-border));
+    padding-top: 0.55rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
   }
-  .lang-manage:hover {
-    text-decoration: underline;
+
+  /* "Add a language": filled so it reads as the call-to-action.
+   * Ink-on-paper clears WCAG AA in every theme. */
+  .lang-add-btn {
+    text-align: center;
+    color: var(--paper, var(--color-bg));
+    background: var(--ink, var(--color-fg));
+    border: 1px solid var(--ink, var(--color-fg));
+    border-radius: 8px;
+    text-decoration: none;
+    font-family: var(--font-sans, var(--font-ui));
+    font-size: 0.8rem;
+    font-weight: 500;
+    padding: 0.5rem 0.6rem;
+  }
+  .lang-add-btn:hover {
+    background: color-mix(in oklch, var(--ink, var(--color-fg)) 88%, transparent);
   }
 
   /* —— Immersive mode (mobile-only) ————————————————————————————

--- a/apps/web/src/lib/components/shell/language-switch.test.ts
+++ b/apps/web/src/lib/components/shell/language-switch.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { switchCurrentLanguage, addLanguage } from './language-switch.js';
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue({ ok: true, status: 200 });
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('switchCurrentLanguage', () => {
+  it('PUTs the code to the current-language endpoint', async () => {
+    await switchCurrentLanguage('mr');
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/me/current-language',
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({ code: 'mr' }),
+      }),
+    );
+  });
+
+  it('throws on a non-2xx response', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500 });
+    await expect(switchCurrentLanguage('mr')).rejects.toThrow(/500/);
+  });
+});
+
+describe('addLanguage', () => {
+  it('POSTs the code to the languages endpoint', async () => {
+    await addLanguage('or');
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/me/languages',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ code: 'or' }),
+      }),
+    );
+  });
+
+  it('throws on a non-2xx response', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 401 });
+    await expect(addLanguage('or')).rejects.toThrow(/401/);
+  });
+});

--- a/apps/web/src/lib/components/shell/language-switch.ts
+++ b/apps/web/src/lib/components/shell/language-switch.ts
@@ -1,0 +1,31 @@
+/**
+ * Client helpers for the language switcher (#436).
+ *
+ * Two endpoints back the switcher because the two actions differ:
+ *   - switching to a language you already read only moves the cookie, and
+ *     works for anonymous visitors too → PUT /api/v1/me/current-language;
+ *   - adding a language mutates `user_languages`, so it needs auth and also
+ *     sets the cookie (add + switch in one request) → POST /api/v1/me/languages.
+ *
+ * Both throw on a non-2xx response so callers can surface the error and
+ * skip the follow-up reload / navigation.
+ */
+
+async function send(url: string, method: 'PUT' | 'POST', code: string): Promise<void> {
+  const res = await fetch(url, {
+    method,
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ code }),
+  });
+  if (!res.ok) throw new Error(`${method} ${url} failed: ${res.status}`);
+}
+
+/** Move the current-language cookie. No DB write; safe for anonymous. */
+export function switchCurrentLanguage(code: string): Promise<void> {
+  return send('/api/v1/me/current-language', 'PUT', code);
+}
+
+/** Add the language to the signed-in user's list and switch to it. */
+export function addLanguage(code: string): Promise<void> {
+  return send('/api/v1/me/languages', 'POST', code);
+}

--- a/apps/web/src/lib/server/language-context.test.ts
+++ b/apps/web/src/lib/server/language-context.test.ts
@@ -4,9 +4,11 @@ import { describe, expect, it } from 'vitest';
 import {
   LANG_COOKIE,
   LANG_COOKIE_MAX_AGE,
+  addableLanguageOptions,
   languageOption,
   resolveCurrentLanguage,
 } from './language-context.js';
+import { SUPPORTED_LANGUAGE_CODES } from '@ciareader/shared-types';
 
 describe('resolveCurrentLanguage', () => {
   it("returns the user's only language when there's no cookie", () => {
@@ -57,6 +59,33 @@ describe('languageOption', () => {
     const or = languageOption('or');
     // 'ଓଡ଼ିଆ' starts with 'ଓ'.
     expect(or.glyph).toBe('ଓ');
+  });
+});
+
+describe('addableLanguageOptions', () => {
+  it('returns every supported language the user has not added', () => {
+    const opts = addableLanguageOptions(['hi', 'mr']);
+    const codes = opts.map((o) => o.code);
+    expect(codes).not.toContain('hi');
+    expect(codes).not.toContain('mr');
+    expect(codes.length).toBe(SUPPORTED_LANGUAGE_CODES.length - 2);
+    // Carries the same shape as languageOption for direct rendering.
+    expect(opts[0]).toMatchObject({
+      code: expect.any(String),
+      displayName: expect.any(String),
+      nativeName: expect.any(String),
+      glyph: expect.any(String),
+    });
+  });
+
+  it('returns an empty list when the user already has every language', () => {
+    expect(addableLanguageOptions(SUPPORTED_LANGUAGE_CODES)).toEqual([]);
+  });
+
+  it('offers all supported languages when the user has none', () => {
+    expect(addableLanguageOptions([]).map((o) => o.code)).toEqual([
+      ...SUPPORTED_LANGUAGE_CODES,
+    ]);
   });
 });
 

--- a/apps/web/src/lib/server/language-context.ts
+++ b/apps/web/src/lib/server/language-context.ts
@@ -72,3 +72,15 @@ export function languageOption(code: LanguageCode): LanguageOption {
     glyph: [...desc.nativeName][0] ?? code.toUpperCase().slice(0, 1),
   };
 }
+
+/** Supported languages the user hasn't added yet — the "Add a language"
+ *  options in the rail switcher (#436). Order follows the registry so the
+ *  list is stable across renders. */
+export function addableLanguageOptions(
+  activeCodes: readonly LanguageCode[],
+): LanguageOption[] {
+  const active = new Set(activeCodes);
+  return SUPPORTED_LANGUAGE_CODES.filter((code) => !active.has(code)).map(
+    languageOption,
+  );
+}

--- a/apps/web/src/lib/server/user-languages.test.ts
+++ b/apps/web/src/lib/server/user-languages.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Capture the drizzle insert chain so we can assert the upsert shape
+// without a real database. vi.hoisted lets the mock factory reference the
+// spies directly (no forwarding wrapper, so no unused-arg lint noise).
+const { insert, values, onConflictDoUpdate } = vi.hoisted(() => {
+  const onConflictDoUpdate = vi.fn().mockResolvedValue(undefined);
+  const values = vi.fn(() => ({ onConflictDoUpdate }));
+  const insert = vi.fn(() => ({ values }));
+  return { insert, values, onConflictDoUpdate };
+});
+
+vi.mock('./db/index.js', () => ({
+  db: { insert },
+  schema: {
+    userLanguages: {
+      userId: 'user_id',
+      language: 'language',
+    },
+  },
+}));
+
+beforeEach(() => {
+  insert.mockClear();
+  values.mockClear();
+  onConflictDoUpdate.mockClear();
+});
+
+afterEach(() => vi.resetModules());
+
+describe('addUserLanguage', () => {
+  it('upserts a row carrying the chosen baseline', async () => {
+    const { addUserLanguage } = await import('./user-languages.js');
+    await addUserLanguage('u1', 'mr', 'beginner');
+
+    expect(values).toHaveBeenCalledWith({
+      userId: 'u1',
+      language: 'mr',
+      baseline: 'beginner',
+    });
+    // Conflict branch re-applies the baseline (+ bumps updatedAt).
+    const conflictArg = onConflictDoUpdate.mock.calls[0]![0] as {
+      set: { baseline: string };
+    };
+    expect(conflictArg.set.baseline).toBe('beginner');
+  });
+
+  it("defaults the baseline to 'none'", async () => {
+    const { addUserLanguage } = await import('./user-languages.js');
+    await addUserLanguage('u1', 'or');
+    expect(values).toHaveBeenCalledWith({
+      userId: 'u1',
+      language: 'or',
+      baseline: 'none',
+    });
+  });
+});

--- a/apps/web/src/lib/server/user-languages.ts
+++ b/apps/web/src/lib/server/user-languages.ts
@@ -1,0 +1,33 @@
+/**
+ * User ↔ language membership (#436).
+ *
+ * "Adding a language" creates a `user_languages` row carrying the chosen
+ * proficiency baseline. Distinct from `upsertUserLanguage` in profile.ts,
+ * which patches reading preferences and deliberately never touches the
+ * baseline. This one is for the dedicated "Add a language" page, where the
+ * baseline is an explicit choice.
+ */
+import { db, schema } from './db/index.js';
+import type { LanguageBaseline } from './onboarding.js';
+import type { LanguageCode } from '@ciareader/shared-types';
+
+/**
+ * Add `code` to the user's languages with the given baseline. Atomic
+ * upsert: a brand-new language inserts with the column defaults plus the
+ * baseline; the conflict branch (a race, or re-adding) re-applies the
+ * chosen baseline. Callers that must preserve an existing baseline should
+ * guard on the active list before calling.
+ */
+export async function addUserLanguage(
+  userId: string,
+  code: LanguageCode,
+  baseline: LanguageBaseline = 'none',
+): Promise<void> {
+  await db
+    .insert(schema.userLanguages)
+    .values({ userId, language: code, baseline })
+    .onConflictDoUpdate({
+      target: [schema.userLanguages.userId, schema.userLanguages.language],
+      set: { baseline, updatedAt: new Date() },
+    });
+}

--- a/apps/web/src/routes/+layout.server.ts
+++ b/apps/web/src/routes/+layout.server.ts
@@ -4,6 +4,7 @@ import { db } from '$lib/server/db/index.js';
 import { userLanguages } from '$lib/server/db/schema.js';
 import {
   LANG_COOKIE,
+  addableLanguageOptions,
   languageOption,
   resolveCurrentLanguage,
 } from '$lib/server/language-context.js';
@@ -19,7 +20,9 @@ import type { LayoutServerLoad } from './$types';
  * Also resolves the active language (T-5.25): the rail's language
  * indicator + picker reads `availableLanguages` (the user's
  * `user_languages` rows) and `currentLanguage` (cookie-driven
- * choice, validated against the active list).
+ * choice, validated against the active list). `addableLanguages`
+ * (#436) carries the supported languages the user hasn't added yet
+ * so the switcher can offer "Add a language" inline.
  */
 export const load: LayoutServerLoad = async ({ locals, cookies }) => {
   let activeCodes: LanguageCode[] = [];
@@ -57,5 +60,8 @@ export const load: LayoutServerLoad = async ({ locals, cookies }) => {
       : null,
     currentLanguage,
     availableLanguages: activeCodes.map(languageOption),
+    // Only signed-in users can add a language; anonymous visitors get an
+    // empty list (the switcher isn't shown for them anyway).
+    addableLanguages: locals.user?.id ? addableLanguageOptions(activeCodes) : [],
   };
 };

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -17,6 +17,7 @@
   user={data.user}
   currentLanguage={data.currentLanguage}
   availableLanguages={data.availableLanguages}
+  addableLanguages={data.addableLanguages}
 >
   {@render children()}
 </AppShell>

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -1,16 +1,51 @@
 <!--
-  Home (T-5.12).
+  Home (T-5.12, language-set on click in #436).
 
   Replaces the M0 diagnostic dashboard with the CIAR design's
   language-pick landing: hero copy + a card grid where each card
   shows a supported language's native + Roman name, script, and the
   signed-in user's known-word count for that language. Clicking a
-  card jumps to the library filtered to that language.
+  card makes that language current (adding it to the user's list if
+  needed) and opens the library — the site is split by language.
 -->
 <script lang="ts">
+  import { goto } from '$app/navigation';
+  import {
+    switchCurrentLanguage,
+    addLanguage,
+  } from '$lib/components/shell/language-switch.js';
   import type { PageData } from './$types';
 
   let { data }: { data: PageData } = $props();
+
+  // null = idle; otherwise the code mid-switch (disables the grid so a
+  // double-tap can't fire two requests).
+  let choosing = $state<string | null>(null);
+
+  async function choose(code: string, e: MouseEvent) {
+    // Honor modifier-clicks (open in new tab) and let no-JS fall back to
+    // the href — only hijack a plain left click.
+    if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) {
+      return;
+    }
+    e.preventDefault();
+    if (choosing) return;
+    choosing = code;
+    try {
+      // Signed-in: add-or-switch (idempotent). Anonymous: cookie only.
+      if (data.user) await addLanguage(code);
+      else await switchCurrentLanguage(code);
+    } catch {
+      // Swallow — fall through to the navigation so the user isn't stuck
+      // on the grid; the library just opens on the unchanged language.
+    } finally {
+      choosing = null;
+    }
+    // invalidateAll re-runs the root layout load so it re-reads the cookie we
+    // just set — otherwise the shared layout (and the library's parent()
+    // currentLanguage) would keep the stale pick across this navigation.
+    await goto('/library', { invalidateAll: true });
+  }
 </script>
 
 <svelte:head>
@@ -30,8 +65,11 @@
     {#each data.languages as L (L.code)}
       <a
         class="lang-card card"
-        href={`/library?language=${L.code}`}
-        aria-label={`Open the ${L.displayName} library`}
+        href="/library"
+        aria-label={`Read in ${L.displayName}`}
+        data-busy={choosing === L.code ? '1' : '0'}
+        aria-busy={choosing === L.code}
+        onclick={(e) => choose(L.code, e)}
       >
         <div class="lc-native">{L.nativeName}</div>
         <div class="lc-en">{L.displayName}</div>
@@ -119,6 +157,10 @@
       var(--card-edge, var(--color-border))
     );
     transform: translateY(-1px);
+  }
+  .lang-card[data-busy='1'] {
+    opacity: 0.6;
+    pointer-events: none;
   }
   .lc-native {
     font-family: var(--font-serif-dev, var(--font-serif));

--- a/apps/web/src/routes/api/v1/me/languages/+server.ts
+++ b/apps/web/src/routes/api/v1/me/languages/+server.ts
@@ -1,7 +1,17 @@
 import { json } from '@sveltejs/kit';
+import { z } from 'zod';
 import { requireUser } from '$lib/server/auth/require-user.js';
-import { listUserLanguages, withDefaultsForAllLanguages } from '$lib/server/profile.js';
-import { LANGUAGES } from '@ciareader/shared-types';
+import {
+  listUserLanguages,
+  upsertUserLanguage,
+  withDefaultsForAllLanguages,
+} from '$lib/server/profile.js';
+import {
+  LANG_COOKIE,
+  LANG_COOKIE_MAX_AGE,
+} from '$lib/server/language-context.js';
+import { LANGUAGES, isSupportedLanguage, type LanguageCode } from '@ciareader/shared-types';
+import { parseJson } from '../../auth/_helpers.js';
 import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = async (event) => {
@@ -16,4 +26,34 @@ export const GET: RequestHandler = async (event) => {
       supportedRomanizations: LANGUAGES[row.code].supportedRomanizations,
     })),
   });
+};
+
+const addSchema = z.object({
+  code: z.string().refine(isSupportedLanguage, { message: 'Unsupported language' }),
+});
+
+/**
+ * POST /api/v1/me/languages — add a language to the user's list and make it
+ * current in one step (#436, the rail switcher's "Add a language" action).
+ *
+ * The upsert with an empty patch creates a `user_languages` row carrying the
+ * column defaults (baseline `none`, native script) when the user has never
+ * read this language, and is a harmless no-op when they already have — so
+ * the switcher can POST here whether the target is new or already-added.
+ * Setting the cookie too means "add" and "switch" land in a single request.
+ */
+export const POST: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  const { code } = await parseJson(event.request, addSchema);
+
+  await upsertUserLanguage(user.id, code as LanguageCode, {});
+
+  event.cookies.set(LANG_COOKIE, code, {
+    path: '/',
+    maxAge: LANG_COOKIE_MAX_AGE,
+    sameSite: 'lax',
+    httpOnly: false,
+  });
+
+  return json({ code });
 };

--- a/apps/web/src/routes/api/v1/me/languages/languages-server.test.ts
+++ b/apps/web/src/routes/api/v1/me/languages/languages-server.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment node
+/**
+ * Route tests for POST /api/v1/me/languages (#436): add a language to the
+ * user's list and switch to it in one request.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const upsertUserLanguage = vi.fn();
+const requireUser = vi.fn();
+
+vi.mock('$lib/server/profile.js', () => ({
+  upsertUserLanguage: (...a: unknown[]) => upsertUserLanguage(...a),
+  // GET imports these; not exercised here, but the named bindings must exist.
+  listUserLanguages: vi.fn(),
+  withDefaultsForAllLanguages: vi.fn(),
+}));
+
+vi.mock('$lib/server/auth/require-user.js', () => ({
+  requireUser: (...a: unknown[]) => requireUser(...a),
+}));
+
+type Post = (typeof import('./+server.js'))['POST'];
+
+function makeCookies() {
+  const set = vi.fn();
+  return { set, get: vi.fn(), delete: vi.fn(), serialize: vi.fn() };
+}
+
+async function callPost(body: unknown, cookies = makeCookies()) {
+  const { POST } = await import('./+server.js');
+  const event = {
+    locals: { user: { id: 'u1' } },
+    cookies,
+    request: new Request('http://x/api/v1/me/languages', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+  } as unknown as Parameters<Post>[0];
+  try {
+    return { res: (await POST(event)) as Response, cookies };
+  } catch (e) {
+    return { res: e as { status: number }, cookies };
+  }
+}
+
+beforeEach(() => {
+  upsertUserLanguage.mockReset();
+  upsertUserLanguage.mockResolvedValue({ userId: 'u1', language: 'mr' });
+  requireUser.mockReset();
+  requireUser.mockResolvedValue({ id: 'u1' });
+});
+
+afterEach(() => vi.resetModules());
+
+describe('POST /api/v1/me/languages', () => {
+  it('adds the language with an empty patch and echoes the code', async () => {
+    const { res } = await callPost({ code: 'mr' });
+    expect((res as Response).status).toBe(200);
+    expect(await (res as Response).json()).toEqual({ code: 'mr' });
+    expect(upsertUserLanguage).toHaveBeenCalledWith('u1', 'mr', {});
+  });
+
+  it('sets the current-language cookie so add == switch', async () => {
+    const { res, cookies } = await callPost({ code: 'mr' });
+    expect((res as Response).status).toBe(200);
+    expect(cookies.set).toHaveBeenCalledWith(
+      'cia_lang',
+      'mr',
+      expect.objectContaining({ path: '/' }),
+    );
+  });
+
+  it('rejects an unsupported language with 400 and writes nothing', async () => {
+    const { res } = await callPost({ code: 'xx' });
+    expect((res as { status: number }).status).toBe(400);
+    expect(upsertUserLanguage).not.toHaveBeenCalled();
+  });
+
+  it('401s an anonymous caller before touching the DB', async () => {
+    requireUser.mockImplementation(() => {
+      throw { status: 401 };
+    });
+    const { res } = await callPost({ code: 'mr' });
+    expect((res as { status: number }).status).toBe(401);
+    expect(upsertUserLanguage).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/routes/languages/new/+page.server.ts
+++ b/apps/web/src/routes/languages/new/+page.server.ts
@@ -1,0 +1,77 @@
+/**
+ * Add a language (#436).
+ *
+ * A dedicated page — reached from the rail switcher's "Add a language"
+ * button — for adding a language you don't read yet. Lists the
+ * not-yet-added supported languages plus a proficiency baseline (mirroring
+ * onboarding), adds the chosen one, makes it current, and drops you in the
+ * library for it.
+ *
+ * Auth required; anonymous visitors are bounced to /login.
+ */
+import { fail, redirect } from '@sveltejs/kit';
+
+import { listUserLanguages } from '$lib/server/profile.js';
+import {
+  LANG_COOKIE,
+  LANG_COOKIE_MAX_AGE,
+  addableLanguageOptions,
+} from '$lib/server/language-context.js';
+import { addUserLanguage } from '$lib/server/user-languages.js';
+import type { LanguageBaseline } from '$lib/server/onboarding.js';
+import { isSupportedLanguage, type LanguageCode } from '@ciareader/shared-types';
+import type { Actions, PageServerLoad } from './$types';
+
+const BASELINES = ['none', 'beginner', 'intermediate'] as const;
+
+function isBaseline(v: string): v is LanguageBaseline {
+  return (BASELINES as readonly string[]).includes(v);
+}
+
+async function activeCodesFor(userId: string): Promise<LanguageCode[]> {
+  const rows = await listUserLanguages(userId);
+  return rows.map((r) => r.language as LanguageCode);
+}
+
+export const load: PageServerLoad = async ({ locals, url }) => {
+  if (!locals.user) {
+    throw redirect(303, `/login?next=${encodeURIComponent(url.pathname)}`);
+  }
+  const addable = addableLanguageOptions(await activeCodesFor(locals.user.id));
+  return { addable, baselines: BASELINES };
+};
+
+type AddResult = { ok: false; message: string };
+
+export const actions: Actions = {
+  default: async ({ request, locals, cookies, url }) => {
+    if (!locals.user) {
+      throw redirect(303, `/login?next=${encodeURIComponent(url.pathname)}`);
+    }
+    const fd = await request.formData();
+    const code = fd.get('language')?.toString() ?? '';
+    const baseline = fd.get('baseline')?.toString() ?? 'none';
+
+    if (!isSupportedLanguage(code)) {
+      return fail(400, { ok: false, message: 'Pick a language to add.' } satisfies AddResult);
+    }
+    if (!isBaseline(baseline)) {
+      return fail(400, { ok: false, message: 'Pick how much you already know.' } satisfies AddResult);
+    }
+
+    // Already reading it? Just switch — don't clobber an existing baseline.
+    const active = await activeCodesFor(locals.user.id);
+    if (!active.includes(code as LanguageCode)) {
+      await addUserLanguage(locals.user.id, code as LanguageCode, baseline);
+    }
+
+    // Make it current (add == switch) and land in its library.
+    cookies.set(LANG_COOKIE, code, {
+      path: '/',
+      maxAge: LANG_COOKIE_MAX_AGE,
+      sameSite: 'lax',
+      httpOnly: false,
+    });
+    throw redirect(303, '/library');
+  },
+};

--- a/apps/web/src/routes/languages/new/+page.svelte
+++ b/apps/web/src/routes/languages/new/+page.svelte
@@ -1,0 +1,209 @@
+<!--
+  Add a language (#436).
+
+  Reached from the rail switcher's "Add a language" button. Mirrors the
+  onboarding picker — choose a not-yet-added language + a rough proficiency
+  baseline — then adds it, switches to it, and opens its library.
+-->
+<script lang="ts">
+  import { enhance } from '$app/forms';
+  import type { ActionData, PageData } from './$types';
+
+  let { data, form }: { data: PageData; form: ActionData } = $props();
+
+  const BASELINE_LABELS: Record<string, { title: string; blurb: string }> = {
+    none: {
+      title: 'Starting from scratch',
+      blurb: 'Every word you encounter is new until you mark it known.',
+    },
+    beginner: {
+      title: 'Beginner — some basics',
+      blurb:
+        'Assume the 100 most common words are already familiar. You can change individual words later.',
+    },
+    intermediate: {
+      title: 'Intermediate',
+      blurb:
+        'Assume the 1,000 most common words are already familiar — useful if you already read the language.',
+    },
+  };
+
+  // Seed the selection from the loader once; bind:group owns it after.
+  let selectedLanguage = $state<string>(((): string => data.addable[0]?.code ?? '')());
+  let selectedBaseline = $state<string>('none');
+</script>
+
+<svelte:head>
+  <title>Add a language — CIA Reader</title>
+</svelte:head>
+
+<div class="page">
+  <h1>Add a language</h1>
+
+  {#if data.addable.length === 0}
+    <p class="lede">
+      You've added every language CIA Reader supports. Switch between them from
+      the language menu in the top-left, or <a href="/profile">manage them in settings</a>.
+    </p>
+  {:else}
+    <p class="lede">
+      Pick a language to add and a rough sense of what you already know. It
+      becomes your current language straight away — you can switch back any time
+      from the menu in the top-left.
+    </p>
+
+    <form method="POST" use:enhance>
+      <fieldset>
+        <legend>Which language do you want to add?</legend>
+        <div class="choices">
+          {#each data.addable as lang (lang.code)}
+            <label class="choice" class:selected={selectedLanguage === lang.code}>
+              <input
+                type="radio"
+                name="language"
+                value={lang.code}
+                bind:group={selectedLanguage}
+              />
+              <span class="native">{lang.nativeName}</span>
+              <span class="meta">{lang.displayName}</span>
+            </label>
+          {/each}
+        </div>
+      </fieldset>
+
+      <fieldset>
+        <legend>Where are you starting from?</legend>
+        <div class="choices stacked">
+          {#each data.baselines as baseline (baseline)}
+            <label class="choice stacked" class:selected={selectedBaseline === baseline}>
+              <input
+                type="radio"
+                name="baseline"
+                value={baseline}
+                bind:group={selectedBaseline}
+              />
+              <span class="choice-title">{BASELINE_LABELS[baseline]?.title ?? baseline}</span>
+              <span class="meta">{BASELINE_LABELS[baseline]?.blurb ?? ''}</span>
+            </label>
+          {/each}
+        </div>
+      </fieldset>
+
+      <div class="actions">
+        <button type="submit" disabled={!selectedLanguage}>Add &amp; switch</button>
+        <a class="cancel" href="/library">Cancel</a>
+      </div>
+      {#if form && !form.ok}
+        <p class="err" role="alert">{form.message}</p>
+      {/if}
+    </form>
+  {/if}
+</div>
+
+<style>
+  .page {
+    max-width: 40rem;
+    margin: 0 auto;
+    padding: 2rem 1.25rem;
+  }
+  h1 {
+    margin: 0 0 0.5rem;
+  }
+  .lede {
+    color: var(--color-fg-muted);
+    margin: 0 0 1.5rem;
+  }
+  .lede a {
+    color: var(--color-accent);
+  }
+  form {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+  fieldset {
+    border: 0;
+    padding: 0;
+    margin: 0;
+  }
+  legend {
+    font-size: var(--font-size-sm);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--color-fg-muted);
+    margin-bottom: 0.5rem;
+  }
+  .choices {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+    gap: 0.5rem;
+  }
+  .choices.stacked {
+    grid-template-columns: 1fr;
+  }
+  .choice {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    padding: 1rem;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    min-height: var(--touch-target);
+  }
+  .choice input {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+  .choice.selected {
+    border-color: var(--color-accent);
+    background: var(--color-surface-2);
+  }
+  .choice .native {
+    font-size: 1.2rem;
+  }
+  .choice-title {
+    font-weight: 600;
+  }
+  .meta {
+    color: var(--color-fg-muted);
+    font-size: var(--font-size-sm);
+  }
+  .actions {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+  button {
+    padding: 0.7rem 1.25rem;
+    background: var(--color-accent);
+    color: var(--color-accent-fg);
+    border: none;
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    font: inherit;
+    min-height: var(--touch-target);
+  }
+  button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+  .cancel {
+    color: var(--color-fg-muted);
+    text-decoration: none;
+  }
+  .cancel:hover {
+    color: var(--color-fg);
+  }
+  .err {
+    color: var(--color-danger);
+    margin: 0;
+  }
+</style>

--- a/apps/web/src/routes/languages/new/page-server.test.ts
+++ b/apps/web/src/routes/languages/new/page-server.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SUPPORTED_LANGUAGE_CODES } from '@ciareader/shared-types';
+
+const listUserLanguages = vi.fn();
+const addUserLanguage = vi.fn();
+
+vi.mock('$lib/server/profile.js', () => ({
+  listUserLanguages: (...a: unknown[]) => listUserLanguages(...a),
+}));
+vi.mock('$lib/server/user-languages.js', () => ({
+  addUserLanguage: (...a: unknown[]) => addUserLanguage(...a),
+}));
+
+type Mod = typeof import('./+page.server.js');
+const USER = { id: 'u1' };
+
+function makeCookies() {
+  return { set: vi.fn(), get: vi.fn(), delete: vi.fn(), serialize: vi.fn() };
+}
+
+async function callLoad(user: typeof USER | null) {
+  const { load } = (await import('./+page.server.js')) as Mod;
+  const event = {
+    locals: { user },
+    url: new URL('http://x/languages/new'),
+  } as unknown as Parameters<Mod['load']>[0];
+  try {
+    return await load(event);
+  } catch (e) {
+    return e as { status: number; location?: string };
+  }
+}
+
+async function callAction(
+  fields: { language?: string; baseline?: string },
+  user: typeof USER | null = USER,
+  cookies = makeCookies(),
+) {
+  const { actions } = (await import('./+page.server.js')) as Mod;
+  const fd = new FormData();
+  if (fields.language !== undefined) fd.append('language', fields.language);
+  if (fields.baseline !== undefined) fd.append('baseline', fields.baseline);
+  const event = {
+    locals: { user },
+    cookies,
+    url: new URL('http://x/languages/new'),
+    request: { formData: () => Promise.resolve(fd) } as unknown as Request,
+  } as unknown as Parameters<Mod['actions']['default']>[0];
+  try {
+    return { res: await actions.default!(event), cookies };
+  } catch (e) {
+    return { res: e as { status: number; location?: string }, cookies };
+  }
+}
+
+beforeEach(() => {
+  listUserLanguages.mockReset();
+  listUserLanguages.mockResolvedValue([{ language: 'hi' }]);
+  addUserLanguage.mockReset();
+  addUserLanguage.mockResolvedValue(undefined);
+});
+
+afterEach(() => vi.resetModules());
+
+describe('/languages/new loader', () => {
+  it('redirects anonymous visitors to /login with a next param', async () => {
+    const res = (await callLoad(null)) as { status: number; location: string };
+    expect(res.status).toBe(303);
+    expect(res.location).toBe('/login?next=%2Flanguages%2Fnew');
+  });
+
+  it('offers the supported languages the user has not added yet', async () => {
+    const data = (await callLoad(USER)) as {
+      addable: Array<{ code: string }>;
+      baselines: readonly string[];
+    };
+    const codes = data.addable.map((l) => l.code);
+    expect(codes).not.toContain('hi'); // already added
+    expect(codes.length).toBe(SUPPORTED_LANGUAGE_CODES.length - 1);
+    expect(data.baselines).toEqual(['none', 'beginner', 'intermediate']);
+  });
+});
+
+describe('/languages/new add action', () => {
+  it('adds the chosen language with its baseline, switches, and redirects to /library', async () => {
+    const { res, cookies } = await callAction({ language: 'mr', baseline: 'beginner' });
+    expect((res as { status: number; location: string }).status).toBe(303);
+    expect((res as { location: string }).location).toBe('/library');
+    expect(addUserLanguage).toHaveBeenCalledWith('u1', 'mr', 'beginner');
+    expect(cookies.set).toHaveBeenCalledWith(
+      'cia_lang',
+      'mr',
+      expect.objectContaining({ path: '/' }),
+    );
+  });
+
+  it('defaults the baseline to none when omitted', async () => {
+    await callAction({ language: 'or' });
+    expect(addUserLanguage).toHaveBeenCalledWith('u1', 'or', 'none');
+  });
+
+  it('just switches (no add) when the language is already active', async () => {
+    listUserLanguages.mockResolvedValue([{ language: 'hi' }, { language: 'mr' }]);
+    const { res, cookies } = await callAction({ language: 'mr', baseline: 'intermediate' });
+    expect(addUserLanguage).not.toHaveBeenCalled();
+    expect(cookies.set).toHaveBeenCalledWith('cia_lang', 'mr', expect.any(Object));
+    expect((res as { status: number }).status).toBe(303);
+  });
+
+  it('rejects an unsupported language with 400', async () => {
+    const { res } = await callAction({ language: 'xx', baseline: 'none' });
+    expect((res as { status: number }).status).toBe(400);
+    expect(addUserLanguage).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown baseline with 400', async () => {
+    const { res } = await callAction({ language: 'mr', baseline: 'fluent' });
+    expect((res as { status: number }).status).toBe(400);
+    expect(addUserLanguage).not.toHaveBeenCalled();
+  });
+
+  it('bounces an anonymous submitter to /login', async () => {
+    const { res } = await callAction({ language: 'mr', baseline: 'none' }, null);
+    expect((res as { status: number; location: string }).status).toBe(303);
+    expect((res as { location: string }).location).toContain('/login');
+  });
+});

--- a/apps/web/src/routes/layout-server.test.ts
+++ b/apps/web/src/routes/layout-server.test.ts
@@ -99,6 +99,28 @@ describe('root +layout.server.ts load', () => {
     expect(data.currentLanguage).toBe('mr');
   });
 
+  it('lists not-yet-added supported languages in addableLanguages (#436)', async () => {
+    userLanguageRows.mockResolvedValue([{ language: 'hi' }, { language: 'mr' }]);
+    const data = await load(
+      makeEvent({
+        locals: { user: { id: 'u1', email: 'a@b.c', displayName: null, role: 'user' } },
+        cookie: 'hi',
+      }),
+    );
+    if (!data) throw new Error('load returned void');
+    const codes = data.addableLanguages.map((l: { code: string }) => l.code);
+    expect(codes).not.toContain('hi');
+    expect(codes).not.toContain('mr');
+    // The remaining MVP languages are offered for one-tap add.
+    expect(codes).toEqual(expect.arrayContaining(['or']));
+  });
+
+  it('offers no addableLanguages to anonymous visitors (#436)', async () => {
+    const data = await load(makeEvent({ locals: {} }));
+    if (!data) throw new Error('load returned void');
+    expect(data.addableLanguages).toEqual([]);
+  });
+
   it('falls back when the cia_lang cookie does not match an active language', async () => {
     userLanguageRows.mockResolvedValue([{ language: 'hi' }]);
     const data = await load(

--- a/apps/web/src/routes/library/+page.server.ts
+++ b/apps/web/src/routes/library/+page.server.ts
@@ -12,7 +12,7 @@
  * default unauth visitors to 'official' so the public landing is the
  * curated library, not a "please log in" wall.
  */
-import { error, redirect } from '@sveltejs/kit';
+import { redirect } from '@sveltejs/kit';
 
 import {
   DEFAULT_PAGE_SIZE,
@@ -30,7 +30,6 @@ import {
   estimatedComprehensionForCollections,
   estimatedComprehensionForTexts,
 } from '$lib/server/learning-stats.js';
-import { LANGUAGES, isSupportedLanguage } from '@ciareader/shared-types';
 import type { LanguageCode } from '@ciareader/shared-types';
 import type { PageServerLoad } from './$types';
 
@@ -55,7 +54,7 @@ function readInt(url: URL, key: string, fallback: number): number {
   return Number.isFinite(n) ? n : fallback;
 }
 
-export const load: PageServerLoad = async ({ url, locals }) => {
+export const load: PageServerLoad = async ({ url, locals, parent }) => {
   const tab = readTab(url.searchParams.get('tab'), Boolean(locals.user));
 
   // Auth gate: 'your' / 'shared' require a logged-in user. 'official'
@@ -67,12 +66,10 @@ export const load: PageServerLoad = async ({ url, locals }) => {
     );
   }
 
-  const langRaw = url.searchParams.get('language');
-  const language: LanguageCode | null =
-    langRaw && isSupportedLanguage(langRaw) ? (langRaw as LanguageCode) : null;
-  if (langRaw && !language) {
-    throw error(400, `Unsupported language '${langRaw}'`);
-  }
+  // The library is scoped to the current language (#436) — set in the rail
+  // switcher (or the home grid), not a per-page dropdown.
+  const { currentLanguage } = await parent();
+  const language = (currentLanguage as LanguageCode | null) ?? null;
 
   const limit = Math.min(
     Math.max(readInt(url, 'limit', DEFAULT_PAGE_SIZE), 1),
@@ -238,11 +235,6 @@ export const load: PageServerLoad = async ({ url, locals }) => {
     chapterBookCards,
     collectionsPage,
     language,
-    languages: Object.values(LANGUAGES).map((d) => ({
-      code: d.code,
-      displayName: d.displayName,
-      nativeName: d.nativeName,
-    })),
     isAuthenticated: Boolean(locals.user),
   };
 };

--- a/apps/web/src/routes/library/+page.svelte
+++ b/apps/web/src/routes/library/+page.svelte
@@ -77,9 +77,10 @@
   const nextOffset = $derived(activePage.offset + activePage.limit);
 
   function hrefWith(overrides: Record<string, string | null>): string {
+    // Language is set globally (rail switcher / home grid), not via the URL,
+    // so it's no longer carried as a query param here (#436).
     const params = new URLSearchParams();
     params.set('tab', data.tab);
-    if (data.language) params.set('language', data.language);
     if (activePage.offset > 0) params.set('offset', String(activePage.offset));
     if (activePage.limit !== 20) params.set('limit', String(activePage.limit));
     for (const [k, v] of Object.entries(overrides)) {
@@ -132,27 +133,11 @@
     </nav>
   </header>
 
-  <form method="get" class="filters">
-    <input type="hidden" name="tab" value={data.tab} />
-    <label>
-      <span class="filter-label">Language</span>
-      <select name="language">
-        <option value="">All languages</option>
-        {#each data.languages as lang (lang.code)}
-          <option value={lang.code} selected={data.language === lang.code}>
-            {lang.displayName} ({lang.nativeName})
-          </option>
-        {/each}
-      </select>
-    </label>
-    <button type="submit" class="filter-go">Filter</button>
-  </form>
-
   <div class="lib-grid">
     {#if data.tab === 'your' && data.isAuthenticated}
       <a
         class="card upload-card"
-        href={data.language ? `/upload?language=${data.language}` : '/upload'}
+        href="/upload"
       >
         <div class="upload-card-body">
           <div class="big" aria-hidden="true">+</div>
@@ -278,9 +263,7 @@
     <p class="empty">
       {#if data.tab === 'your'}
         You haven't uploaded any texts yet — try the
-        <a href={data.language ? `/upload?language=${data.language}` : '/upload'}
-          >+ Add a text</a
-        > tile above.
+        <a href="/upload">+ Add a text</a> tile above.
       {:else if data.tab === 'shared'}
         No shared texts yet. Sharing lands in a future ticket.
       {:else if data.tab === 'collections'}
@@ -413,48 +396,6 @@
       transparent
     );
     color: var(--ink, var(--color-fg));
-  }
-
-  .filters {
-    display: flex;
-    align-items: end;
-    gap: 0.5rem;
-    margin-bottom: 1rem;
-  }
-  .filters label {
-    flex: 1;
-    max-width: 18rem;
-  }
-  .filter-label {
-    display: block;
-    font-size: 0.62rem;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: var(--ink-3, var(--color-fg-muted));
-    margin-bottom: 0.25rem;
-  }
-  .filters select {
-    display: block;
-    width: 100%;
-    padding: 0.45rem 0.65rem;
-    font: inherit;
-    font-size: 0.85rem;
-    border: 1px solid var(--rule, var(--color-border));
-    border-radius: 8px;
-    background: var(--card, var(--color-bg));
-    color: var(--ink, var(--color-fg));
-    min-height: 36px;
-  }
-  .filter-go {
-    height: 36px;
-    padding: 0 0.85rem;
-    font-family: var(--font-sans, var(--font-ui));
-    font-size: 0.78rem;
-    background: var(--ink, var(--color-fg));
-    color: var(--paper, var(--color-bg));
-    border: 1px solid var(--ink, var(--color-fg));
-    border-radius: 8px;
-    cursor: pointer;
   }
 
   .lib-grid {

--- a/apps/web/src/routes/library/page-server.test.ts
+++ b/apps/web/src/routes/library/page-server.test.ts
@@ -41,11 +41,17 @@ vi.mock('$lib/server/collections.js', () => ({
 type LoadFn = (typeof import('./+page.server.js'))['load'];
 const USER = { id: 'user-1', role: 'user' as const };
 
-async function callLoad(url: string, user: typeof USER | null = USER) {
+async function callLoad(
+  url: string,
+  user: typeof USER | null = USER,
+  currentLanguage: string | null = 'hi',
+) {
   const { load } = await import('./+page.server.js');
   const event = {
     locals: { user },
     url: new URL(url),
+    // #436: the library scopes to the layout's resolved current language.
+    parent: async () => ({ currentLanguage }),
   } as unknown as Parameters<LoadFn>[0];
   try {
     return await load(event);
@@ -125,25 +131,31 @@ describe('/library loader', () => {
     expect(listSharedTexts).toHaveBeenCalled();
   });
 
-  it('forwards a language filter to the underlying service', async () => {
+  it('scopes the listing to the current language (#436)', async () => {
     listOwnedTexts.mockResolvedValueOnce({
       cards: [],
       totalCount: 0,
       limit: 20,
       offset: 0,
     });
-    await callLoad('http://x/library?tab=your&language=mr');
+    await callLoad('http://x/library?tab=your', USER, 'mr');
     expect(listOwnedTexts).toHaveBeenCalledWith(
       { id: USER.id },
       expect.objectContaining({ language: 'mr' }),
     );
   });
 
-  it('rejects an unsupported language with 400', async () => {
-    const res = (await callLoad('http://x/library?language=xx')) as {
-      status: number;
+  it('echoes the current language back to the page (#436)', async () => {
+    listOwnedTexts.mockResolvedValueOnce({
+      cards: [],
+      totalCount: 0,
+      limit: 20,
+      offset: 0,
+    });
+    const data = (await callLoad('http://x/library?tab=your', USER, 'or')) as {
+      language: string;
     };
-    expect(res.status).toBe(400);
+    expect(data.language).toBe('or');
   });
 
   it('paginates collection cards before fetching comprehension (T-12.5)', async () => {

--- a/apps/web/src/routes/upload/+page.server.ts
+++ b/apps/web/src/routes/upload/+page.server.ts
@@ -59,23 +59,23 @@ const txtFormSchema = z.object({
 
 const formSchema = z.union([txtFormSchema, pasteFormSchema]);
 
-export const load: PageServerLoad = async ({ locals, url }) => {
+export const load: PageServerLoad = async ({ locals, url, parent }) => {
   if (!locals.user) {
     throw redirect(303, `/login?next=${encodeURIComponent(url.pathname)}`);
   }
-  // Pre-select the language the user arrived from — the library's
-  // "Add a text" card links to e.g. /upload?language=eu. Fall back to the
-  // first supported language when the param is absent or unrecognized.
-  const requested = url.searchParams.get('language');
+  // The upload targets the current language (#436) — the site is split by
+  // language, so a text is imported into whichever language the rail
+  // switcher has active. Fall back to the first supported code in the
+  // (signed-in-but-no-language) edge case the resolver guards against.
+  const { currentLanguage } = await parent();
   const selectedLanguage: LanguageCode =
-    requested && isSupportedLanguage(requested) ? requested : SUPPORTED_LANGUAGE_CODES[0]!;
+    currentLanguage && isSupportedLanguage(currentLanguage)
+      ? (currentLanguage as LanguageCode)
+      : SUPPORTED_LANGUAGE_CODES[0]!;
   return {
     selectedLanguage,
-    languages: SUPPORTED_LANGUAGE_CODES.map((code) => ({
-      code,
-      displayName: LANGUAGES[code].displayName,
-      nativeName: LANGUAGES[code].nativeName,
-    })),
+    selectedLanguageName: LANGUAGES[selectedLanguage].nativeName,
+    selectedLanguageDisplay: LANGUAGES[selectedLanguage].displayName,
     limits: {
       maxTitleLength: MAX_TITLE_LEN,
       // The browser uses the paste cap by default and bumps to the

--- a/apps/web/src/routes/upload/+page.svelte
+++ b/apps/web/src/routes/upload/+page.svelte
@@ -8,13 +8,9 @@
     form,
   }: { data: PageData; form: ActionData } = $props();
 
-  // Initial state seeded from any failed-submit echo (paste-action
-  // values), else the language the user arrived from (data.selectedLanguage,
-  // derived from ?language= — e.g. the Basque library's "Add a text" card),
-  // so the form doesn't silently default to Hindi.
-  let language = $state(
-    untrack(() => form?.values?.language ?? data.selectedLanguage),
-  );
+  // The upload language is fixed to the current language (#436) — the site
+  // is split by language and the rail switcher picks it — so there's no
+  // per-form language chooser; it's submitted as a hidden field below.
   let title = $state(untrack(() => form?.values?.title ?? ''));
   let body = $state(untrack(() => form?.values?.body ?? ''));
 
@@ -235,16 +231,18 @@
     ondragover={onDragOver}
     ondrop={onDrop}
   >
-    <label>
-      Language
-      <select name="language" bind:value={language} required>
-        {#each data.languages as lang (lang.code)}
-          <option value={lang.code}>
-            {lang.displayName} ({lang.nativeName})
-          </option>
-        {/each}
-      </select>
-    </label>
+    <!-- Language is fixed to the current language (#436). Submitted as a
+         hidden field; switch languages from the menu in the top-left. -->
+    <input type="hidden" name="language" value={data.selectedLanguage} />
+    <div class="lang-fixed">
+      <span class="lang-fixed-label">Importing into</span>
+      <span class="lang-fixed-value">
+        {data.selectedLanguageName} · {data.selectedLanguageDisplay}
+      </span>
+      <span class="lang-fixed-hint">
+        Change the language from the menu in the top-left.
+      </span>
+    </div>
 
     <label>
       Title {#if isFileMode}<span class="hint">(optional)</span>{/if}
@@ -363,8 +361,7 @@
     font-size: 0.9rem;
   }
   form input,
-  form textarea,
-  form select {
+  form textarea {
     display: block;
     width: 100%;
     margin-top: 0.25rem;
@@ -375,6 +372,33 @@
     background: var(--color-bg);
     color: var(--color-fg);
     min-height: 44px;
+  }
+
+  /* Fixed-language banner (#436): a read-only stand-in for the old
+     language <select>, since the upload target now follows the current
+     language. */
+  .lang-fixed {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    padding: 0.6rem 0.75rem;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    background: var(--color-bg);
+  }
+  .lang-fixed-label {
+    font-size: 0.62rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-fg-muted);
+  }
+  .lang-fixed-value {
+    font-size: 1rem;
+    color: var(--color-fg);
+  }
+  .lang-fixed-hint {
+    font-size: 0.75rem;
+    color: var(--color-fg-muted);
   }
   form textarea {
     min-height: 12rem;

--- a/apps/web/src/routes/upload/page-server.test.ts
+++ b/apps/web/src/routes/upload/page-server.test.ts
@@ -35,11 +35,17 @@ const USER = {
   emailVerifiedAt: new Date('2026-01-01T00:00:00Z'),
 };
 
-async function callLoad(user: typeof USER | null, urlStr = 'http://x/upload') {
+async function callLoad(
+  user: typeof USER | null,
+  currentLanguage: string | null = 'hi',
+  urlStr = 'http://x/upload',
+) {
   const { load } = (await import('./+page.server.js')) as Mod;
   const event = {
     locals: { user },
     url: new URL(urlStr),
+    // #436: the upload target follows the layout's current language.
+    parent: async () => ({ currentLanguage }),
   } as unknown as Parameters<Mod['load']>[0];
   try {
     return await load(event);
@@ -118,19 +124,14 @@ afterEach(() => {
 });
 
 describe('/upload loader', () => {
-  it('returns the language list and the input limits for an authenticated user', async () => {
+  it('returns the input limits for an authenticated user', async () => {
     const data = (await callLoad(USER)) as {
-      languages: Array<{ code: string }>;
       limits: {
         maxTitleLength: number;
         maxPasteBytes: number;
         maxTxtBytes: number;
       };
     };
-    expect(data.languages.length).toBeGreaterThan(0);
-    expect(data.languages.map((l) => l.code)).toEqual(
-      expect.arrayContaining(['hi', 'mr', 'or']),
-    );
     expect(data.limits.maxPasteBytes).toBeGreaterThan(0);
     // .txt path must allow strictly more bytes than paste.
     expect(data.limits.maxTxtBytes).toBeGreaterThan(data.limits.maxPasteBytes);
@@ -142,22 +143,19 @@ describe('/upload loader', () => {
     expect(res.location).toBe('/login?next=%2Fupload');
   });
 
-  it('pre-selects the language from ?language= (e.g. the Basque library card)', async () => {
-    const data = (await callLoad(USER, 'http://x/upload?language=eu')) as {
+  it('targets the current language (#436)', async () => {
+    const data = (await callLoad(USER, 'eu')) as {
       selectedLanguage: string;
+      selectedLanguageName: string;
+      selectedLanguageDisplay: string;
     };
     expect(data.selectedLanguage).toBe('eu');
+    expect(data.selectedLanguageDisplay).toBe('Basque');
+    expect(data.selectedLanguageName).toBe('Euskara');
   });
 
-  it('defaults selectedLanguage to the first supported language without ?language=', async () => {
-    const data = (await callLoad(USER)) as { selectedLanguage: string };
-    expect(data.selectedLanguage).toBe('hi');
-  });
-
-  it('ignores an unrecognized ?language= and falls back to the default', async () => {
-    const data = (await callLoad(USER, 'http://x/upload?language=xx')) as {
-      selectedLanguage: string;
-    };
+  it('falls back to the first supported language when none is current', async () => {
+    const data = (await callLoad(USER, null)) as { selectedLanguage: string };
     expect(data.selectedLanguage).toBe('hi');
   });
 });

--- a/apps/web/src/routes/words/+page.server.ts
+++ b/apps/web/src/routes/words/+page.server.ts
@@ -1,10 +1,11 @@
 /**
- * Words manager loader (T-10.6).
+ * Words manager loader (T-10.6, scoped by language in #436).
  *
- * Lists the caller's vocabulary — every lemma they've touched —
- * filtered by an optional language code, an optional status bucket,
- * and an optional free-text query. Joined against `lemmas` so we
- * read headword + POS + gloss in a single query.
+ * Lists the caller's vocabulary — every lemma they've touched — for the
+ * current language (the site is split by language; the rail switcher picks
+ * it), narrowed by an optional status bucket and an optional free-text
+ * query. Joined against `lemmas` so we read headword + POS + gloss in a
+ * single query.
  *
  * Auth required. Anonymous visitors are bounced to /login with a
  * `next` param so they return here after signing in.
@@ -14,12 +15,7 @@ import { error, redirect } from '@sveltejs/kit';
 
 import { db } from '$lib/server/db/index.js';
 import { lemmas, userKnownLemmas } from '$lib/server/db/schema.js';
-import {
-  isSupportedLanguage,
-  LANGUAGES,
-  SUPPORTED_LANGUAGE_CODES,
-  type LanguageCode,
-} from '@ciareader/shared-types';
+import { LANGUAGES, type LanguageCode } from '@ciareader/shared-types';
 import type { PageServerLoad } from './$types';
 
 export type WordsStatus = 'all' | 'unknown' | 'learning' | 'known' | 'ignored';
@@ -44,14 +40,6 @@ export type WordRow = {
   updatedAt: Date;
 };
 
-function readLanguage(raw: string | null): LanguageCode | null {
-  if (!raw) return null;
-  if (!isSupportedLanguage(raw)) {
-    throw error(400, `Unsupported language '${raw}'`);
-  }
-  return raw as LanguageCode;
-}
-
 function readStatus(raw: string | null): WordsStatus {
   if (!raw) return 'all';
   if (!VALID_STATUSES.includes(raw as WordsStatus)) {
@@ -60,7 +48,7 @@ function readStatus(raw: string | null): WordsStatus {
   return raw as WordsStatus;
 }
 
-export const load: PageServerLoad = async ({ url, locals }) => {
+export const load: PageServerLoad = async ({ url, locals, parent }) => {
   if (!locals.user) {
     throw redirect(
       303,
@@ -68,7 +56,9 @@ export const load: PageServerLoad = async ({ url, locals }) => {
     );
   }
 
-  const language = readLanguage(url.searchParams.get('language'));
+  // The current language drives the page (#436) — the rail switcher sets it.
+  const { currentLanguage } = await parent();
+  const language = (currentLanguage as LanguageCode | null) ?? null;
   const status = readStatus(url.searchParams.get('status'));
   const q = (url.searchParams.get('q') ?? '').trim();
 
@@ -118,10 +108,8 @@ export const load: PageServerLoad = async ({ url, locals }) => {
       status,
       q,
     },
-    languages: SUPPORTED_LANGUAGE_CODES.map((code) => ({
-      code,
-      displayName: LANGUAGES[code].displayName,
-      nativeName: LANGUAGES[code].nativeName,
-    })),
+    // Native name of the active language for the heading. No per-page
+    // picker anymore — switching languages happens in the rail (#436).
+    languageName: language ? LANGUAGES[language].nativeName : null,
   };
 };

--- a/apps/web/src/routes/words/+page.svelte
+++ b/apps/web/src/routes/words/+page.svelte
@@ -27,8 +27,9 @@
   };
 
   function hrefWith(overrides: Record<string, string | null>): string {
+    // Language is no longer a URL param — the rail switcher's current
+    // language scopes the list (#436). Only status + query live in the URL.
     const params = new URLSearchParams();
-    if (data.filters.language) params.set('language', data.filters.language);
     if (data.filters.status !== 'all') params.set('status', data.filters.status);
     if (data.filters.q) params.set('q', data.filters.q);
     for (const [k, v] of Object.entries(overrides)) {
@@ -70,9 +71,8 @@
       <h1 class="title">Words</h1>
       <p class="sub">
         {data.rows.length}{data.truncated ? '+' : ''} entries
-        {#if data.filters.language}
-          · {data.languages.find((l) => l.code === data.filters.language)
-            ?.nativeName}
+        {#if data.languageName}
+          · {data.languageName}
         {/if}
       </p>
     </div>
@@ -86,13 +86,6 @@
           autocomplete="off"
         />
       </div>
-      {#if data.filters.language}
-        <input
-          type="hidden"
-          name="language"
-          value={data.filters.language}
-        />
-      {/if}
       {#if data.filters.status !== 'all'}
         <input type="hidden" name="status" value={data.filters.status} />
       {/if}
@@ -112,23 +105,7 @@
     {/each}
   </nav>
 
-  <div class="language-row" aria-label="Language filter">
-    <a
-      class="language-chip"
-      data-active={data.filters.language === null ? '1' : '0'}
-      href={hrefWith({ language: null })}
-    >
-      All
-    </a>
-    {#each data.languages as language (language.code)}
-      <a
-        class="language-chip"
-        data-active={data.filters.language === language.code ? '1' : '0'}
-        href={hrefWith({ language: language.code })}
-      >
-        {language.nativeName}
-      </a>
-    {/each}
+  <div class="language-row" aria-label="Export">
     {#if data.filters.language}
       <a class="export-link" href={exportHref(data.filters.language)}>
         Export CSV
@@ -139,8 +116,8 @@
 
   {#if data.rows.length === 0}
     <p class="empty">
-      {#if data.filters.q || data.filters.status !== 'all' || data.filters.language}
-        No words match those filters. <a href={hrefWith({ q: null, status: null, language: null })}>Clear all</a>.
+      {#if data.filters.q || data.filters.status !== 'all'}
+        No words match those filters. <a href={hrefWith({ q: null, status: null })}>Clear all</a>.
       {:else}
         You haven't marked any words yet. Open a text and click any word to
         add it to your vocabulary.
@@ -320,7 +297,6 @@
     flex-wrap: wrap;
     margin: -0.25rem 0 0.9rem;
   }
-  .language-chip,
   .export-link {
     min-height: 32px;
     display: inline-flex;
@@ -331,24 +307,7 @@
     padding: 0 0.7rem;
     font-family: var(--font-sans, var(--font-ui));
     font-size: 0.76rem;
-    color: var(--ink-2, var(--color-fg-muted));
     text-decoration: none;
-    background: var(--paper, var(--color-bg));
-  }
-  .language-chip[data-active='1'] {
-    border-color: color-mix(
-      in oklch,
-      var(--ink, var(--color-fg)) 22%,
-      var(--rule, var(--color-border))
-    );
-    color: var(--ink, var(--color-fg));
-    background: color-mix(
-      in oklch,
-      var(--ink, var(--color-fg)) 6%,
-      var(--paper, var(--color-bg))
-    );
-  }
-  .export-link {
     margin-left: auto;
     background: var(--ink, var(--color-fg));
     border-color: var(--ink, var(--color-fg));

--- a/apps/web/src/routes/words/page-server.test.ts
+++ b/apps/web/src/routes/words/page-server.test.ts
@@ -54,13 +54,21 @@ describe('words +page.server.ts load', () => {
   type LoadInput = {
     locals: { user: { id: string } | null };
     url: URL;
+    currentLanguage: string | null;
   };
 
   async function callLoad(input: Partial<LoadInput> = {}) {
     const { load } = await import('./+page.server.js');
     const url = input.url ?? new URL('http://x/words');
     const locals = input.locals ?? { user: { id: 'u1' } };
-    return load({ url, locals } as unknown as Parameters<typeof load>[0]);
+    // #436: the words list scopes to the layout's resolved current language.
+    const currentLanguage =
+      'currentLanguage' in input ? input.currentLanguage : 'hi';
+    return load({
+      url,
+      locals,
+      parent: async () => ({ currentLanguage }),
+    } as unknown as Parameters<typeof load>[0]);
   }
 
   it('redirects unauthenticated visitors to /login with a next param', async () => {
@@ -90,21 +98,14 @@ describe('words +page.server.ts load', () => {
     const data = await callLoad({});
     expect(data?.rows).toHaveLength(1);
     expect(data?.rows[0]?.headword).toBe('प्रभात');
-    expect(data?.filters).toEqual({ language: null, status: 'all', q: '' });
+    expect(data?.filters).toEqual({ language: 'hi', status: 'all', q: '' });
     expect(data?.truncated).toBe(false);
   });
 
-  it('echoes the language filter when valid', async () => {
-    const data = await callLoad({
-      url: new URL('http://x/words?language=hi'),
-    });
-    expect(data?.filters.language).toBe('hi');
-  });
-
-  it("rejects an unsupported language with 400", async () => {
-    await expect(
-      callLoad({ url: new URL('http://x/words?language=fr') }),
-    ).rejects.toMatchObject({ status: 400 });
+  it('scopes the list to the current language (#436)', async () => {
+    const data = await callLoad({ currentLanguage: 'mr' });
+    expect(data?.filters.language).toBe('mr');
+    expect(data?.languageName).toBe('मराठी');
   });
 
   it("rejects an unknown status with 400", async () => {


### PR DESCRIPTION
Closes #436.

The site is now split by language: you pick a current language from the top-left logo switcher, and **library / words / upload** are scoped to it. The per-page language pickers are gone.

## What changed
- **Pages follow the global pick.** library, words and upload read `currentLanguage` from the layout (`await parent()`) instead of a `?language=` param / per-page selector. The home grid sets the current language on click and opens the library for it.
- **Switcher = switch in place.** The logo dropdown lists only the languages you already read. Adding a language is its own page.
- **Dedicated "Add a language" page** (`/languages/new`): pick a not-yet-added language + a proficiency baseline (mirrors onboarding) → adds it, switches to it, and drops you in the library. Reached via the switcher's last **"Add a language"** button (shown only when something is addable).
- **Contrast fix.** The old switcher footer link used accent-on-transparent, which was near-invisible on the dark card (the "can't be seen well" item in the issue).

## Backend
- `POST /api/v1/me/languages` — baseline-`none` quick add-and-switch (used by the home grid card click); preserves an existing baseline.
- `addUserLanguage(userId, code, baseline)` in `lib/server/user-languages.ts` — baseline-aware upsert for the add page.
- The root layout exposes `addableLanguages` so the switcher can show/hide the add button.

## Tests
- New: `/languages/new` page-server, `POST /api/v1/me/languages`, `addUserLanguage`, the `language-switch` client helpers, `addableLanguageOptions`, and an `addableLanguages` layout-load case.
- Updated: library / words / upload loader tests now drive language from `parent()` instead of the URL.
- Full web suite green (1727 tests), svelte-check 0/0, eslint clean, coverage above the floor, `vite build` succeeds.

## Manual verification
Ran the app and stepped through: switcher (active langs + "Add a language" only), the add page (language + baseline → Add & switch → library), the current-language scoping on library/words/upload, the dark-mode contrast fix, and confirmed the chosen baseline persists in `user_languages` without clobbering existing rows.