### PR TITLE
feat(api): list texts + collection detail endpoints for API clients

### DIFF
--- a/apps/web/src/routes/api/v1/collections/[id]/+server.ts
+++ b/apps/web/src/routes/api/v1/collections/[id]/+server.ts
@@ -4,11 +4,13 @@
 import { error, json } from '@sveltejs/kit';
 import { z } from 'zod';
 
-import { requireUser } from '$lib/server/auth/require-user.js';
+import { requireUser, resolveUser } from '$lib/server/auth/require-user.js';
 import {
   CollectionError,
   deleteCollection,
+  loadCollectionDetail,
   updateCollection,
+  viewerHasCollectionShare,
 } from '$lib/server/collections.js';
 import { parseJson } from '../../auth/_helpers.js';
 import type { RequestHandler } from './$types';
@@ -60,4 +62,61 @@ export const DELETE: RequestHandler = async (event) => {
     if (e instanceof CollectionError) throw error(e.status, e.message);
     throw e;
   }
+};
+
+/**
+ * GET /api/v1/collections/:id — collection detail + ordered member texts,
+ * for a Bearer/API client (the web uses the page loader). Visibility gate
+ * mirrors the collection-detail page: owner, admin, anyone for `official`,
+ * or a viewer with a share grant. Anything else 404s (not 403) so a private
+ * collection never leaks its existence.
+ */
+export const GET: RequestHandler = async (event) => {
+  const id = event.params.id;
+  if (!id || !UUID_RE.test(id)) throw error(400, 'Invalid collection id');
+
+  const detail = await loadCollectionDetail(id);
+  if (!detail) throw error(404, 'Collection not found');
+
+  const c = detail.collection;
+  const viewer = await resolveUser(event);
+  const isOwner = Boolean(viewer && c.ownerId === viewer.id);
+  const isAdmin = viewer?.role === 'admin';
+  const hasShare =
+    !isOwner &&
+    !isAdmin &&
+    viewer != null &&
+    c.visibility !== 'official' &&
+    (await viewerHasCollectionShare(viewer.id, c.id));
+  if (c.visibility !== 'official' && !isOwner && !isAdmin && !hasShare) {
+    throw error(404, 'Collection not found');
+  }
+
+  return json({
+    collection: {
+      id: c.id,
+      ownerId: c.ownerId,
+      language: c.language,
+      kind: c.kind,
+      title: c.title,
+      description: c.description,
+      coverUrl: c.coverUrl,
+      visibility: c.visibility,
+      createdAt: c.createdAt,
+      updatedAt: c.updatedAt,
+    },
+    items: detail.items.map((item) => ({
+      position: item.position,
+      sectionTitle: item.sectionTitle,
+      text: {
+        id: item.text.id,
+        title: item.text.title,
+        language: item.text.language,
+        sourceType: item.text.sourceType,
+        status: item.text.status,
+        visibility: item.text.visibility,
+        createdAt: item.text.createdAt,
+      },
+    })),
+  });
 };

