### PR TITLE
fix(reader): Basque popup fixes — all-caps lemma, ref-search snap-back, headword translations

### DIFF
--- a/apps/web/src/lib/components/reader/WordPopup.svelte
+++ b/apps/web/src/lib/components/reader/WordPopup.svelte
@@ -331,6 +331,7 @@
     // tab is intentionally preserved across words.
     adminRefResults = null;
     adminRefWord = null;
+    adminRefAutoFor = null;
     adminRefError = null;
     adminRefLoading = false;
     adminRefSearch = '';
@@ -436,7 +437,14 @@
   let adminRefLoading = $state(false);
   let adminRefError = $state<string | null>(null);
   let adminRefResults = $state<BasqueRefResult[] | null>(null);
+  // The word whose results are currently shown (the last lookup, manual or
+  // auto). Distinct from `adminRefAutoFor` below.
   let adminRefWord = $state<string | null>(null);
+  // The parsed lemma the auto-load effect last fetched for. Tracked
+  // separately from `adminRefWord` so a manual search (which changes
+  // `adminRefWord`) doesn't make the effect think the token changed and
+  // re-load the parsed headword on top of the admin's search.
+  let adminRefAutoFor = $state<string | null>(null);
   // Reference search box (replaces the static header): seeded from the lemma,
   // editable, with Elhuyar autocomplete so the admin can pick the exact entry
   // ("Afrika", not "afrikaans") even when the parsed lemma is wrong/mis-cased.
@@ -567,10 +575,16 @@
   }
 
   // Auto-load on open — the panel is expanded by default (no toggle).
+  // Fires once per parsed lemma (tracked in `adminRefAutoFor`); a manual
+  // search updates `adminRefWord`, not `adminRefAutoFor`, so it won't be
+  // clobbered here. A new token resets `adminRefAutoFor` (token effect),
+  // and selecting an internal lemma changes `adminRefLookupWord`, both of
+  // which legitimately re-trigger the auto-load.
   $effect(() => {
     if (!showAdminRef) return;
     const word = adminRefLookupWord;
-    if (!word || adminRefWord === word) return;
+    if (!word || adminRefAutoFor === word) return;
+    adminRefAutoFor = word;
     void loadAdminRef();
   });
 
@@ -595,6 +609,17 @@
         }
       }
       internalResults = [...byHeadword.values()].slice(0, 8);
+      // If the typed text exactly matches a dictionary headword, load its
+      // translations straight away: editing the headword should update the
+      // Translations panel, not just the suggestion list. Guarded on the
+      // lemma id so we don't refetch the entry that's already shown.
+      const wanted = term.normalize('NFC').toLowerCase();
+      const exact = [...byHeadword.values()].find(
+        (r) => r.headword.normalize('NFC').toLowerCase() === wanted,
+      );
+      if (exact && exact.id !== payload?.lemma.id) {
+        void loadLemmaTranslations(exact);
+      }
     } catch {
       /* internal search is a convenience — ignore failures */
     }
@@ -620,12 +645,9 @@
     }
   }
 
