### PR TITLE
feat(android): library screen, language switch, nav + Compose UI tests (Phase 2)

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -65,6 +65,14 @@ android {
         compose = true
         buildConfig = true
     }
+
+    testOptions {
+        unitTests {
+            // Robolectric needs merged Android resources/manifest to host
+            // Compose UI tests on the JVM.
+            isIncludeAndroidResources = true
+        }
+    }
 }
 
 dependencies {
@@ -97,6 +105,10 @@ dependencies {
 
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
+    // Robolectric runs Compose UI tests on the JVM (no emulator in CI).
+    testImplementation(libs.robolectric)
+    testImplementation(platform(libs.androidx.compose.bom))
+    testImplementation(libs.androidx.ui.test.junit4)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/apps/android/app/src/main/java/com/ciareader/reader/core/network/ApiResult.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/core/network/ApiResult.kt
@@ -1,0 +1,27 @@
+package com.ciareader.reader.core.network
+
+import retrofit2.HttpException
+import java.io.IOException
+
+/** Generic result for data-layer calls the UI renders (success or message). */
+sealed interface Outcome<out T> {
+    data class Success<T>(val data: T) : Outcome<T>
+    data class Failure(val message: String) : Outcome<Nothing>
+}
+
+/** Runs a network call, mapping transport/HTTP errors to a user-facing message. */
+suspend fun <T> apiCall(block: suspend () -> T): Outcome<T> = try {
+    Outcome.Success(block())
+} catch (e: HttpException) {
+    Outcome.Failure(httpMessage(e.code()))
+} catch (_: IOException) {
+    Outcome.Failure("Network error — check your connection and try again.")
+}
+
+fun httpMessage(code: Int): String = when (code) {
+    401 -> "Please sign in again."
+    403 -> "You don't have access to that."
+    404 -> "Not found."
+    in 500..599 -> "The server had a problem. Please try again."
+    else -> "Something went wrong ($code)."
+}

--- a/apps/android/app/src/main/java/com/ciareader/reader/data/language/LanguageDtos.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/data/language/LanguageDtos.kt
@@ -1,0 +1,25 @@
+package com.ciareader.reader.data.language
+
+import kotlinx.serialization.Serializable
+
+/** Mirrors GET /api/v1/me/languages. */
+@Serializable
+data class LanguagesResponseDto(val languages: List<LanguageDto> = emptyList())
+
+@Serializable
+data class LanguageDto(
+    val code: String,
+    val displayName: String,
+    val nativeName: String,
+    val script: String,
+    val isDefault: Boolean = false,
+    val scriptPreference: String? = null,
+    val romanizationScheme: String? = null,
+    val supportedRomanizations: List<String> = emptyList(),
+)
+
+@Serializable
+data class SetLanguageRequest(val code: String)
+
+@Serializable
+data class SetLanguageResponseDto(val code: String)

--- a/apps/android/app/src/main/java/com/ciareader/reader/data/language/LanguageRepository.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/data/language/LanguageRepository.kt
@@ -1,0 +1,42 @@
+package com.ciareader.reader.data.language
+
+import com.ciareader.reader.core.network.Outcome
+import com.ciareader.reader.core.network.apiCall
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** UI-facing language descriptor. */
+data class Language(
+    val code: String,
+    val displayName: String,
+    val nativeName: String,
+    val script: String,
+    val isDefault: Boolean,
+) {
+    /** Hebrew script (Yiddish) reads right-to-left. */
+    val isRtl: Boolean get() = script.equals("Hebr", ignoreCase = true)
+}
+
+interface LanguageRepository {
+    suspend fun myLanguages(): Outcome<List<Language>>
+    suspend fun setCurrent(code: String): Outcome<String>
+}
+
+@Singleton
+class LanguageRepositoryImpl @Inject constructor(
+    private val api: LanguagesApi,
+) : LanguageRepository {
+    override suspend fun myLanguages(): Outcome<List<Language>> =
+        apiCall { api.myLanguages().languages.map { it.toDomain() } }
+
+    override suspend fun setCurrent(code: String): Outcome<String> =
+        apiCall { api.setLanguage(SetLanguageRequest(code)).code }
+}
+
+private fun LanguageDto.toDomain() = Language(
+    code = code,
+    displayName = displayName,
+    nativeName = nativeName,
+    script = script,
+    isDefault = isDefault,
+)

--- a/apps/android/app/src/main/java/com/ciareader/reader/data/language/LanguagesApi.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/data/language/LanguagesApi.kt
@@ -1,0 +1,15 @@
+package com.ciareader.reader.data.language
+
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+
+interface LanguagesApi {
+    @GET("api/v1/me/languages")
+    suspend fun myLanguages(): LanguagesResponseDto
+
+    // POST (not the cookie-only PUT /me/current-language) so a Bearer client
+    // persists the choice server-side and gets the cookie set as a side effect.
+    @POST("api/v1/me/languages")
+    suspend fun setLanguage(@Body body: SetLanguageRequest): SetLanguageResponseDto
+}

--- a/apps/android/app/src/main/java/com/ciareader/reader/data/library/LibraryApi.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/data/library/LibraryApi.kt
@@ -1,0 +1,16 @@
+package com.ciareader.reader.data.library
+
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+/** Library listing under GET /api/v1/texts. */
+interface LibraryApi {
+    @GET("api/v1/texts")
+    suspend fun listTexts(
+        @Query("scope") scope: String,
+        // Explicit — a Bearer client sends no current-language cookie.
+        @Query("language") language: String,
+        @Query("limit") limit: Int? = null,
+        @Query("offset") offset: Int? = null,
+    ): LibraryPageDto
+}

--- a/apps/android/app/src/main/java/com/ciareader/reader/data/library/LibraryDtos.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/data/library/LibraryDtos.kt
@@ -1,0 +1,23 @@
+package com.ciareader.reader.data.library
+
+import kotlinx.serialization.Serializable
+
+/** Mirrors the `ListPage` shape from GET /api/v1/texts. */
+@Serializable
+data class LibraryPageDto(
+    val cards: List<TextCardDto> = emptyList(),
+    val totalCount: Int = 0,
+    val limit: Int = 0,
+    val offset: Int = 0,
+)
+
+@Serializable
+data class TextCardDto(
+    val id: String,
+    val title: String,
+    val language: String,
+    val sourceType: String,
+    val status: String,
+    val visibility: String,
+    val createdAt: String,
+)

--- a/apps/android/app/src/main/java/com/ciareader/reader/data/library/LibraryRepository.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/data/library/LibraryRepository.kt
@@ -1,0 +1,44 @@
+package com.ciareader.reader.data.library
+
+import com.ciareader.reader.core.network.Outcome
+import com.ciareader.reader.core.network.apiCall
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** Which library tab to list. Maps to the endpoint's `scope` param. */
+enum class LibraryScope(val wire: String) {
+    OWNED("owned"),
+    SHARED("shared"),
+    OFFICIAL("official"),
+}
+
+/** UI-facing library entry (the wire DTO trimmed to what a card needs). */
+data class TextCard(
+    val id: String,
+    val title: String,
+    val language: String,
+    val status: String,
+) {
+    val isReady: Boolean get() = status == "ready"
+}
+
+interface LibraryRepository {
+    suspend fun listTexts(scope: LibraryScope, language: String): Outcome<List<TextCard>>
+}
+
+@Singleton
+class LibraryRepositoryImpl @Inject constructor(
+    private val api: LibraryApi,
+) : LibraryRepository {
+    override suspend fun listTexts(scope: LibraryScope, language: String): Outcome<List<TextCard>> =
+        apiCall {
+            api.listTexts(scope = scope.wire, language = language).cards.map { it.toDomain() }
+        }
+}
+
+private fun TextCardDto.toDomain() = TextCard(
+    id = id,
+    title = title,
+    language = language,
+    status = status,
+)

--- a/apps/android/app/src/main/java/com/ciareader/reader/di/BindingsModule.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/di/BindingsModule.kt
@@ -4,6 +4,10 @@ import com.ciareader.reader.core.auth.DataStoreTokenStore
 import com.ciareader.reader.core.auth.TokenStore
 import com.ciareader.reader.data.auth.AuthRepository
 import com.ciareader.reader.data.auth.AuthRepositoryImpl
+import com.ciareader.reader.data.language.LanguageRepository
+import com.ciareader.reader.data.language.LanguageRepositoryImpl
+import com.ciareader.reader.data.library.LibraryRepository
+import com.ciareader.reader.data.library.LibraryRepositoryImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -21,4 +25,12 @@ abstract class BindingsModule {
     @Binds
     @Singleton
     abstract fun bindAuthRepository(impl: AuthRepositoryImpl): AuthRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindLibraryRepository(impl: LibraryRepositoryImpl): LibraryRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindLanguageRepository(impl: LanguageRepositoryImpl): LanguageRepository
 }

--- a/apps/android/app/src/main/java/com/ciareader/reader/di/NetworkModule.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/di/NetworkModule.kt
@@ -5,6 +5,8 @@ import com.ciareader.reader.core.network.AuthInterceptor
 import com.ciareader.reader.core.network.TokenAuthenticator
 import com.ciareader.reader.data.auth.AuthApi
 import com.ciareader.reader.data.auth.TokenRefreshApi
+import com.ciareader.reader.data.language.LanguagesApi
+import com.ciareader.reader.data.library.LibraryApi
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -101,6 +103,16 @@ object NetworkModule {
     @Singleton
     fun provideAuthApi(@Authenticated retrofit: Retrofit): AuthApi =
         retrofit.create(AuthApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideLibraryApi(@Authenticated retrofit: Retrofit): LibraryApi =
+        retrofit.create(LibraryApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideLanguagesApi(@Authenticated retrofit: Retrofit): LanguagesApi =
+        retrofit.create(LanguagesApi::class.java)
 
     private val JSON_MEDIA_TYPE = "application/json".toMediaType()
 }

--- a/apps/android/app/src/main/java/com/ciareader/reader/ui/CiaReaderRoot.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/ui/CiaReaderRoot.kt
@@ -1,31 +1,22 @@
 package com.ciareader.reader.ui
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ciareader.reader.ui.auth.LoginScreen
+import com.ciareader.reader.ui.navigation.CiaReaderNavHost
 
 /**
  * App root. Auth-gates the UI: while credentials resolve we show a spinner,
- * then route to the login screen or the (placeholder) home. A fuller NavHost
- * arrives with the library in Phase 2.
+ * then route to the login screen or the in-app navigation graph.
  */
 @Composable
 fun CiaReaderRoot(rootViewModel: RootViewModel = hiltViewModel()) {
@@ -35,7 +26,7 @@ fun CiaReaderRoot(rootViewModel: RootViewModel = hiltViewModel()) {
         when (isAuthenticated) {
             null -> LoadingScreen()
             false -> LoginScreen()
-            true -> HomePlaceholderScreen(onLogout = rootViewModel::logout)
+            true -> CiaReaderNavHost(onLogout = rootViewModel::logout)
         }
     }
 }
@@ -44,29 +35,5 @@ fun CiaReaderRoot(rootViewModel: RootViewModel = hiltViewModel()) {
 private fun LoadingScreen() {
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         CircularProgressIndicator()
-    }
-}
-
-@Composable
-private fun HomePlaceholderScreen(onLogout: () -> Unit) {
-    Scaffold { padding ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding)
-                .padding(24.dp),
-            verticalArrangement = Arrangement.Center,
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            Text("You're signed in 🎉", style = MaterialTheme.typography.headlineSmall)
-            Spacer(Modifier.height(8.dp))
-            Text(
-                "Library and reader land in the next phases.",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Spacer(Modifier.height(24.dp))
-            Button(onClick = onLogout) { Text("Log out") }
-        }
     }
 }

--- a/apps/android/app/src/main/java/com/ciareader/reader/ui/auth/LoginScreen.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/ui/auth/LoginScreen.kt
@@ -45,7 +45,7 @@ fun LoginScreen(viewModel: LoginViewModel = hiltViewModel()) {
 }
 
 @Composable
-private fun LoginScreenContent(
+internal fun LoginScreenContent(
     state: LoginUiState,
     onEmailChange: (String) -> Unit,
     onPasswordChange: (String) -> Unit,

--- a/apps/android/app/src/main/java/com/ciareader/reader/ui/library/LibraryScreen.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/ui/library/LibraryScreen.kt
@@ -1,0 +1,175 @@
+package com.ciareader.reader.ui.library
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.ciareader.reader.data.language.Language
+import com.ciareader.reader.data.library.TextCard
+
+@Composable
+fun LibraryScreen(
+    onOpenText: (String) -> Unit,
+    onLogout: () -> Unit,
+    viewModel: LibraryViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    LibraryScreenContent(
+        state = state,
+        onSelectLanguage = viewModel::selectLanguage,
+        onOpenText = onOpenText,
+        onRetry = viewModel::load,
+        onLogout = onLogout,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun LibraryScreenContent(
+    state: LibraryUiState,
+    onSelectLanguage: (String) -> Unit,
+    onOpenText: (String) -> Unit,
+    onRetry: () -> Unit,
+    onLogout: () -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Library") },
+                actions = {
+                    LanguageSwitcher(
+                        languages = state.languages,
+                        currentLabel = state.currentLanguageLabel,
+                        onSelect = onSelectLanguage,
+                    )
+                    TextButton(onClick = onLogout) { Text("Log out") }
+                },
+            )
+        },
+    ) { padding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+        ) {
+            when {
+                state.isLoading ->
+                    CircularProgressIndicator(Modifier.align(Alignment.Center))
+
+                state.errorMessage != null ->
+                    ErrorState(message = state.errorMessage, onRetry = onRetry)
+
+                state.texts.isEmpty() ->
+                    EmptyState()
+
+                else ->
+                    TextList(texts = state.texts, onOpenText = onOpenText)
+            }
+        }
+    }
+}
+
+@Composable
+private fun LanguageSwitcher(
+    languages: List<Language>,
+    currentLabel: String,
+    onSelect: (String) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    TextButton(onClick = { expanded = true }) {
+        Text(currentLabel.ifEmpty { "Language" })
+    }
+    DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+        languages.forEach { lang ->
+            DropdownMenuItem(
+                text = { Text("${lang.displayName} · ${lang.nativeName}") },
+                onClick = {
+                    expanded = false
+                    onSelect(lang.code)
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun TextList(texts: List<TextCard>, onOpenText: (String) -> Unit) {
+    LazyColumn(modifier = Modifier.fillMaxSize()) {
+        items(texts, key = { it.id }) { card ->
+            ListItem(
+                headlineContent = { Text(card.title) },
+                supportingContent = {
+                    if (!card.isReady) Text(card.status, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                },
+                modifier = Modifier.clickable(enabled = card.isReady) { onOpenText(card.id) },
+            )
+            HorizontalDivider()
+        }
+    }
+}
+
+@Composable
+private fun EmptyState() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text("No texts yet", style = MaterialTheme.typography.titleMedium)
+        Text(
+            "Add a text from the web app to start reading.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
+@Composable
+private fun ErrorState(message: String, onRetry: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            message,
+            color = MaterialTheme.colorScheme.error,
+            textAlign = TextAlign.Center,
+        )
+        Button(onClick = onRetry, modifier = Modifier.padding(top = 16.dp)) {
+            Text("Retry")
+        }
+    }
+}

--- a/apps/android/app/src/main/java/com/ciareader/reader/ui/library/LibraryViewModel.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/ui/library/LibraryViewModel.kt
@@ -1,0 +1,88 @@
+package com.ciareader.reader.ui.library
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ciareader.reader.core.network.Outcome
+import com.ciareader.reader.data.language.Language
+import com.ciareader.reader.data.language.LanguageRepository
+import com.ciareader.reader.data.library.LibraryRepository
+import com.ciareader.reader.data.library.LibraryScope
+import com.ciareader.reader.data.library.TextCard
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class LibraryUiState(
+    val isLoading: Boolean = true,
+    val languages: List<Language> = emptyList(),
+    val currentLanguage: String? = null,
+    val texts: List<TextCard> = emptyList(),
+    val errorMessage: String? = null,
+) {
+    /** Human label for the active language (display name, falling back to code). */
+    val currentLanguageLabel: String
+        get() = languages.firstOrNull { it.code == currentLanguage }?.displayName
+            ?: currentLanguage.orEmpty()
+}
+
+@HiltViewModel
+class LibraryViewModel @Inject constructor(
+    private val languageRepository: LanguageRepository,
+    private val libraryRepository: LibraryRepository,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(LibraryUiState())
+    val state: StateFlow<LibraryUiState> = _state.asStateFlow()
+
+    init {
+        load()
+    }
+
+    fun load() {
+        _state.update { it.copy(isLoading = true, errorMessage = null) }
+        viewModelScope.launch {
+            when (val langs = languageRepository.myLanguages()) {
+                is Outcome.Failure ->
+                    _state.update { it.copy(isLoading = false, errorMessage = langs.message) }
+
+                is Outcome.Success -> {
+                    val languages = langs.data
+                    val current = _state.value.currentLanguage
+                        ?: languages.firstOrNull { it.isDefault }?.code
+                        ?: languages.firstOrNull()?.code
+                    _state.update { it.copy(languages = languages, currentLanguage = current) }
+                    if (current != null) {
+                        loadTexts(current)
+                    } else {
+                        _state.update { it.copy(isLoading = false) }
+                    }
+                }
+            }
+        }
+    }
+
+    fun selectLanguage(code: String) {
+        if (code == _state.value.currentLanguage) return
+        _state.update { it.copy(currentLanguage = code, isLoading = true, errorMessage = null) }
+        viewModelScope.launch {
+            // Persist server-side. The explicit `language` arg drives the listing
+            // regardless, so a failed persist doesn't block the local switch.
+            languageRepository.setCurrent(code)
+            loadTexts(code)
+        }
+    }
+
+    private suspend fun loadTexts(language: String) {
+        when (val res = libraryRepository.listTexts(LibraryScope.OWNED, language)) {
+            is Outcome.Success ->
+                _state.update { it.copy(isLoading = false, texts = res.data, errorMessage = null) }
+
+            is Outcome.Failure ->
+                _state.update { it.copy(isLoading = false, errorMessage = res.message) }
+        }
+    }
+}

--- a/apps/android/app/src/main/java/com/ciareader/reader/ui/navigation/CiaReaderNavHost.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/ui/navigation/CiaReaderNavHost.kt
@@ -1,0 +1,39 @@
+package com.ciareader.reader.ui.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavType
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
+import com.ciareader.reader.ui.library.LibraryScreen
+import com.ciareader.reader.ui.reader.ReaderStubScreen
+
+object Routes {
+    const val LIBRARY = "library"
+    const val READER = "reader/{textId}"
+    fun reader(textId: String) = "reader/$textId"
+}
+
+/** In-app navigation graph (shown once authenticated). */
+@Composable
+fun CiaReaderNavHost(onLogout: () -> Unit) {
+    val navController = rememberNavController()
+    NavHost(navController = navController, startDestination = Routes.LIBRARY) {
+        composable(Routes.LIBRARY) {
+            LibraryScreen(
+                onOpenText = { textId -> navController.navigate(Routes.reader(textId)) },
+                onLogout = onLogout,
+            )
+        }
+        composable(
+            route = Routes.READER,
+            arguments = listOf(navArgument("textId") { type = NavType.StringType }),
+        ) { backStackEntry ->
+            ReaderStubScreen(
+                textId = backStackEntry.arguments?.getString("textId").orEmpty(),
+                onBack = { navController.popBackStack() },
+            )
+        }
+    }
+}

--- a/apps/android/app/src/main/java/com/ciareader/reader/ui/reader/ReaderStubScreen.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/ui/reader/ReaderStubScreen.kt
@@ -1,0 +1,54 @@
+package com.ciareader.reader.ui.reader
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+
+/**
+ * Placeholder reader. The real reading surface (tappable tokens, word popup,
+ * RTL, pagination) arrives in Phase 3 — this just confirms navigation works.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ReaderStubScreen(textId: String, onBack: () -> Unit) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Reader") },
+                navigationIcon = { TextButton(onClick = onBack) { Text("Back") } },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(24.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text("Reader", style = MaterialTheme.typography.headlineSmall)
+            Spacer(Modifier.height(8.dp))
+            Text(
+                "Text $textId — the reading surface arrives in Phase 3.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}

--- a/apps/android/app/src/test/java/com/ciareader/reader/data/LibraryLanguageSerializationTest.kt
+++ b/apps/android/app/src/test/java/com/ciareader/reader/data/LibraryLanguageSerializationTest.kt
@@ -1,0 +1,60 @@
+package com.ciareader.reader.data
+
+import com.ciareader.reader.data.language.LanguagesResponseDto
+import com.ciareader.reader.data.library.LibraryPageDto
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Guards the library/language DTOs against drift from the server shapes. */
+class LibraryLanguageSerializationTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+    }
+
+    @Test
+    fun decodesTextsListPage() {
+        val payload = """
+            {
+              "cards": [
+                {
+                  "id": "t1", "title": "एक कहानी", "language": "hi",
+                  "sourceType": "paste", "status": "ready",
+                  "visibility": "private", "createdAt": "2026-06-21T00:00:00.000Z"
+                }
+              ],
+              "totalCount": 1, "limit": 20, "offset": 0
+            }
+        """.trimIndent()
+
+        val page = json.decodeFromString<LibraryPageDto>(payload)
+        assertEquals(1, page.cards.size)
+        assertEquals("t1", page.cards[0].id)
+        assertEquals(20, page.limit)
+    }
+
+    @Test
+    fun decodesLanguagesAndToleratesExtraFields() {
+        val payload = """
+            {
+              "languages": [
+                {
+                  "code": "yi", "displayName": "Yiddish", "nativeName": "ייִדיש",
+                  "script": "Hebr", "isDefault": false,
+                  "scriptPreference": "native", "romanizationScheme": null,
+                  "supportedRomanizations": ["yivo"], "futureField": 1
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val res = json.decodeFromString<LanguagesResponseDto>(payload)
+        assertEquals(1, res.languages.size)
+        assertEquals("Hebr", res.languages[0].script)
+        assertTrue(res.languages[0].supportedRomanizations.contains("yivo"))
+    }
+}

--- a/apps/android/app/src/test/java/com/ciareader/reader/data/language/LanguageRepositoryTest.kt
+++ b/apps/android/app/src/test/java/com/ciareader/reader/data/language/LanguageRepositoryTest.kt
@@ -1,0 +1,68 @@
+package com.ciareader.reader.data.language
+
+import com.ciareader.reader.core.network.Outcome
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LanguageRepositoryTest {
+
+    @Test
+    fun mapsLanguagesAndDetectsRtl() = runTest {
+        val api = FakeLanguagesApi(
+            languages = listOf(
+                lang("hi", "Hindi", "हिन्दी", "Deva", isDefault = true),
+                lang("yi", "Yiddish", "ייִדיש", "Hebr"),
+            ),
+        )
+        val repo = LanguageRepositoryImpl(api)
+
+        val result = repo.myLanguages()
+
+        assertTrue(result is Outcome.Success)
+        val langs = (result as Outcome.Success).data
+        assertEquals(listOf("hi", "yi"), langs.map { it.code })
+        assertFalse(langs[0].isRtl)   // Devanagari
+        assertTrue(langs[1].isRtl)    // Hebrew
+        assertTrue(langs[0].isDefault)
+    }
+
+    @Test
+    fun setCurrentReturnsConfirmedCode() = runTest {
+        val api = FakeLanguagesApi(languages = emptyList())
+        val repo = LanguageRepositoryImpl(api)
+
+        val result = repo.setCurrent("mr")
+
+        assertTrue(result is Outcome.Success)
+        assertEquals("mr", (result as Outcome.Success).data)
+        assertEquals("mr", api.lastSetCode)
+    }
+
+    private fun lang(
+        code: String,
+        displayName: String,
+        nativeName: String,
+        script: String,
+        isDefault: Boolean = false,
+    ) = LanguageDto(
+        code = code,
+        displayName = displayName,
+        nativeName = nativeName,
+        script = script,
+        isDefault = isDefault,
+    )
+}
+
+private class FakeLanguagesApi(
+    private val languages: List<LanguageDto>,
+) : LanguagesApi {
+    var lastSetCode: String? = null
+    override suspend fun myLanguages() = LanguagesResponseDto(languages)
+    override suspend fun setLanguage(body: SetLanguageRequest): SetLanguageResponseDto {
+        lastSetCode = body.code
+        return SetLanguageResponseDto(body.code)
+    }
+}

--- a/apps/android/app/src/test/java/com/ciareader/reader/data/library/LibraryRepositoryTest.kt
+++ b/apps/android/app/src/test/java/com/ciareader/reader/data/library/LibraryRepositoryTest.kt
@@ -1,0 +1,78 @@
+package com.ciareader.reader.data.library
+
+import com.ciareader.reader.core.network.Outcome
+import kotlinx.coroutines.test.runTest
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import retrofit2.HttpException
+import retrofit2.Response
+
+class LibraryRepositoryTest {
+
+    @Test
+    fun mapsCardsToDomainAndFlagsReadiness() = runTest {
+        val api = FakeLibraryApi(
+            page = LibraryPageDto(
+                cards = listOf(
+                    card("t1", status = "ready"),
+                    card("t2", status = "processing"),
+                ),
+                totalCount = 2,
+            ),
+        )
+        val repo = LibraryRepositoryImpl(api)
+
+        val result = repo.listTexts(LibraryScope.OWNED, "hi")
+
+        assertTrue(result is Outcome.Success)
+        val cards = (result as Outcome.Success).data
+        assertEquals(listOf("t1", "t2"), cards.map { it.id })
+        assertTrue(cards[0].isReady)
+        assertFalse(cards[1].isReady)
+        assertEquals("owned" to "hi", api.lastScope to api.lastLanguage)
+    }
+
+    @Test
+    fun mapsHttpErrorToFailure() = runTest {
+        val repo = LibraryRepositoryImpl(FakeLibraryApi(error = http(403)))
+        val result = repo.listTexts(LibraryScope.OFFICIAL, "yi")
+        assertTrue(result is Outcome.Failure)
+        assertEquals("You don't have access to that.", (result as Outcome.Failure).message)
+    }
+
+    private fun card(id: String, status: String) = TextCardDto(
+        id = id,
+        title = "Title $id",
+        language = "hi",
+        sourceType = "paste",
+        status = status,
+        visibility = "private",
+        createdAt = "2026-06-21T00:00:00Z",
+    )
+
+    private fun http(code: Int) =
+        HttpException(Response.error<Any>(code, "e".toResponseBody("text/plain".toMediaType())))
+}
+
+private class FakeLibraryApi(
+    private val page: LibraryPageDto? = null,
+    private val error: Throwable? = null,
+) : LibraryApi {
+    var lastScope: String? = null
+    var lastLanguage: String? = null
+    override suspend fun listTexts(
+        scope: String,
+        language: String,
+        limit: Int?,
+        offset: Int?,
+    ): LibraryPageDto {
+        lastScope = scope
+        lastLanguage = language
+        error?.let { throw it }
+        return page!!
+    }
+}

--- a/apps/android/app/src/test/java/com/ciareader/reader/ui/auth/LoginScreenTest.kt
+++ b/apps/android/app/src/test/java/com/ciareader/reader/ui/auth/LoginScreenTest.kt
@@ -1,0 +1,83 @@
+package com.ciareader.reader.ui.auth
+
+import android.app.Application
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.ciareader.reader.ui.theme.CiaReaderTheme
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Compose UI test for the login screen, run on the JVM via Robolectric (no
+ * emulator). Uses a plain Application (not the @HiltAndroidApp) since the
+ * stateless content composable needs no DI.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class)
+class LoginScreenTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    private fun setContent(
+        state: LoginUiState,
+        onSubmit: () -> Unit = {},
+        onToggleMode: () -> Unit = {},
+        onSendMagicLink: () -> Unit = {},
+    ) {
+        compose.setContent {
+            CiaReaderTheme {
+                LoginScreenContent(
+                    state = state,
+                    onEmailChange = {},
+                    onPasswordChange = {},
+                    onDisplayNameChange = {},
+                    onSubmit = onSubmit,
+                    onToggleMode = onToggleMode,
+                    onSendMagicLink = onSendMagicLink,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun loginMode_showsLogInCta_andHidesDisplayNameField() {
+        setContent(LoginUiState(email = "a@b.co", password = "secret1234"))
+        compose.onNodeWithText("Log in").assertIsDisplayed()
+        compose.onNodeWithText("Display name (optional)").assertDoesNotExist()
+    }
+
+    @Test
+    fun registerMode_showsCreateAccount_andDisplayNameField() {
+        setContent(
+            LoginUiState(mode = AuthMode.REGISTER, email = "a@b.co", password = "secret1234"),
+        )
+        compose.onNodeWithText("Create account").assertIsDisplayed()
+        compose.onNodeWithText("Display name (optional)").assertIsDisplayed()
+    }
+
+    @Test
+    fun tappingSubmit_invokesCallback() {
+        var submitted = false
+        setContent(
+            LoginUiState(email = "a@b.co", password = "secret1234"),
+            onSubmit = { submitted = true },
+        )
+        compose.onNodeWithText("Log in").performClick()
+        assertTrue(submitted)
+    }
+
+    @Test
+    fun errorMessage_isShown() {
+        setContent(
+            LoginUiState(email = "a@b.co", password = "x", errorMessage = "Invalid email or password."),
+        )
+        compose.onNodeWithText("Invalid email or password.").assertIsDisplayed()
+    }
+}

--- a/apps/android/app/src/test/java/com/ciareader/reader/ui/library/LibraryScreenTest.kt
+++ b/apps/android/app/src/test/java/com/ciareader/reader/ui/library/LibraryScreenTest.kt
@@ -1,0 +1,102 @@
+package com.ciareader.reader.ui.library
+
+import android.app.Application
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.ciareader.reader.data.language.Language
+import com.ciareader.reader.data.library.TextCard
+import com.ciareader.reader.ui.theme.CiaReaderTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class)
+class LibraryScreenTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    private fun setContent(
+        state: LibraryUiState,
+        onOpenText: (String) -> Unit = {},
+        onSelectLanguage: (String) -> Unit = {},
+        onRetry: () -> Unit = {},
+        onLogout: () -> Unit = {},
+    ) {
+        compose.setContent {
+            CiaReaderTheme {
+                LibraryScreenContent(
+                    state = state,
+                    onSelectLanguage = onSelectLanguage,
+                    onOpenText = onOpenText,
+                    onRetry = onRetry,
+                    onLogout = onLogout,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun showsTextsAndTapOpensReady() {
+        var opened: String? = null
+        setContent(
+            LibraryUiState(
+                isLoading = false,
+                languages = listOf(lang("hi", "Hindi")),
+                currentLanguage = "hi",
+                texts = listOf(TextCard("t1", "Story One", "hi", "ready")),
+            ),
+            onOpenText = { opened = it },
+        )
+        compose.onNodeWithText("Story One").assertIsDisplayed()
+        compose.onNodeWithText("Story One").performClick()
+        assertEquals("t1", opened)
+    }
+
+    @Test
+    fun showsEmptyState() {
+        setContent(
+            LibraryUiState(
+                isLoading = false,
+                languages = listOf(lang("hi", "Hindi")),
+                currentLanguage = "hi",
+                texts = emptyList(),
+            ),
+        )
+        compose.onNodeWithText("No texts yet").assertIsDisplayed()
+    }
+
+    @Test
+    fun showsCurrentLanguageLabel() {
+        setContent(
+            LibraryUiState(
+                isLoading = false,
+                languages = listOf(lang("hi", "Hindi")),
+                currentLanguage = "hi",
+                texts = emptyList(),
+            ),
+        )
+        compose.onNodeWithText("Hindi").assertIsDisplayed()
+    }
+
+    @Test
+    fun showsErrorAndRetry() {
+        var retried = false
+        setContent(
+            LibraryUiState(isLoading = false, errorMessage = "Network error — check your connection and try again."),
+            onRetry = { retried = true },
+        )
+        compose.onNodeWithText("Retry").assertIsDisplayed()
+        compose.onNodeWithText("Retry").performClick()
+        assertEquals(true, retried)
+    }
+
+    private fun lang(code: String, displayName: String) =
+        Language(code = code, displayName = displayName, nativeName = displayName, script = "Deva", isDefault = true)
+}

--- a/apps/android/app/src/test/java/com/ciareader/reader/ui/library/LibraryViewModelTest.kt
+++ b/apps/android/app/src/test/java/com/ciareader/reader/ui/library/LibraryViewModelTest.kt
@@ -1,0 +1,100 @@
+package com.ciareader.reader.ui.library
+
+import com.ciareader.reader.core.network.Outcome
+import com.ciareader.reader.data.language.Language
+import com.ciareader.reader.data.language.LanguageRepository
+import com.ciareader.reader.data.library.LibraryRepository
+import com.ciareader.reader.data.library.LibraryScope
+import com.ciareader.reader.data.library.TextCard
+import com.ciareader.reader.util.MainDispatcherRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class LibraryViewModelTest {
+
+    @get:Rule
+    val mainRule = MainDispatcherRule()
+
+    @Test
+    fun loadsLanguagesThenTextsForDefaultLanguage() = runTest(mainRule.dispatcher) {
+        val langRepo = FakeLanguageRepository(
+            languages = listOf(lang("hi", isDefault = true), lang("yi")),
+        )
+        val libRepo = FakeLibraryRepository(byLanguage = mapOf("hi" to listOf(card("t1"))))
+
+        val vm = LibraryViewModel(langRepo, libRepo)
+        advanceUntilIdle()
+
+        val s = vm.state.value
+        assertEquals(listOf("hi", "yi"), s.languages.map { it.code })
+        assertEquals("hi", s.currentLanguage)
+        assertEquals(listOf("t1"), s.texts.map { it.id })
+        assertFalse(s.isLoading)
+        assertNull(s.errorMessage)
+    }
+
+    @Test
+    fun languageFailureSurfacesError() = runTest(mainRule.dispatcher) {
+        val vm = LibraryViewModel(
+            FakeLanguageRepository(error = "boom"),
+            FakeLibraryRepository(),
+        )
+        advanceUntilIdle()
+
+        assertEquals("boom", vm.state.value.errorMessage)
+        assertFalse(vm.state.value.isLoading)
+    }
+
+    @Test
+    fun selectLanguageLoadsThatLanguageAndPersists() = runTest(mainRule.dispatcher) {
+        val langRepo = FakeLanguageRepository(
+            languages = listOf(lang("hi", isDefault = true), lang("mr")),
+        )
+        val libRepo = FakeLibraryRepository(
+            byLanguage = mapOf("hi" to listOf(card("h1")), "mr" to listOf(card("m1"), card("m2"))),
+        )
+        val vm = LibraryViewModel(langRepo, libRepo)
+        advanceUntilIdle()
+
+        vm.selectLanguage("mr")
+        advanceUntilIdle()
+
+        assertEquals("mr", vm.state.value.currentLanguage)
+        assertEquals(listOf("m1", "m2"), vm.state.value.texts.map { it.id })
+        assertEquals("mr", langRepo.lastSetCode)
+    }
+
+    private fun lang(code: String, isDefault: Boolean = false) =
+        Language(code = code, displayName = code.uppercase(), nativeName = code, script = "Deva", isDefault = isDefault)
+
+    private fun card(id: String) = TextCard(id = id, title = "Title $id", language = "hi", status = "ready")
+}
+
+private class FakeLanguageRepository(
+    private val languages: List<Language> = emptyList(),
+    private val error: String? = null,
+) : LanguageRepository {
+    var lastSetCode: String? = null
+    override suspend fun myLanguages(): Outcome<List<Language>> =
+        error?.let { Outcome.Failure(it) } ?: Outcome.Success(languages)
+
+    override suspend fun setCurrent(code: String): Outcome<String> {
+        lastSetCode = code
+        return Outcome.Success(code)
+    }
+}
+
+private class FakeLibraryRepository(
+    private val byLanguage: Map<String, List<TextCard>> = emptyMap(),
+    private val error: String? = null,
+) : LibraryRepository {
+    override suspend fun listTexts(scope: LibraryScope, language: String): Outcome<List<TextCard>> =
+        error?.let { Outcome.Failure(it) } ?: Outcome.Success(byLanguage[language] ?: emptyList())
+}

--- a/apps/android/app/src/test/java/com/ciareader/reader/util/MainDispatcherRule.kt
+++ b/apps/android/app/src/test/java/com/ciareader/reader/util/MainDispatcherRule.kt
@@ -1,0 +1,24 @@
+package com.ciareader.reader.util
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+/** Swaps Dispatchers.Main for a test dispatcher so viewModelScope works in JVM tests. */
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule(
+    val dispatcher: TestDispatcher = StandardTestDispatcher(),
+) : TestWatcher() {
+    override fun starting(description: Description) {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}

--- a/apps/android/app/src/test/resources/robolectric.properties
+++ b/apps/android/app/src/test/resources/robolectric.properties
@@ -1,0 +1,3 @@
+# Robolectric runs framework code at this SDK. Pinned to 34 (compileSdk 35
+# is fine for compilation; Robolectric 4.14 ships sandboxes up to 34).
+sdk=34

--- a/apps/android/gradle/libs.versions.toml
+++ b/apps/android/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ datastore = "1.1.1"
 junit = "4.13.2"
 androidxJunit = "1.2.1"
 espresso = "3.6.1"
+robolectric = "4.14.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -50,6 +51,7 @@ androidx-datastore-preferences = { group = "androidx.datastore", name = "datasto
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxJunit" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso" }
+robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Phase 2 of the Android client (follows #444, merged). **Pairs with #445** (the web `GET /api/v1/texts` + `/collections/:id` endpoints) for live data — this PR builds and is fully tested standalone via fakes.

## What
- **Data layer** — `LibraryApi` (`GET /api/v1/texts?scope=&language=`) and `LanguagesApi` (`GET`/`POST /me/languages`); `LibraryRepository` / `LanguageRepository` map wire DTOs to UI models behind a generic `Outcome<T>`. Language is passed explicitly (cookieless Bearer client); RTL derived from script (`Hebr` → Yiddish).
- **UI** — `NavHost` (library → reader), library screen with a language switcher dropdown, loading / empty / error+retry states, tap-to-open. Reader is a stub (`ReaderStubScreen`) until Phase 3.
- **Compose UI-test infra** — Robolectric, so UI tests run on the JVM under the existing `unit-tests` task (no emulator in CI). `testOptions.unitTests.isIncludeAndroidResources = true` + a pinned `robolectric.properties`.

## Tests (25 total, lint clean)
- Unit: `LibraryRepository`, `LanguageRepository`, DTO serialization, `LibraryViewModel` (happy-path load, error surface, language switch + persist).
- UI (Robolectric Compose): `LoginScreenTest`, `LibraryScreenTest` (renders texts, tap-opens, empty state, error+retry, current-language label).

## Notes
- Library lists `scope=owned` for now; official-library browsing + collection (chapter-book) detail are follow-ups.
- CI split into separate checks is in #446; until that merges this PR runs the combined Android check.