--- a/apps/web/src/routes/api/v1/collections/[id]/collection-detail-server.test.ts
+++ b/apps/web/src/routes/api/v1/collections/[id]/collection-detail-server.test.ts
@@ -1,0 +1,139 @@
+// @vitest-environment node
+/**
+ * Route tests for GET /api/v1/collections/:id (collection detail).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const loadCollectionDetail = vi.fn();
+const viewerHasCollectionShare = vi.fn();
+const resolveUser = vi.fn();
+
+vi.mock('$lib/server/collections.js', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/collections.js')>(
+    '$lib/server/collections.js',
+  );
+  return {
+    ...actual,
+    loadCollectionDetail: (...a: unknown[]) => loadCollectionDetail(...a),
+    viewerHasCollectionShare: (...a: unknown[]) => viewerHasCollectionShare(...a),
+  };
+});
+
+vi.mock('$lib/server/auth/require-user.js', () => ({
+  resolveUser: (...a: unknown[]) => resolveUser(...a),
+  requireUser: (...a: unknown[]) => resolveUser(...a),
+}));
+
+type GetFn = (typeof import('./+server.js'))['GET'];
+
+const ID = '11111111-1111-1111-1111-111111111111';
+const OWNER = { id: 'owner-1', role: 'user' as const };
+
+function detail(collectionOverrides: Record<string, unknown> = {}) {
+  const ts = new Date('2026-04-27T00:00:00Z');
+  return {
+    collection: {
+      id: ID,
+      ownerId: OWNER.id,
+      language: 'hi',
+      kind: 'chapter_book',
+      title: 'Book',
+      description: null,
+      coverUrl: null,
+      visibility: 'private',
+      createdAt: ts,
+      updatedAt: ts,
+      ...collectionOverrides,
+    },
+    items: [
+      {
+        position: 0,
+        sectionTitle: null,
+        text: {
+          id: 'text-1',
+          ownerId: OWNER.id,
+          language: 'hi',
+          title: 'Ch 1',
+          sourceType: 'epub',
+          status: 'ready',
+          visibility: 'private',
+          createdAt: ts,
+          updatedAt: ts,
+        },
+      },
+    ],
+  };
+}
+
+async function callGet(id = ID, viewer: { id: string; role: 'user' | 'admin' } | null = OWNER) {
+  resolveUser.mockResolvedValueOnce(viewer);
+  const { GET } = await import('./+server.js');
+  const event = {
+    params: { id },
+    request: new Request('http://x'),
+    url: new URL('http://x'),
+  } as unknown as Parameters<GetFn>[0];
+  try {
+    return await GET(event);
+  } catch (e) {
+    return e as { status: number };
+  }
+}
+
+beforeEach(() => {
+  loadCollectionDetail.mockReset();
+  viewerHasCollectionShare.mockReset();
+  resolveUser.mockReset();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('GET /api/v1/collections/:id', () => {
+  it('rejects a non-UUID id with 400 before any lookup', async () => {
+    const res = (await callGet('not-a-uuid')) as { status: number };
+    expect(res.status).toBe(400);
+    expect(loadCollectionDetail).not.toHaveBeenCalled();
+  });
+
+  it('404s when the collection does not exist', async () => {
+    loadCollectionDetail.mockResolvedValueOnce(null);
+    const res = (await callGet()) as { status: number };
+    expect(res.status).toBe(404);
+  });
+
+  it('returns the collection + projected items for the owner', async () => {
+    loadCollectionDetail.mockResolvedValueOnce(detail());
+    const res = (await callGet()) as Response;
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.collection.id).toBe(ID);
+    expect(json.items).toHaveLength(1);
+    expect(json.items[0]).toMatchObject({ position: 0, sectionTitle: null });
+    expect(json.items[0].text).toMatchObject({ id: 'text-1', title: 'Ch 1' });
+  });
+
+  it('404s a private collection for a non-owner without a share', async () => {
+    loadCollectionDetail.mockResolvedValueOnce(detail());
+    viewerHasCollectionShare.mockResolvedValueOnce(false);
+    const res = (await callGet(ID, { id: 'someone-else', role: 'user' })) as {
+      status: number;
+    };
+    expect(res.status).toBe(404);
+  });
+
+  it('allows a non-owner who has a share grant', async () => {
+    loadCollectionDetail.mockResolvedValueOnce(detail());
+    viewerHasCollectionShare.mockResolvedValueOnce(true);
+    const res = (await callGet(ID, { id: 'someone-else', role: 'user' })) as Response;
+    expect(res.status).toBe(200);
+  });
+
+  it('serves an official collection to anyone, no auth or share check', async () => {
+    loadCollectionDetail.mockResolvedValueOnce(detail({ visibility: 'official' }));
+    const res = (await callGet(ID, null)) as Response;
+    expect(res.status).toBe(200);
+    expect(viewerHasCollectionShare).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/routes/api/v1/texts/+server.ts
+++ b/apps/web/src/routes/api/v1/texts/+server.ts
@@ -17,7 +17,7 @@
 import { error, json } from '@sveltejs/kit';
 import { z } from 'zod';
 
-import { requireVerifiedUser } from '$lib/server/auth/require-user.js';
+import { requireUser, requireVerifiedUser } from '$lib/server/auth/require-user.js';
 import {
   consumeRateLimit,
   rateLimitHeaders,
@@ -31,6 +31,11 @@ import {
   MAX_TXT_BYTES,
   MAX_TITLE_LEN,
 } from '$lib/server/texts/upload.js';
+import {
+  listOfficialTexts,
+  listOwnedTexts,
+  listSharedTexts,
+} from '$lib/server/texts/library.js';
 import type { RequestHandler } from './$types';
 import { parseJson } from '../auth/_helpers.js';
 import { SUPPORTED_LANGUAGE_CODES, type LanguageCode } from '@ciareader/shared-types';
@@ -121,4 +126,49 @@ export const POST: RequestHandler = async (event) => {
     if (err instanceof TextValidationError) throw error(err.status, err.message);
     throw err;
   }
+};
+
+// GET /api/v1/texts — list library texts for a Bearer/API client.
+//
+// The web library reads the active language from the layout's
+// current-language cookie; a mobile client sends no cookie, so language
+// is an explicit query param here. `scope` selects the library tab:
+//   - owned    — the caller's own imports (auth required)
+//   - shared   — texts shared with the caller (auth required)
+//   - official — the public official library (no auth required)
+// Pagination magnitude is clamped by the service (clampPage).
+const listQuerySchema = z.object({
+  scope: z.enum(['owned', 'shared', 'official']).default('owned'),
+  language: z
+    .enum(SUPPORTED_LANGUAGE_CODES as readonly [LanguageCode, ...LanguageCode[]])
+    .optional(),
+  limit: z.coerce.number().int().positive().optional(),
+  offset: z.coerce.number().int().nonnegative().optional(),
+});
+
+export const GET: RequestHandler = async (event) => {
+  const parsed = listQuerySchema.safeParse({
+    scope: event.url.searchParams.get('scope') ?? undefined,
+    language: event.url.searchParams.get('language') ?? undefined,
+    limit: event.url.searchParams.get('limit') ?? undefined,
+    offset: event.url.searchParams.get('offset') ?? undefined,
+  });
+  if (!parsed.success) {
+    throw error(
+      400,
+      parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; '),
+    );
+  }
+  const { scope, language, limit, offset } = parsed.data;
+  const opts = { limit, offset, language };
+
+  if (scope === 'official') {
+    return json(await listOfficialTexts(opts));
+  }
+  const user = await requireUser(event);
+  const page =
+    scope === 'owned'
+      ? await listOwnedTexts({ id: user.id }, opts)
+      : await listSharedTexts({ id: user.id }, opts);
+  return json(page);
 };

--- a/apps/web/src/routes/api/v1/texts/texts-server.test.ts
+++ b/apps/web/src/routes/api/v1/texts/texts-server.test.ts
@@ -37,7 +37,18 @@ vi.mock('$lib/server/auth/rate-limits.js', async () => {
   };
 });
 
+const listOwnedTexts = vi.fn();
+const listSharedTexts = vi.fn();
+const listOfficialTexts = vi.fn();
+
+vi.mock('$lib/server/texts/library.js', () => ({
+  listOwnedTexts: (...a: unknown[]) => listOwnedTexts(...a),
+  listSharedTexts: (...a: unknown[]) => listSharedTexts(...a),
+  listOfficialTexts: (...a: unknown[]) => listOfficialTexts(...a),
+}));
+
 type PostFn = (typeof import('./+server.js'))['POST'];
+type GetFn = (typeof import('./+server.js'))['GET'];
 
 const USER = { id: 'user-1', role: 'user' as const };
 
@@ -71,6 +82,9 @@ beforeEach(() => {
   createTxtText.mockReset();
   requireUser.mockReset();
   consumeRateLimit.mockReset();
+  listOwnedTexts.mockReset();
+  listSharedTexts.mockReset();
+  listOfficialTexts.mockReset();
   consumeRateLimit.mockResolvedValue({
     limit: 50,
     remaining: 49,
@@ -232,5 +246,77 @@ describe('POST /api/v1/texts', () => {
     const json = await res.json();
     expect(json.error).toBe('rate_limited');
     expect(createPastedText).not.toHaveBeenCalled();
+  });
+});
+
+const PAGE = { cards: [], totalCount: 0, limit: 20, offset: 0 };
+
+async function callGet(query = '', user: typeof USER | null = USER) {
+  if (user) {
+    requireUser.mockResolvedValueOnce(user);
+  } else {
+    requireUser.mockImplementationOnce(() => {
+      throw { status: 401, body: { message: 'Unauthorized' } };
+    });
+  }
+  const { GET } = await import('./+server.js');
+  const url = `http://x/api/v1/texts${query}`;
+  const event = {
+    url: new URL(url),
+    request: new Request(url),
+  } as unknown as Parameters<GetFn>[0];
+  try {
+    return await GET(event);
+  } catch (e) {
+    return e as { status: number };
+  }
+}
+
+describe('GET /api/v1/texts', () => {
+  it('defaults to owned scope and returns the page', async () => {
+    listOwnedTexts.mockResolvedValueOnce({ ...PAGE, totalCount: 2 });
+    const res = (await callGet('')) as Response;
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.totalCount).toBe(2);
+    expect(listOwnedTexts).toHaveBeenCalledWith(
+      { id: USER.id },
+      { limit: undefined, offset: undefined, language: undefined },
+    );
+    expect(listOfficialTexts).not.toHaveBeenCalled();
+  });
+
+  it('serves official scope without requiring auth', async () => {
+    listOfficialTexts.mockResolvedValueOnce(PAGE);
+    const res = (await callGet('?scope=official', null)) as Response;
+    expect(res.status).toBe(200);
+    expect(listOfficialTexts).toHaveBeenCalledTimes(1);
+    expect(requireUser).not.toHaveBeenCalled();
+  });
+
+  it('passes language + pagination through to the shared query', async () => {
+    listSharedTexts.mockResolvedValueOnce(PAGE);
+    await callGet('?scope=shared&language=hi&limit=5&offset=10');
+    expect(listSharedTexts).toHaveBeenCalledWith(
+      { id: USER.id },
+      { limit: 5, offset: 10, language: 'hi' },
+    );
+  });
+
+  it('rejects an unsupported language with 400', async () => {
+    const res = (await callGet('?language=xx')) as { status: number };
+    expect(res.status).toBe(400);
+    expect(listOwnedTexts).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown scope with 400', async () => {
+    const res = (await callGet('?scope=bogus')) as { status: number };
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 401 for owned scope when unauthenticated', async () => {
+    const res = (await callGet('?scope=owned', null)) as { status: number };
+    expect(res.status).toBe(401);
+    expect(listOwnedTexts).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What

Two read endpoints so a cookieless Bearer/API client (the Android app) can drive the library — today these views exist only as SvelteKit page loaders, unreachable without a session cookie.

- **`GET /api/v1/texts`** — lists library texts. `?scope=owned|shared|official` (default `owned`), `?language=` (required for cookieless clients — there's no current-language cookie), `?limit`/`?offset`. Thin wrapper over the existing `listOwnedTexts` / `listSharedTexts` / `listOfficialTexts`. `official` is public; `owned`/`shared` require auth.
- **`GET /api/v1/collections/:id`** — collection detail + ordered member texts. Visibility gate mirrors the collection-detail page exactly (owner / admin / official / share-grant → else **404**, never leaking a private collection's existence).

Both project to a lean text shape (no chapter bodies). Part of the M12 mobile-readiness direction (#102).

## Tests
- 20 vitest specs green: `texts-server.test.ts` adds GET cases (scope routing, language/pagination passthrough, invalid-param 400s, 401 unauth, official-no-auth); new `collection-detail-server.test.ts` covers the authz matrix (owner / share / official / 404 / bad-UUID).
- `svelte-check` 0 errors, eslint clean.

## Notes
Unblocks the Android library screen (Phase 2). No new tables or migrations — pure read endpoints over existing services.