-  // Clicking an internal result loads that lemma's full translations into the
-  // normal Translations section.
-  async function selectInternalLemma(hit: InternalHit): Promise<void> {
-    headwordInput = hit.headword;
-    headwordEdited = true;
-    internalResults = [];
+  // Load a dictionary lemma's full translations into the normal Translations
+  // section. Shared by the click handler and the type-an-exact-match path.
+  async function loadLemmaTranslations(hit: InternalHit): Promise<void> {
     loadError = null;
     try {
       const res = await fetch(`/api/v1/lemmas/${hit.id}/translations`);
@@ -634,6 +656,15 @@
     } catch (e) {
       loadError = `Network error: ${(e as Error).message}`;
     }
+  }
+
+  // Clicking an internal result (or pressing Enter on the top one) loads that
+  // lemma and closes the suggestion list.
+  async function selectInternalLemma(hit: InternalHit): Promise<void> {
+    headwordInput = hit.headword;
+    headwordEdited = true;
+    internalResults = [];
+    await loadLemmaTranslations(hit);
   }
 
   // Seed the editable headword from the resolved word, but never clobber an
@@ -1591,10 +1622,11 @@
         {:else}
           <h2 class="sp-word">
             <!-- Editable headword: type over it to search the internal
-                 dictionary as you go (results below; click one to load it into
-                 the Translations section). After a pause it also re-runs the
-                 admin reference lookup for the typed word. Lets you recover when
-                 the NLP parsed the wrong lemma. -->
+                 dictionary as you go (results below). An exact headword match
+                 — or Enter / clicking a result — loads that lemma into the
+                 Translations section. After a pause it also re-runs the admin
+                 reference lookup for the typed word. Lets you recover when the
+                 NLP parsed the wrong lemma. -->
             <input
               class="sp-word-input"
               data-testid="headword-input"
@@ -1605,7 +1637,13 @@
               value={headwordInput}
               oninput={(e) => onHeadwordInput((e.currentTarget as HTMLInputElement).value)}
               onkeydown={(e) => {
-                if (e.key === 'Escape') internalResults = [];
+                if (e.key === 'Escape') {
+                  internalResults = [];
+                } else if (e.key === 'Enter' && internalResults[0]) {
+                  // Load the top suggestion without forcing a click.
+                  e.preventDefault();
+                  void selectInternalLemma(internalResults[0]);
+                }
               }}
             />
             {#if payload}
@@ -2145,7 +2183,7 @@
         </div>
         {#if adminRefLoading}
           <p class="muted small" data-testid="admin-ref-loading">
-            Looking up “{adminRefLookupWord}”…
+            Looking up “{adminRefWord ?? adminRefLookupWord}”…
           </p>
         {:else if adminRefError}
           <p class="err small" data-testid="admin-ref-error">{adminRefError}</p>

--- a/apps/web/src/lib/components/reader/WordPopup.test.ts
+++ b/apps/web/src/lib/components/reader/WordPopup.test.ts
@@ -674,6 +674,75 @@ describe('WordPopup — admin Basque reference panel', () => {
     });
     expect(document.body.querySelector('[data-testid="admin-ref"]')).toBeNull();
   });
+
+  it('keeps a manual reference search and does not snap back to the parsed headword', async () => {
+    // Reference results vary by the `word=` query param, and carry an entry
+    // in every language tab so the assertion holds whichever tab is active.
+    const refFor = (word: string) => ({
+      word,
+      results: ['elhuyar_es', 'elhuyar_en', 'euskaltzaindia'].map((source) => ({
+        source,
+        label: source,
+        headword: word,
+        pos: 'iz.',
+        definition: `def-${word}`,
+        examples: [],
+        url: `https://hiztegiak.elhuyar.eus/eu/${word}`,
+      })),
+    });
+    const fetchMock = vi.fn(async (input: unknown) => {
+      const url = new URL(String(input), 'http://localhost');
+      if (url.pathname.includes('/admin/basque-dictionary/autocomplete')) {
+        return jres({ term: url.searchParams.get('term'), terms: [] });
+      }
+      if (url.pathname.includes('/admin/basque-dictionary')) {
+        return jres(refFor(url.searchParams.get('word') ?? ''));
+      }
+      return jres(TRANSLATIONS);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(WordPopup, {
+      token: makeToken({ surface: 'etxe', lemmaId: 'lem-eu' }),
+      language: 'eu',
+      isOwner: false,
+      isAdmin: true,
+      onClose: vi.fn(),
+    });
+
+    // Auto-load shows the parsed headword's entry first.
+    await waitFor(() => {
+      expect(document.body.querySelector('[data-testid="admin-ref"]')!.textContent).toContain(
+        'def-etxe',
+      );
+    });
+
+    // Admin searches a different word in the reference box.
+    const search = document.body.querySelector<HTMLInputElement>('[data-testid="ref-search"]')!;
+    search.value = 'pena';
+    search.dispatchEvent(new Event('input', { bubbles: true }));
+    search.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+    // The panel shows the searched word's entry…
+    await waitFor(() => {
+      expect(document.body.querySelector('[data-testid="admin-ref"]')!.textContent).toContain(
+        'def-pena',
+      );
+    });
+
+    // …and does not revert to the parsed headword (the bug). Give any pending
+    // auto-load effect a chance to fire, then confirm the search held.
+    await new Promise((r) => setTimeout(r, 50));
+    const panel = document.body.querySelector('[data-testid="admin-ref"]')!;
+    expect(panel.textContent).toContain('def-pena');
+    expect(panel.textContent).not.toContain('def-etxe');
+    // The parsed headword was fetched exactly once (on open) — no auto-reload
+    // stomped the manual search.
+    const etxeCalls = fetchMock.mock.calls.filter((c) =>
+      String(c[0]).includes('basque-dictionary?word=etxe'),
+    );
+    expect(etxeCalls.length).toBe(1);
+  });
 });
 
 describe('WordPopup — book frequency', () => {
@@ -1764,6 +1833,117 @@ describe('WordPopup — editable headword search', () => {
         ),
       ).toBe(true);
     });
+    expect(input.value).toBe('pena');
+  });
+
+  it('loads translations on an exact headword match as you type (no click)', async () => {
+    const fetchMock = vi.fn(async (input: unknown) => {
+      const url = String(input);
+      if (url.includes('/dictionary/eu/lemmas')) {
+        return jres({
+          lemmas: [{ id: 'lem-pena', headword: 'pena', pos: 'NOUN', glossDefault: 'sorrow' }],
+        });
+      }
+      if (url.includes('/api/v1/lemmas/lem-pena/translations')) {
+        return jres({
+          lemma: { id: 'lem-pena', headword: 'pena', pos: 'NOUN', glossDefault: 'sorrow' },
+          translations: { personal: [], official: [], community: [] },
+        });
+      }
+      return jres({
+        lemma: { id: 'lem-1', headword: 'Pena', pos: 'PROPN', glossDefault: null },
+        translations: { personal: [], official: [], community: [] },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(WordPopup, {
+      token: makeToken({ surface: 'Pena', lemmaId: 'lem-1' }),
+      language: 'eu',
+      isOwner: false,
+      onClose: vi.fn(),
+    });
+
+    const input = await waitFor(() => {
+      const el = document.body.querySelector<HTMLInputElement>('[data-testid="headword-input"]');
+      if (!el) throw new Error('no headword input');
+      return el;
+    });
+
+    input.value = 'pena';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+
+    // Typing the exact headword loads that lemma's translations — no click on
+    // the suggestion list required.
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some((c) =>
+          String(c[0]).includes('/api/v1/lemmas/lem-pena/translations'),
+        ),
+      ).toBe(true);
+    });
+    // No suggestion was clicked.
+    expect(document.body.querySelector('.sp-word-result')).not.toBeNull();
+  });
+
+  it('loads the top suggestion when Enter is pressed (no exact match, no click)', async () => {
+    const fetchMock = vi.fn(async (input: unknown) => {
+      const url = String(input);
+      if (url.includes('/dictionary/eu/lemmas')) {
+        return jres({
+          lemmas: [{ id: 'lem-pena', headword: 'pena', pos: 'NOUN', glossDefault: 'sorrow' }],
+        });
+      }
+      if (url.includes('/api/v1/lemmas/lem-pena/translations')) {
+        return jres({
+          lemma: { id: 'lem-pena', headword: 'pena', pos: 'NOUN', glossDefault: 'sorrow' },
+          translations: { personal: [], official: [], community: [] },
+        });
+      }
+      return jres({
+        lemma: { id: 'lem-1', headword: 'Pena', pos: 'PROPN', glossDefault: null },
+        translations: { personal: [], official: [], community: [] },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(WordPopup, {
+      token: makeToken({ surface: 'Pena', lemmaId: 'lem-1' }),
+      language: 'eu',
+      isOwner: false,
+      onClose: vi.fn(),
+    });
+
+    const input = await waitFor(() => {
+      const el = document.body.querySelector<HTMLInputElement>('[data-testid="headword-input"]');
+      if (!el) throw new Error('no headword input');
+      return el;
+    });
+
+    // A prefix that does not exactly match the headword: nothing auto-loads.
+    input.value = 'pen';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    await waitFor(() => {
+      expect(
+        document.body.querySelector('[data-testid="headword-results"]')?.textContent,
+      ).toContain('pena');
+    });
+    expect(
+      fetchMock.mock.calls.some((c) =>
+        String(c[0]).includes('/api/v1/lemmas/lem-pena/translations'),
+      ),
+    ).toBe(false);
+
+    // Enter loads the top suggestion and closes the list.
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some((c) =>
+          String(c[0]).includes('/api/v1/lemmas/lem-pena/translations'),
+        ),
+      ).toBe(true);
+    });
+    expect(document.body.querySelector('[data-testid="headword-results"]')).toBeNull();
     expect(input.value).toBe('pena');
   });
 });

