### PR TITLE
Reader: chapter selector + TOC, whole-book progress, top-bar cleanup

### DIFF
--- a/apps/web/e2e/reader-progress.spec.ts
+++ b/apps/web/e2e/reader-progress.spec.ts
@@ -1,21 +1,24 @@
 /**
  * Reader page-counter, progress-percentage, and progress-bar tests.
  *
- * Covered behaviors:
- *   - The "Page X of Y" counter increments on next-page click and
- *     resets to 1 on a fresh chapter load.
- *   - The displayed start/end percentage range stays in sync with
- *     the inline `width: %` on the `.read` / `.current` progress
- *     bar segments.
- *   - Word-based math: pages with many words advance the bar more
- *     than pages with few words (the per-page range varies with
- *     actual word density, not with a uniform pages/N split).
- *   - Walking from page 1 to the last page covers ~100% of the bar.
+ * Progress is now WHOLE-BOOK for chapter-books (each chapter is its own
+ * one-chapter text inside a collection): the footer percentage spans
+ * the entire book, reaching 0% at the start of the first chapter and
+ * 100% at the end of the last — not 0→100 within each chapter. The
+ * footer is three columns (`.pager-pages` · `.pager-pct` · `.pager-chapter`)
+ * and the bar is a single `.read` fill (0 → endPct) plus a `.dot`
+ * marker at endPct.
  *
- * Reads a multi-page owned chapter from the dev DB (`crush@test.local`)
- * so we don't hardcode UUIDs and so edge-cases naturally surface in
- * real publisher content (chapter intros / outros are often sparse,
- * mid-chapter prose is dense).
+ * Covered behaviors:
+ *   - "Page X of Y" increments on next-page click and resets per chapter.
+ *   - Whole-book progress is ~0% on the first chapter and ~100% at the
+ *     end of the last chapter.
+ *   - Per-page range varies with word density (pages with many words
+ *     advance the bar more), and progress increases monotonically.
+ *   - The `.read` bar width and the `.dot` position both track endPct.
+ *
+ * Reads an owned chapter-book from the dev DB (`crush@test.local`) so
+ * we don't hardcode UUIDs.
  */
 import { test, expect, type Page } from '@playwright/test';
 import postgres from 'postgres';
@@ -26,38 +29,70 @@ const DATABASE_URL =
 const TEST_EMAIL = 'crush@test.local';
 
 // Tight viewport so a multi-thousand-word chapter reliably renders
-// across multiple display pages. The default Desktop Chrome viewport
-// (1280×720) can fit a 5k-word chapter into a single column on a
-// wide screen — fine in practice but it makes the page-counter
-// assertions meaningless.
+// across multiple display pages.
 test.use({ viewport: { width: 800, height: 600 } });
 
-/** Smallest chapter token count we accept — enough to span at least
- *  several display pages at the default viewport. */
+/** Smallest chapter token count we accept for the multi-page chapter. */
 const MIN_CHAPTER_TOKENS = 800;
 