--- a/services/nlp/app/pipelines/stanza_ud.py
+++ b/services/nlp/app/pipelines/stanza_ud.py
@@ -78,11 +78,7 @@ def _has_target_script(surface: str, script: str | None) -> bool:
     ranges = _SCRIPT_RANGES.get(script)
     if ranges is None:
         return True
-    return any(
-        start <= ord(ch) <= end
-        for ch in surface
-        for start, end in ranges
-    )
+    return any(start <= ord(ch) <= end for ch in surface for start, end in ranges)
 
 
 def _has_letter(surface: str) -> bool:
@@ -119,6 +115,28 @@ def should_treat_as_word(surface: str, upos: str, *, script: str | None) -> bool
     if _has_letter(surface) and not _has_target_script(surface, script):
         return False
     return True
+
+
+def _is_allcaps_word(surface: str) -> bool:
+    """Return True for a multi-letter, fully-uppercase surface.
+
+    Headings and emphasised words ("HITZAURREA") confuse Stanza's
+    lemmatizer: its dictionary cache is keyed on normal case, so an
+    all-caps form that misses the cache falls through to the character
+    seq2seq model, which can drop or duplicate letters
+    ("HITZAURREA" → "hitzaure" instead of "hitzaurre"). Title-case
+    ("Hitzaurrea") and lowercase forms hit the cache and lemmatize
+    correctly, so they return False here.
+
+    ``str.isupper()`` is only True when there is at least one cased
+    character and every cased character is uppercase, so non-cased
+    scripts (Devanagari, Odia, Hebrew) always return False — the
+    re-lemmatization path never fires for them. The ≥2-letter floor
+    skips single initials ("A") where a re-run buys nothing.
+    """
+    if not surface.isupper():
+        return False
+    return sum(1 for ch in surface if ch.isalpha()) >= 2
 
 
 def _trailing_split_mark(surface: str) -> str | None:
@@ -214,6 +232,9 @@ class StanzaUDPipeline(Pipeline):
         tokens: list[Token] = []
         idx = 0
         cursor = 0
+        # Memoizes the lowercased re-lemmatization of all-caps words so a
+        # heading repeated across a chapter only runs the extra pass once.
+        relemma_cache: dict[str, str | None] = {}
         for sentence in doc.sentences:
             for word in sentence.words:
                 start = getattr(word, "start_char", None)
@@ -247,6 +268,16 @@ class StanzaUDPipeline(Pipeline):
                     upos,
                     script=self._script,
                 )
+                # Repair the lemma of an all-caps lexical word by
+                # re-lemmatizing a lowercased copy (see
+                # ``_is_allcaps_word``). PROPN / NUM / SYM / X are skipped:
+                # a proper noun's capitalized lemma and the
+                # ``lemma == surface`` contract for the rest would only
+                # regress under lowercasing.
+                if is_word and upos not in NON_OOV_UPOS and _is_allcaps_word(surface):
+                    repaired = self._relemmatize_lower(surface, relemma_cache)
+                    if repaired:
+                        lemma = repaired
                 is_oov = is_word and lemma == surface and upos not in NON_OOV_UPOS
                 tokens.append(
                     Token(
@@ -304,6 +335,29 @@ class StanzaUDPipeline(Pipeline):
                 tokens.append(self._make_gap_token(idx, tail))
         return tokens
 
+    def _relemmatize_lower(self, surface: str, cache: dict[str, str | None]) -> str | None:
+        """Lemmatize a lowercased copy of ``surface`` and return its lemma.
+
+        Used to recover a usable lemma for an all-caps word whose
+        uppercased form tripped Stanza's seq2seq fallback. Returns
+        ``None`` (caller keeps the original lemma) when the lowercased
+        form re-tokenizes into anything other than a single lemmatized
+        word, so we never silently swap in a lemma derived from a
+        different segmentation. Results are memoized in ``cache``.
+        """
+        key = surface.lower()
+        if key in cache:
+            return cache[key]
+        result: str | None = None
+        redoc = self._nlp(key)
+        words = [w for s in redoc.sentences for w in s.words]
+        if len(words) == 1:
+            candidate = (words[0].lemma or "").strip()
+            if candidate:
+                result = candidate
+        cache[key] = result
+        return result
+
     @staticmethod
     def _doc_has_offsets(doc: Any) -> bool:
         for sentence in getattr(doc, "sentences", ()):
@@ -345,6 +399,7 @@ __all__ = [
     "NON_WORD_UPOS",
     "StanzaLike",
     "StanzaUDPipeline",
+    "_is_allcaps_word",
     "_trailing_split_mark",
     "parse_feats",
     "should_treat_as_word",

--- a/services/nlp/tests/test_basque_pipeline.py
+++ b/services/nlp/tests/test_basque_pipeline.py
@@ -1,0 +1,149 @@
+"""Unit tests for :class:`app.pipelines.basque.BasquePipeline`.
+
+Like the Hindi/Marathi pipeline tests, these inject a minimal fake
+Stanza-like object so we exercise the pipeline's output-shaping logic
+without the ~600MB UD_Basque-BDT model. The focus here is the all-caps
+lemma-repair pass (see ``_is_allcaps_word`` / ``_relemmatize_lower`` in
+``app.pipelines.stanza_ud``): Stanza's character seq2seq fallback mangles
+all-caps words ("HITZAURREA" → "hitzaure"), so the pipeline re-lemmatizes
+a lowercased copy and adopts that lemma for genuine lexical words.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from app.pipelines.basque import BasquePipeline
+from app.pipelines.stanza_ud import _is_allcaps_word
+
+
+@dataclass
+class FakeWord:
+    text: str
+    lemma: str | None = None
+    upos: str = "NOUN"
+    feats: str | None = None
+
+
+@dataclass
+class FakeSentence:
+    words: list[FakeWord] = field(default_factory=list)
+
+
+@dataclass
+class FakeDoc:
+    sentences: list[FakeSentence] = field(default_factory=list)
+
+
+class CasingFakeStanza:
+    """Fake whose lemmatization depends on the *case* of the input.
+
+    Mirrors how the real Basque model behaves: a normal-case word that
+    hits the dictionary cache lemmatizes correctly, while an all-caps
+    form misses the cache and the seq2seq fallback drops a letter. The
+    ``table`` maps an exact input string to the ``(text, lemma, upos)``
+    rows it should produce; unknown inputs fall back to one NOUN whose
+    lemma equals the surface.
+    """
+
+    def __init__(self, table: dict[str, list[tuple[str, str, str]]]) -> None:
+        self._table = table
+        self.calls: list[str] = []
+
+    def __call__(self, text: str) -> FakeDoc:
+        self.calls.append(text)
+        rows = self._table.get(text, [(text, text, "NOUN")])
+        words = [FakeWord(text=t, lemma=lm, upos=up) for (t, lm, up) in rows]
+        return FakeDoc(sentences=[FakeSentence(words=words)] if words else [])
+
+
+def _pipe(table: dict[str, list[tuple[str, str, str]]]) -> tuple[BasquePipeline, CasingFakeStanza]:
+    fake = CasingFakeStanza(table)
+    return BasquePipeline(nlp=fake, script="Latn"), fake
+
+
+def _word_tokens(result):
+    return [t for t in result.tokens if t.is_word]
+
+
+# --- _is_allcaps_word ---------------------------------------------------
+
+
+def test_is_allcaps_word_true_for_multiletter_uppercase():
+    assert _is_allcaps_word("HITZAURREA") is True
+    assert _is_allcaps_word("EZ") is True
+
+
+def test_is_allcaps_word_false_for_title_and_lower_case():
+    assert _is_allcaps_word("Hitzaurrea") is False
+    assert _is_allcaps_word("hitzaurrea") is False
+
+
+def test_is_allcaps_word_false_for_single_letter_and_non_letters():
+    assert _is_allcaps_word("A") is False
+    assert _is_allcaps_word("123") is False
+    assert _is_allcaps_word("") is False
+
+
+# --- all-caps lemma repair ---------------------------------------------
+
+
+def test_allcaps_lemma_is_repaired_from_lowercased_form():
+    # All-caps input lemmatizes wrong; the lowercased form is correct.
+    pipe, fake = _pipe(
+        {
+            "HITZAURREA": [("HITZAURREA", "hitzaure", "NOUN")],
+            "hitzaurrea": [("hitzaurrea", "hitzaurre", "NOUN")],
+        }
+    )
+    [tok] = _word_tokens(pipe.process("HITZAURREA"))
+    # Surface is preserved as typed; the lemma is the repaired one.
+    assert tok.surface == "HITZAURREA"
+    assert tok.candidates[0].lemma == "hitzaurre"
+    # The pipeline re-ran the model on the lowercased copy.
+    assert "hitzaurrea" in fake.calls
+
+
+def test_title_case_word_is_not_re_lemmatized():
+    pipe, fake = _pipe({"Hitzaurrea": [("Hitzaurrea", "hitzaurre", "NOUN")]})
+    [tok] = _word_tokens(pipe.process("Hitzaurrea"))
+    assert tok.candidates[0].lemma == "hitzaurre"
+    # No lowercased re-run — title case already lemmatizes correctly.
+    assert fake.calls == ["Hitzaurrea"]
+
+
+def test_allcaps_proper_noun_lemma_is_left_alone():
+    # PROPN keeps its capitalized lemma; no lowercased re-run happens.
+    pipe, fake = _pipe({"BAIONA": [("BAIONA", "Baiona", "PROPN")]})
+    [tok] = _word_tokens(pipe.process("BAIONA"))
+    assert tok.candidates[0].lemma == "Baiona"
+    assert fake.calls == ["BAIONA"]
+
+
+def test_allcaps_repair_is_memoized_across_repeats():
+    pipe, fake = _pipe(
+        {
+            "HITZAURREA HITZAURREA": [
+                ("HITZAURREA", "hitzaure", "NOUN"),
+                ("HITZAURREA", "hitzaure", "NOUN"),
+            ],
+            "hitzaurrea": [("hitzaurrea", "hitzaurre", "NOUN")],
+        }
+    )
+    toks = _word_tokens(pipe.process("HITZAURREA HITZAURREA"))
+    assert [t.candidates[0].lemma for t in toks] == ["hitzaurre", "hitzaurre"]
+    # One full-text call + a single memoized lowercased re-run.
+    assert fake.calls.count("hitzaurrea") == 1
+
+
+def test_allcaps_repair_skipped_when_lowercase_resegments():
+    # If the lowercased copy tokenizes into >1 word we keep the original
+    # lemma rather than grafting one from a different segmentation.
+    pipe, _ = _pipe(
+        {
+            "ETAB": [("ETAB", "etab", "NOUN")],
+            "etab": [("eta", "eta", "CCONJ"), ("b", "b", "NOUN")],
+        }
+    )
+    [tok] = _word_tokens(pipe.process("ETAB"))
+    assert tok.candidates[0].lemma == "etab"


### PR DESCRIPTION
Follow-ups to the editable-headword + admin reference panel work (#439), all found while testing Basque curation in the reader popup.

## Changes
- **All-caps lemma repair (NLP)** — Stanza's Basque lemmatizer resolves normal-case words from a dictionary cache, but all-caps forms that miss it fall through to a character seq2seq model that mangles some words (`HITZAURREA` → `hitzaure` instead of `hitzaurre`). For an all-caps *lexical* word we now re-lemmatize a lowercased copy and adopt that lemma. PROPN/NUM/SYM/X are skipped so proper nouns keep their capitalized lemma (`BAIONA` → `Baiona`), a result is only taken when the lowercased copy re-tokenizes to a single word, and re-runs are memoized per document. Non-cased scripts never enter the branch (`str.isupper()` is always false for them), so Hindi / Marathi / Odia / Yiddish are unaffected.
- **Reference search no longer snaps back to the parsed headword** — the auto-load effect guarded on `adminRefWord`, which *every* search mutates, so searching a word other than the parsed lemma re-triggered the auto-load and reloaded the parsed headword on top of it. The auto-loaded word is now tracked separately (`adminRefAutoFor`), and the "Looking up…" message shows the word actually being fetched.
- **Editing the headword updates the Translations panel** — an exact dictionary-headword match loads that lemma's translations as you type, and Enter loads the top suggestion. Previously only clicking a suggestion loaded translations.

## Tests
- **NLP** — new `services/nlp/tests/test_basque_pipeline.py` (all-caps repair, PROPN preserved, title/lowercase untouched, memoization, re-segmentation skip). Full suite: 693 passed, 92.67% coverage.
- **Web** — new `WordPopup` cases for the ref-search persistence and the headword exact-match / Enter behavior; each was confirmed to fail without its fix. Full suite: 1751 passed; `eslint` + `svelte-check` clean.

Verified the all-caps fix against the real Stanza model (`HITZAURREA` → `hitzaurre`, `BAIONA` → `Baiona`). Note: stored token lemmas are computed at import time, so existing texts need re-import to pick up the new lemma in the reader; the editable headword box is the in-reader recovery path in the meantime.