-async function findMultiPageChapter(): Promise<{ id: string; title: string }> {
+type Chapter = { id: string; title: string; position: number; words: number };
+
+/** Find one owned chapter-book (the one containing the single biggest
+ *  ready chapter) and return all of its chapters in order. The specs
+ *  derive the first chapter (book start = 0%), the last chapter (book
+ *  end = 100%), and the biggest chapter (multi-page) from this list. */
+async function findBookChapters(): Promise<{
+  first: Chapter;
+  last: Chapter;
+  biggest: Chapter;
+}> {
   const sql = postgres(DATABASE_URL);
   try {
-    const rows = await sql<Array<{ id: string; title: string }>>`
-      SELECT t.id, t.title
-      FROM texts t
-      JOIN text_chapters tc ON tc.text_id = t.id
-      JOIN collection_items ci ON ci.text_id = t.id
-      JOIN collections c ON c.id = ci.collection_id
-      JOIN users u ON u.id = c.owner_id
-      WHERE u.email = ${TEST_EMAIL}
-        AND c.kind = 'chapter_book'
-        AND t.status = 'ready'
-        AND tc.token_count >= ${MIN_CHAPTER_TOKENS}
-      ORDER BY tc.token_count DESC
-      LIMIT 1
+    const rows = await sql<Array<Chapter>>`
+      WITH owned AS (
+        SELECT c.id
+        FROM collections c
+        JOIN users u ON u.id = c.owner_id
+        WHERE u.email = ${TEST_EMAIL} AND c.kind = 'chapter_book'
+      ),
+      members AS (
+        SELECT
+          ci.collection_id,
+          ci.position,
+          t.id AS text_id,
+          t.title,
+          COALESCE(SUM(tc.token_count), 0)::int AS words
+        FROM collection_items ci
+        JOIN texts t ON t.id = ci.text_id
+        LEFT JOIN text_chapters tc ON tc.text_id = t.id
+        WHERE ci.collection_id IN (SELECT id FROM owned)
+          AND t.status = 'ready'
+        GROUP BY ci.collection_id, ci.position, t.id, t.title
+      ),
+      target_book AS (
+        SELECT collection_id
+        FROM members
+        WHERE words >= ${MIN_CHAPTER_TOKENS}
+        ORDER BY words DESC
+        LIMIT 1
+      )
+      SELECT t.id, t.title, m.position, m.words
+      FROM members m
+      JOIN texts t ON t.id = m.text_id
+      WHERE m.collection_id = (SELECT collection_id FROM target_book)
+      ORDER BY m.position
     `;
     expect(
-      rows[0],
-      `need a ready chapter-book chapter with >= ${MIN_CHAPTER_TOKENS} words for ${TEST_EMAIL}`,
-    ).toBeDefined();
-    return rows[0]!;
+      rows.length,
+      `need an owned chapter_book with a >= ${MIN_CHAPTER_TOKENS}-word chapter for ${TEST_EMAIL}`,
+    ).toBeGreaterThan(0);
+    const chapters = rows.map((r) => ({ ...r, words: Number(r.words) }));
+    const biggest = chapters.reduce((a, b) => (b.words > a.words ? b : a));
+    return {
+      first: chapters[0]!,
+      last: chapters[chapters.length - 1]!,
+      biggest,
+    };
   } finally {
     await sql.end();
   }
@@ -70,8 +105,8 @@ function parsePageCounter(text: string): { current: number; total: number } {
 }
 
 /** Parse the formatted `startPct–endPct%` range (or single `endPct%`
- *  when start equals end at the formatted precision). Note: the
- *  separator is an en-dash (U+2013), not a hyphen. */
+ *  when start equals end at the formatted precision). Separator is an
+ *  en-dash (U+2013). */
 function parsePctRange(text: string): { start: number; end: number } {
   const range = /([\d.]+)[–-]([\d.]+)\s*%/.exec(text);
   if (range)
@@ -92,47 +127,38 @@ async function readPageCounter(page: Page): Promise<{ current: number; total: nu
 /** Wait for the column-flow measurement to settle so `pageCount`
  *  reflects the real chapter (initially 1 until measure() runs). */
 async function waitForMeasureSettled(page: Page): Promise<{ current: number; total: number }> {
-  await expect.poll(
-    async () => (await readPageCounter(page)).total,
-    {
+  await expect
+    .poll(async () => (await readPageCounter(page)).total, {
       message: 'pageCount should rise above 1 once measure() has run',
       timeout: 10_000,
-    },
-  ).toBeGreaterThan(1);
+    })
+    .toBeGreaterThan(1);
   return readPageCounter(page);
 }
 
+/** The whole-book range lives in `.pager-pct` (center footer column). */
 async function readPctRange(page: Page): Promise<{ start: number; end: number }> {
-  return parsePctRange(
-    await page.locator('.reader-foot-meta > .muted').last().innerText(),
-  );
+  return parsePctRange(await page.locator('.pager-pct').first().innerText());
 }
 
-/** Inline `width: N%` on the .read element of the progress bar. */
+/** Inline `width: N%` on the `.read` fill — tracks endPct (read-through). */
 async function readBarReadWidth(page: Page): Promise<number> {
   return await page
     .locator('.reader-foot-bar > .read')
     .evaluate((el) => Number.parseFloat((el as HTMLElement).style.width) || 0);
 }
 
-/** Inline `width: N%` on the .current element of the progress bar. */
-async function readBarCurrentWidth(page: Page): Promise<number> {
+/** Inline `left: N%` on the `.dot` position marker — tracks endPct. */
+async function readBarDotLeft(page: Page): Promise<number> {
   return await page
-    .locator('.reader-foot-bar > .current')
-    .evaluate((el) => Number.parseFloat((el as HTMLElement).style.width) || 0);
+    .locator('.reader-foot-bar > .dot')
+    .evaluate((el) => Number.parseFloat((el as HTMLElement).style.left) || 0);
 }
 
-/** Click the within-chapter next-page arrow. Either label fires
- *  the same handler — the label flips to "Next chapter" when the
- *  next click will leave the current chapter. */
 async function clickNext(page: Page) {
-  await page
-    .getByRole('button', { name: /^Next (page|chapter)$/ })
-    .click();
+  await page.getByRole('button', { name: /^Next (page|chapter)$/ }).click();
 }
 
-/** Wait until the page counter reports the expected page number.
- *  Allows the click + measure + layout flush to settle. */
 async function expectOnPage(page: Page, expected: number) {
   await expect
     .poll(async () => (await readPageCounter(page)).current, {
@@ -142,14 +168,14 @@ async function expectOnPage(page: Page, expected: number) {
     .toBe(expected);
 }
 
-test.describe('Reader page counter + progress', () => {
-  let chapterId: string;
+test.describe('Reader page counter + whole-book progress', () => {
+  let book: { first: Chapter; last: Chapter; biggest: Chapter };
   test.beforeAll(async () => {
-    chapterId = (await findMultiPageChapter()).id;
+    book = await findBookChapters();
   });
 
   test('page counter increments on next-page click and shows total', async ({ page }) => {
-    await page.goto(`/reader/${chapterId}?mode=page&chapter=0&token=0`);
+    await page.goto(`/reader/${book.biggest.id}?mode=page&chapter=0&token=0`);
     const initial = await waitForMeasureSettled(page);
     expect(initial.current).toBe(1);
 
@@ -162,43 +188,65 @@ test.describe('Reader page counter + progress', () => {
     await expectOnPage(page, 3);
   });
 
-  test('start percentage on page 1 is 0%', async ({ page }) => {
-    await page.goto(`/reader/${chapterId}?mode=page&chapter=0&token=0`);
-    await waitForMeasureSettled(page);
-    await expect.poll(async () => (await readPctRange(page)).start, {
-      timeout: 5_000,
-    }).toBe(0);
-    // Bar's "read" segment should also be 0%.
-    expect(await readBarReadWidth(page)).toBe(0);
+  test('whole-book progress is ~0% at the start of the first chapter', async ({ page }) => {
+    await page.goto(`/reader/${book.first.id}?mode=page&chapter=0&token=0`);
+    await expect(page.locator('.pager-pct').first()).toBeVisible({ timeout: 10_000 });
+    await page.waitForLoadState('networkidle');
+    // First chapter → no words before it in the book → the range START
+    // is 0%. (The .read fill tracks endPct — how far you've read THROUGH
+    // the page — so it's non-zero even on page 1; that's covered by the
+    // bar-tracking test below, not here.)
+    await expect
+      .poll(async () => (await readPctRange(page)).start, { timeout: 5_000 })
+      .toBeLessThanOrEqual(0.5);
   });
 
-  test('progress bar widths track the displayed startPct and (endPct - startPct)', async ({
-    page,
-  }) => {
-    await page.goto(`/reader/${chapterId}?mode=page&chapter=0&token=0`);
+  test('whole-book progress reaches ~100% at the end of the last chapter', async ({ page }) => {
+    await page.goto(`/reader/${book.last.id}?mode=page&endOfChapter=1`);
+    await expect(page.locator('.pager-pct').first()).toBeVisible({ timeout: 10_000 });
+    await page.waitForLoadState('networkidle');
+    // Land on the actual last page, then read the end percentage.
+    await expect
+      .poll(
+        async () => {
+          const s = await readPageCounter(page);
+          return s.current === s.total;
+        },
+        { timeout: 10_000, message: 'should settle on the last page of the last chapter' },
+      )
+      .toBe(true);
+    const last = await readPctRange(page);
+    expect(last.end, `last page endPct was ${last.end}; expected >= 95`).toBeGreaterThanOrEqual(
+      95,
+    );
+    expect(await readBarReadWidth(page)).toBeGreaterThanOrEqual(95);
+  });
+
+  test('progress increases monotonically and the bar + dot track endPct', async ({ page }) => {
+    await page.goto(`/reader/${book.biggest.id}?mode=page&chapter=0&token=0`);
     const total = (await waitForMeasureSettled(page)).total;
     const pagesToCheck = Math.min(total, 5);
 
+    let prevEnd = -1;
     for (let i = 0; i < pagesToCheck; i += 1) {
-      // Wait for the current page state to settle (poll until the
-      // bar width is stable for one iteration).
       await page.waitForTimeout(150);
-      const { start, end } = await readPctRange(page);
+      const { end } = await readPctRange(page);
       const barRead = await readBarReadWidth(page);
-      const barCurrent = await readBarCurrentWidth(page);
-      // Displayed values are rounded to integer percent precision
-      // for short chapters, so we allow a 1.5%-point tolerance to
-      // cover the parse-then-compare round-trip. The .read bar
-      // tracks startPct verbatim; the .current bar tracks the
-      // (end - start) range.
+      const dotLeft = await readBarDotLeft(page);
+      // Both the fill and the dot track the displayed end percentage.
+      // Displayed values round to the book's precision, so allow a
+      // 1.5-point tolerance for the parse-then-compare round-trip.
       expect(
-        Math.abs(barRead - start),
-        `page ${i + 1}: bar read width (${barRead}) should match startPct (${start})`,
+        Math.abs(barRead - end),
+        `page ${i + 1}: bar read width (${barRead}) should match endPct (${end})`,
       ).toBeLessThanOrEqual(1.5);
       expect(
-        Math.abs(barCurrent - (end - start)),
-        `page ${i + 1}: bar current width (${barCurrent}) should match endPct - startPct (${end - start})`,
+        Math.abs(dotLeft - end),
+        `page ${i + 1}: dot position (${dotLeft}) should match endPct (${end})`,
       ).toBeLessThanOrEqual(1.5);
+      // Progress never goes backwards as we page forward.
+      expect(end, `page ${i + 1}: endPct should not decrease`).toBeGreaterThanOrEqual(prevEnd);
+      prevEnd = end;
 
       if (i < pagesToCheck - 1) {
         await clickNext(page);
@@ -210,11 +258,7 @@ test.describe('Reader page counter + progress', () => {
   test('pages with many words advance the bar more than pages with few words', async ({
     page,
   }) => {
-    // Word-based math: each page contributes (wordsOnPage / totalWords)
-    // to the bar. Real publisher content is uneven — chapter intros
-    // / outros pack fewer words per page than mid-chapter prose. If
-    // the per-page range were uniform, this test would fail.
-    await page.goto(`/reader/${chapterId}?mode=page&chapter=0&token=0`);
+    await page.goto(`/reader/${book.biggest.id}?mode=page&chapter=0&token=0`);
     const total = (await waitForMeasureSettled(page)).total;
     test.skip(total < 4, 'need at least 4 pages to see meaningful variance');
 
@@ -231,46 +275,13 @@ test.describe('Reader page counter + progress', () => {
 
     const minRange = Math.min(...ranges);
     const maxRange = Math.max(...ranges);
+    expect(minRange, `minimum per-page range was ${minRange}; expected > 0`).toBeGreaterThan(0);
+    // Denser pages contribute meaningfully more than sparser ones.
+    // 1.3× is comfortably above the "uniform pages/N split" bug
+    // pattern (~1.0×) while tolerant of CSS column-packing smoothing.
     expect(
-      minRange,
-      `minimum per-page range was ${minRange}; expected > 0`,
-    ).toBeGreaterThan(0);
-    // The denser page should contribute meaningfully more than the
-    // sparser one. Real publisher content shows 2-3× variance; the
-    // CI seed (lorem-ipsum with mixed paragraph sizes) typically
-    // settles around 1.3-1.6× because CSS column packing smooths
-    // variance. 1.3× is comfortably above the "uniform pages/N
-    // split" bug pattern (which would produce ~1.0×) and still
-    // strict enough that a regression to "all pages equal" fails.
-    expect(
-      maxRange / Math.max(0.1, minRange),
+      maxRange / Math.max(0.01, minRange),
       `max/min range ratio ${maxRange}/${minRange}; expected > 1.3×`,
     ).toBeGreaterThan(1.3);
-  });
-
-  test('walking from page 1 to the last page covers ~100% of the chapter', async ({
-    page,
-  }) => {
-    await page.goto(`/reader/${chapterId}?mode=page&chapter=0&token=0`);
-    const total = (await waitForMeasureSettled(page)).total;
-
-    // First page should start at 0%.
-    await expect.poll(async () => (await readPctRange(page)).start).toBe(0);
-
-    // Jump straight to the last page via the cross-text "endOfChapter"
-    // handoff URL — the same flag the reader uses internally when
-    // arriving via prev-text nav. Verifies endPct hits ~100% there.
-    await page.goto(`/reader/${chapterId}?mode=page&endOfChapter=1`);
-    await waitForMeasureSettled(page);
-    await expect
-      .poll(async () => (await readPageCounter(page)).current, {
-        timeout: 10_000,
-      })
-      .toBe(total);
-    const last = await readPctRange(page);
-    expect(
-      last.end,
-      `last page endPct was ${last.end}; expected ≥ 95`,
-    ).toBeGreaterThanOrEqual(95);
   });
 });

--- a/apps/web/src/lib/components/reader/ChapterNav.svelte
+++ b/apps/web/src/lib/components/reader/ChapterNav.svelte
@@ -1,0 +1,384 @@
+<!--
+  Reader chapter selector (chrome shared by all three reader modes).
+
+  Renders the current chapter title flanked by prev/next chapter
+  arrows, with a caret that opens a dropdown table-of-contents listing
+  every chapter + its word count. Plain text — no pill chrome. The
+  entry list + current index come from `buildReaderToc` (reader-toc.ts)
+  so this component is layout-agnostic (in-text chapters and chapter-
+  book collections look identical here). Navigation is via real
+  `<a href>`s (SvelteKit intercepts the click) so each entry preserves
+  the active reader `mode` and is middle-click / SSR friendly.
+
+  Dropdown open/close + outside-click + Escape mirror the AppShell
+  language picker. Arrow keys move focus between rows and, while the
+  menu is open, are kept from bubbling to the window-level ←/→
+  page-flip handler.
+-->
+<script lang="ts">
+  import { tick } from 'svelte';
+
+  import type { ReaderTocEntry } from './reader-toc.js';
+
+  let {
+    entries,
+    currentIndex,
+    nextLocked = false,
+  }: {
+    entries: ReaderTocEntry[];
+    currentIndex: number;
+    /** Course-gating on the immediate next sibling (collections only).
+     *  The next arrow then routes through `?skipLock=1` + shows a hint,
+     *  mirroring the previous cross-text strip. TOC jumps stay free. */
+    nextLocked?: boolean;
+  } = $props();
+
+  const current = $derived(entries[currentIndex] ?? entries[0] ?? null);
+  const hasMultiple = $derived(entries.length > 1);
+  const prev = $derived(currentIndex > 0 ? entries[currentIndex - 1] : null);
+  const next = $derived(
+    currentIndex >= 0 && currentIndex < entries.length - 1
+      ? entries[currentIndex + 1]
+      : null,
+  );
+  const nextHref = $derived(
+    next ? (nextLocked ? `${next.href}&skipLock=1` : next.href) : null,
+  );
+
+  let open = $state(false);
+  let menuEl = $state<HTMLDivElement | null>(null);
+  let triggerEl = $state<HTMLButtonElement | null>(null);
+
+  function close() {
+    open = false;
+  }
+
+  // Close on outside-click / Escape while open (mirrors AppShell).
+  $effect(() => {
+    if (!open) return;
+    function onPointer(e: MouseEvent) {
+      const t = e.target as HTMLElement | null;
+      if (!t) return;
+      if (t.closest('.chapter-nav-menu')) return;
+      if (t.closest('.chapter-nav-trigger')) return;
+      close();
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        close();
+        triggerEl?.focus();
+      }
+    }
+    document.addEventListener('mousedown', onPointer);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onPointer);
+      document.removeEventListener('keydown', onKey);
+    };
+  });
+
+  // On open, focus + scroll the current row into view so a long TOC
+  // lands on "you are here" rather than the top.
+  $effect(() => {
+    if (!open) return;
+    void tick().then(() => {
+      const active =
+        menuEl?.querySelector<HTMLElement>('[aria-checked="true"]') ??
+        menuEl?.querySelector<HTMLElement>('[role="menuitemradio"]');
+      if (active && typeof active.scrollIntoView === 'function') {
+        active.scrollIntoView({ block: 'nearest' });
+      }
+      active?.focus();
+    });
+  });
+
+  function rowEls(): HTMLElement[] {
+    return Array.from(
+      menuEl?.querySelectorAll<HTMLElement>('[role="menuitemradio"]') ?? [],
+    );
+  }
+
+  function onMenuKeydown(e: KeyboardEvent) {
+    // Shield the window-level page-flip (←/→) + Esc handlers while the
+    // reader is driving the menu with the keyboard.
+    if (
+      ['ArrowDown', 'ArrowUp', 'ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(
+        e.key,
+      )
+    ) {
+      e.stopPropagation();
+    }
+    const rows = rowEls();
+    if (rows.length === 0) return;
+    const idx = rows.indexOf(document.activeElement as HTMLElement);
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      (rows[Math.min(rows.length - 1, idx + 1)] ?? rows[0])?.focus();
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      (rows[Math.max(0, idx - 1)] ?? rows[rows.length - 1])?.focus();
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      rows[0]?.focus();
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      rows[rows.length - 1]?.focus();
+    }
+  }
+</script>
+
+<div class="chapter-nav" data-testid="chapter-nav">
+  {#if hasMultiple}
+    {#if prev}
+      <a
+        class="chapter-nav-arrow"
+        href={prev.href}
+        aria-label="Previous chapter"
+        title="Previous chapter"
+        onclick={close}>‹</a
+      >
+    {:else}
+      <span class="chapter-nav-arrow is-disabled" aria-hidden="true">‹</span>
+    {/if}
+
+    <button
+      type="button"
+      class="chapter-nav-trigger"
+      bind:this={triggerEl}
+      aria-haspopup="menu"
+      aria-expanded={open}
+      onclick={() => (open = !open)}
+    >
+      <span class="chapter-nav-title" dir="auto">{current?.title ?? ''}</span>
+      <span class="chapter-nav-caret" aria-hidden="true">▾</span>
+    </button>
+
+    {#if nextHref}
+      <a
+        class="chapter-nav-arrow"
+        class:is-locked={nextLocked}
+        href={nextHref}
+        aria-label={nextLocked
+          ? 'Next chapter (locked — finish this one to advance)'
+          : 'Next chapter'}
+        title={nextLocked
+          ? 'Next chapter (locked — finish this one to advance)'
+          : 'Next chapter'}
+        onclick={close}>›</a
+      >
+    {:else}
+      <span class="chapter-nav-arrow is-disabled" aria-hidden="true">›</span>
+    {/if}
+
+    {#if open}
+      <div
+        class="chapter-nav-menu"
+        role="menu"
+        tabindex="-1"
+        aria-label="Chapters"
+        bind:this={menuEl}
+        onkeydown={onMenuKeydown}
+      >
+        <ul class="chapter-nav-list">
+          {#each entries as entry (entry.key)}
+            <li>
+              <a
+                class="chapter-nav-row"
+                role="menuitemradio"
+                aria-checked={entry.isCurrent}
+                data-active={entry.isCurrent ? '1' : '0'}
+                tabindex="-1"
+                href={entry.href}
+                onclick={close}
+              >
+                <span class="chapter-nav-num" aria-hidden="true">{entry.number}</span>
+                <span class="chapter-nav-row-text">
+                  <span class="chapter-nav-row-title" dir="auto">{entry.title}</span>
+                  <span class="chapter-nav-row-meta"
+                    >{entry.words.toLocaleString()} words</span
+                  >
+                </span>
+                {#if entry.isCurrent}
+                  <span class="chapter-nav-row-current" aria-label="Current">●</span>
+                {/if}
+              </a>
+            </li>
+          {/each}
+        </ul>
+      </div>
+    {/if}
+  {:else if current}
+    <span class="chapter-nav-title chapter-nav-title-static" dir="auto"
+      >{current.title}</span
+    >
+  {/if}
+</div>
+
+<style>
+  .chapter-nav {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35rem;
+    min-width: 0;
+  }
+
+  /* Plain chevrons — no pill chrome. Full-contrast ink so they read
+     on the paper surface in both themes. */
+  .chapter-nav-arrow {
+    flex-shrink: 0;
+    display: grid;
+    place-items: center;
+    width: 28px;
+    height: 28px;
+    border-radius: 6px;
+    color: var(--ink-2, var(--color-fg));
+    text-decoration: none;
+    font-size: 1.25rem;
+    line-height: 1;
+    transition:
+      background 150ms ease,
+      color 150ms ease;
+  }
+  .chapter-nav-arrow:hover {
+    background: color-mix(in oklch, var(--ink, var(--color-fg)) 7%, transparent);
+    color: var(--ink, var(--color-fg));
+  }
+  .chapter-nav-arrow.is-disabled {
+    opacity: 0.25;
+    cursor: default;
+  }
+  .chapter-nav-arrow.is-locked {
+    opacity: 0.55;
+  }
+
+  .chapter-nav-trigger {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    max-width: min(60vw, 22rem);
+    padding: 0.25rem 0.4rem;
+    border: 0;
+    background: transparent;
+    color: var(--ink, var(--color-fg));
+    font-family: var(--font-serif-dev, var(--font-serif));
+    font-size: 1.05rem;
+    font-weight: 500;
+    cursor: pointer;
+    border-radius: 6px;
+    transition: background 150ms ease;
+  }
+  .chapter-nav-trigger:hover {
+    background: color-mix(in oklch, var(--ink, var(--color-fg)) 6%, transparent);
+  }
+  .chapter-nav-title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+  }
+  .chapter-nav-title-static {
+    color: var(--ink, var(--color-fg));
+    font-family: var(--font-serif-dev, var(--font-serif));
+    font-size: 1.05rem;
+    font-weight: 500;
+    max-width: min(70vw, 26rem);
+  }
+  .chapter-nav-caret {
+    flex-shrink: 0;
+    font-size: 0.7rem;
+    color: var(--ink-3, var(--color-fg-muted));
+  }
+
+  /* Dropdown surface — mirrors the AppShell language picker. */
+  .chapter-nav-menu {
+    position: absolute;
+    top: calc(100% + 8px);
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 50;
+    min-width: 260px;
+    max-width: min(92vw, 360px);
+    max-height: min(70dvh, 480px);
+    overflow-y: auto;
+    background: var(--paper, var(--color-bg));
+    color: var(--ink, var(--color-fg));
+    border: 1px solid var(--card-edge, var(--color-border));
+    border-radius: 10px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+    padding: 0.5rem;
+  }
+  .chapter-nav-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+  }
+  .chapter-nav-row {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+    padding: 0.5rem 0.6rem;
+    border: 1px solid transparent;
+    border-radius: 8px;
+    background: transparent;
+    color: var(--ink, var(--color-fg));
+    text-decoration: none;
+    text-align: left;
+    cursor: pointer;
+    transition:
+      border-color 150ms ease,
+      background 150ms ease;
+  }
+  .chapter-nav-row:hover,
+  .chapter-nav-row:focus-visible {
+    border-color: color-mix(
+      in oklch,
+      var(--accent, var(--color-accent)) 50%,
+      var(--card-edge, var(--color-border))
+    );
+    outline: none;
+  }
+  .chapter-nav-row[data-active='1'] {
+    border-color: var(--accent, var(--color-accent));
+    background: var(--accent-soft, var(--color-accent));
+  }
+  .chapter-nav-num {
+    flex-shrink: 0;
+    min-width: 1.6rem;
+    text-align: right;
+    font-family: var(--font-mono-display, var(--font-mono));
+    font-feature-settings: 'tnum';
+    font-size: 0.8rem;
+    color: var(--ink-3, var(--color-fg-muted));
+  }
+  .chapter-nav-row-text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+    flex: 1;
+    min-width: 0;
+  }
+  .chapter-nav-row-title {
+    font-family: var(--font-serif-dev, var(--font-serif));
+    font-size: 0.95rem;
+    color: var(--ink, var(--color-fg));
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .chapter-nav-row-meta {
+    font-family: var(--font-sans, var(--font-ui));
+    font-size: 0.72rem;
+    color: var(--ink-3, var(--color-fg-muted));
+  }
+  .chapter-nav-row-current {
+    flex-shrink: 0;
+    color: var(--accent-ink, var(--color-accent));
+    font-size: 0.7rem;
+  }
+</style>

--- a/apps/web/src/lib/components/reader/ChapterNav.test.ts
+++ b/apps/web/src/lib/components/reader/ChapterNav.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render } from '@testing-library/svelte';
+
+import ChapterNav from './ChapterNav.svelte';
+import type { ReaderTocEntry } from './reader-toc.js';
+
+afterEach(cleanup);
+
+function entry(
+  i: number,
+  overrides: Partial<ReaderTocEntry> = {},
+): ReaderTocEntry {
+  return {
+    key: `k${i}`,
+    number: i + 1,
+    title: `Chapter ${i + 1}`,
+    words: (i + 1) * 100,
+    href: `/reader/t?mode=page&chapter=${i}`,
+    isCurrent: false,
+    ...overrides,
+  };
+}
+
+function threeChapters(currentIndex = 1): ReaderTocEntry[] {
+  return [0, 1, 2].map((i) =>
+    entry(i, { isCurrent: i === currentIndex, title: `Ch ${i + 1}` }),
+  );
+}
+
+describe('ChapterNav', () => {
+  it('shows the current chapter title and opens/closes the TOC on the trigger', async () => {
+    const { container } = render(ChapterNav, {
+      props: { entries: threeChapters(1), currentIndex: 1 },
+    });
+    const trigger = container.querySelector(
+      '.chapter-nav-trigger',
+    ) as HTMLButtonElement;
+    expect(trigger.textContent).toContain('Ch 2');
+    expect(container.querySelector('.chapter-nav-menu')).toBeNull();
+
+    await fireEvent.click(trigger);
+    expect(container.querySelector('.chapter-nav-menu')).not.toBeNull();
+
+    await fireEvent.click(trigger);
+    expect(container.querySelector('.chapter-nav-menu')).toBeNull();
+  });
+
+  it('lists every chapter with its word count and flags the current one', async () => {
+    const { container } = render(ChapterNav, {
+      props: { entries: threeChapters(1), currentIndex: 1 },
+    });
+    await fireEvent.click(
+      container.querySelector('.chapter-nav-trigger') as HTMLButtonElement,
+    );
+    const rows = container.querySelectorAll('[role="menuitemradio"]');
+    expect(rows).toHaveLength(3);
+    expect(rows[1]!.getAttribute('aria-checked')).toBe('true');
+    expect(rows[0]!.getAttribute('aria-checked')).toBe('false');
+    // Word counts render (200 words for the 2nd chapter).
+    expect(container.querySelector('.chapter-nav-menu')!.textContent).toContain(
+      '200 words',
+    );
+  });
+
+  it('closes on Escape and on outside-click', async () => {
+    const { container } = render(ChapterNav, {
+      props: { entries: threeChapters(0), currentIndex: 0 },
+    });
+    const trigger = container.querySelector(
+      '.chapter-nav-trigger',
+    ) as HTMLButtonElement;
+
+    await fireEvent.click(trigger);
+    expect(container.querySelector('.chapter-nav-menu')).not.toBeNull();
+    await fireEvent.keyDown(document, { key: 'Escape' });
+    expect(container.querySelector('.chapter-nav-menu')).toBeNull();
+
+    await fireEvent.click(trigger);
+    expect(container.querySelector('.chapter-nav-menu')).not.toBeNull();
+    await fireEvent.mouseDown(document.body);
+    expect(container.querySelector('.chapter-nav-menu')).toBeNull();
+  });
+
+  it('renders a plain static title with no caret/arrows for a single chapter', () => {
+    const { container } = render(ChapterNav, {
+      props: {
+        entries: [entry(0, { isCurrent: true, title: 'Solo' })],
+        currentIndex: 0,
+      },
+    });
+    expect(container.querySelector('.chapter-nav-trigger')).toBeNull();
+    expect(container.querySelector('.chapter-nav-arrow')).toBeNull();
+    expect(
+      container.querySelector('.chapter-nav-title-static')!.textContent,
+    ).toContain('Solo');
+  });
+
+  it('points the arrows at the adjacent chapters and disables the ends', () => {
+    const first = render(ChapterNav, {
+      props: { entries: threeChapters(0), currentIndex: 0 },
+    });
+    const firstArrows = first.container.querySelectorAll('.chapter-nav-arrow');
+    // prev is disabled (span), next is a link to chapter 1.
+    expect(firstArrows[0]!.classList.contains('is-disabled')).toBe(true);
+    expect((firstArrows[1] as HTMLAnchorElement).getAttribute('href')).toBe(
+      '/reader/t?mode=page&chapter=1',
+    );
+    first.unmount();
+
+    const last = render(ChapterNav, {
+      props: { entries: threeChapters(2), currentIndex: 2 },
+    });
+    const lastArrows = last.container.querySelectorAll('.chapter-nav-arrow');
+    expect((lastArrows[0] as HTMLAnchorElement).getAttribute('href')).toBe(
+      '/reader/t?mode=page&chapter=1',
+    );
+    expect(lastArrows[1]!.classList.contains('is-disabled')).toBe(true);
+  });
+
+  it('routes a course-locked next arrow through ?skipLock=1', () => {
+    const { container } = render(ChapterNav, {
+      props: { entries: threeChapters(0), currentIndex: 0, nextLocked: true },
+    });
+    const next = container.querySelectorAll('.chapter-nav-arrow')[1] as HTMLAnchorElement;
+    expect(next.getAttribute('href')).toBe('/reader/t?mode=page&chapter=1&skipLock=1');
+    expect(next.classList.contains('is-locked')).toBe(true);
+  });
+
+  it('marks titles dir="auto" so RTL (Hebrew-script) chapters align', async () => {
+    const { container } = render(ChapterNav, {
+      props: {
+        entries: threeChapters(0).map((e) => ({ ...e, title: 'אלף' })),
+        currentIndex: 0,
+      },
+    });
+    expect(
+      container.querySelector('.chapter-nav-title')!.getAttribute('dir'),
+    ).toBe('auto');
+    await fireEvent.click(
+      container.querySelector('.chapter-nav-trigger') as HTMLButtonElement,
+    );
+    expect(
+      container.querySelector('.chapter-nav-row-title')!.getAttribute('dir'),
+    ).toBe('auto');
+  });
+
+  it('keeps menu arrow-key navigation from bubbling to the window page-flip handler', async () => {
+    const { container } = render(ChapterNav, {
+      props: { entries: threeChapters(0), currentIndex: 0 },
+    });
+    await fireEvent.click(
+      container.querySelector('.chapter-nav-trigger') as HTMLButtonElement,
+    );
+    const rows = container.querySelectorAll<HTMLElement>('[role="menuitemradio"]');
+    const winSpy = vi.fn();
+    window.addEventListener('keydown', winSpy);
+    rows[0]!.focus();
+    await fireEvent.keyDown(rows[0]!, { key: 'ArrowDown' });
+    window.removeEventListener('keydown', winSpy);
+    // Focus advanced AND the event never reached the window.
+    expect(document.activeElement).toBe(rows[1]);
+    expect(winSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/components/reader/ReaderPage.svelte
+++ b/apps/web/src/lib/components/reader/ReaderPage.svelte
@@ -23,6 +23,7 @@
   import type { ProgressAnchor } from './progress-client.js';
   import {
     WORD_SELECTOR,
+    bookProgressPct,
     buildPageWordIndex,
     columnIndexForElement,
     computePctRead,
@@ -54,6 +55,8 @@
     nextTextId = null,
     collectionPosition = null,
     collectionTotal = null,
+    bookWordsBefore = 0,
+    bookWordsTotal = 0,
     startAtEndOfChapter = false,
   }: {
     chapters: ChapterView[];
@@ -88,6 +91,16 @@
      *  uninformative "Ch. 1 / 1" you'd see on a one-chapter text. */
     collectionPosition?: number | null;
     collectionTotal?: number | null;
+    /** Whole-book word totals for the footer's book-level percentage.
+     *  `bookWordsBefore` = words in the book before this loaded text's
+     *  first chapter; `bookWordsTotal` = the whole book. Both default
+     *  to 0, which makes the footer fall back to summing this text's
+     *  own chapters — i.e. unchanged for ordinary multi-chapter texts.
+     *  Non-zero only for chapter-books (each chapter is its own text),
+     *  where they make the bar span the whole book instead of one
+     *  chapter. Display-only: persisted progress stays per-text. */
+    bookWordsBefore?: number;
+    bookWordsTotal?: number;
   } = $props();
 
   const current = $derived(chapters[Math.max(0, Math.min(chapterIdx, chapters.length - 1))]);
@@ -193,7 +206,11 @@
   let endPct = $state(0);
 
   const totalTokens = $derived(chapters.reduce((sum, c) => sum + Math.max(0, c.tokenCount), 0));
-  const pctPrecision = $derived(pctPrecisionFor(totalTokens));
+  // Precision tracks the BOOK total so a small loaded chapter inside a
+  // long book doesn't snap the percentage to 0-decimal "stuck" steps.
+  const pctPrecision = $derived(
+    pctPrecisionFor(bookWordsTotal > 0 ? bookWordsTotal : totalTokens),
+  );
 
   // Per-measure cache of word→column mapping. `findFirstWordInColumn`
   // forces a layout flush per token; building once per measure and
@@ -473,26 +490,44 @@
       if (entry.columnIndex < pageInChapter) domBeforePage += 1;
       if (entry.columnIndex <= pageInChapter) domThroughPage += 1;
     }
+    // DISPLAY value — whole-book fractions. For an ordinary
+    // multi-chapter text bookWords* are 0, so this collapses to the
+    // loaded text's own total (unchanged). For a chapter-book it spans
+    // every sibling chapter, so the bar climbs across the whole book
+    // and reaches 100% only on the final chapter — which is why the
+    // display can't honor `boundary.completed` (a chapter-book's single
+    // loaded chapter reports "completed" at the end of *every* chapter).
+    const display = bookProgressPct({
+      wordsBeforeChapter,
+      currentChapterWords,
+      domBeforePage,
+      domThroughPage,
+      domTotal,
+      bookWordsBefore,
+      bookWordsTotal,
+      chaptersTotal: totalWordsInText,
+    });
+    startPct = display.startPct;
+    endPct = display.endPct;
+    if (!onProgress) return;
+    // PERSIST value — per-loaded-text pctRead, keeping the
+    // `completed → 100` guarantee that T-8.6 course gating + the
+    // library cards depend on. Deliberately NOT the whole-book display
+    // value above: persistence stays per-text so each chapter of a
+    // chapter-book still reaches 100% on its own.
     const ratio = domTotal > 0 ? currentChapterWords / domTotal : 0;
-    const startWords = wordsBeforeChapter + domBeforePage * ratio;
-    const endWords = wordsBeforeChapter + domThroughPage * ratio;
-
-    const startPctNext =
-      totalWordsInText > 0 ? (startWords / totalWordsInText) * 100 : 0;
-    const endPctNext = boundary.completed
+    const endWordsInText = wordsBeforeChapter + domThroughPage * ratio;
+    const endPctPersist = boundary.completed
       ? 100
       : totalWordsInText > 0
-        ? (endWords / totalWordsInText) * 100
+        ? (endWordsInText / totalWordsInText) * 100
         : 0;
-    startPct = startPctNext;
-    endPct = endPctNext;
-    if (!onProgress) return;
     // Resume position is the first word on this page; pctRead reports
     // how far the user has READ — i.e. the end-of-page boundary —
     // so the library card matches the reader footer.
     const next: ProgressAnchor = {
       ...anchor,
-      pctRead: endPctNext,
+      pctRead: endPctPersist,
     };
     const key = `${next.chapterIdx}:${next.tokenIdx}:${next.pctRead}`;
     if (key === lastReportedKey) return;
@@ -641,22 +676,17 @@
   </button>
 </div>
 
-<footer class="reader-foot" aria-label="Chapter progress">
+<footer class="reader-foot" aria-label="Reading progress">
   <div class="reader-foot-meta">
-    <span class="pager-pages">
-      Page {pageInChapter + 1} of {pageCount}
-      <span class="muted">
-        · Ch. {counterCurrent} / {counterTotal} · {(current?.tokenCount ?? 0).toLocaleString()} words
-      </span>
+    <span class="pager-pages">Page {pageInChapter + 1} of {pageCount}</span>
+    <span class="pager-pct" aria-label="Progress through the book">
+      {formatPctRange(startPct, endPct, pctPrecision)}
     </span>
-    <span class="muted">{formatPctRange(startPct, endPct, pctPrecision)}</span>
+    <span class="pager-chapter">Ch. {counterCurrent} / {counterTotal}</span>
   </div>
   <div class="reader-foot-bar">
-    <i class="read" style="width: {startPct}%"></i>
-    <i
-      class="current"
-      style="left: {startPct}%; width: {Math.max(0, endPct - startPct)}%"
-    ></i>
+    <i class="read" style="width: {endPct}%"></i>
+    <i class="dot" style="left: {endPct}%"></i>
   </div>
 </footer>
 
@@ -860,49 +890,68 @@
       padding: 0.75rem 1.75rem 0.9rem;
     }
   }
+  /* Three columns: page (left) · whole-book progress (center) ·
+     chapter counter (right). Grid (not space-between) so the center
+     stays optically centered regardless of the side labels' widths. */
   .reader-foot-meta {
-    display: flex;
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
     align-items: baseline;
-    justify-content: space-between;
     font-size: 0.72rem;
     color: var(--ink-3, var(--color-fg-muted));
-    margin-bottom: 0.4rem;
+    margin-bottom: 0.5rem;
   }
   .pager-pages {
+    justify-self: start;
     font-family: var(--font-mono-display, var(--font-mono));
     font-feature-settings: 'tnum';
     letter-spacing: 0.04em;
     color: var(--ink-2, var(--color-fg));
   }
-  .muted {
+  /* Current page's whole-book progress range (e.g. 0.0–0.3%). */
+  .pager-pct {
+    justify-self: center;
+    font-family: var(--font-mono-display, var(--font-mono));
+    font-feature-settings: 'tnum';
+    letter-spacing: 0.04em;
+    color: var(--ink-2, var(--color-fg));
+  }
+  .pager-chapter {
+    justify-self: end;
+    font-family: var(--font-mono-display, var(--font-mono));
+    font-feature-settings: 'tnum';
+    letter-spacing: 0.04em;
     color: var(--ink-3, var(--color-fg-muted));
   }
+  /* Thin full-width track: a muted-accent fill up to the read position
+     and a solid accent dot marking "you are here". */
   .reader-foot-bar {
-    height: 3px;
+    height: 4px;
     background: color-mix(in oklch, var(--ink, var(--color-fg)) 8%, transparent);
     border-radius: 2px;
     position: relative;
-    overflow: hidden;
   }
-  .reader-foot-bar > i {
+  .reader-foot-bar > i.read {
     position: absolute;
+    left: 0;
     top: 0;
     bottom: 0;
     border-radius: 2px;
-    transition:
-      width 250ms ease,
-      left 250ms ease;
+    background: color-mix(in oklch, var(--accent, var(--color-accent)) 40%, transparent);
+    transition: width 250ms ease;
   }
-  /* Words read before the current page — muted accent so the eye
-     reads it as "behind me" rather than "active". */
-  .reader-foot-bar > i.read {
-    left: 0;
-    background: color-mix(in oklch, var(--accent, var(--color-accent)) 45%, transparent);
-  }
-  /* Words on the current page — full-strength accent so the active
-     range stands out as the "you are here" segment. */
-  .reader-foot-bar > i.current {
+  .reader-foot-bar > i.dot {
+    position: absolute;
+    top: 50%;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
     background: var(--accent, var(--color-accent));
+    transform: translate(-50%, -50%);
+    /* Paper-colored halo so the dot reads against both the filled and
+       empty parts of the track. */
+    box-shadow: 0 0 0 2px var(--paper, var(--color-bg));
+    transition: left 250ms ease;
   }
 
   /* Respect reduced-motion: skip the page-flip slide. */

--- a/apps/web/src/lib/components/reader/reader-progress.test.ts
+++ b/apps/web/src/lib/components/reader/reader-progress.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  bookProgressPct,
   buildPageWordIndex,
   columnIndexForElement,
   computePctRead,
@@ -426,6 +427,88 @@ describe('reader progress helpers', () => {
       });
       expect(index.entries).toHaveLength(0);
       expect(firstWordInColumnFromIndex(index, 0)).toBeNull();
+    });
+  });
+
+  describe('bookProgressPct', () => {
+    it('matches the loaded-text math when no book totals are given (in-text)', () => {
+      // chapter 1 of a 2-chapter text: 100 words before, 200 in this
+      // chapter rendered into 4 columns (50 words each), page 1 of 4.
+      const { startPct, endPct } = bookProgressPct({
+        wordsBeforeChapter: 100,
+        currentChapterWords: 200,
+        domBeforePage: 50, // words in columns before the current page
+        domThroughPage: 100, // words through the current page
+        domTotal: 200,
+        bookWordsBefore: 0,
+        bookWordsTotal: 0, // → falls back to chaptersTotal
+        chaptersTotal: 300,
+      });
+      // start = (100 + 50) / 300; end = (100 + 100) / 300
+      expect(startPct).toBeCloseTo(50, 5);
+      expect(endPct).toBeCloseTo(66.6667, 3);
+    });
+
+    it('reaches 100% only on the final page of the loaded text (in-text)', () => {
+      const { endPct } = bookProgressPct({
+        wordsBeforeChapter: 100,
+        currentChapterWords: 200,
+        domBeforePage: 150,
+        domThroughPage: 200, // through the last column → whole chapter
+        domTotal: 200,
+        bookWordsBefore: 0,
+        bookWordsTotal: 0,
+        chaptersTotal: 300,
+      });
+      expect(endPct).toBeCloseTo(100, 5);
+    });
+
+    it('spans the whole book for a chapter-book chapter (does NOT snap to 100 mid-book)', () => {
+      // Whole book = 1000 words; this is the 2nd chapter (300 words
+      // before it), itself 200 words, and we are on its LAST page.
+      const { startPct, endPct } = bookProgressPct({
+        wordsBeforeChapter: 0, // the loaded text has only this 1 chapter
+        currentChapterWords: 200,
+        domBeforePage: 100,
+        domThroughPage: 200, // last page of this chapter
+        domTotal: 200,
+        bookWordsBefore: 300,
+        bookWordsTotal: 1000,
+        chaptersTotal: 200,
+      });
+      // start = (300 + 100) / 1000; end = (300 + 200) / 1000 = 50%,
+      // NOT 100% even though this chapter's own last page is "done".
+      expect(startPct).toBeCloseTo(40, 5);
+      expect(endPct).toBeCloseTo(50, 5);
+    });
+
+    it('hits 100% on the final chapter of a chapter-book', () => {
+      const { endPct } = bookProgressPct({
+        wordsBeforeChapter: 0,
+        currentChapterWords: 200,
+        domBeforePage: 150,
+        domThroughPage: 200,
+        domTotal: 200,
+        bookWordsBefore: 800, // last chapter starts at 800/1000
+        bookWordsTotal: 1000,
+        chaptersTotal: 200,
+      });
+      expect(endPct).toBeCloseTo(100, 5);
+    });
+
+    it('returns 0/0 when every total is empty', () => {
+      expect(
+        bookProgressPct({
+          wordsBeforeChapter: 0,
+          currentChapterWords: 0,
+          domBeforePage: 0,
+          domThroughPage: 0,
+          domTotal: 0,
+          bookWordsBefore: 0,
+          bookWordsTotal: 0,
+          chaptersTotal: 0,
+        }),
+      ).toEqual({ startPct: 0, endPct: 0 });
     });
   });
 });

--- a/apps/web/src/lib/components/reader/reader-progress.ts
+++ b/apps/web/src/lib/components/reader/reader-progress.ts
@@ -241,6 +241,56 @@ export function computePctRead(
   return Math.max(0, Math.min(100, ((before + inChapter) / total) * 100));
 }
 
+/**
+ * Whole-book progress fractions for the page reader's footer
+ * (DISPLAY ONLY — the value persisted to the server stays per-loaded-
+ * text; see `ReaderPage.reportProgress`).
+ *
+ * The page reader knows, from its per-measure DOM column index, how
+ * many word spans sit before / through the current page within *this*
+ * chapter. To turn that into a fraction of the whole book we:
+ *   - scale the DOM word counts to the chapter's canonical tokenCount
+ *     (`ratio = currentChapterWords / domTotal`) so a chapter that
+ *     happens to render into many columns still contributes exactly
+ *     its tokenCount;
+ *   - add `wordsBeforeChapter` (earlier chapters of the *loaded text*)
+ *     and `bookWordsBefore` (earlier chapters of the *book* that live
+ *     in sibling texts — the chapter-book case, where each chapter is
+ *     its own one-chapter `texts` row);
+ *   - divide by the whole-book total, falling back to the loaded
+ *     text's own total when no book totals are supplied (the in-text
+ *     multi-chapter case → identical to the previous behavior).
+ *
+ * Crucially this does NOT take a `completed` flag: a chapter-book's
+ * single loaded chapter reports "completed" at its last page, so
+ * honoring that here would snap the bar to 100% at the end of every
+ * chapter. Letting the cumulative math run reaches 100% only on the
+ * final chapter's final page.
+ */
+export function bookProgressPct(args: {
+  wordsBeforeChapter: number;
+  currentChapterWords: number;
+  domBeforePage: number;
+  domThroughPage: number;
+  domTotal: number;
+  /** Words in the whole book before the loaded text's first chapter.
+   *  0 for an ordinary in-text multi-chapter text. */
+  bookWordsBefore: number;
+  /** Whole-book word total. <= 0 falls back to `chaptersTotal`. */
+  bookWordsTotal: number;
+  /** Sum of tokenCounts across the loaded text's own chapters. */
+  chaptersTotal: number;
+}): { startPct: number; endPct: number } {
+  const denom = args.bookWordsTotal > 0 ? args.bookWordsTotal : args.chaptersTotal;
+  if (denom <= 0) return { startPct: 0, endPct: 0 };
+  const ratio = args.domTotal > 0 ? args.currentChapterWords / args.domTotal : 0;
+  const base = Math.max(0, args.bookWordsBefore) + Math.max(0, args.wordsBeforeChapter);
+  const startWords = base + Math.max(0, args.domBeforePage) * ratio;
+  const endWords = base + Math.max(0, args.domThroughPage) * ratio;
+  const clamp = (w: number) => Math.max(0, Math.min(100, (w / denom) * 100));
+  return { startPct: clamp(startWords), endPct: clamp(endWords) };
+}
+
 // Choose decimal precision for the progress display so flipping one
 // page advances the number by ~1 unit. With ~200 words/page typical:
 // short texts (< 5k tokens) get clean integers, mid-length (5k–50k)

--- a/apps/web/src/lib/components/reader/reader-toc.test.ts
+++ b/apps/web/src/lib/components/reader/reader-toc.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildReaderToc, type ReaderTocInput } from './reader-toc.js';
+
+const baseInput: ReaderTocInput = {
+  textId: 'text-1',
+  mode: 'page',
+  chapters: [{ idx: 0, title: 'Only', tokenCount: 500 }],
+  currentChapterIdx: 0,
+  collection: null,
+};
+
+describe('buildReaderToc — in-text multi-chapter', () => {
+  const input: ReaderTocInput = {
+    ...baseInput,
+    chapters: [
+      { idx: 0, title: 'Intro', tokenCount: 100 },
+      { idx: 1, title: '  ', tokenCount: 200 }, // blank → fallback
+      { idx: 2, title: 'End', tokenCount: 300 },
+    ],
+    currentChapterIdx: 1,
+  };
+
+  it('builds one entry per chapter with ?chapter= hrefs preserving mode', () => {
+    const toc = buildReaderToc({ ...input, mode: 'continuous' });
+    expect(toc.kind).toBe('in-text');
+    expect(toc.total).toBe(3);
+    expect(toc.entries.map((e) => e.href)).toEqual([
+      '/reader/text-1?mode=continuous&chapter=0',
+      '/reader/text-1?mode=continuous&chapter=1',
+      '/reader/text-1?mode=continuous&chapter=2',
+    ]);
+  });
+
+  it('numbers chapters from 1 and falls back to "Chapter N" for blank titles', () => {
+    const toc = buildReaderToc(input);
+    expect(toc.entries.map((e) => `${e.number}:${e.title}`)).toEqual([
+      '1:Intro',
+      '2:Chapter 2',
+      '3:End',
+    ]);
+  });
+
+  it('marks the active chapter current and reports its index', () => {
+    const toc = buildReaderToc(input);
+    expect(toc.currentIndex).toBe(1);
+    expect(toc.entries[1]!.isCurrent).toBe(true);
+    expect(toc.entries.filter((e) => e.isCurrent)).toHaveLength(1);
+  });
+
+  it('leaves book totals zero so the page reader uses its own sums', () => {
+    const toc = buildReaderToc(input);
+    expect(toc.bookWordsBefore).toBe(0);
+    expect(toc.bookWordsTotal).toBe(0);
+  });
+});
+
+describe('buildReaderToc — chapter-book collection', () => {
+  const input: ReaderTocInput = {
+    ...baseInput,
+    textId: 'text-b', // the loaded one-chapter text
+    chapters: [{ idx: 0, title: 'Chapter Two', tokenCount: 200 }],
+    currentChapterIdx: 0,
+    collection: {
+      position: 1,
+      chapters: [
+        { textId: 'text-a', position: 0, title: 'One', tokenCount: 100 },
+        { textId: 'text-b', position: 1, title: 'Two', tokenCount: 200 },
+        { textId: 'text-c', position: 2, title: 'Three', tokenCount: 300 },
+      ],
+    },
+  };
+
+  it('builds entries from siblings with /reader/<textId> hrefs preserving mode', () => {
+    const toc = buildReaderToc(input);
+    expect(toc.kind).toBe('collection');
+    expect(toc.total).toBe(3);
+    expect(toc.entries.map((e) => e.href)).toEqual([
+      '/reader/text-a?mode=page',
+      '/reader/text-b?mode=page',
+      '/reader/text-c?mode=page',
+    ]);
+  });
+
+  it('marks the current sibling by position, not the loaded chapter idx', () => {
+    const toc = buildReaderToc(input);
+    expect(toc.currentIndex).toBe(1);
+    expect(toc.entries[1]!.key).toBe('text-b');
+    expect(toc.entries[1]!.isCurrent).toBe(true);
+  });
+
+  it('computes whole-book totals (words before + grand total)', () => {
+    const toc = buildReaderToc(input);
+    expect(toc.bookWordsBefore).toBe(100); // text-a only
+    expect(toc.bookWordsTotal).toBe(600); // 100 + 200 + 300
+  });
+
+  it('falls back to "Untitled" for blank sibling titles', () => {
+    const toc = buildReaderToc({
+      ...input,
+      collection: {
+        position: 0,
+        chapters: [
+          { textId: 'text-a', position: 0, title: '', tokenCount: 0 },
+        ],
+      },
+    });
+    expect(toc.entries[0]!.title).toBe('Untitled');
+  });
+});
+
+describe('buildReaderToc — single standalone chapter', () => {
+  it('yields a single entry and zero book totals', () => {
+    const toc = buildReaderToc(baseInput);
+    expect(toc.kind).toBe('single');
+    expect(toc.total).toBe(1);
+    expect(toc.currentIndex).toBe(0);
+    expect(toc.bookWordsTotal).toBe(0);
+  });
+});

--- a/apps/web/src/lib/components/reader/reader-toc.ts
+++ b/apps/web/src/lib/components/reader/reader-toc.ts
@@ -1,0 +1,133 @@
+/**
+ * Reader chapter table-of-contents model.
+ *
+ * The reader presents one of two physical chapter layouts behind a
+ * single chapter-selector dropdown:
+ *
+ *   - **in-text**: a multi-chapter `texts` row (paste / .txt auto-split).
+ *     All chapter titles + token counts ship in `data.chapters`;
+ *     navigation flips `?chapter=N` on the same text.
+ *   - **collection**: a chapter-book — each chapter is its own
+ *     one-chapter `texts` row inside a collection. The sibling list
+ *     (title + summed tokenCount) comes from `readerCollectionContext`;
+ *     navigation loads a different `textId`.
+ *
+ * `buildReaderToc` flattens both into a uniform entry list the
+ * `ChapterNav` component renders, and exposes the whole-book word
+ * totals the page footer needs to show progress across the *book*
+ * rather than the loaded chapter. A standalone single-chapter text
+ * yields a single entry (the component then hides the dropdown/arrows).
+ *
+ * Pure + framework-free so it carries unit coverage; the `.svelte`
+ * component and `+page.*` route files are excluded from the gate.
+ */
+
+export type ReaderLayoutMode = 'page' | 'paged_scroll' | 'continuous';
+
+export type ReaderTocEntry = {
+  /** Stable key for `{#each}` (textId for collections, `ch-N` otherwise). */
+  key: string;
+  /** 1-based display number. */
+  number: number;
+  title: string;
+  /** Word (token) count for this chapter. */
+  words: number;
+  /** Navigation target — always preserves the current reader `mode`. */
+  href: string;
+  isCurrent: boolean;
+};
+
+export type ReaderToc = {
+  entries: ReaderTocEntry[];
+  /** Index into `entries` of the current chapter, or -1. */
+  currentIndex: number;
+  total: number;
+  /** Words in the whole book before the loaded text's first chapter.
+   *  0 for in-text / single (the page reader uses its own totals). */
+  bookWordsBefore: number;
+  /** Whole-book word total. 0 for in-text / single. */
+  bookWordsTotal: number;
+  kind: 'collection' | 'in-text' | 'single';
+};
+
+export type ReaderTocInput = {
+  textId: string;
+  mode: ReaderLayoutMode;
+  /** The loaded text's own chapters (every entry carries idx + title +
+   *  tokenCount; only the active one carries body/tokens). */
+  chapters: Array<{ idx: number; title: string | null; tokenCount: number }>;
+  /** 0-based index of the active chapter within `chapters`. */
+  currentChapterIdx: number;
+  /** Collection sibling list when the text is part of a collection. */
+  collection: {
+    chapters: Array<{
+      textId: string;
+      position: number;
+      title: string;
+      tokenCount: number;
+    }>;
+    position: number;
+  } | null;
+};
+
+function clampInt(n: number): number {
+  return Number.isFinite(n) ? Math.max(0, Math.floor(n)) : 0;
+}
+
+export function buildReaderToc(input: ReaderTocInput): ReaderToc {
+  const mode = input.mode;
+
+  // --- Collection (chapter-book): siblings drive the TOC + book totals.
+  if (input.collection && input.collection.chapters.length > 0) {
+    const ordered = input.collection.chapters;
+    const entries: ReaderTocEntry[] = ordered.map((c, i) => ({
+      key: c.textId,
+      number: i + 1,
+      title: c.title?.trim() || 'Untitled',
+      words: clampInt(c.tokenCount),
+      href: `/reader/${c.textId}?mode=${mode}`,
+      isCurrent: c.position === input.collection!.position,
+    }));
+    let currentIndex = entries.findIndex((e) => e.isCurrent);
+    if (currentIndex < 0) currentIndex = 0;
+    const bookWordsBefore = ordered
+      .filter((c) => c.position < input.collection!.position)
+      .reduce((sum, c) => sum + clampInt(c.tokenCount), 0);
+    const bookWordsTotal = ordered.reduce(
+      (sum, c) => sum + clampInt(c.tokenCount),
+      0,
+    );
+    return {
+      entries,
+      currentIndex,
+      total: entries.length,
+      bookWordsBefore,
+      bookWordsTotal,
+      kind: 'collection',
+    };
+  }
+
+  // --- In-text multi-chapter: data.chapters already has everything.
+  const chapters = input.chapters;
+  const entries: ReaderTocEntry[] = chapters.map((c) => ({
+    key: `ch-${c.idx}`,
+    number: c.idx + 1,
+    title: c.title?.trim() || `Chapter ${c.idx + 1}`,
+    words: clampInt(c.tokenCount),
+    href: `/reader/${input.textId}?mode=${mode}&chapter=${c.idx}`,
+    isCurrent: c.idx === input.currentChapterIdx,
+  }));
+  let currentIndex = entries.findIndex((e) => e.isCurrent);
+  if (currentIndex < 0) currentIndex = 0;
+
+  return {
+    entries,
+    currentIndex,
+    total: entries.length,
+    // In-text / single: the page reader already sums its own chapters,
+    // so signal "use your own totals" with zeroes.
+    bookWordsBefore: 0,
+    bookWordsTotal: 0,
+    kind: chapters.length > 1 ? 'in-text' : 'single',
+  };
+}

--- a/apps/web/src/lib/server/collections.test.ts
+++ b/apps/web/src/lib/server/collections.test.ts
@@ -67,7 +67,8 @@ vi.mock('./db/index.js', () => ({
       collectionId: 'cs.collection_id',
       sharedWithUserId: 'cs.shared_with_user_id',
     },
-    texts: { id: 't.id', language: 't.language' },
+    texts: { id: 't.id', language: 't.language', title: 't.title' },
+    textChapters: { textId: 'tc.text_id', tokenCount: 'tc.token_count' },
     users: { id: 'u.id' },
   },
 }));
@@ -727,9 +728,9 @@ describe('readerCollectionContext', () => {
   it('reports prev/next around a middle text', async () => {
     queue.push([{ collection: baseCollection, position: 1 }]); // hit
     queue.push([
-      { textId: 'a', position: 0 },
-      { textId: 'b', position: 1 },
-      { textId: 'c', position: 2 },
+      { textId: 'a', position: 0, title: 'One', tokenCount: 100 },
+      { textId: 'b', position: 1, title: 'Two', tokenCount: 200 },
+      { textId: 'c', position: 2, title: 'Three', tokenCount: 300 },
     ]); // siblings
     const out = await readerCollectionContext('b');
     expect(out?.prevTextId).toBe('a');
@@ -741,8 +742,8 @@ describe('readerCollectionContext', () => {
   it('null prev for the first text + null next for the last', async () => {
     queue.push([{ collection: baseCollection, position: 0 }]); // first
     queue.push([
-      { textId: 'a', position: 0 },
-      { textId: 'b', position: 1 },
+      { textId: 'a', position: 0, title: 'One', tokenCount: 100 },
+      { textId: 'b', position: 1, title: 'Two', tokenCount: 200 },
     ]);
     const first = await readerCollectionContext('a');
     expect(first?.prevTextId).toBeNull();
@@ -750,12 +751,28 @@ describe('readerCollectionContext', () => {
 
     queue.push([{ collection: baseCollection, position: 1 }]); // last
     queue.push([
-      { textId: 'a', position: 0 },
-      { textId: 'b', position: 1 },
+      { textId: 'a', position: 0, title: 'One', tokenCount: 100 },
+      { textId: 'b', position: 1, title: 'Two', tokenCount: 200 },
     ]);
     const last = await readerCollectionContext('b');
     expect(last?.prevTextId).toBe('a');
     expect(last?.nextTextId).toBeNull();
+  });
+
+  it('surfaces the sibling chapter list with titles + token sums for the TOC', async () => {
+    queue.push([{ collection: baseCollection, position: 0 }]); // hit
+    queue.push([
+      { textId: 'a', position: 0, title: 'Prologue', tokenCount: 120 },
+      { textId: 'b', position: 1, title: '  ', tokenCount: 0 },
+      { textId: 'c', position: 2, title: 'Finale', tokenCount: 340 },
+    ]); // siblings
+    const out = await readerCollectionContext('a');
+    expect(out?.chapters).toEqual([
+      { textId: 'a', position: 0, title: 'Prologue', tokenCount: 120 },
+      // Blank title falls back to 'Untitled'.
+      { textId: 'b', position: 1, title: 'Untitled', tokenCount: 0 },
+      { textId: 'c', position: 2, title: 'Finale', tokenCount: 340 },
+    ]);
   });
 });
 

--- a/apps/web/src/lib/server/collections.ts
+++ b/apps/web/src/lib/server/collections.ts
@@ -782,12 +782,27 @@ export async function viewerHasCollectionShareForText(
  * a text that's a member of multiple collections still gives a
  * predictable nav strip.
  */
+/** One chapter (member text) of a collection, shaped for the reader's
+ *  chapter-selector TOC + whole-book progress. Each member of a
+ *  chapter-book is a single-chapter `texts` row, so `tokenCount` is the
+ *  sum of that text's chapter token counts (one chapter in practice). */
+export type ReaderCollectionChapter = {
+  textId: string;
+  position: number;
+  title: string;
+  tokenCount: number;
+};
+
 export type ReaderCollectionContext = {
   collection: Collection;
   position: number;
   prevTextId: string | null;
   nextTextId: string | null;
   totalCount: number;
+  /** Every sibling in display order — drives the reader's chapter TOC
+   *  dropdown and the whole-book progress math. Cheap to ship inline:
+   *  one small row per chapter (id + title + count). */
+  chapters: ReaderCollectionChapter[];
 };
 
 export async function readerCollectionContext(
@@ -808,17 +823,46 @@ export async function readerCollectionContext(
     .limit(1)) as Array<{ collection: Collection; position: number }>;
   if (!hit) return null;
 
+  // Pull every sibling with its title + summed token count in one
+  // grouped query — same COUNT/groupBy idiom as listCollectionsForUser.
+  // leftJoin on text_chapters so a member whose chapter rows haven't
+  // landed yet still appears (tokenCount 0) rather than dropping out.
   const siblings = (await db
     .select({
       textId: schema.collectionItems.textId,
       position: schema.collectionItems.position,
+      title: schema.texts.title,
+      tokenCount: sql<number>`COALESCE(SUM(${schema.textChapters.tokenCount}), 0)::int`,
     })
     .from(schema.collectionItems)
+    .innerJoin(
+      schema.texts,
+      eq(schema.texts.id, schema.collectionItems.textId),
+    )
+    .leftJoin(
+      schema.textChapters,
+      eq(schema.textChapters.textId, schema.collectionItems.textId),
+    )
     .where(eq(schema.collectionItems.collectionId, hit.collection.id))
+    .groupBy(
+      schema.collectionItems.textId,
+      schema.collectionItems.position,
+      schema.texts.title,
+    )
     .orderBy(asc(schema.collectionItems.position))) as Array<{
     textId: string;
     position: number;
+    title: string | null;
+    tokenCount: number;
   }>;
+  const chapters: ReaderCollectionChapter[] = siblings.map((s) => ({
+    textId: s.textId,
+    position: s.position,
+    // Empty / whitespace titles fall back to 'Untitled', matching the
+    // chapter-book creation default.
+    title: s.title?.trim() || 'Untitled',
+    tokenCount: Math.max(0, s.tokenCount ?? 0),
+  }));
   const totalCount = siblings.length;
   const idx = siblings.findIndex((s) => s.position === hit.position);
   return {
@@ -830,5 +874,6 @@ export async function readerCollectionContext(
         ? (siblings[idx + 1]?.textId ?? null)
         : null,
     totalCount,
+    chapters,
   };
 }

--- a/apps/web/src/lib/styles/tokens.css
+++ b/apps/web/src/lib/styles/tokens.css
@@ -86,8 +86,6 @@
   --w-l2-bg: oklch(0.86 0.1 75);
   --w-l3-bg: oklch(0.8 0.12 70);
   --w-known-bg: transparent;
-  --w-ignored-bg: transparent;
-  --w-ignored-ink: var(--ink-4);
   /* #435: admin "no definition yet" overlay. A magenta hue (≈330)
    * deliberately apart from the saffron status palette so flagged
    * words never read as a learning state. Ink is dark enough on the
@@ -356,14 +354,13 @@ html[data-hl='background'] .word[data-s='2'] {
 html[data-hl='background'] .word[data-s='3'] {
   background: var(--w-l3-bg);
 }
-html[data-hl='background'] .word[data-s='4'] {
-  background: var(--w-known-bg);
-}
+/* Known + ignored render identically — plain body text with no tint,
+ * underline, or strike-through. An ignored word is just one the reader
+ * never wants flagged (proper nouns, numbers), so it should read like a
+ * known word rather than being crossed out. */
+html[data-hl='background'] .word[data-s='4'],
 html[data-hl='background'] .word[data-s='5'] {
-  color: var(--w-ignored-ink);
-  text-decoration: line-through;
-  text-decoration-color: var(--ink-4);
-  text-decoration-thickness: 0.5px;
+  background: var(--w-known-bg);
 }
 
 html[data-hl='underline'] .word[data-s='0'] {
@@ -382,15 +379,9 @@ html[data-hl='underline'] .word[data-s='3'] {
   background: transparent;
   box-shadow: inset 0 -2.5px 0 oklch(0.62 0.15 70);
 }
-html[data-hl='underline'] .word[data-s='4'] {
-  box-shadow: none;
-}
+html[data-hl='underline'] .word[data-s='4'],
 html[data-hl='underline'] .word[data-s='5'] {
   box-shadow: none;
-  color: var(--w-ignored-ink);
-  text-decoration: line-through;
-  text-decoration-color: var(--ink-4);
-  text-decoration-thickness: 0.5px;
 }
 
 html[data-hl='colored_text'] .word[data-s='0'] {
@@ -409,16 +400,10 @@ html[data-hl='colored_text'] .word[data-s='3'] {
   background: transparent;
   color: oklch(0.45 0.15 70);
 }
-html[data-hl='colored_text'] .word[data-s='4'] {
+html[data-hl='colored_text'] .word[data-s='4'],
+html[data-hl='colored_text'] .word[data-s='5'] {
   color: var(--w-known-ink);
 }
-html[data-hl='colored_text'] .word[data-s='5'] {
-  color: var(--w-ignored-ink);
-  text-decoration: line-through;
-  text-decoration-color: var(--ink-4);
-  text-decoration-thickness: 0.5px;
-}
-
 /* —— Admin overlay: flag words with no definition yet (#435) ————————
  * Admins toggle `data-flag-undefined` on <html> from the reader
  * settings popover. While it's set, every word whose lemma carries no

--- a/apps/web/src/routes/+layout.server.ts
+++ b/apps/web/src/routes/+layout.server.ts
@@ -7,7 +7,7 @@ import {
   languageOption,
   resolveCurrentLanguage,
 } from '$lib/server/language-context.js';
-import type { LanguageCode } from '@ciareader/shared-types';
+import { isSupportedLanguage, type LanguageCode } from '@ciareader/shared-types';
 import type { LayoutServerLoad } from './$types';
 
 /**
@@ -29,7 +29,13 @@ export const load: LayoutServerLoad = async ({ locals, cookies }) => {
         .select({ language: userLanguages.language })
         .from(userLanguages)
         .where(eq(userLanguages.userId, locals.user.id));
-      activeCodes = rows.map((r) => r.language as LanguageCode);
+      // Filter to codes this build's registry knows about. A user may
+      // carry a row for a language added in a newer deploy (staged
+      // language rollout, or a worktree behind main); `languageOption`
+      // would otherwise crash the whole layout on the unknown code.
+      activeCodes = rows
+        .map((r) => r.language as string)
+        .filter(isSupportedLanguage);
     } catch (err) {
       // Don't take the layout offline over a bad query — the picker
       // just renders empty in that case.

--- a/apps/web/src/routes/reader/[textId]/+page.server.ts
+++ b/apps/web/src/routes/reader/[textId]/+page.server.ts
@@ -257,6 +257,10 @@ export const load: PageServerLoad = async ({ params, locals, url }) => {
           totalCount: collectionContext.totalCount,
           prevTextId: collectionContext.prevTextId,
           nextTextId: collectionContext.nextTextId,
+          // Full sibling list for the reader's chapter-selector TOC +
+          // whole-book progress (T-5.x reader chrome). One small row
+          // per chapter — cheap to ship inline.
+          chapters: collectionContext.chapters,
           // T-8.6: course-kind gate. UI flips the next link to a
           // disabled state with a tooltip; ?skipLock=1 overrides.
           nextLocked,

--- a/apps/web/src/routes/reader/[textId]/+page.svelte
+++ b/apps/web/src/routes/reader/[textId]/+page.svelte
@@ -27,7 +27,7 @@
     READING_WIDTH_REM,
     type ReaderSettings as ReaderSettingsT,
   } from '$lib/components/reader/reader-settings.js';
-  import type { LanguageCode } from '@ciareader/shared-types';
+  import { LANGUAGES, type LanguageCode } from '@ciareader/shared-types';
   import type { PageData } from './$types';
 
   let { data }: { data: PageData } = $props();
@@ -55,6 +55,13 @@
   $effect(() => {
     showRomanization = data.showRomanization;
   });
+  // Romanization only applies to non-Latin scripts. Basque (Latin) has
+  // no romanization layer, so the registry lists no schemes — hide the
+  // toggle entirely there, mirroring how ReaderSettings hides the
+  // scheme picker.
+  const canRomanize = $derived(
+    (LANGUAGES[data.text.language as LanguageCode]?.supportedRomanizations.length ?? 0) > 0,
+  );
 
   // T-5.1b: live reader settings. Seeded from the server-loaded
   // user_languages row; the popover updates this state on every
@@ -452,16 +459,18 @@
     </div>
 
     <div class="reader-tools">
-      <button
-        type="button"
-        class="roman-toggle"
-        data-active={showRomanization ? '1' : '0'}
-        onclick={toggleRomanization}
-        aria-pressed={showRomanization}
-        title="Toggle romanization"
-      >
-        Aa
-      </button>
+      {#if canRomanize}
+        <button
+          type="button"
+          class="roman-toggle"
+          data-active={showRomanization ? '1' : '0'}
+          onclick={toggleRomanization}
+          aria-pressed={showRomanization}
+          title="Toggle romanization"
+        >
+          Aa
+        </button>
+      {/if}
 
       {#if data.isAdmin || (data.isOwner && liveStatus === 'failed')}
         <!-- T-11.3: owners get a Retry button when their own text
@@ -644,7 +653,11 @@
   .reader-top {
     position: sticky;
     top: 0;
-    z-index: 5;
+    /* Above the body's page-flip arrows (z-index 8) so the chapter TOC
+       dropdown — which lives in this sticky header's stacking context —
+       overlays them. Stays below the overlay sheets (z-index 40) so a
+       mobile word/settings sheet still covers the header. */
+    z-index: 10;
     display: grid;
     grid-template-columns: 1fr;
     gap: 0.5rem 1rem;
@@ -657,6 +670,21 @@
       grid-template-columns: auto 1fr auto;
       align-items: center;
       padding: 1rem 1.75rem;
+    }
+  }
+  /* The side panel anchors BELOW the header (top: --reader-top-h), so
+     the header spans the full width. Cancel the reader's side-panel
+     padding here so the right-aligned tools reach the true right edge
+     instead of stopping at the panel's left boundary. */
+  @media (min-width: 960px) {
+    .reader-top {
+      margin-right: -380px;
+      /* Desktop shows the word panel as a static column (z-index 40).
+         Lift the header above it so the chapter TOC dropdown clears the
+         panel on narrower desktop widths where it would otherwise be
+         occluded. The panel is non-dimmed here, so the header sitting
+         above it is fine. */
+      z-index: 41;
     }
   }
   /* T-5.27: small × close button replacing the "← Library" crumb. */
@@ -729,8 +757,26 @@
   .reader-tools {
     display: flex;
     align-items: center;
+    justify-content: flex-end;
     gap: 0.5rem;
     flex-wrap: wrap;
+  }
+  /* Settings gear is a plain icon button — no border, no fill, just the
+     same muted ink as the other tools, with a subtle hover. */
+  .settings-toggle {
+    width: 32px;
+    height: 32px;
+    display: grid;
+    place-items: center;
+    border: 0;
+    border-radius: 8px;
+    background: transparent;
+    color: var(--ink-2, var(--color-fg-muted));
+    cursor: pointer;
+  }
+  .settings-toggle:hover {
+    background: color-mix(in oklch, var(--ink, var(--color-fg)) 6%, transparent);
+    color: var(--ink, var(--color-fg));
   }
   .roman-toggle {
     width: 32px;

--- a/apps/web/src/routes/reader/[textId]/+page.svelte
+++ b/apps/web/src/routes/reader/[textId]/+page.svelte
@@ -4,6 +4,7 @@
 
   import AlignmentHighlighter from '$lib/components/reader/AlignmentHighlighter.svelte';
   import AudioPlayer from '$lib/components/reader/AudioPlayer.svelte';
+  import ChapterNav from '$lib/components/reader/ChapterNav.svelte';
   import ReaderContinuous from '$lib/components/reader/ReaderContinuous.svelte';
   import ReaderPage from '$lib/components/reader/ReaderPage.svelte';
   import ReaderScroll from '$lib/components/reader/ReaderScroll.svelte';
@@ -11,6 +12,7 @@
   import { ProgressWriter, type ProgressAnchor } from '$lib/components/reader/progress-client.js';
   import { computePctRead } from '$lib/components/reader/reader-progress.js';
   import { buildReaderAnchorUrl } from '$lib/components/reader/url-anchor.js';
+  import { buildReaderToc } from '$lib/components/reader/reader-toc.js';
   import {
     isImmersiveAttributeSet,
     setImmersiveAttribute,
@@ -160,6 +162,29 @@
     setFlagUndefinedAttribute(data.isAdmin && flagUndefined);
     return () => setFlagUndefinedAttribute(false);
   });
+
+  // Chapter table-of-contents model — drives the shared chapter
+  // selector dropdown + the page footer's whole-book progress. Handles
+  // both layouts uniformly: multi-chapter texts (jump via ?chapter=N)
+  // and chapter-books (each chapter is its own text, jump via textId).
+  const toc = $derived(
+    buildReaderToc({
+      textId: data.text.id,
+      mode: data.mode,
+      chapters: data.chapters.map((c) => ({
+        idx: c.idx,
+        title: c.title,
+        tokenCount: c.tokenCount,
+      })),
+      currentChapterIdx: data.anchor.chapterIdx,
+      collection: data.collectionContext
+        ? {
+            chapters: data.collectionContext.chapters,
+            position: data.collectionContext.position,
+          }
+        : null,
+    }),
+  );
 
   function shouldPoll(s: typeof data.text.status): boolean {
     return s === 'pending' || s === 'processing';
@@ -377,59 +402,53 @@
 
 <div class="reader" data-mode={data.mode} style={readerStyle}>
   <header class="reader-top" bind:this={readerTopEl}>
-    <a class="reader-close" href="/library" aria-label="Close reader" title="Close reader">
-      <svg
-        viewBox="0 0 24 24"
-        width="14"
-        height="14"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="1.8"
-        stroke-linecap="round"
-        aria-hidden="true"
-      >
-        <path d="M6 6l12 12" />
-        <path d="M18 6L6 18" />
-      </svg>
-    </a>
-    <div class="reader-meta">
+    <div class="reader-top-left">
+      <a class="reader-close" href="/library" aria-label="Close reader" title="Close reader">
+        <svg
+          viewBox="0 0 24 24"
+          width="14"
+          height="14"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.8"
+          stroke-linecap="round"
+          aria-hidden="true"
+        >
+          <path d="M6 6l12 12" />
+          <path d="M18 6L6 18" />
+        </svg>
+      </a>
       {#if data.collectionContext}
-        <p class="reader-coll-strip">
-          <span class="reader-coll-nav">
-            {#if data.collectionContext.prevTextId}
-              <a
-                href={`/reader/${data.collectionContext.prevTextId}`}
-                class="reader-coll-arrow"
-                title="Previous text"
-                aria-label="Previous text in collection">‹ prev</a
-              >
-            {/if}
-            {#if data.collectionContext.nextTextId}
-              {#if data.collectionContext.nextLocked}
-                <a
-                  href={`/reader/${data.collectionContext.nextTextId}?skipLock=1`}
-                  class="reader-coll-arrow reader-coll-locked"
-                  title="Course gate — finish this text or click to skip"
-                  aria-label="Next text (locked — finish to advance, or click to skip)">next 🔒</a
-                >
-              {:else}
-                <a
-                  href={`/reader/${data.collectionContext.nextTextId}`}
-                  class="reader-coll-arrow"
-                  title="Next text"
-                  aria-label="Next text in collection">next ›</a
-                >
-              {/if}
-            {/if}
-          </span>
-        </p>
+        <a
+          class="reader-book"
+          href={`/collections/${data.collectionContext.collectionId}`}
+          title={data.collectionContext.collectionTitle}
+        >
+          {data.collectionContext.collectionTitle}
+        </a>
+      {:else}
+        <span class="reader-book reader-book-static" title={data.text.title}>
+          {data.text.title}
+        </span>
       {/if}
-      <h1 class="t">{data.text.title}</h1>
-      <p class="a">
-        <span class="badge">{data.text.language}</span>
-        <span class="badge status-{liveStatus}">{statusLabel}</span>
-        <span class="badge">{data.text.visibility}</span>
-      </p>
+    </div>
+
+    <div class="reader-top-center">
+      {#if toc.entries.length > 1}
+        <ChapterNav
+          entries={toc.entries}
+          currentIndex={toc.currentIndex}
+          nextLocked={data.collectionContext?.nextLocked ?? false}
+        />
+      {/if}
+      {#if liveStatus !== 'ready'}
+        <span
+          class="reader-status reader-status-{liveStatus}"
+          role={liveStatus === 'failed' ? 'alert' : 'status'}
+        >
+          {statusLabel}
+        </span>
+      {/if}
     </div>
 
     <div class="reader-tools">
@@ -535,6 +554,8 @@
       nextTextId={data.collectionContext?.nextTextId ?? null}
       collectionPosition={data.collectionContext?.position ?? null}
       collectionTotal={data.collectionContext?.totalCount ?? null}
+      bookWordsBefore={toc.bookWordsBefore}
+      bookWordsTotal={toc.bookWordsTotal}
       startAtEndOfChapter={data.anchor.endOfChapter ?? false}
     />
   {:else if data.mode === 'paged_scroll'}
@@ -658,79 +679,52 @@
     background: color-mix(in oklch, var(--ink, var(--color-fg)) 6%, transparent);
     border-color: var(--rule, var(--color-border));
   }
-  .reader-meta {
+  .reader-top-left {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
     min-width: 0;
   }
-  .reader-coll-strip {
-    margin: 0 0 0.25rem;
-    display: flex;
-    align-items: baseline;
-    gap: 0.55rem;
-    font-size: 0.7rem;
-    color: var(--ink-3, var(--color-fg-muted));
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    flex-wrap: wrap;
-  }
-  .reader-coll-nav {
-    display: flex;
-    gap: 0.5rem;
-    margin-left: auto;
-  }
-  .reader-coll-arrow {
-    color: var(--accent, var(--color-accent));
-    text-decoration: none;
-    font-weight: 500;
-  }
-  .reader-coll-arrow:hover {
-    text-decoration: underline;
-  }
-  .reader-coll-locked {
-    color: var(--ink-3, var(--color-fg-muted));
-    opacity: 0.7;
-  }
-  .reader-meta .t {
-    margin: 0;
+  /* Book / collection title on the left — links to the collection page
+     when this text is a chapter of one, otherwise a plain label. */
+  .reader-book {
     font-family: var(--font-serif-dev, var(--font-serif));
-    font-size: 1.125rem;
+    font-size: 0.95rem;
     font-weight: 500;
-    color: var(--ink, var(--color-fg));
+    color: var(--ink-2, var(--color-fg));
+    text-decoration: none;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    max-width: min(40vw, 18rem);
   }
-  .reader-meta .a {
-    margin: 0.15rem 0 0;
+  a.reader-book:hover {
+    color: var(--ink, var(--color-fg));
+    text-decoration: underline;
+  }
+  .reader-book-static {
+    color: var(--ink, var(--color-fg));
+  }
+  .reader-top-center {
     display: flex;
-    flex-wrap: wrap;
-    gap: 0.3rem;
+    align-items: center;
+    justify-content: center;
+    gap: 0.6rem;
+    min-width: 0;
+  }
+  /* Processing / failed shown as plain inline text (no pill). */
+  .reader-status {
     font-family: var(--font-sans, var(--font-ui));
-    font-size: 0.78rem;
+    font-size: 0.72rem;
+    white-space: nowrap;
     color: var(--ink-3, var(--color-fg-muted));
   }
-  .badge {
-    display: inline-flex;
-    align-items: center;
-    height: 22px;
-    padding: 0 0.6rem;
-    border-radius: 999px;
-    background: color-mix(in oklch, var(--ink, var(--color-fg)) 6%, transparent);
-    color: var(--ink-2, var(--color-fg-muted));
-    font-size: 0.7rem;
-    letter-spacing: 0.01em;
-  }
-  .status-ready {
-    background: var(--green-soft, color-mix(in srgb, #197a2f 12%, transparent));
-    color: var(--green, #197a2f);
-  }
-  .status-failed {
-    background: var(--rose-soft, color-mix(in srgb, #b03131 12%, transparent));
-    color: var(--rose, #b03131);
-  }
-  .status-processing,
-  .status-pending {
-    background: var(--accent-soft, color-mix(in srgb, #b07a31 12%, transparent));
+  .reader-status-processing,
+  .reader-status-pending {
     color: var(--accent-ink, #b07a31);
+  }
+  .reader-status-failed {
+    color: var(--rose, #b03131);
   }
   .reader-tools {
     display: flex;

--- a/apps/web/src/routes/reader/[textId]/page-server.test.ts
+++ b/apps/web/src/routes/reader/[textId]/page-server.test.ts
@@ -63,10 +63,11 @@ vi.mock('$lib/server/texts/progress.js', async () => {
 // `userLanguagesRow`.
 let userLanguagesRow: Record<string, unknown> | null = null;
 // T-8.3: the loader now calls readerCollectionContext. Mock to
-// "no collection" so existing tests stay focused on the reader
-// surface; tests that care can override.
+// "no collection" by default so existing tests stay focused on the
+// reader surface; tests that care stage a return value.
+const readerCollectionContext = vi.fn();
 vi.mock('$lib/server/collections.js', () => ({
-  readerCollectionContext: async () => null,
+  readerCollectionContext: (...a: unknown[]) => readerCollectionContext(...a),
 }));
 
 // T-9.1: the loader pulls audio for the active text + chapter.
@@ -160,6 +161,9 @@ beforeEach(() => {
   getTextProgress.mockResolvedValue(null);
   // No persisted reader settings unless a test stages a row.
   userLanguagesRow = null;
+  // Default to "text belongs to no collection".
+  readerCollectionContext.mockReset();
+  readerCollectionContext.mockResolvedValue(null);
 });
 
 afterEach(() => {
@@ -505,6 +509,36 @@ describe('/reader/[textId] loader', () => {
     // Loader is called once with the active chapter id + viewer id.
     expect(loadChapterPhraseSpans).toHaveBeenCalledTimes(1);
     expect(loadChapterPhraseSpans).toHaveBeenCalledWith('c0', USER.id);
+  });
+
+  it('surfaces the collection chapter list for the chapter-selector TOC', async () => {
+    getReadableText.mockResolvedValueOnce(ownedTextWithChapters(1));
+    readerCollectionContext.mockResolvedValueOnce({
+      collection: { id: 'col-1', title: 'Big Book', kind: 'chapter_book' },
+      position: 1,
+      totalCount: 3,
+      prevTextId: 'prev-text',
+      nextTextId: 'next-text',
+      chapters: [
+        { textId: 'prev-text', position: 0, title: 'One', tokenCount: 100 },
+        { textId: VALID_ID, position: 1, title: 'Two', tokenCount: 200 },
+        { textId: 'next-text', position: 2, title: 'Three', tokenCount: 300 },
+      ],
+    });
+    const data = (await callLoad(`http://x/reader/${VALID_ID}`)) as {
+      collectionContext: {
+        chapters: Array<{ textId: string; title: string; tokenCount: number }>;
+      } | null;
+    };
+    expect(data.collectionContext?.chapters).toHaveLength(3);
+    expect(data.collectionContext?.chapters[1]).toEqual({
+      textId: VALID_ID,
+      position: 1,
+      title: 'Two',
+      tokenCount: 200,
+    });
+    // The TOC list must not blow the mobile SSR payload budget.
+    expect(jsonPayloadBytes(data)).toBeLessThan(MOBILE_RESPONSE_BUDGET_BYTES);
   });
 
   it('skips phraseSpans loading when the chapter has no tokens (T-14.3)', async () => {


### PR DESCRIPTION
## What & why

Reworks the page-mode reader chrome around a reference layout, and fixes a real progress bug for chapter-books.

### Chapter selector + table-of-contents
- A centered chapter selector in the shared reader chrome: the current chapter title (plain text, no pill) flanked by prev/next **chapter** arrows, with a caret that opens a dropdown **TOC listing every chapter and its word count**.
- Works uniformly for both layouts: multi-chapter texts (`?chapter=N`) and **chapter-books** (each chapter is its own one-chapter text inside a collection — navigates per-text), preserving the active reader mode. Reuses the AppShell dropdown pattern (outside-click + Esc + `role="menu"`/`aria-checked`, arrow-key nav shielded from the page-flip handler).

### Whole-book progress (the bug fix)
- A chapter-book's footer used to run **0→100% per chapter** because progress was computed over the single loaded chapter-text. The footer now spans the **whole book** and only reaches 100% on the final chapter.
- `readerCollectionContext` is extended to return the sibling list (title + summed `tokenCount`) in one grouped query, feeding both the TOC and the book-total math.
- **Display-only:** persisted per-text `pctRead` is unchanged, so course gating (T-8.6) and library cards keep their per-text contract. New pure helpers `buildReaderToc` + `bookProgressPct` carry unit coverage.
- Footer is now three columns — `Page N of M` · book range · `Ch. X / Y` — with a position dot on a full-width bar.

### Top-bar cleanup
- Dropped the decorative language/status/visibility **badge pills** (status shows as plain text only when not ready).
- Hide the romanization (**Aa**) toggle for languages with no romanization schemes in the registry (e.g. **Basque**, Latin script).
- Settings gear is now a plain borderless icon button (was falling back to default browser button chrome); tools are right-aligned.

### Other
- `fix(reader)`: ignored words render like known words — no strike-through/underline (was crossed out).
- `fix(layout)`: skip `user_languages` codes the build's registry doesn't recognize, so an unknown code can't 500 the whole layout (defensive; surfaced while testing a worktree behind `main`). Drop this commit if you'd rather not include it.

### Top-bar tools
- Hide the romanization (**Aa**) toggle for languages with no romanization schemes (e.g. Basque).
- Settings gear is a plain borderless icon button; tools are right-aligned.
- The header spans full width on desktop (cancels the word-panel padding) so the tools reach the true right edge.
- Raise the sticky header's z-index above the page-flip arrows + desktop word panel so the chapter TOC dropdown overlays them.

## Commits
- `feat(reader)`: chapter selector + TOC dropdown and whole-book progress
- `fix(reader)`: render ignored words like known words
- `fix(layout)`: skip unrecognized user_languages codes
- `fix(reader)`: tidy reader top-bar tools
- `test(e2e)`: align reader-progress spec with whole-book footer

## Testing
- `pnpm check` (svelte-check) 0/0, `eslint` clean, `pnpm test` **1772 passing** (incl. new `reader-toc` / `ChapterNav` / `bookProgressPct` tests + extended collections/loader tests).
- `pnpm test:e2e` **8 Playwright tests passing** (reader cross-text nav + the rewritten whole-book progress spec).
- Manually verified against a real 48-chapter Hindi chapter-book and a Basque collection (Aa hidden, dropdown over the page arrows), in page mode.

> No ticket number was supplied for this work — happy to add `Closes #N` / `Refs #N` if you point me at the issue(s).
