### PR TITLE
feat(reader): PDF upload + image reader with click-to-translate

### DIFF
--- a/apps/web/drizzle/0049_superb_champions.sql
+++ b/apps/web/drizzle/0049_superb_champions.sql
@@ -1,0 +1,6 @@
+ALTER TYPE "public"."text_source_type" ADD VALUE 'pdf';--> statement-breakpoint
+ALTER TABLE "text_chapters" ADD COLUMN "page_image_key" text;--> statement-breakpoint
+ALTER TABLE "text_chapters" ADD COLUMN "page_image_mime" text;--> statement-breakpoint
+ALTER TABLE "text_chapters" ADD COLUMN "page_width" integer;--> statement-breakpoint
+ALTER TABLE "text_chapters" ADD COLUMN "page_height" integer;--> statement-breakpoint
+ALTER TABLE "text_tokens" ADD COLUMN "bbox" jsonb;

--- a/apps/web/drizzle/meta/0049_snapshot.json
+++ b/apps/web/drizzle/meta/0049_snapshot.json
@@ -1,0 +1,5907 @@
+{
+  "id": "a9083bd4-ce98-425b-b582-163274197eca",
+  "prevId": "5a9e80c5-0bb9-415f-b35f-e6577f4a0875",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_rate_limit_events": {
+      "name": "api_rate_limit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_hash": {
+          "name": "subject_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_rate_limit_events_subject_window_idx": {
+          "name": "api_rate_limit_events_subject_window_idx",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_rate_limit_events_user_idx": {
+          "name": "api_rate_limit_events_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_rate_limit_events_user_id_users_id_fk": {
+          "name": "api_rate_limit_events_user_id_users_id_fk",
+          "tableFrom": "api_rate_limit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.audio_alignments": {
+      "name": "audio_alignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "audio_file_id": {
+          "name": "audio_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_ms": {
+          "name": "start_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_ms": {
+          "name": "end_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "alignment_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audio_alignments_timeline_idx": {
+          "name": "audio_alignments_timeline_idx",
+          "columns": [
+            {
+              "expression": "audio_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audio_alignments_audio_file_id_audio_files_id_fk": {
+          "name": "audio_alignments_audio_file_id_audio_files_id_fk",
+          "tableFrom": "audio_alignments",
+          "tableTo": "audio_files",
+          "columnsFrom": [
+            "audio_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audio_alignments_token_id_text_tokens_id_fk": {
+          "name": "audio_alignments_token_id_text_tokens_id_fk",
+          "tableFrom": "audio_alignments",
+          "tableTo": "text_tokens",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "audio_alignments_audio_file_id_token_id_uq": {
+          "name": "audio_alignments_audio_file_id_token_id_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "audio_file_id",
+            "token_id"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.audio_files": {
+      "name": "audio_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime": {
+          "name": "mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license": {
+          "name": "license",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by_id": {
+          "name": "uploaded_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audio_files_text_idx": {
+          "name": "audio_files_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audio_files_chapter_idx": {
+          "name": "audio_files_chapter_idx",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audio_files_text_id_texts_id_fk": {
+          "name": "audio_files_text_id_texts_id_fk",
+          "tableFrom": "audio_files",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audio_files_chapter_id_text_chapters_id_fk": {
+          "name": "audio_files_chapter_id_text_chapters_id_fk",
+          "tableFrom": "audio_files",
+          "tableTo": "text_chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audio_files_uploaded_by_id_users_id_fk": {
+          "name": "audio_files_uploaded_by_id_users_id_fk",
+          "tableFrom": "audio_files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.basque_reference_cache": {
+      "name": "basque_reference_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "word": {
+          "name": "word",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "results": {
+          "name": "results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "basque_reference_cache_word_source_uq": {
+          "name": "basque_reference_cache_word_source_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "word",
+            "source"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.collection_items": {
+      "name": "collection_items",
+      "schema": "",
+      "columns": {
+        "collection_id": {
+          "name": "collection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_title": {
+          "name": "section_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collection_items_order_idx": {
+          "name": "collection_items_order_idx",
+          "columns": [
+            {
+              "expression": "collection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collection_items_collection_id_collections_id_fk": {
+          "name": "collection_items_collection_id_collections_id_fk",
+          "tableFrom": "collection_items",
+          "tableTo": "collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collection_items_text_id_texts_id_fk": {
+          "name": "collection_items_text_id_texts_id_fk",
+          "tableFrom": "collection_items",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "collection_items_collection_id_text_id_pk": {
+          "name": "collection_items_collection_id_text_id_pk",
+          "columns": [
+            "collection_id",
+            "text_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.collection_shares": {
+      "name": "collection_shares",
+      "schema": "",
+      "columns": {
+        "collection_id": {
+          "name": "collection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shared_with_user_id": {
+          "name": "shared_with_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by_id": {
+          "name": "granted_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collection_shares_recipient_idx": {
+          "name": "collection_shares_recipient_idx",
+          "columns": [
+            {
+              "expression": "shared_with_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collection_shares_collection_id_collections_id_fk": {
+          "name": "collection_shares_collection_id_collections_id_fk",
+          "tableFrom": "collection_shares",
+          "tableTo": "collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collection_shares_shared_with_user_id_users_id_fk": {
+          "name": "collection_shares_shared_with_user_id_users_id_fk",
+          "tableFrom": "collection_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "shared_with_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collection_shares_granted_by_id_users_id_fk": {
+          "name": "collection_shares_granted_by_id_users_id_fk",
+          "tableFrom": "collection_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "collection_shares_collection_id_shared_with_user_id_pk": {
+          "name": "collection_shares_collection_id_shared_with_user_id_pk",
+          "columns": [
+            "collection_id",
+            "shared_with_user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.collections": {
+      "name": "collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "collection_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'chapter_book'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "collection_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collections_owner_idx": {
+          "name": "collections_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collections_visibility_idx": {
+          "name": "collections_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collections_owner_id_users_id_fk": {
+          "name": "collections_owner_id_users_id_fk",
+          "tableFrom": "collections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.curator_languages": {
+      "name": "curator_languages",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "curator_languages_user_idx": {
+          "name": "curator_languages_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "curator_languages_user_id_users_id_fk": {
+          "name": "curator_languages_user_id_users_id_fk",
+          "tableFrom": "curator_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "curator_languages_granted_by_users_id_fk": {
+          "name": "curator_languages_granted_by_users_id_fk",
+          "tableFrom": "curator_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "curator_languages_user_id_language_pk": {
+          "name": "curator_languages_user_id_language_pk",
+          "columns": [
+            "user_id",
+            "language"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.dictionary_imports": {
+      "name": "dictionary_imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_name": {
+          "name": "source_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_at": {
+          "name": "run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lemmas_created": {
+          "name": "lemmas_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lemmas_updated": {
+          "name": "lemmas_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lemmas_skipped_curator_locked": {
+          "name": "lemmas_skipped_curator_locked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "translations_created": {
+          "name": "translations_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "translations_updated": {
+          "name": "translations_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by_user_id": {
+          "name": "triggered_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'succeeded'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "dictionary_imports_language_idx": {
+          "name": "dictionary_imports_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dictionary_imports_source_latest_idx": {
+          "name": "dictionary_imports_source_latest_idx",
+          "columns": [
+            {
+              "expression": "source_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dictionary_imports_triggered_by_user_id_users_id_fk": {
+          "name": "dictionary_imports_triggered_by_user_id_users_id_fk",
+          "tableFrom": "dictionary_imports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triggered_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.form_lemma_overrides": {
+      "name": "form_lemma_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_nfc": {
+          "name": "surface_nfc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_signature": {
+          "name": "context_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "chosen_lemma_id": {
+          "name": "chosen_lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "promoted_at": {
+          "name": "promoted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "promoted_by": {
+          "name": "promoted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "form_lemma_overrides_lookup_idx": {
+          "name": "form_lemma_overrides_lookup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface_nfc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "form_lemma_overrides_chosen_lemma_id_lemmas_id_fk": {
+          "name": "form_lemma_overrides_chosen_lemma_id_lemmas_id_fk",
+          "tableFrom": "form_lemma_overrides",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "chosen_lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_lemma_overrides_promoted_by_users_id_fk": {
+          "name": "form_lemma_overrides_promoted_by_users_id_fk",
+          "tableFrom": "form_lemma_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "promoted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "form_lemma_overrides_lang_surface_ctx_uq": {
+          "name": "form_lemma_overrides_lang_surface_ctx_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "language",
+            "surface_nfc",
+            "context_signature"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.grammar_features": {
+      "name": "grammar_features",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "feat_key": {
+          "name": "feat_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feat_value": {
+          "name": "feat_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos_scope": {
+          "name": "pos_scope",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "short_label": {
+          "name": "short_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "long_label": {
+          "name": "long_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "grammar_features_key_idx": {
+          "name": "grammar_features_key_idx",
+          "columns": [
+            {
+              "expression": "feat_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grammar_features_key_value_uq": {
+          "name": "grammar_features_key_value_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "feat_key",
+            "feat_value"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.group_memberships": {
+      "name": "group_memberships",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by_id": {
+          "name": "added_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "group_memberships_user_idx": {
+          "name": "group_memberships_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_memberships_group_id_groups_id_fk": {
+          "name": "group_memberships_group_id_groups_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_memberships_user_id_users_id_fk": {
+          "name": "group_memberships_user_id_users_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_memberships_added_by_id_users_id_fk": {
+          "name": "group_memberships_added_by_id_users_id_fk",
+          "tableFrom": "group_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "added_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "group_memberships_group_id_user_id_pk": {
+          "name": "group_memberships_group_id_user_id_pk",
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "groups_owner_idx": {
+          "name": "groups_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_owner_id_users_id_fk": {
+          "name": "groups_owner_id_users_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemma_edit_history": {
+      "name": "lemma_edit_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phrase_id": {
+          "name": "phrase_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "editor_id": {
+          "name": "editor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "lemma_edit_change_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change": {
+          "name": "change",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_edit_history_lemma_idx": {
+          "name": "lemma_edit_history_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_edit_history_phrase_idx": {
+          "name": "lemma_edit_history_phrase_idx",
+          "columns": [
+            {
+              "expression": "phrase_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_edit_history_editor_idx": {
+          "name": "lemma_edit_history_editor_idx",
+          "columns": [
+            {
+              "expression": "editor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_edit_history_lemma_id_lemmas_id_fk": {
+          "name": "lemma_edit_history_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_edit_history",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lemma_edit_history_phrase_id_phrases_id_fk": {
+          "name": "lemma_edit_history_phrase_id_phrases_id_fk",
+          "tableFrom": "lemma_edit_history",
+          "tableTo": "phrases",
+          "columnsFrom": [
+            "phrase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lemma_edit_history_editor_id_users_id_fk": {
+          "name": "lemma_edit_history_editor_id_users_id_fk",
+          "tableFrom": "lemma_edit_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "editor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemma_forms": {
+      "name": "lemma_forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "romanization": {
+          "name": "romanization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "lemma_form_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'import'"
+        },
+        "paradigm_slot_id": {
+          "name": "paradigm_slot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quarantined_at": {
+          "name": "quarantined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quarantine_reason": {
+          "name": "quarantine_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_forms_lemma_idx": {
+          "name": "lemma_forms_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_forms_surface_idx": {
+          "name": "lemma_forms_surface_idx",
+          "columns": [
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_forms_surface_lookup_idx": {
+          "name": "lemma_forms_surface_lookup_idx",
+          "columns": [
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "quarantined_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_forms_lemma_id_lemmas_id_fk": {
+          "name": "lemma_forms_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_forms",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lemma_forms_paradigm_slot_id_paradigm_slots_id_fk": {
+          "name": "lemma_forms_paradigm_slot_id_paradigm_slots_id_fk",
+          "tableFrom": "lemma_forms",
+          "tableTo": "paradigm_slots",
+          "columnsFrom": [
+            "paradigm_slot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemma_proposals": {
+      "name": "lemma_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "proposer_id": {
+          "name": "proposer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headword": {
+          "name": "headword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos": {
+          "name": "pos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gloss_default": {
+          "name": "gloss_default",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "lemma_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "promoted_lemma_id": {
+          "name": "promoted_lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_id": {
+          "name": "reviewer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_note": {
+          "name": "reviewer_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lemma_proposals_lang_status_idx": {
+          "name": "lemma_proposals_lang_status_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemma_proposals_headword_idx": {
+          "name": "lemma_proposals_headword_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "headword",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pos",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemma_proposals_proposer_id_users_id_fk": {
+          "name": "lemma_proposals_proposer_id_users_id_fk",
+          "tableFrom": "lemma_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "proposer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "lemma_proposals_promoted_lemma_id_lemmas_id_fk": {
+          "name": "lemma_proposals_promoted_lemma_id_lemmas_id_fk",
+          "tableFrom": "lemma_proposals",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "promoted_lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "lemma_proposals_reviewer_id_users_id_fk": {
+          "name": "lemma_proposals_reviewer_id_users_id_fk",
+          "tableFrom": "lemma_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.lemmas": {
+      "name": "lemmas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headword": {
+          "name": "headword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos": {
+          "name": "pos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script": {
+          "name": "script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gloss_default": {
+          "name": "gloss_default",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_rank": {
+          "name": "frequency_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "translation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "curator_locked": {
+          "name": "curator_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "headword_nukta_stripped": {
+          "name": "headword_nukta_stripped",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "replace(replace(replace(replace(translate(normalize(\"headword\", NFD), '़', ''), 'װ', 'וו'), 'ױ', 'וי'), 'ײ', 'יי'), 'יַי', 'ייַ')",
+            "type": "stored"
+          }
+        },
+        "paradigm_id": {
+          "name": "paradigm_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stem": {
+          "name": "stem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "lemmas_language_headword_pos_idx": {
+          "name": "lemmas_language_headword_pos_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "headword",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pos",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_language_idx": {
+          "name": "lemmas_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_language_frequency_idx": {
+          "name": "lemmas_language_frequency_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "frequency_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_source_lookup_idx": {
+          "name": "lemmas_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lemmas_language_headword_stripped_idx": {
+          "name": "lemmas_language_headword_stripped_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "headword_nukta_stripped",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lemmas_paradigm_id_paradigms_id_fk": {
+          "name": "lemmas_paradigm_id_paradigms_id_fk",
+          "tableFrom": "lemmas",
+          "tableTo": "paradigms",
+          "columnsFrom": [
+            "paradigm_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.magic_links": {
+      "name": "magic_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "magic_links_user_idx": {
+          "name": "magic_links_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "magic_links_expires_idx": {
+          "name": "magic_links_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "magic_links_user_id_users_id_fk": {
+          "name": "magic_links_user_id_users_id_fk",
+          "tableFrom": "magic_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.nlp_jobs": {
+      "name": "nlp_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "nlp_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nlp_jobs_text_idx": {
+          "name": "nlp_jobs_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nlp_jobs_status_idx": {
+          "name": "nlp_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nlp_jobs_text_id_texts_id_fk": {
+          "name": "nlp_jobs_text_id_texts_id_fk",
+          "tableFrom": "nlp_jobs",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.paradigm_slots": {
+      "name": "paradigm_slots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "paradigm_id": {
+          "name": "paradigm_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot_key": {
+          "name": "slot_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "suffix": {
+          "name": "suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "paradigm_slots_paradigm_idx": {
+          "name": "paradigm_slots_paradigm_idx",
+          "columns": [
+            {
+              "expression": "paradigm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "paradigm_slots_paradigm_id_paradigms_id_fk": {
+          "name": "paradigm_slots_paradigm_id_paradigms_id_fk",
+          "tableFrom": "paradigm_slots",
+          "tableTo": "paradigms",
+          "columnsFrom": [
+            "paradigm_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "paradigm_slots_paradigm_key_uq": {
+          "name": "paradigm_slots_paradigm_key_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "paradigm_id",
+            "slot_key"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.paradigms": {
+      "name": "paradigms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos": {
+          "name": "pos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "paradigms_language_pos_idx": {
+          "name": "paradigms_language_pos_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pos",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "paradigms_language_pos_name_uq": {
+          "name": "paradigms_language_pos_name_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "language",
+            "pos",
+            "name"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.parse_reports": {
+      "name": "parse_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_nfc": {
+          "name": "surface_nfc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_signature": {
+          "name": "context_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "original_candidates": {
+          "name": "original_candidates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "corrected_lemma_id": {
+          "name": "corrected_lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "correction_type": {
+          "name": "correction_type",
+          "type": "token_correction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "parse_report_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "assigned_reviewer_id": {
+          "name": "assigned_reviewer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_note": {
+          "name": "resolution_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duplicate_count": {
+          "name": "duplicate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parse_reports_lang_status_idx": {
+          "name": "parse_reports_lang_status_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parse_reports_dedup_idx": {
+          "name": "parse_reports_dedup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface_nfc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_signature",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "corrected_lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parse_reports_token_id_text_tokens_id_fk": {
+          "name": "parse_reports_token_id_text_tokens_id_fk",
+          "tableFrom": "parse_reports",
+          "tableTo": "text_tokens",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "parse_reports_corrected_lemma_id_lemmas_id_fk": {
+          "name": "parse_reports_corrected_lemma_id_lemmas_id_fk",
+          "tableFrom": "parse_reports",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "corrected_lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "parse_reports_reporter_id_users_id_fk": {
+          "name": "parse_reports_reporter_id_users_id_fk",
+          "tableFrom": "parse_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "parse_reports_assigned_reviewer_id_users_id_fk": {
+          "name": "parse_reports_assigned_reviewer_id_users_id_fk",
+          "tableFrom": "parse_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_reviewer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.personal_api_keys": {
+      "name": "personal_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "personal_api_keys_user_idx": {
+          "name": "personal_api_keys_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "personal_api_keys_active_user_idx": {
+          "name": "personal_api_keys_active_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personal_api_keys_user_id_users_id_fk": {
+          "name": "personal_api_keys_user_id_users_id_fk",
+          "tableFrom": "personal_api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "personal_api_keys_hash_unique": {
+          "name": "personal_api_keys_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.phrase_chapter_spans": {
+      "name": "phrase_chapter_spans",
+      "schema": "",
+      "columns": {
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phrase_id": {
+          "name": "phrase_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_token_idx": {
+          "name": "start_token_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_token_idx": {
+          "name": "end_token_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "phrase_chapter_spans_chapter_idx": {
+          "name": "phrase_chapter_spans_chapter_idx",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "phrase_chapter_spans_phrase_idx": {
+          "name": "phrase_chapter_spans_phrase_idx",
+          "columns": [
+            {
+              "expression": "phrase_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "phrase_chapter_spans_chapter_id_text_chapters_id_fk": {
+          "name": "phrase_chapter_spans_chapter_id_text_chapters_id_fk",
+          "tableFrom": "phrase_chapter_spans",
+          "tableTo": "text_chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "phrase_chapter_spans_phrase_id_phrases_id_fk": {
+          "name": "phrase_chapter_spans_phrase_id_phrases_id_fk",
+          "tableFrom": "phrase_chapter_spans",
+          "tableTo": "phrases",
+          "columnsFrom": [
+            "phrase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "phrase_chapter_spans_chapter_id_start_token_idx_phrase_id_pk": {
+          "name": "phrase_chapter_spans_chapter_id_start_token_idx_phrase_id_pk",
+          "columns": [
+            "chapter_id",
+            "start_token_idx",
+            "phrase_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.phrase_proposals": {
+      "name": "phrase_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_normalised": {
+          "name": "surface_normalised",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern_id": {
+          "name": "pattern_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "promoted_at": {
+          "name": "promoted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promoted_phrase_id": {
+          "name": "promoted_phrase_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "phrase_proposals_promotion_lookup_idx": {
+          "name": "phrase_proposals_promotion_lookup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface_normalised",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "phrase_proposals_chapter_id_text_chapters_id_fk": {
+          "name": "phrase_proposals_chapter_id_text_chapters_id_fk",
+          "tableFrom": "phrase_proposals",
+          "tableTo": "text_chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "phrase_proposals_promoted_phrase_id_phrases_id_fk": {
+          "name": "phrase_proposals_promoted_phrase_id_phrases_id_fk",
+          "tableFrom": "phrase_proposals",
+          "tableTo": "phrases",
+          "columnsFrom": [
+            "promoted_phrase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "phrase_proposals_occurrence_uq": {
+          "name": "phrase_proposals_occurrence_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chapter_id",
+            "surface_normalised",
+            "pattern_id"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.phrase_tokens": {
+      "name": "phrase_tokens",
+      "schema": "",
+      "columns": {
+        "phrase_id": {
+          "name": "phrase_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "phrase_tokens_surface_idx": {
+          "name": "phrase_tokens_surface_idx",
+          "columns": [
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "phrase_tokens_phrase_id_phrases_id_fk": {
+          "name": "phrase_tokens_phrase_id_phrases_id_fk",
+          "tableFrom": "phrase_tokens",
+          "tableTo": "phrases",
+          "columnsFrom": [
+            "phrase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "phrase_tokens_lemma_id_lemmas_id_fk": {
+          "name": "phrase_tokens_lemma_id_lemmas_id_fk",
+          "tableFrom": "phrase_tokens",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "phrase_tokens_phrase_id_position_pk": {
+          "name": "phrase_tokens_phrase_id_position_pk",
+          "columns": [
+            "phrase_id",
+            "position"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.phrases": {
+      "name": "phrases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_normalised": {
+          "name": "surface_normalised",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos": {
+          "name": "pos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gloss_default": {
+          "name": "gloss_default",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_rank": {
+          "name": "frequency_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "translation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "curator_locked": {
+          "name": "curator_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "phrases_language_surface_idx": {
+          "name": "phrases_language_surface_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface_normalised",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "phrases_language_idx": {
+          "name": "phrases_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "phrases_language_frequency_idx": {
+          "name": "phrases_language_frequency_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "frequency_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "phrases_source_lookup_idx": {
+          "name": "phrases_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by": {
+          "name": "replaced_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "refresh_tokens_user_idx": {
+          "name": "refresh_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_expires_idx": {
+          "name": "refresh_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.sentence_translations": {
+      "name": "sentence_translations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_language": {
+          "name": "target_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_hash": {
+          "name": "text_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "translation": {
+          "name": "translation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sentence_translations_key_uq": {
+          "name": "sentence_translations_key_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "language",
+            "target_language",
+            "model",
+            "text_hash"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.text_chapters": {
+      "name": "text_chapters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idx": {
+          "name": "idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "page_image_key": {
+          "name": "page_image_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_image_mime": {
+          "name": "page_image_mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_width": {
+          "name": "page_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_height": {
+          "name": "page_height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "text_chapters_text_idx": {
+          "name": "text_chapters_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_chapters_text_id_texts_id_fk": {
+          "name": "text_chapters_text_id_texts_id_fk",
+          "tableFrom": "text_chapters",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "text_chapters_text_idx_uq": {
+          "name": "text_chapters_text_idx_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "text_id",
+            "idx"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.text_group_shares": {
+      "name": "text_group_shares",
+      "schema": "",
+      "columns": {
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by_id": {
+          "name": "granted_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "text_group_shares_group_idx": {
+          "name": "text_group_shares_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_group_shares_text_id_texts_id_fk": {
+          "name": "text_group_shares_text_id_texts_id_fk",
+          "tableFrom": "text_group_shares",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_group_shares_group_id_groups_id_fk": {
+          "name": "text_group_shares_group_id_groups_id_fk",
+          "tableFrom": "text_group_shares",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_group_shares_granted_by_id_users_id_fk": {
+          "name": "text_group_shares_granted_by_id_users_id_fk",
+          "tableFrom": "text_group_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "text_group_shares_text_id_group_id_pk": {
+          "name": "text_group_shares_text_id_group_id_pk",
+          "columns": [
+            "text_id",
+            "group_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.text_shares": {
+      "name": "text_shares",
+      "schema": "",
+      "columns": {
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shared_with_user_id": {
+          "name": "shared_with_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "text_share_permission",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'read'"
+        },
+        "granted_by_id": {
+          "name": "granted_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "text_shares_recipient_idx": {
+          "name": "text_shares_recipient_idx",
+          "columns": [
+            {
+              "expression": "shared_with_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_shares_text_id_texts_id_fk": {
+          "name": "text_shares_text_id_texts_id_fk",
+          "tableFrom": "text_shares",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_shares_shared_with_user_id_users_id_fk": {
+          "name": "text_shares_shared_with_user_id_users_id_fk",
+          "tableFrom": "text_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "shared_with_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_shares_granted_by_id_users_id_fk": {
+          "name": "text_shares_granted_by_id_users_id_fk",
+          "tableFrom": "text_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "text_shares_text_id_shared_with_user_id_pk": {
+          "name": "text_shares_text_id_shared_with_user_id_pk",
+          "columns": [
+            "text_id",
+            "shared_with_user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.text_tokens": {
+      "name": "text_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idx": {
+          "name": "idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lemma_candidates": {
+          "name": "lemma_candidates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_ambiguous": {
+          "name": "is_ambiguous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_oov": {
+          "name": "is_oov",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_word": {
+          "name": "is_word",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sentence_idx": {
+          "name": "sentence_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "romanization": {
+          "name": "romanization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_forms": {
+          "name": "number_forms",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bbox": {
+          "name": "bbox",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "text_tokens_chapter_scan_idx": {
+          "name": "text_tokens_chapter_scan_idx",
+          "columns": [
+            {
+              "expression": "chapter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "text_tokens_lemma_idx": {
+          "name": "text_tokens_lemma_idx",
+          "columns": [
+            {
+              "expression": "lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "text_tokens_chapter_id_text_chapters_id_fk": {
+          "name": "text_tokens_chapter_id_text_chapters_id_fk",
+          "tableFrom": "text_tokens",
+          "tableTo": "text_chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "text_tokens_lemma_id_lemmas_id_fk": {
+          "name": "text_tokens_lemma_id_lemmas_id_fk",
+          "tableFrom": "text_tokens",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "text_tokens_chapter_idx_uq": {
+          "name": "text_tokens_chapter_idx_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chapter_id",
+            "idx"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.texts": {
+      "name": "texts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "status_error": {
+          "name": "status_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "texts_owner_idx": {
+          "name": "texts_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "texts_visibility_idx": {
+          "name": "texts_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "texts_owner_id_users_id_fk": {
+          "name": "texts_owner_id_users_id_fk",
+          "tableFrom": "texts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.token_corrections": {
+      "name": "token_corrections",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "token_correction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chosen_lemma_id": {
+          "name": "chosen_lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "token_corrections_token_idx": {
+          "name": "token_corrections_token_idx",
+          "columns": [
+            {
+              "expression": "token_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "token_corrections_chosen_lemma_idx": {
+          "name": "token_corrections_chosen_lemma_idx",
+          "columns": [
+            {
+              "expression": "chosen_lemma_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "token_corrections_user_id_users_id_fk": {
+          "name": "token_corrections_user_id_users_id_fk",
+          "tableFrom": "token_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "token_corrections_token_id_text_tokens_id_fk": {
+          "name": "token_corrections_token_id_text_tokens_id_fk",
+          "tableFrom": "token_corrections",
+          "tableTo": "text_tokens",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "token_corrections_chosen_lemma_id_lemmas_id_fk": {
+          "name": "token_corrections_chosen_lemma_id_lemmas_id_fk",
+          "tableFrom": "token_corrections",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "chosen_lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "token_corrections_user_id_token_id_pk": {
+          "name": "token_corrections_user_id_token_id_pk",
+          "columns": [
+            "user_id",
+            "token_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.translation_reports": {
+      "name": "translation_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "translation_id": {
+          "name": "translation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "translation_report_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "translation_report_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_note": {
+          "name": "resolution_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "translation_reports_status_idx": {
+          "name": "translation_reports_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translation_reports_translation_idx": {
+          "name": "translation_reports_translation_idx",
+          "columns": [
+            {
+              "expression": "translation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "translation_reports_translation_id_translations_id_fk": {
+          "name": "translation_reports_translation_id_translations_id_fk",
+          "tableFrom": "translation_reports",
+          "tableTo": "translations",
+          "columnsFrom": [
+            "translation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "translation_reports_reporter_id_users_id_fk": {
+          "name": "translation_reports_reporter_id_users_id_fk",
+          "tableFrom": "translation_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "translation_reports_resolved_by_users_id_fk": {
+          "name": "translation_reports_resolved_by_users_id_fk",
+          "tableFrom": "translation_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "translation_reports_reporter_translation_uq": {
+          "name": "translation_reports_reporter_translation_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "reporter_id",
+            "translation_id"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.translation_votes": {
+      "name": "translation_votes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "translation_id": {
+          "name": "translation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "translation_vote_value",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "translation_votes_translation_idx": {
+          "name": "translation_votes_translation_idx",
+          "columns": [
+            {
+              "expression": "translation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translation_votes_user_idx": {
+          "name": "translation_votes_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "translation_votes_user_id_users_id_fk": {
+          "name": "translation_votes_user_id_users_id_fk",
+          "tableFrom": "translation_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "translation_votes_translation_id_translations_id_fk": {
+          "name": "translation_votes_translation_id_translations_id_fk",
+          "tableFrom": "translation_votes",
+          "tableTo": "translations",
+          "columnsFrom": [
+            "translation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "translation_votes_user_id_translation_id_pk": {
+          "name": "translation_votes_user_id_translation_id_pk",
+          "columns": [
+            "user_id",
+            "translation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.translations": {
+      "name": "translations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "translation_target_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'lemma'"
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "translation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_translation_id": {
+          "name": "parent_translation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_language": {
+          "name": "target_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "source_attribution": {
+          "name": "source_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_rank": {
+          "name": "display_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "translations_target_idx": {
+          "name": "translations_target_idx",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translations_submitted_by_idx": {
+          "name": "translations_submitted_by_idx",
+          "columns": [
+            {
+              "expression": "submitted_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translations_source_lookup_idx": {
+          "name": "translations_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "translations_submitted_by_users_id_fk": {
+          "name": "translations_submitted_by_users_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "translations_parent_translation_id_translations_id_fk": {
+          "name": "translations_parent_translation_id_translations_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "translations",
+          "columnsFrom": [
+            "parent_translation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_audio_listening": {
+      "name": "user_audio_listening",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audio_file_id": {
+          "name": "audio_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "listened_ms": {
+          "name": "listened_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_listened_at": {
+          "name": "last_listened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_audio_listening_user_text_idx": {
+          "name": "user_audio_listening_user_text_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_audio_listening_text_idx": {
+          "name": "user_audio_listening_text_idx",
+          "columns": [
+            {
+              "expression": "text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_audio_listening_user_id_users_id_fk": {
+          "name": "user_audio_listening_user_id_users_id_fk",
+          "tableFrom": "user_audio_listening",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_audio_listening_audio_file_id_audio_files_id_fk": {
+          "name": "user_audio_listening_audio_file_id_audio_files_id_fk",
+          "tableFrom": "user_audio_listening",
+          "tableTo": "audio_files",
+          "columnsFrom": [
+            "audio_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_audio_listening_text_id_texts_id_fk": {
+          "name": "user_audio_listening_text_id_texts_id_fk",
+          "tableFrom": "user_audio_listening",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_audio_listening_user_id_audio_file_id_pk": {
+          "name": "user_audio_listening_user_id_audio_file_id_pk",
+          "columns": [
+            "user_id",
+            "audio_file_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_known_lemmas": {
+      "name": "user_known_lemmas",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lemma_id": {
+          "name": "lemma_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "known_lemma_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'learning'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "mined_sentence": {
+          "name": "mined_sentence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mined_chapter_id": {
+          "name": "mined_chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mined_token_idx": {
+          "name": "mined_token_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_known_lemmas_user_idx": {
+          "name": "user_known_lemmas_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_known_lemmas_user_id_users_id_fk": {
+          "name": "user_known_lemmas_user_id_users_id_fk",
+          "tableFrom": "user_known_lemmas",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_known_lemmas_lemma_id_lemmas_id_fk": {
+          "name": "user_known_lemmas_lemma_id_lemmas_id_fk",
+          "tableFrom": "user_known_lemmas",
+          "tableTo": "lemmas",
+          "columnsFrom": [
+            "lemma_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_known_lemmas_mined_chapter_id_text_chapters_id_fk": {
+          "name": "user_known_lemmas_mined_chapter_id_text_chapters_id_fk",
+          "tableFrom": "user_known_lemmas",
+          "tableTo": "text_chapters",
+          "columnsFrom": [
+            "mined_chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_known_lemmas_user_id_lemma_id_pk": {
+          "name": "user_known_lemmas_user_id_lemma_id_pk",
+          "columns": [
+            "user_id",
+            "lemma_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_known_phrases": {
+      "name": "user_known_phrases",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phrase_id": {
+          "name": "phrase_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "known_lemma_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'learning'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_known_phrases_user_idx": {
+          "name": "user_known_phrases_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_known_phrases_user_id_users_id_fk": {
+          "name": "user_known_phrases_user_id_users_id_fk",
+          "tableFrom": "user_known_phrases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_known_phrases_phrase_id_phrases_id_fk": {
+          "name": "user_known_phrases_phrase_id_phrases_id_fk",
+          "tableFrom": "user_known_phrases",
+          "tableTo": "phrases",
+          "columnsFrom": [
+            "phrase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_known_phrases_user_id_phrase_id_pk": {
+          "name": "user_known_phrases_user_id_phrase_id_pk",
+          "columns": [
+            "user_id",
+            "phrase_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_languages": {
+      "name": "user_languages",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script_preference": {
+          "name": "script_preference",
+          "type": "script_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "romanization_scheme": {
+          "name": "romanization_scheme",
+          "type": "romanization_scheme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'iso15919'"
+        },
+        "known_words_count_cache": {
+          "name": "known_words_count_cache",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "known_phrases_count_cache": {
+          "name": "known_phrases_count_cache",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reader_layout_mode": {
+          "name": "reader_layout_mode",
+          "type": "reader_layout_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'page'"
+        },
+        "words_per_page": {
+          "name": "words_per_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 250
+        },
+        "font_family": {
+          "name": "font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_size": {
+          "name": "font_size",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 18
+        },
+        "line_spacing": {
+          "name": "line_spacing",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1.6
+        },
+        "highlight_style": {
+          "name": "highlight_style",
+          "type": "highlight_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'background'"
+        },
+        "reading_width": {
+          "name": "reading_width",
+          "type": "reading_width",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "baseline": {
+          "name": "baseline",
+          "type": "language_baseline",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_languages_user_id_users_id_fk": {
+          "name": "user_languages_user_id_users_id_fk",
+          "tableFrom": "user_languages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_languages_user_id_language_pk": {
+          "name": "user_languages_user_id_language_pk",
+          "columns": [
+            "user_id",
+            "language"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_text_progress": {
+      "name": "user_text_progress",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_id": {
+          "name": "text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_chapter_idx": {
+          "name": "last_chapter_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_token_idx": {
+          "name": "last_token_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pct_read": {
+          "name": "pct_read",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_text_progress_user_idx": {
+          "name": "user_text_progress_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_text_progress_user_id_users_id_fk": {
+          "name": "user_text_progress_user_id_users_id_fk",
+          "tableFrom": "user_text_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_text_progress_text_id_texts_id_fk": {
+          "name": "user_text_progress_text_id_texts_id_fk",
+          "tableFrom": "user_text_progress",
+          "tableTo": "texts",
+          "columnsFrom": [
+            "text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_text_progress_user_id_text_id_pk": {
+          "name": "user_text_progress_user_id_text_id_pk",
+          "columns": [
+            "user_id",
+            "text_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_preference": {
+          "name": "theme_preference",
+          "type": "theme_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarded_at": {
+          "name": "onboarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    }
+  },
+  "enums": {
+    "public.alignment_source": {
+      "name": "alignment_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "imported",
+        "whisper"
+      ]
+    },
+    "public.collection_kind": {
+      "name": "collection_kind",
+      "schema": "public",
+      "values": [
+        "chapter_book",
+        "course",
+        "anthology"
+      ]
+    },
+    "public.collection_visibility": {
+      "name": "collection_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "shared",
+        "official"
+      ]
+    },
+    "public.highlight_style": {
+      "name": "highlight_style",
+      "schema": "public",
+      "values": [
+        "underline",
+        "background",
+        "colored_text"
+      ]
+    },
+    "public.known_lemma_status": {
+      "name": "known_lemma_status",
+      "schema": "public",
+      "values": [
+        "unknown",
+        "learning",
+        "known",
+        "ignored"
+      ]
+    },
+    "public.language": {
+      "name": "language",
+      "schema": "public",
+      "values": [
+        "hi",
+        "mr",
+        "or",
+        "yi",
+        "eu"
+      ]
+    },
+    "public.language_baseline": {
+      "name": "language_baseline",
+      "schema": "public",
+      "values": [
+        "none",
+        "beginner",
+        "intermediate"
+      ]
+    },
+    "public.lemma_edit_change_type": {
+      "name": "lemma_edit_change_type",
+      "schema": "public",
+      "values": [
+        "lemma_update",
+        "lemma_unlock",
+        "lemma_lock",
+        "translation_insert",
+        "translation_update",
+        "translation_hide",
+        "translation_unhide",
+        "form_insert",
+        "form_delete",
+        "lemma_merge",
+        "lemma_split",
+        "translation_reorder",
+        "phrase_update",
+        "phrase_lock",
+        "phrase_unlock",
+        "phrase_hide",
+        "phrase_unhide",
+        "phrase_merge"
+      ]
+    },
+    "public.lemma_form_source": {
+      "name": "lemma_form_source",
+      "schema": "public",
+      "values": [
+        "import",
+        "pipeline",
+        "curator",
+        "generator"
+      ]
+    },
+    "public.lemma_proposal_status": {
+      "name": "lemma_proposal_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.nlp_job_status": {
+      "name": "nlp_job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.parse_report_status": {
+      "name": "parse_report_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "triaged",
+        "resolved",
+        "rejected",
+        "duplicate",
+        "deferred"
+      ]
+    },
+    "public.reader_layout_mode": {
+      "name": "reader_layout_mode",
+      "schema": "public",
+      "values": [
+        "page",
+        "paged_scroll",
+        "continuous"
+      ]
+    },
+    "public.reading_width": {
+      "name": "reading_width",
+      "schema": "public",
+      "values": [
+        "narrow",
+        "medium",
+        "wide"
+      ]
+    },
+    "public.romanization_scheme": {
+      "name": "romanization_scheme",
+      "schema": "public",
+      "values": [
+        "iso15919",
+        "iast",
+        "hunterian",
+        "itrans",
+        "yivo"
+      ]
+    },
+    "public.script_preference": {
+      "name": "script_preference",
+      "schema": "public",
+      "values": [
+        "native",
+        "native_with_romanization",
+        "romanization_only"
+      ]
+    },
+    "public.text_share_permission": {
+      "name": "text_share_permission",
+      "schema": "public",
+      "values": [
+        "read"
+      ]
+    },
+    "public.text_source_type": {
+      "name": "text_source_type",
+      "schema": "public",
+      "values": [
+        "paste",
+        "txt",
+        "epub",
+        "zip",
+        "pdf"
+      ]
+    },
+    "public.text_status": {
+      "name": "text_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.text_visibility": {
+      "name": "text_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "shared",
+        "official"
+      ]
+    },
+    "public.theme_preference": {
+      "name": "theme_preference",
+      "schema": "public",
+      "values": [
+        "system",
+        "light",
+        "dark"
+      ]
+    },
+    "public.token_correction_type": {
+      "name": "token_correction_type",
+      "schema": "public",
+      "values": [
+        "pick_candidate",
+        "manual_lemma",
+        "new_lemma",
+        "mark_proper_noun",
+        "mark_foreign",
+        "mark_not_a_word"
+      ]
+    },
+    "public.translation_report_reason": {
+      "name": "translation_report_reason",
+      "schema": "public",
+      "values": [
+        "spam",
+        "incorrect",
+        "offensive",
+        "duplicate",
+        "other"
+      ]
+    },
+    "public.translation_report_status": {
+      "name": "translation_report_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "resolved_hidden",
+        "resolved_kept",
+        "dismissed"
+      ]
+    },
+    "public.translation_source": {
+      "name": "translation_source",
+      "schema": "public",
+      "values": [
+        "official_dictionary",
+        "curator",
+        "user",
+        "nlp"
+      ]
+    },
+    "public.translation_target_type": {
+      "name": "translation_target_type",
+      "schema": "public",
+      "values": [
+        "lemma",
+        "phrase"
+      ]
+    },
+    "public.translation_vote_value": {
+      "name": "translation_vote_value",
+      "schema": "public",
+      "values": [
+        "up",
+        "down"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "curator",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -344,6 +344,13 @@
       "when": 1782002730387,
       "tag": "0048_overconfident_stark_industries",
       "breakpoints": true
+    },
+    {
+      "idx": 49,
+      "version": "7",
+      "when": 1782103478214,
+      "tag": "0049_superb_champions",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -33,6 +33,7 @@
     "jsdom": "^25.0.1",
     "jszip": "^3.10.1",
     "nodemailer": "^6.9.15",
+    "pdfjs-dist": "^6.0.227",
     "postgres": "^3.4.4",
     "undici": "^6.21.1",
     "zod": "^3.23.8"

--- a/apps/web/src/lib/components/reader/ChapterBody.svelte
+++ b/apps/web/src/lib/components/reader/ChapterBody.svelte
@@ -40,6 +40,7 @@
     isOwner = false,
     isAdmin = false,
     textId,
+    pageImage = null,
   }: {
     chapter: ChapterView;
     /** T-6.2: drives the CorrectionModal's dictionary-search
@@ -50,6 +51,12 @@
     isAdmin?: boolean;
     /** Owning text id — drives the popup's book-wide frequency lookup. */
     textId: string;
+    /** PDF image reader: when set, render the page image with clickable
+     *  word hotspots (positioned by each token's bbox) instead of
+     *  reflowed text. All the popup / known-words machinery below is
+     *  reused — the hotspots carry `data-token-id` so `onChapterClick`
+     *  and the hover tooltip work unchanged. */
+    pageImage?: { url: string; width: number | null; height: number | null } | null;
   } = $props();
 
   // Text direction comes from the shared registry (rtl for Yiddish's
@@ -175,6 +182,18 @@
     if (!tokensWithOverrides) return new Map<string, ServerToken>();
     return new Map(tokensWithOverrides.map((t) => [t.id, t]));
   });
+
+  // PDF image reader: word tokens that carry a bounding box, rendered as
+  // absolutely-positioned hotspots over the page image.
+  const overlayTokens = $derived.by(() => {
+    if (!pageImage || !tokensWithOverrides) return [];
+    return tokensWithOverrides.filter((t) => t.isWord && t.bbox);
+  });
+  const pageAspect = $derived(
+    pageImage && pageImage.width && pageImage.height
+      ? `${pageImage.width} / ${pageImage.height}`
+      : null,
+  );
 
   // Click → side panel (locked until closed). Hover → tooltip
   // (transient). Click and hover are independent so the side panel
@@ -598,7 +617,31 @@
   ontouchend={onTouchEnd}
   ontouchcancel={onTouchEnd}
 >
-  {#if displayParagraphs}
+  {#if pageImage}
+    <!-- PDF image reader: the original page with transparent, clickable
+         word hotspots positioned by each token's normalized bbox. The
+         real page is always visible so OCR mistakes can be verified. -->
+    <div
+      class="page-overlay"
+      data-testid="page-overlay"
+      style={pageAspect ? `aspect-ratio: ${pageAspect}` : undefined}
+    >
+      <img class="page-img" src={pageImage.url} alt={`Page ${chapter.idx + 1}`} />
+      {#each overlayTokens as t (t.id)}
+        <span
+          class="ovl-hotspot"
+          class:anchor={activeToken?.id === t.id}
+          class:no-definition={t.hasDefinition === false}
+          data-token-id={t.id}
+          data-token-idx={t.idx}
+          data-lemma-id={t.lemmaId ?? undefined}
+          data-s={statusToCode(t.status)}
+          title={t.surface}
+          style={`left:${(t.bbox!.x * 100).toFixed(3)}%;top:${(t.bbox!.y * 100).toFixed(3)}%;width:${(t.bbox!.w * 100).toFixed(3)}%;height:${(t.bbox!.h * 100).toFixed(3)}%`}
+        ></span>
+      {/each}
+    </div>
+  {:else if displayParagraphs}
     {#each displayParagraphs as paragraph, pIdx (pIdx)}
       <p class="body">
         {#each paragraph as group, gIdx (gIdx)}{#if group.kind === 'plain'}{@render renderSegment(group.segment)}{:else}<phrase
@@ -636,6 +679,7 @@
   {isOwner}
   {isAdmin}
   {textId}
+  {pageImage}
   onClose={closePopup}
   onPhraseCreated={(phraseId: string) => {
     void onPhraseCreated(phraseId);
@@ -666,6 +710,58 @@
   }
   .word:hover {
     background: color-mix(in srgb, var(--color-accent) 12%, transparent);
+  }
+  /* PDF image reader (overlay). The page image fills a centered column;
+     transparent hotspots sit over each word so clicks open the same
+     WordPopup the text reader uses. */
+  .page-overlay {
+    position: relative;
+    width: 100%;
+    max-width: 100%;
+    margin: 0 auto;
+    line-height: 0;
+  }
+  .page-img {
+    display: block;
+    width: 100%;
+    height: auto;
+    user-select: none;
+  }
+  .ovl-hotspot {
+    position: absolute;
+    cursor: pointer;
+    border-radius: 2px;
+    /* A faint fill marks every recognized word as clickable without
+       drowning the page; status tints below layer on top. */
+    background: color-mix(in oklch, var(--accent, var(--color-accent)) 8%, transparent);
+    transition: background 80ms ease, box-shadow 80ms ease;
+  }
+  .ovl-hotspot:hover {
+    background: color-mix(in oklch, var(--accent, var(--color-accent)) 24%, transparent);
+  }
+  /* Known + ignored words drop the fill — the learner already has them. */
+  .ovl-hotspot[data-s='4'],
+  .ovl-hotspot[data-s='5'] {
+    background: transparent;
+  }
+  .ovl-hotspot[data-s='4']:hover,
+  .ovl-hotspot[data-s='5']:hover {
+    background: color-mix(in oklch, var(--accent, var(--color-accent)) 14%, transparent);
+  }
+  /* Learning words get the saffron study tint, mirroring tokens.css. */
+  .ovl-hotspot[data-s='2'] {
+    background: color-mix(in oklch, var(--w-l2-bg, #f4c95d) 45%, transparent);
+  }
+  /* Selected word: a clear accent ring (meets the 3:1 non-text UI
+     contrast guidance over the page image). */
+  .ovl-hotspot.anchor {
+    box-shadow: 0 0 0 2px var(--accent, var(--color-accent));
+    background: color-mix(in oklch, var(--accent, var(--color-accent)) 18%, transparent);
+  }
+  /* Admin "flag undefined words" overlay — dashed magenta box, matching
+     the text reader's no-definition affordance. */
+  :global(html[data-flag-undefined]) .ovl-hotspot.no-definition {
+    box-shadow: 0 0 0 1px var(--magenta, #c026d3);
   }
   /* T-14.3 / T-14.3b: phrase wrappers are an unknown element so we
      have to opt them into inline display explicitly. The visible

--- a/apps/web/src/lib/components/reader/ReaderImage.svelte
+++ b/apps/web/src/lib/components/reader/ReaderImage.svelte
@@ -1,0 +1,200 @@
+<!--
+  PDF image reader (one page per chapter).
+
+  Shows the original page image with clickable word overlays (the default)
+  or a reflowed-text view of the same page's OCR, toggled by the user.
+  Both views render through ChapterBody, so the WordPopup / known-words /
+  translation machinery is identical to the text reader — the only
+  difference is whether ChapterBody gets a `pageImage` prop.
+
+  Page navigation re-runs the loader via `?chapter=N` (same pattern the
+  text reader uses for cross-chapter moves), so each page ships its own
+  image + tokens on demand.
+-->
+<script lang="ts">
+  import { goto } from '$app/navigation';
+
+  import ChapterBody from './ChapterBody.svelte';
+  import { computePctRead } from './reader-progress.js';
+  import type { ProgressAnchor } from './progress-client.js';
+  import type { ChapterView } from './types.js';
+  import type { LanguageCode } from '@ciareader/shared-types';
+
+  let {
+    chapters,
+    chapterIdx,
+    textId,
+    language,
+    showRomanization = false,
+    isOwner = false,
+    isAdmin = false,
+    onProgress,
+  }: {
+    chapters: ChapterView[];
+    chapterIdx: number;
+    textId: string;
+    language: LanguageCode;
+    showRomanization?: boolean;
+    isOwner?: boolean;
+    isAdmin?: boolean;
+    onProgress?: (anchor: ProgressAnchor) => void;
+  } = $props();
+
+  const activeChapter = $derived(chapters[chapterIdx] ?? null);
+  const pageCount = $derived(chapters.length);
+
+  // 'image' shows the page scan + clickable overlays; 'text' shows the
+  // reflowed OCR. Default to image — that's the whole point of a PDF.
+  let view = $state<'image' | 'text'>('image');
+
+  const hasImage = $derived(!!activeChapter?.pageImageUrl);
+  const pageImage = $derived(
+    activeChapter?.pageImageUrl
+      ? {
+          url: activeChapter.pageImageUrl,
+          width: activeChapter.pageWidth ?? null,
+          height: activeChapter.pageHeight ?? null,
+        }
+      : null,
+  );
+
+  function goToPage(idx: number) {
+    const clamped = Math.max(0, Math.min(idx, pageCount - 1));
+    if (clamped === chapterIdx) return;
+    void goto(`/reader/${textId}?chapter=${clamped}`, { keepFocus: true });
+  }
+
+  // Report progress as the active page so the resume-anchor + whole-book
+  // progress track which page the reader is on.
+  $effect(() => {
+    const idx = chapterIdx;
+    onProgress?.({
+      chapterIdx: idx,
+      tokenIdx: 0,
+      pctRead: computePctRead(chapters, idx, 0),
+    });
+  });
+</script>
+
+<div class="reader-image">
+  <div class="page-toolbar">
+    <div class="page-nav">
+      <button
+        type="button"
+        onclick={() => goToPage(chapterIdx - 1)}
+        disabled={chapterIdx <= 0}
+        aria-label="Previous page"
+      >‹</button>
+      <span class="page-indicator" aria-live="polite">
+        Page {chapterIdx + 1} / {pageCount}
+      </span>
+      <button
+        type="button"
+        onclick={() => goToPage(chapterIdx + 1)}
+        disabled={chapterIdx >= pageCount - 1}
+        aria-label="Next page"
+      >›</button>
+    </div>
+
+    {#if hasImage}
+      <div class="view-toggle" role="group" aria-label="Page view">
+        <button
+          type="button"
+          class:active={view === 'image'}
+          aria-pressed={view === 'image'}
+          onclick={() => (view = 'image')}
+        >Image</button>
+        <button
+          type="button"
+          class:active={view === 'text'}
+          aria-pressed={view === 'text'}
+          onclick={() => (view = 'text')}
+        >Text</button>
+      </div>
+    {/if}
+  </div>
+
+  <div class="page-body">
+    {#if activeChapter}
+      {#key activeChapter.id + ':' + view}
+        <ChapterBody
+          chapter={activeChapter}
+          {language}
+          {showRomanization}
+          {isOwner}
+          {isAdmin}
+          {textId}
+          pageImage={view === 'image' ? pageImage : null}
+        />
+      {/key}
+    {/if}
+  </div>
+</div>
+
+<style>
+  .reader-image {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  }
+  .page-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+    padding: 0.6rem 1.25rem;
+    border-bottom: 1px solid var(--rule, var(--color-border));
+  }
+  .page-nav {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+  .page-nav button,
+  .view-toggle button {
+    min-height: 34px;
+    min-width: 34px;
+    padding: 0 0.7rem;
+    border: 1px solid var(--rule, var(--color-border));
+    border-radius: 8px;
+    background: transparent;
+    color: var(--ink, var(--color-fg));
+    font: inherit;
+    cursor: pointer;
+  }
+  .page-nav button[disabled] {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+  .page-indicator {
+    font-size: 0.85rem;
+    color: var(--ink-2, var(--color-fg-muted));
+    min-width: 7rem;
+    text-align: center;
+  }
+  .view-toggle {
+    display: inline-flex;
+    gap: 0.25rem;
+  }
+  .view-toggle button.active {
+    background: var(--accent-soft, var(--color-accent));
+    border-color: var(--accent, var(--color-accent));
+    color: var(--accent-ink, var(--color-accent-fg, #fff));
+  }
+  .page-body {
+    flex: 1;
+    overflow: auto;
+    /* Center the page column with comfortable gutters; cap width so a
+       page image doesn't stretch absurdly wide on desktop. */
+    padding: 1rem;
+    display: flex;
+    justify-content: center;
+  }
+  .page-body :global(.page-overlay),
+  .page-body :global([dir]) {
+    width: 100%;
+    max-width: 48rem;
+  }
+</style>

--- a/apps/web/src/lib/components/reader/WordPopup.svelte
+++ b/apps/web/src/lib/components/reader/WordPopup.svelte
@@ -99,6 +99,7 @@
     isOwner,
     isAdmin = false,
     textId = '',
+    pageImage = null,
     onClose,
     onStatusChange,
     onCorrectionApplied,
@@ -106,6 +107,10 @@
     onPersonalTranslationChange,
   }: {
     token: ServerToken | null;
+    /** PDF image reader: the active page image, so the popup can show a
+     *  crop of the clicked word (using the token's bbox) for verifying
+     *  OCR against the real glyphs. Null in the text reader. */
+    pageImage?: { url: string; width: number | null; height: number | null } | null;
     /** T-14.3: surface the longest phrase containing the click
      *  target. When non-null, the popup renders a phrase banner
      *  (status flips + gloss + headword) above the existing token
@@ -157,6 +162,30 @@
       gloss: string | null,
     ) => void;
   } = $props();
+
+  // PDF image reader: a CSS-cropped view of the clicked word straight
+  // off the page image, so the reader can compare what OCR read against
+  // the real glyphs and fix it via the headword search below. Pure
+  // background-position sprite crop — no new asset, no fetch.
+  const wordCropStyle = $derived.by<string | null>(() => {
+    const b = token?.bbox;
+    if (!pageImage || !b || !(b.w > 0) || !(b.h > 0)) return null;
+    const bgSizeX = b.w < 1 ? 100 / b.w : 100;
+    const bgSizeY = b.h < 1 ? 100 / b.h : 100;
+    const posX = b.w < 1 ? (b.x / (1 - b.w)) * 100 : 0;
+    const posY = b.h < 1 ? (b.y / (1 - b.h)) * 100 : 0;
+    const imgW = pageImage.width || 1;
+    const imgH = pageImage.height || 1;
+    // Keep the crop box's aspect equal to the word region's pixel aspect
+    // so the glyphs aren't stretched.
+    const aspect = (b.w * imgW) / (b.h * imgH || 1);
+    return (
+      `background-image:url('${pageImage.url}');` +
+      `background-size:${bgSizeX.toFixed(2)}% ${bgSizeY.toFixed(2)}%;` +
+      `background-position:${posX.toFixed(2)}% ${posY.toFixed(2)}%;` +
+      `aspect-ratio:${aspect.toFixed(4)}`
+    );
+  });
 
   // T-14.3: optimistic phrase status, mirroring the lemma path.
   // Re-syncs from the prop whenever the user clicks into a
@@ -1610,6 +1639,18 @@
         >
           ×
         </button>
+        {#if wordCropStyle}
+          <!-- PDF reader: crop of the word from the page image, so a
+               misread OCR surface can be checked against the real glyphs
+               and corrected via the headword search. -->
+          <div
+            class="sp-word-crop"
+            data-testid="word-crop"
+            style={wordCropStyle}
+            role="img"
+            aria-label="Word as it appears on the page"
+          ></div>
+        {/if}
         {#if token.numberForms && numberDisplay()}
           <h2 class="sp-word num-title">
             <span>{token.numberForms.digitsLatin}</span>
@@ -2413,6 +2454,18 @@
   .sp-head {
     position: relative;
     margin-bottom: 0.85rem;
+  }
+  /* PDF reader: cropped word image. Fixed height; width follows the
+     word's pixel aspect via the inline aspect-ratio. A light frame +
+     surface tint separates it from the page background. */
+  .sp-word-crop {
+    height: 2.4rem;
+    max-width: 100%;
+    margin: 0 1.9rem 0.5rem 0;
+    background-repeat: no-repeat;
+    background-color: var(--paper, var(--color-bg));
+    border: 1px solid var(--rule, var(--color-border));
+    border-radius: 4px;
   }
   .sp-close {
     position: absolute;

--- a/apps/web/src/lib/components/reader/chapter-body-overlay.test.ts
+++ b/apps/web/src/lib/components/reader/chapter-body-overlay.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render } from '@testing-library/svelte';
+
+import ChapterBody from './ChapterBody.svelte';
+import type { ChapterView, ServerToken } from './types.js';
+
+beforeAll(() => {
+  // jsdom doesn't ship matchMedia; WordPopup (mounted by ChapterBody)
+  // reads it to switch between mobile/desktop layouts.
+  if (!window.matchMedia) {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: (query: string) => ({
+        matches: false,
+        media: query,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+        onchange: null,
+      }),
+    });
+  }
+});
+
+function word(overrides: Partial<ServerToken> = {}): ServerToken {
+  return {
+    id: 't1',
+    idx: 0,
+    surface: 'Egun',
+    isWord: true,
+    isAmbiguous: false,
+    isOov: false,
+    lemmaId: 'lem-1',
+    romanization: null,
+    glossDefault: 'day',
+    personalGloss: null,
+    candidates: [],
+    features: {},
+    numberForms: null,
+    status: 'unknown',
+    hasDefinition: true,
+    bbox: { x: 0.1, y: 0.2, w: 0.3, h: 0.05 },
+    ...overrides,
+  };
+}
+
+function chapter(tokens: ServerToken[]): ChapterView {
+  return {
+    id: 'chap-0',
+    idx: 0,
+    title: null,
+    body: tokens.map((t) => t.surface).join(' '),
+    tokenCount: tokens.length,
+    tokens,
+    phraseSpans: [],
+  };
+}
+
+const PAGE_IMAGE = { url: '/pdf-assets/texts/x/pages/0.webp', width: 800, height: 1200 };
+
+beforeEach(() => {
+  // WordPopup mounts unconditionally; stub fetch so any background lookup
+  // in its empty state can't hit the network during the test.
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => new Response('{}', { status: 200 })),
+  );
+});
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('ChapterBody — PDF image overlay', () => {
+  it('renders the page image and one clickable hotspot per word, positioned by bbox', () => {
+    const { container } = render(ChapterBody, {
+      chapter: chapter([
+        word(),
+        // whitespace token: no hotspot
+        word({ id: 'ws', idx: 1, surface: ' ', isWord: false, bbox: null }),
+        word({ id: 't2', idx: 2, surface: 'on', bbox: { x: 0.5, y: 0.2, w: 0.1, h: 0.05 } }),
+      ]),
+      language: 'eu',
+      textId: 'x',
+      pageImage: PAGE_IMAGE,
+    });
+
+    const img = container.querySelector('img.page-img') as HTMLImageElement | null;
+    expect(img).not.toBeNull();
+    expect(img!.getAttribute('src')).toBe(PAGE_IMAGE.url);
+
+    const hotspots = container.querySelectorAll('.ovl-hotspot');
+    // Two word tokens have boxes; the whitespace token has none.
+    expect(hotspots).toHaveLength(2);
+
+    const first = hotspots[0] as HTMLElement;
+    expect(first.getAttribute('data-token-id')).toBe('t1');
+    // The bbox (0.1, 0.2, 0.3, 0.05) maps to percentage insets. jsdom
+    // normalizes `10.000%` → `10%`.
+    expect(first.style.left).toBe('10%');
+    expect(first.style.top).toBe('20%');
+    expect(first.style.width).toBe('30%');
+    expect(first.style.height).toBe('5%');
+  });
+
+  it('reflects known-word status on the hotspot via data-s', () => {
+    const { container } = render(ChapterBody, {
+      chapter: chapter([word({ status: 'learning' })]),
+      language: 'eu',
+      textId: 'x',
+      pageImage: PAGE_IMAGE,
+    });
+    const hotspot = container.querySelector('.ovl-hotspot') as HTMLElement;
+    // 'learning' maps to status code '2' (see STATUS_TO_CODE).
+    expect(hotspot.getAttribute('data-s')).toBe('2');
+  });
+
+  it('renders reflowed text (no overlay) when pageImage is absent', () => {
+    const { container } = render(ChapterBody, {
+      chapter: chapter([word()]),
+      language: 'eu',
+      textId: 'x',
+    });
+    expect(container.querySelector('.ovl-hotspot')).toBeNull();
+    expect(container.querySelector('.page-overlay')).toBeNull();
+    // Falls back to the normal word-span render.
+    expect(container.querySelector('.word')).not.toBeNull();
+  });
+});

--- a/apps/web/src/lib/components/reader/types.ts
+++ b/apps/web/src/lib/components/reader/types.ts
@@ -147,6 +147,11 @@ export type ServerToken = {
    *  is explicitly `false`, so an absent value is treated as "unknown,
    *  don't flag." */
   hasDefinition?: boolean;
+  /** PDF source only: the word's bounding box on the page image,
+   *  normalized to 0..1 of the page width/height. Drives the clickable
+   *  word hotspots in the image reader. Null/absent for text tokens and
+   *  for whitespace/punctuation. */
+  bbox?: { x: number; y: number; w: number; h: number } | null;
 };
 
 /**
@@ -181,6 +186,12 @@ export type ChapterView = {
    *  null when the chapter hasn't been processed yet (sibling to
    *  `tokens` null state). */
   phraseSpans: ChapterPhraseSpan[] | null;
+  /** PDF source only: the page image to render in the image reader, and
+   *  its natural pixel size (for the container aspect ratio). Null for
+   *  non-PDF chapters / pages not yet processed. */
+  pageImageUrl?: string | null;
+  pageWidth?: number | null;
+  pageHeight?: number | null;
 };
 
 export type ReaderLayoutMode = 'page' | 'paged_scroll' | 'continuous';

--- a/apps/web/src/lib/pdf/render-client.test.ts
+++ b/apps/web/src/lib/pdf/render-client.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+
+import { maxImagePaintCoverage } from './render-client';
+
+// pdf.js Util.transform: m1 × m2 over [a,b,c,d,e,f] affine matrices.
+function transform(m1: number[], m2: number[]): number[] {
+  return [
+    m1[0]! * m2[0]! + m1[2]! * m2[1]!,
+    m1[1]! * m2[0]! + m1[3]! * m2[1]!,
+    m1[0]! * m2[2]! + m1[2]! * m2[3]!,
+    m1[1]! * m2[2]! + m1[3]! * m2[3]!,
+    m1[0]! * m2[4]! + m1[2]! * m2[5]! + m1[4]!,
+    m1[1]! * m2[4]! + m1[3]! * m2[5]! + m1[5]!,
+  ];
+}
+
+const CODES = { save: 10, restore: 11, transform: 12, image: [20, 21] };
+const PAGE_W = 600;
+const PAGE_H = 800;
+
+function coverage(fnArray: number[], argsArray: unknown[]): number {
+  return maxImagePaintCoverage(fnArray, argsArray, CODES, transform, PAGE_W, PAGE_H);
+}
+
+describe('maxImagePaintCoverage', () => {
+  it('reports ~full coverage for a page-sized image (a scan)', () => {
+    // scale CTM to the whole page, then paint the image.
+    const cov = coverage([12, 20], [[PAGE_W, 0, 0, PAGE_H, 0, 0], null]);
+    expect(cov).toBeCloseTo(1, 5);
+  });
+
+  it('reports small coverage for a small inline image', () => {
+    const cov = coverage([12, 21], [[60, 0, 0, 80, 0, 0], null]);
+    expect(cov).toBeCloseTo(0.01, 5);
+  });
+
+  it('returns 0 when no image is painted', () => {
+    expect(coverage([12, 12], [[PAGE_W, 0, 0, PAGE_H, 0, 0], [2, 0, 0, 2, 0, 0]])).toBe(0);
+  });
+
+  it('respects save/restore scoping (transform does not leak past restore)', () => {
+    // save, scale-to-page, restore, then paint a 1x1 image at identity.
+    const cov = coverage(
+      [10, 12, 11, 20],
+      [null, [PAGE_W, 0, 0, PAGE_H, 0, 0], null, null],
+    );
+    expect(cov).toBeCloseTo(1 / (PAGE_W * PAGE_H), 8);
+  });
+
+  it('returns 0 for a zero-area page', () => {
+    expect(maxImagePaintCoverage([20], [null], CODES, transform, 0, 0)).toBe(0);
+  });
+});

--- a/apps/web/src/lib/pdf/render-client.ts
+++ b/apps/web/src/lib/pdf/render-client.ts
@@ -36,9 +36,16 @@ export interface RenderedPage {
 
 export interface LoadedPdf {
   numPages: number;
-  /** True when the document carries a usable embedded text layer. When
-   *  false the pages are scans and must be OCR'd. */
+  /** True when the document carries an embedded text layer (any
+   *  extractable text). NOTE: scanned books often ship a *poor* OCR
+   *  text layer, so this being true does NOT mean the text is good —
+   *  see `isScanned`. */
   hasTextLayer: boolean;
+  /** True when the sampled pages are dominated by a full-page image —
+   *  i.e. a scan. A scanned PDF should be OCR'd even if it carries an
+   *  embedded (usually bad) text layer, so this drives the default to
+   *  Vision OCR rather than "use built-in text". */
+  isScanned: boolean;
   doc: import('pdfjs-dist').PDFDocumentProxy;
 }
 
@@ -56,6 +63,11 @@ const IMAGE_QUALITY = 0.85;
 // A real text layer yields plenty of characters in the first few pages; a
 // scan yields ~none.
 const TEXT_LAYER_MIN_CHARS = 40;
+// Pages sampled to classify the document (text layer + scanned-ness).
+const CLASSIFY_SAMPLE_PAGES = 5;
+// A single painted image covering at least this fraction of the page marks
+// the page as a scan (image-dominated).
+const SCANNED_IMAGE_COVERAGE = 0.5;
 
 let pdfjsPromise: Promise<typeof import('pdfjs-dist')> | null = null;
 
@@ -74,33 +86,107 @@ async function loadPdfjs(): Promise<typeof import('pdfjs-dist')> {
   return pdfjsPromise;
 }
 
-/** Load a PDF and probe whether it has an embedded text layer. */
+/**
+ * Largest single image-paint coverage on a page, as a fraction of page
+ * area. Walks the operator list tracking the current transform matrix
+ * (CTM) — an image is painted into the unit square transformed by the
+ * CTM, so its on-page size is read straight off the matrix. A scanned
+ * page is essentially one image covering the whole page (~1.0); a
+ * born-digital text page has little or no image area.
+ *
+ * Pure + parameterized (OPS codes + matrix multiply passed in) so it can
+ * be unit-tested without pdf.js.
+ */
+export function maxImagePaintCoverage(
+  fnArray: number[],
+  argsArray: unknown[],
+  codes: { save: number; restore: number; transform: number; image: number[] },
+  multiply: (m1: number[], m2: number[]) => number[],
+  pageWidth: number,
+  pageHeight: number,
+): number {
+  const pageArea = pageWidth * pageHeight;
+  if (!(pageArea > 0)) return 0;
+  const imageOps = new Set(codes.image);
+  let ctm = [1, 0, 0, 1, 0, 0];
+  const stack: number[][] = [];
+  let maxArea = 0;
+  for (let i = 0; i < fnArray.length; i += 1) {
+    const fn = fnArray[i];
+    if (fn === undefined) continue;
+    if (fn === codes.save) {
+      stack.push(ctm.slice());
+    } else if (fn === codes.restore) {
+      const prev = stack.pop();
+      if (prev) ctm = prev;
+    } else if (fn === codes.transform) {
+      const a = argsArray[i];
+      if (Array.isArray(a) && a.length >= 6) ctm = multiply(ctm, a as number[]);
+    } else if (imageOps.has(fn)) {
+      const w = Math.hypot(ctm[0]!, ctm[1]!);
+      const h = Math.hypot(ctm[2]!, ctm[3]!);
+      maxArea = Math.max(maxArea, w * h);
+    }
+  }
+  return maxArea / pageArea;
+}
+
+/** Load a PDF and classify it: does it have an embedded text layer, and
+ *  is it a scan (image-dominated)? */
 export async function loadPdf(file: File): Promise<LoadedPdf> {
   const pdfjs = await loadPdfjs();
   const data = await file.arrayBuffer();
   const doc = await pdfjs.getDocument({ data }).promise;
-  return {
-    numPages: doc.numPages,
-    hasTextLayer: await detectTextLayer(doc),
-    doc,
-  };
+  const { hasTextLayer, isScanned } = await classifyPdf(pdfjs, doc);
+  return { numPages: doc.numPages, hasTextLayer, isScanned, doc };
 }
 
-async function detectTextLayer(
+async function classifyPdf(
+  pdfjs: typeof import('pdfjs-dist'),
   doc: import('pdfjs-dist').PDFDocumentProxy,
-): Promise<boolean> {
-  const sample = Math.min(doc.numPages, 3);
+): Promise<{ hasTextLayer: boolean; isScanned: boolean }> {
+  const ops = pdfjs.OPS as unknown as Record<string, number>;
+  // -1 is a safe sentinel (op codes are >= 0, so it never matches) for the
+  // rare case an OPS name is absent in some pdf.js build.
+  const codes = {
+    save: ops.save ?? -1,
+    restore: ops.restore ?? -1,
+    transform: ops.transform ?? -1,
+    image: [
+      ops.paintImageXObject,
+      ops.paintInlineImageXObject,
+      ops.paintImageMaskXObject,
+      ops.paintImageXObjectRepeat,
+    ].filter((c): c is number => typeof c === 'number'),
+  };
+  const sample = Math.min(doc.numPages, CLASSIFY_SAMPLE_PAGES);
   let chars = 0;
+  let scannedPages = 0;
   for (let i = 1; i <= sample; i += 1) {
     const page = await doc.getPage(i);
     const tc = await page.getTextContent();
     for (const it of tc.items) {
       if ('str' in it) chars += it.str.trim().length;
     }
+    const viewport = page.getViewport({ scale: 1 });
+    const opList = await page.getOperatorList();
+    const coverage = maxImagePaintCoverage(
+      opList.fnArray,
+      opList.argsArray,
+      codes,
+      pdfjs.Util.transform,
+      viewport.width,
+      viewport.height,
+    );
+    if (coverage >= SCANNED_IMAGE_COVERAGE) scannedPages += 1;
     page.cleanup();
-    if (chars >= TEXT_LAYER_MIN_CHARS) return true;
   }
-  return chars >= TEXT_LAYER_MIN_CHARS;
+  return {
+    hasTextLayer: chars >= TEXT_LAYER_MIN_CHARS,
+    // Most sampled pages dominated by an image → treat the doc as a scan
+    // (default to OCR), even if it ships a poor embedded text layer.
+    isScanned: sample > 0 && scannedPages / sample >= 0.5,
+  };
 }
 
 function clamp01(v: number): number {

--- a/apps/web/src/lib/pdf/render-client.ts
+++ b/apps/web/src/lib/pdf/render-client.ts
@@ -1,0 +1,291 @@
+/**
+ * Client-side PDF rasterization + text-layer extraction (browser only).
+ *
+ * The browser does the CPU-heavy work — rendering each page to an image
+ * with pdf.js — so the server never rasterizes and the source PDF never
+ * leaves the user's machine. For born-digital PDFs we also pull the
+ * embedded text layer (text + per-run boxes) so the server can skip OCR.
+ *
+ * pdf.js is imported dynamically so it never loads during SSR; call these
+ * functions from browser event handlers only.
+ */
+
+/** One run from the PDF text layer, normalized to 0..1, top-left origin.
+ *  Mirrors the server-side `BornDigitalItem`. */
+export interface BornDigitalItem {
+  str: string;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  eol?: boolean;
+}
+
+export interface BornDigitalPayload {
+  items: BornDigitalItem[];
+}
+
+export interface RenderedPage {
+  blob: Blob;
+  width: number;
+  height: number;
+  mime: string;
+  /** Set only when the text layer was used and the page had text. */
+  bornDigital: BornDigitalPayload | null;
+}
+
+export interface LoadedPdf {
+  numPages: number;
+  /** True when the document carries a usable embedded text layer. When
+   *  false the pages are scans and must be OCR'd. */
+  hasTextLayer: boolean;
+  doc: import('pdfjs-dist').PDFDocumentProxy;
+}
+
+export interface ImportProgress {
+  done: number;
+  total: number;
+}
+
+// 150 DPI keeps page images small enough to upload quickly while staying
+// crisp enough for Vision OCR and comfortable on-screen reading.
+const TARGET_DPI = 150;
+const PDF_POINTS_PER_INCH = 72;
+const IMAGE_MIME = 'image/webp';
+const IMAGE_QUALITY = 0.85;
+// A real text layer yields plenty of characters in the first few pages; a
+// scan yields ~none.
+const TEXT_LAYER_MIN_CHARS = 40;
+
+let pdfjsPromise: Promise<typeof import('pdfjs-dist')> | null = null;
+
+async function loadPdfjs(): Promise<typeof import('pdfjs-dist')> {
+  if (!pdfjsPromise) {
+    pdfjsPromise = (async () => {
+      const pdfjs = await import('pdfjs-dist');
+      // Vite resolves `?url` to the emitted worker asset URL (typed via
+      // vite/client ambient declarations).
+      const workerUrl = (await import('pdfjs-dist/build/pdf.worker.min.mjs?url'))
+        .default as string;
+      pdfjs.GlobalWorkerOptions.workerSrc = workerUrl;
+      return pdfjs;
+    })();
+  }
+  return pdfjsPromise;
+}
+
+/** Load a PDF and probe whether it has an embedded text layer. */
+export async function loadPdf(file: File): Promise<LoadedPdf> {
+  const pdfjs = await loadPdfjs();
+  const data = await file.arrayBuffer();
+  const doc = await pdfjs.getDocument({ data }).promise;
+  return {
+    numPages: doc.numPages,
+    hasTextLayer: await detectTextLayer(doc),
+    doc,
+  };
+}
+
+async function detectTextLayer(
+  doc: import('pdfjs-dist').PDFDocumentProxy,
+): Promise<boolean> {
+  const sample = Math.min(doc.numPages, 3);
+  let chars = 0;
+  for (let i = 1; i <= sample; i += 1) {
+    const page = await doc.getPage(i);
+    const tc = await page.getTextContent();
+    for (const it of tc.items) {
+      if ('str' in it) chars += it.str.trim().length;
+    }
+    page.cleanup();
+    if (chars >= TEXT_LAYER_MIN_CHARS) return true;
+  }
+  return chars >= TEXT_LAYER_MIN_CHARS;
+}
+
+function clamp01(v: number): number {
+  if (!Number.isFinite(v)) return 0;
+  return Math.min(1, Math.max(0, v));
+}
+
+async function extractTextItems(
+  pdfjs: typeof import('pdfjs-dist'),
+  page: import('pdfjs-dist').PDFPageProxy,
+  viewport: import('pdfjs-dist').PageViewport,
+  width: number,
+  height: number,
+): Promise<BornDigitalItem[]> {
+  const tc = await page.getTextContent();
+  const items: BornDigitalItem[] = [];
+  for (const it of tc.items) {
+    if (!('str' in it)) continue; // skip marked-content items
+    const s = it.str;
+    if (!s) {
+      // Empty item that only marks an end-of-line: flag the previous run.
+      if (it.hasEOL && items.length) items[items.length - 1]!.eol = true;
+      continue;
+    }
+    // Map the text-space transform into device (canvas) coords via the
+    // viewport, then read off the glyph box: x/baseline from the matrix,
+    // height from the font scale, width from the item's advance.
+    const t = pdfjs.Util.transform(viewport.transform, it.transform);
+    const fontHeight = Math.hypot(t[1], t[3]) || Math.abs(t[3]);
+    const wDev = it.width * viewport.scale;
+    const xDev = t[4];
+    const yTop = t[5] - fontHeight;
+    items.push({
+      str: s,
+      x: clamp01(xDev / width),
+      y: clamp01(yTop / height),
+      w: clamp01(wDev / width),
+      h: clamp01(fontHeight / height),
+      eol: it.hasEOL === true,
+    });
+  }
+  return items;
+}
+
+function canvasToBlob(canvas: HTMLCanvasElement): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (b) => (b ? resolve(b) : reject(new Error('canvas.toBlob returned null'))),
+      IMAGE_MIME,
+      IMAGE_QUALITY,
+    );
+  });
+}
+
+/** Render one page (1-based) to a WebP image, optionally with its text
+ *  layer. */
+export async function renderPage(
+  doc: import('pdfjs-dist').PDFDocumentProxy,
+  pageNum: number,
+  useTextLayer: boolean,
+): Promise<RenderedPage> {
+  const pdfjs = await loadPdfjs();
+  const page = await doc.getPage(pageNum);
+  const viewport = page.getViewport({ scale: TARGET_DPI / PDF_POINTS_PER_INCH });
+  const width = Math.ceil(viewport.width);
+  const height = Math.ceil(viewport.height);
+
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('2d canvas context unavailable');
+  await page.render({ canvas, canvasContext: ctx, viewport }).promise;
+  const blob = await canvasToBlob(canvas);
+
+  let bornDigital: BornDigitalPayload | null = null;
+  if (useTextLayer) {
+    const items = await extractTextItems(pdfjs, page, viewport, width, height);
+    if (items.length) bornDigital = { items };
+  }
+  page.cleanup();
+  return { blob, width, height, mime: IMAGE_MIME, bornDigital };
+}
+
+async function errorText(res: Response): Promise<string> {
+  try {
+    const body = (await res.json()) as { message?: string; error?: string };
+    return body.message ?? body.error ?? `HTTP ${res.status}`;
+  } catch {
+    return `HTTP ${res.status}`;
+  }
+}
+
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const t = setTimeout(resolve, ms);
+    signal?.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(t);
+        reject(new Error('cancelled'));
+      },
+      { once: true },
+    );
+  });
+}
+
+/**
+ * Upload one rendered page, retrying on 5xx (transient OCR errors, e.g.
+ * Google billing-propagation flaps right after enabling). 4xx fails fast
+ * — those are caller-fixable, not transient. The FormData is rebuilt per
+ * attempt since a consumed request body can't be re-sent.
+ */
+async function uploadPage(
+  textId: string,
+  pageIdx: number,
+  rendered: RenderedPage,
+  signal?: AbortSignal,
+): Promise<void> {
+  const backoffs = [0, 3000, 6000, 10000]; // ~19s total across 4 tries
+  let lastErr: Error | null = null;
+  for (let attempt = 0; attempt < backoffs.length; attempt += 1) {
+    if (signal?.aborted) throw new Error('cancelled');
+    if (backoffs[attempt]! > 0) await delay(backoffs[attempt]!, signal);
+    const form = new FormData();
+    form.set('image', rendered.blob, `page-${pageIdx}.webp`);
+    form.set('width', String(rendered.width));
+    form.set('height', String(rendered.height));
+    if (rendered.bornDigital) {
+      form.set('bornDigital', JSON.stringify(rendered.bornDigital));
+    }
+    let res: Response;
+    try {
+      res = await fetch(`/api/v1/texts/${textId}/pages/${pageIdx}`, {
+        method: 'POST',
+        body: form,
+        signal,
+      });
+    } catch (e) {
+      if (signal?.aborted) throw e;
+      lastErr = e as Error; // network blip — retry
+      continue;
+    }
+    if (res.ok) return;
+    const msg = await errorText(res);
+    if (res.status < 500) throw new Error(msg); // 4xx: don't retry
+    lastErr = new Error(msg); // 5xx: retry
+  }
+  throw lastErr ?? new Error('upload failed');
+}
+
+/**
+ * Import an already-loaded PDF: create the text shell, then render + stream
+ * each page to the server, reporting progress. Returns the new text id.
+ */
+export async function importLoadedPdf(
+  loaded: LoadedPdf,
+  opts: {
+    title: string;
+    language: string;
+    useTextLayer: boolean;
+    onProgress?: (p: ImportProgress) => void;
+    signal?: AbortSignal;
+  },
+): Promise<{ id: string }> {
+  const beginRes = await fetch('/api/v1/texts/pdf/begin', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      language: opts.language,
+      title: opts.title,
+      pageCount: loaded.numPages,
+    }),
+    signal: opts.signal,
+  });
+  if (!beginRes.ok) throw new Error(await errorText(beginRes));
+  const { id } = (await beginRes.json()) as { id: string };
+
+  for (let p = 1; p <= loaded.numPages; p += 1) {
+    if (opts.signal?.aborted) throw new Error('cancelled');
+    const rendered = await renderPage(loaded.doc, p, opts.useTextLayer);
+    // Server page index is 0-based; pdf.js pages are 1-based.
+    await uploadPage(id, p - 1, rendered, opts.signal);
+    opts.onProgress?.({ done: p, total: loaded.numPages });
+  }
+  await loaded.doc.cleanup();
+  return { id };
+}

--- a/apps/web/src/lib/server/db/schema.ts
+++ b/apps/web/src/lib/server/db/schema.ts
@@ -1092,6 +1092,12 @@ export const textSourceType = pgEnum('text_source_type', [
   'txt',
   'epub',
   'zip',
+  // PDF upload (image reader). The browser rasterizes each page to an
+  // image client-side; the server stores only the page images and OCRs
+  // them. One `text_chapters` row per page carries the page image, and
+  // each `text_tokens` row carries a `bbox` so clicks on the image map
+  // to words. The source PDF is never uploaded.
+  'pdf',
 ]);
 
 export const textStatus = pgEnum('text_status', [
@@ -1268,6 +1274,14 @@ export const textChapters = pgTable(
     // Cheap precompute on insert. The reader's library cards and
     // progress bars need it; computing it on read is wasteful.
     tokenCount: integer('token_count').notNull().default(0),
+    // PDF source only: when a chapter represents a PDF page, these hold
+    // the stored page image (rasterized client-side, OCR'd server-side)
+    // so the reader can show the original page with clickable word
+    // overlays. Null for paste / txt / epub / zip chapters.
+    pageImageKey: text('page_image_key'),
+    pageImageMime: text('page_image_mime'),
+    pageWidth: integer('page_width'),
+    pageHeight: integer('page_height'),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => ({
@@ -1399,6 +1413,18 @@ export const textTokens = pgTable(
       // form is the reading. Optional so chapters processed before
       // Basque number support keep type-checking.
       eu?: { spelled: string; romanized: string };
+    } | null>(),
+    /** PDF source only: the word's bounding box on the page image,
+     *  normalized to 0..1 of the page width/height (resolution-
+     *  independent so the reader overlay scales to whatever size the
+     *  image renders at). Drives the clickable word hotspots in the
+     *  image reader. Null for non-PDF tokens and for
+     *  whitespace/punctuation tokens that have no clickable box. */
+    bbox: jsonb('bbox').$type<{
+      x: number;
+      y: number;
+      w: number;
+      h: number;
     } | null>(),
   },
   (t) => ({

--- a/apps/web/src/lib/server/nlp-client.test.ts
+++ b/apps/web/src/lib/server/nlp-client.test.ts
@@ -56,4 +56,66 @@ describe('nlpClient', () => {
 
     await expect(nlpClient.process('xx', 'hi')).rejects.toThrow(/NLP service 400: unsupported language/);
   });
+
+  it('ocr() posts a multipart body with the image + fields', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          language: 'eu',
+          pipeline_id: 'stanza-eu',
+          width: 800,
+          height: 1200,
+          body: 'Egun on',
+          tokens: [],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    );
+
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    const out = await nlpClient.ocr('eu', bytes, {
+      width: 800,
+      height: 1200,
+      mime: 'image/webp',
+      bornDigital: { items: [{ str: 'Egun', x: 0.1, y: 0.1, w: 0.2, h: 0.05 }] },
+    });
+    expect(out.width).toBe(800);
+    expect(out.body).toBe('Egun on');
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toMatch(/\/ocr$/);
+    expect(init?.method).toBe('POST');
+    // Multipart: body is FormData, and fetch (not us) sets the boundary,
+    // so we must NOT have forced a JSON content-type.
+    expect(init?.body).toBeInstanceOf(FormData);
+    const form = init!.body as FormData;
+    expect(form.get('language')).toBe('eu');
+    expect(form.get('width')).toBe('800');
+    expect(form.get('height')).toBe('1200');
+    expect(form.get('engine')).toBe('vision');
+    expect(JSON.parse(String(form.get('born_digital')))).toEqual({
+      items: [{ str: 'Egun', x: 0.1, y: 0.1, w: 0.2, h: 0.05 }],
+    });
+    expect(form.get('image')).toBeInstanceOf(Blob);
+  });
+
+  it('ocr() omits born_digital and defaults engine when not provided', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          language: 'eu',
+          pipeline_id: 'stanza-eu',
+          width: 10,
+          height: 10,
+          body: '',
+          tokens: [],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    );
+    await nlpClient.ocr('eu', new Uint8Array([0]), { width: 10, height: 10 });
+    const form = fetchMock.mock.calls[0]![1]!.body as FormData;
+    expect(form.get('born_digital')).toBeNull();
+    expect(form.get('engine')).toBe('vision');
+  });
 });

--- a/apps/web/src/lib/server/nlp-client.ts
+++ b/apps/web/src/lib/server/nlp-client.ts
@@ -94,6 +94,74 @@ export interface ProcessResponse {
   proposed_phrases?: ProposedPhrase[];
 }
 
+/** A word's bounding box on a PDF page image, normalized to 0..1 of the
+ *  page width/height (mirrors the Python `BBox`). Drives the clickable
+ *  word hotspots in the image reader. */
+export interface OcrBBox {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/** A `NlpToken` plus its page-image bounding box. `bbox` is null for
+ *  whitespace/punctuation and for words the aligner couldn't place. */
+export interface OcrToken extends NlpToken {
+  bbox: OcrBBox | null;
+}
+
+export interface OcrResponse {
+  language: string;
+  pipeline_id: string;
+  /** Page image pixel dimensions (echoed from the upload). */
+  width: number;
+  height: number;
+  /** Reconstructed page text — stored as the chapter body. */
+  body: string;
+  tokens: OcrToken[];
+  proposed_phrases?: ProposedPhrase[];
+}
+
+/** One run from a PDF's embedded text layer, extracted client-side via
+ *  pdf.js. Coords are normalized 0..1, top-left origin. `eol` marks the
+ *  end of a visual line. */
+export interface BornDigitalItem {
+  str: string;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  eol?: boolean;
+}
+
+export interface BornDigitalPayload {
+  items: BornDigitalItem[];
+}
+
+/** A previously-captured OCR layout: the page text plus one box per
+ *  character (parallel to `text`; null for whitespace). Replaying it lets
+ *  the server re-tokenize a page with the current model WITHOUT calling
+ *  Vision again (free reprocess). */
+export interface OcrLayout {
+  text: string;
+  charBoxes: Array<[number, number, number, number] | null>;
+}
+
+export interface OcrOptions {
+  /** Rendered page-image pixel dimensions (the client knows these). */
+  width: number;
+  height: number;
+  /** Image mime; the served file's Content-Type is derived from it. */
+  mime?: string;
+  /** 'vision' (default) or 'vision_llm' (on-demand AI proofread). */
+  engine?: 'vision' | 'vision_llm';
+  /** When the page came from a PDF text layer, the extracted runs —
+   *  Python uses them instead of calling Vision. */
+  bornDigital?: BornDigitalPayload | null;
+  /** Stored OCR layout to replay for a free re-tokenize (no Vision). */
+  layout?: OcrLayout | null;
+}
+
 export interface HealthResponse {
   status: string;
   languages: string[];
@@ -144,5 +212,50 @@ export const nlpClient = {
       method: 'POST',
       body: JSON.stringify({ language, surfaces }),
     });
+  },
+  /**
+   * OCR one PDF page image into tokens + per-token bounding boxes. Posts
+   * a multipart body (image blob + fields) — we can't reuse `request`,
+   * which forces a JSON content-type; here fetch must set the multipart
+   * boundary itself.
+   */
+  async ocr(
+    language: string,
+    imageBytes: Uint8Array,
+    opts: OcrOptions,
+  ): Promise<OcrResponse> {
+    const form = new FormData();
+    form.set('language', language);
+    form.set('width', String(opts.width));
+    form.set('height', String(opts.height));
+    form.set('engine', opts.engine ?? 'vision');
+    if (opts.bornDigital) {
+      form.set('born_digital', JSON.stringify(opts.bornDigital));
+    }
+    if (opts.layout) {
+      form.set(
+        'layout',
+        JSON.stringify({ text: opts.layout.text, char_boxes: opts.layout.charBoxes }),
+      );
+    }
+    form.set(
+      'image',
+      // Cast: TS's DOM lib types BlobPart as ArrayBuffer-backed, but a
+      // Uint8Array<ArrayBufferLike> is a valid blob part at runtime.
+      new Blob([imageBytes as BlobPart], { type: opts.mime ?? 'image/webp' }),
+      'page',
+    );
+    const res = await fetch(new URL('/ocr', NLP_SERVICE_URL), {
+      method: 'POST',
+      body: form,
+      // @ts-expect-error — Node's fetch reads undici's `dispatcher`;
+      // RequestInit doesn't type it. Keeps the long timeout for Vision.
+      dispatcher: nlpDispatcher,
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => '');
+      throw new Error(`NLP service ${res.status}: ${body || res.statusText}`);
+    }
+    return (await res.json()) as OcrResponse;
   },
 };

--- a/apps/web/src/lib/server/pdf/storage.ts
+++ b/apps/web/src/lib/server/pdf/storage.ts
@@ -1,0 +1,120 @@
+/**
+ * Object-storage abstraction for PDF page images.
+ *
+ * PDFs are rasterized page-by-page in the browser (pdf.js) and the
+ * rendered images are uploaded to the server; the source PDF itself
+ * never leaves the client. The only persisted artifact is one image
+ * per page, shown in the reader with clickable word overlays.
+ *
+ * Mirrors `audio/storage.ts` deliberately so the two share a mental
+ * model and a future S3 backend (Hetzner Object Storage, T-13.x) drops
+ * in the same way:
+ *
+ *   - 'local' (default in dev / CI): writes under a directory keyed by
+ *     `PDF_LOCAL_ROOT`.
+ *   - 's3' (prod): wired in the deployment ticket.
+ *
+ * The interface is intentionally small (`put`, `delete`, `urlFor`) so a
+ * route handler doesn't reason about which backend is active.
+ */
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+export interface PdfStorage {
+  /** Writes the page image blob under `key`. */
+  put(key: string, body: Uint8Array, mime: string): Promise<void>;
+  delete(key: string): Promise<void>;
+  /** Returns the URL the reader should fetch. May be a local
+   *  /pdf-assets/<key> path (dev) or a presigned S3 URL (prod). */
+  urlFor(key: string): string;
+}
+
+const LOCAL_ROOT = process.env.PDF_LOCAL_ROOT ?? '/tmp/ciareader-pdf';
+
+class LocalPdfStorage implements PdfStorage {
+  async put(key: string, body: Uint8Array, mime: string): Promise<void> {
+    // mime is recorded on the chapter row; the /pdf-assets route picks
+    // Content-Type from the extension, so the local blob isn't tagged.
+    void mime;
+    const file = path.join(LOCAL_ROOT, key);
+    await fs.mkdir(path.dirname(file), { recursive: true });
+    await fs.writeFile(file, body);
+  }
+  async delete(key: string): Promise<void> {
+    const file = path.join(LOCAL_ROOT, key);
+    try {
+      await fs.unlink(file);
+    } catch {
+      // Idempotent — missing key is not an error.
+    }
+  }
+  urlFor(key: string): string {
+    return `/pdf-assets/${key}`;
+  }
+}
+
+let singleton: PdfStorage | null = null;
+
+export function getPdfStorage(): PdfStorage {
+  if (!singleton) {
+    // S3 wiring lives in the deployment ticket (T-13.x). For dev +
+    // tests the local backend is the only branch.
+    singleton = new LocalPdfStorage();
+  }
+  return singleton;
+}
+
+export function setPdfStorage(s: PdfStorage): void {
+  singleton = s;
+}
+
+/**
+ * Storage key for a page image. One image per (text, page index). The
+ * extension is derived from the chosen image mime so the served file's
+ * Content-Type matches. Keying by `idx` (not a random id) means a
+ * re-OCR / re-render of the same page overwrites in place.
+ */
+export function pageImageStorageKey(
+  textId: string,
+  idx: number,
+  mime: string,
+): string {
+  const ext = extForMime(mime);
+  return `texts/${textId}/pages/${idx}.${ext}`;
+}
+
+const EXT_BY_MIME: Record<string, string> = {
+  'image/webp': 'webp',
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+};
+
+export const MIME_BY_EXT: Record<string, string> = {
+  '.webp': 'image/webp',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+};
+
+function extForMime(mime: string): string {
+  return EXT_BY_MIME[mime.toLowerCase()] ?? 'webp';
+}
+
+export function isAllowedPageImageMime(mime: string): boolean {
+  return mime.toLowerCase() in EXT_BY_MIME;
+}
+
+/** Hard cap on a single uploaded page image. A 200-DPI A4 page as WebP
+ *  is well under 1MB; 8MB leaves generous headroom for dense colour
+ *  scans while keeping a single page from pinning memory. */
+export const MAX_PAGE_IMAGE_BYTES = 8 * 1024 * 1024;
+
+/** Extract the owning text id from a `texts/<uuid>/pages/...` key so the
+ *  serving route can run a `canReadText` gate. Returns null for any key
+ *  that doesn't match the expected page-image shape. */
+export function textIdFromPageKey(key: string): string | null {
+  const m = key.match(
+    /^texts\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\/pages\//i,
+  );
+  return m ? m[1]! : null;
+}

--- a/apps/web/src/lib/server/texts/in-process-dispatcher.ts
+++ b/apps/web/src/lib/server/texts/in-process-dispatcher.ts
@@ -38,7 +38,7 @@ import { and, eq, isNull } from 'drizzle-orm';
 import { LANGUAGES, stripNukta, type LanguageCode } from '@ciareader/shared-types';
 
 import { db, schema } from '../db/index.js';
-import { nlpClient, type NlpToken } from '../nlp-client.js';
+import { nlpClient, type NlpToken, type ProposedPhrase } from '../nlp-client.js';
 import { looksLikeNumberToken } from '$lib/components/reader/types.js';
 import type {
   Lemma,
@@ -55,7 +55,7 @@ import {
 import { rebuildChapterSpans } from './phrase-spans.js';
 import { upsertPhraseProposals } from './phrase-proposals.js';
 
-type LemmaIndex = {
+export type LemmaIndex = {
   /** `${headword} ${pos}` → id. Strict-POS lookup. */
   byHeadwordPos: Map<string, string>;
   /** `headword` → id (first row wins). Loose fallback. */
@@ -104,7 +104,7 @@ type LemmaIndex = {
  * round-trips. For an MVP-sized lemma table (~50k Hindi entries)
  * this is a few MB of strings — well within process memory.
  */
-async function loadLemmaIndex(
+export async function loadLemmaIndex(
   language: LanguageCode,
 ): Promise<LemmaIndex> {
   const rows = (await db
@@ -361,25 +361,39 @@ async function pickLemmaId(
   return ensureLemma(language, top, index);
 }
 
-async function processChapter(
-  chapter: Pick<TextChapter, 'id' | 'body'>,
-  language: LanguageCode,
-  index: LemmaIndex,
-): Promise<number> {
-  const result = await nlpClient.process(language, chapter.body);
+/**
+ * Resolve lemmas for a chapter's tokens and persist them, then rebuild
+ * phrase spans + proposals. Shared by the text pipeline (tokens from
+ * `nlpClient.process`) and the PDF pipeline (tokens from `nlpClient.ocr`,
+ * each carrying a `bbox`). Idempotent: replaces any existing tokens for
+ * the chapter so a re-process / re-OCR overwrites rather than duplicates.
+ *
+ * `tokens` is the NLP token shape with an optional `bbox` — null/absent
+ * for text chapters, a normalized box for PDF page words.
+ */
+export async function persistTokens(args: {
+  chapterId: string;
+  language: LanguageCode;
+  index: LemmaIndex;
+  tokens: Array<
+    NlpToken & { bbox?: { x: number; y: number; w: number; h: number } | null }
+  >;
+  proposedPhrases?: ProposedPhrase[];
+}): Promise<number> {
+  const { chapterId, language, index, tokens } = args;
   // Resolve / auto-create lemmas first so each token's lemma_id is
   // ready for the bulk insert. We can't `Promise.all` because
   // ensureLemma writes into the shared index — sequential keeps
   // duplicate inserts from racing each other across tokens of the
   // same lemma.
   const resolvedLemmaIds: Array<string | null> = [];
-  for (const t of result.tokens) {
+  for (const t of tokens) {
     resolvedLemmaIds.push(await pickLemmaId(t, language, index));
   }
-  const rows = result.tokens.map((t, i) => {
+  const rows = tokens.map((t, i) => {
     const lemmaId = resolvedLemmaIds[i] ?? null;
     return {
-      chapterId: chapter.id,
+      chapterId,
       idx: t.idx,
       surface: t.surface,
       lemmaId,
@@ -402,16 +416,20 @@ async function processChapter(
       // rule-based romanization (see LemmaIndex.romanizationBySurface).
       romanization: index.romanizationBySurface.get(t.surface) ?? t.romanization,
       numberForms: t.number_forms ?? null,
+      // PDF source only — normalized word box on the page image. Null
+      // for text chapters and for whitespace/punctuation.
+      bbox: t.bbox ?? null,
     };
   }) satisfies Array<Omit<TextToken, 'id'>>;
-  if (rows.length === 0) return 0;
-  // Replace any previous tokens for idempotency (re-processing a
-  // text via T-6.8 admin endpoint should overwrite, not duplicate).
+  // Replace any previous tokens for idempotency (re-processing a text
+  // via T-6.8 admin endpoint, or re-OCR of a PDF page, should overwrite
+  // not duplicate). Always delete first — even when the new token list
+  // is empty (a blank PDF page) — so stale rows don't survive.
   await db
     .delete(schema.textTokens)
-    .where(eq(schema.textTokens.chapterId, chapter.id));
+    .where(eq(schema.textTokens.chapterId, chapterId));
   // Postgres caps a single statement at 65534 bound parameters.
-  // text_tokens has ~10 columns, so a 7000-token chapter alone
+  // text_tokens has ~11 columns, so a 7000-token chapter alone
   // would blow past the cap as one INSERT. Batch.
   const BATCH = 1000;
   for (let off = 0; off < rows.length; off += BATCH) {
@@ -421,10 +439,7 @@ async function processChapter(
   // text_tokens are in place. Failures bubble up so a span-resolver
   // crash flips the text to 'failed' rather than leaving it
   // half-indexed.
-  await rebuildChapterSpans({
-    chapterId: chapter.id,
-    language,
-  });
+  await rebuildChapterSpans({ chapterId, language });
   // T-14.5a: persist any rule-based phrase proposals the NLP
   // service emitted. Older NLP service builds may omit
   // `proposed_phrases` — we default to an empty list so a stale
@@ -432,15 +447,26 @@ async function processChapter(
   // The upsert is idempotent on `(chapter_id, surface_normalised,
   // pattern_id)` so a re-process of the same chapter doesn't
   // duplicate.
-  const proposals = result.proposed_phrases ?? [];
+  const proposals = args.proposedPhrases ?? [];
   if (proposals.length > 0) {
-    await upsertPhraseProposals({
-      chapterId: chapter.id,
-      language,
-      proposals,
-    });
+    await upsertPhraseProposals({ chapterId, language, proposals });
   }
   return rows.length;
+}
+
+async function processChapter(
+  chapter: Pick<TextChapter, 'id' | 'body'>,
+  language: LanguageCode,
+  index: LemmaIndex,
+): Promise<number> {
+  const result = await nlpClient.process(language, chapter.body);
+  return persistTokens({
+    chapterId: chapter.id,
+    language,
+    index,
+    tokens: result.tokens,
+    proposedPhrases: result.proposed_phrases,
+  });
 }
 
 /**

--- a/apps/web/src/lib/server/texts/pdf-page.test.ts
+++ b/apps/web/src/lib/server/texts/pdf-page.test.ts
@@ -56,12 +56,12 @@ vi.mock('../db/index.js', () => ({
   },
 }));
 
-const ocrMock = vi.fn(async (..._args: unknown[]): Promise<unknown> => undefined);
+const ocrMock = vi.fn<(...args: unknown[]) => Promise<unknown>>();
 vi.mock('../nlp-client.js', () => ({
   nlpClient: { ocr: (...args: unknown[]) => ocrMock(...args) },
 }));
 
-const putMock = vi.fn(async (..._args: unknown[]) => {});
+const putMock = vi.fn<(...args: unknown[]) => Promise<void>>();
 vi.mock('../pdf/storage.js', async (orig) => {
   const actual = (await orig()) as object;
   return {
@@ -70,15 +70,15 @@ vi.mock('../pdf/storage.js', async (orig) => {
   };
 });
 
-const persistTokensMock = vi.fn(async (..._args: unknown[]): Promise<number> => 7);
+const persistTokensMock = vi.fn<(...args: unknown[]) => Promise<number>>();
 vi.mock('./in-process-dispatcher.js', () => ({
   loadLemmaIndex: vi.fn(async () => ({})),
   persistTokens: (...args: unknown[]) => persistTokensMock(...args),
 }));
 
-const markProcessing = vi.fn(async (..._args: unknown[]) => {});
-const markReady = vi.fn(async (..._args: unknown[]) => {});
-const markFailed = vi.fn(async (..._args: unknown[]) => {});
+const markProcessing = vi.fn<(...args: unknown[]) => Promise<void>>();
+const markReady = vi.fn<(...args: unknown[]) => Promise<void>>();
+const markFailed = vi.fn<(...args: unknown[]) => Promise<void>>();
 vi.mock('./jobs.js', () => ({
   markTextProcessing: (...a: unknown[]) => markProcessing(...a),
   markTextReady: (...a: unknown[]) => markReady(...a),
@@ -110,6 +110,7 @@ describe('processPdfPage', () => {
     ocrMock.mockReset();
     putMock.mockClear();
     persistTokensMock.mockClear();
+    persistTokensMock.mockResolvedValue(7);
     markProcessing.mockClear();
     markReady.mockClear();
     markFailed.mockClear();

--- a/apps/web/src/lib/server/texts/pdf-page.test.ts
+++ b/apps/web/src/lib/server/texts/pdf-page.test.ts
@@ -1,0 +1,217 @@
+// @vitest-environment node
+/**
+ * Tests for processPdfPage — the per-page PDF ingest orchestration.
+ *
+ * Collaborators (db, storage, NLP client, lemma resolution, status
+ * helpers) are mocked so the test exercises just this module's logic:
+ * store image → OCR → update chapter → persist tokens → flip the text to
+ * ready when the last page lands.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- db mock: staged select results + recorded updates ----------------
+const staged: Array<unknown[]> = [];
+function stage(rows: unknown[]) {
+  staged.push(rows);
+}
+function nextStaged(): unknown[] {
+  const v = staged.shift();
+  if (!v) throw new Error('Test bug: no staged result available');
+  return v;
+}
+const updates: Array<unknown> = [];
+
+function makeSelectChain() {
+  const chain: Record<string, unknown> = {};
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.limit = vi.fn(() => chain);
+  chain.then = (resolve: (v: unknown) => unknown) => resolve(nextStaged());
+  return chain;
+}
+function makeUpdateChain() {
+  const chain: Record<string, unknown> = {};
+  chain.set = vi.fn((v: unknown) => {
+    updates.push(v);
+    return chain;
+  });
+  chain.where = vi.fn(() => chain);
+  chain.then = (resolve: (v: unknown) => unknown) => resolve(undefined);
+  return chain;
+}
+
+vi.mock('../db/index.js', () => ({
+  db: {
+    select: () => makeSelectChain(),
+    update: () => makeUpdateChain(),
+  },
+  schema: {
+    texts: { id: 'texts.id' },
+    textChapters: {
+      id: 'text_chapters.id',
+      textId: 'text_chapters.text_id',
+      idx: 'text_chapters.idx',
+      pageImageKey: 'text_chapters.page_image_key',
+    },
+  },
+}));
+
+const ocrMock = vi.fn(async (..._args: unknown[]): Promise<unknown> => undefined);
+vi.mock('../nlp-client.js', () => ({
+  nlpClient: { ocr: (...args: unknown[]) => ocrMock(...args) },
+}));
+
+const putMock = vi.fn(async (..._args: unknown[]) => {});
+vi.mock('../pdf/storage.js', async (orig) => {
+  const actual = (await orig()) as object;
+  return {
+    ...actual,
+    getPdfStorage: () => ({ put: putMock, delete: vi.fn(), urlFor: (k: string) => k }),
+  };
+});
+
+const persistTokensMock = vi.fn(async (..._args: unknown[]): Promise<number> => 7);
+vi.mock('./in-process-dispatcher.js', () => ({
+  loadLemmaIndex: vi.fn(async () => ({})),
+  persistTokens: (...args: unknown[]) => persistTokensMock(...args),
+}));
+
+const markProcessing = vi.fn(async (..._args: unknown[]) => {});
+const markReady = vi.fn(async (..._args: unknown[]) => {});
+const markFailed = vi.fn(async (..._args: unknown[]) => {});
+vi.mock('./jobs.js', () => ({
+  markTextProcessing: (...a: unknown[]) => markProcessing(...a),
+  markTextReady: (...a: unknown[]) => markReady(...a),
+  markTextFailed: (...a: unknown[]) => markFailed(...a),
+}));
+
+import { processPdfPage, PdfPageError } from './pdf-page.js';
+
+const TEXT_ID = '11111111-1111-1111-1111-111111111111';
+
+function stageOcrResult(body = 'Egun on') {
+  ocrMock.mockResolvedValueOnce({
+    language: 'eu',
+    pipeline_id: 'stanza-eu',
+    width: 800,
+    height: 1200,
+    body,
+    tokens: [
+      { idx: 0, surface: 'Egun', is_word: true, candidates: [], bbox: { x: 0.1, y: 0.1, w: 0.2, h: 0.05 } },
+    ],
+    proposed_phrases: [],
+  });
+}
+
+describe('processPdfPage', () => {
+  beforeEach(() => {
+    staged.length = 0;
+    updates.length = 0;
+    ocrMock.mockReset();
+    putMock.mockClear();
+    persistTokensMock.mockClear();
+    markProcessing.mockClear();
+    markReady.mockClear();
+    markFailed.mockClear();
+  });
+  afterEach(() => vi.clearAllMocks());
+
+  it('stores the image, OCRs, updates the chapter, and marks ready on the last page', async () => {
+    // selects, in order: text, chapter, total count, done count
+    stage([{ id: TEXT_ID, sourceType: 'pdf', status: 'pending', language: 'eu', ownerId: 'u1' }]);
+    stage([{ id: 'chap-0' }]);
+    stage([{ total: 1 }]);
+    stage([{ done: 1 }]);
+    stageOcrResult();
+
+    const result = await processPdfPage({
+      textId: TEXT_ID,
+      idx: 0,
+      imageBytes: new Uint8Array([1, 2, 3]),
+      mime: 'image/webp',
+      width: 800,
+      height: 1200,
+      bornDigital: { items: [{ str: 'Egun', x: 0.1, y: 0.1, w: 0.2, h: 0.05 }] },
+    });
+
+    expect(markProcessing).toHaveBeenCalledWith(TEXT_ID);
+    // Image stored under the per-page key.
+    expect(putMock).toHaveBeenCalledOnce();
+    expect(putMock.mock.calls[0]![0]).toBe(`texts/${TEXT_ID}/pages/0.webp`);
+    // OCR called with the born-digital payload.
+    expect(ocrMock).toHaveBeenCalledOnce();
+    expect(ocrMock.mock.calls[0]![2]).toMatchObject({
+      width: 800,
+      height: 1200,
+      bornDigital: { items: [{ str: 'Egun', x: 0.1, y: 0.1, w: 0.2, h: 0.05 }] },
+    });
+    // Chapter row updated with body + page image metadata.
+    expect(updates[0]).toMatchObject({
+      body: 'Egun on',
+      pageImageKey: `texts/${TEXT_ID}/pages/0.webp`,
+      pageImageMime: 'image/webp',
+      pageWidth: 800,
+      pageHeight: 1200,
+    });
+    expect(persistTokensMock).toHaveBeenCalledOnce();
+    expect(markReady).toHaveBeenCalledWith(TEXT_ID);
+    expect(result).toMatchObject({ chapterId: 'chap-0', complete: true });
+  });
+
+  it('does not mark ready until every page is processed', async () => {
+    stage([{ id: TEXT_ID, sourceType: 'pdf', status: 'processing', language: 'eu', ownerId: 'u1' }]);
+    stage([{ id: 'chap-1' }]);
+    stage([{ total: 3 }]);
+    stage([{ done: 1 }]);
+    stageOcrResult();
+
+    const result = await processPdfPage({
+      textId: TEXT_ID,
+      idx: 1,
+      imageBytes: new Uint8Array([1]),
+      mime: 'image/webp',
+      width: 800,
+      height: 1200,
+    });
+
+    // Already processing — no re-flip.
+    expect(markProcessing).not.toHaveBeenCalled();
+    expect(markReady).not.toHaveBeenCalled();
+    expect(result.complete).toBe(false);
+  });
+
+  it('rejects a non-PDF text without touching storage', async () => {
+    stage([{ id: TEXT_ID, sourceType: 'txt', status: 'ready', language: 'eu', ownerId: 'u1' }]);
+
+    await expect(
+      processPdfPage({
+        textId: TEXT_ID,
+        idx: 0,
+        imageBytes: new Uint8Array([1]),
+        mime: 'image/webp',
+        width: 10,
+        height: 10,
+      }),
+    ).rejects.toBeInstanceOf(PdfPageError);
+    expect(putMock).not.toHaveBeenCalled();
+    expect(ocrMock).not.toHaveBeenCalled();
+  });
+
+  it('marks the text failed when OCR throws', async () => {
+    stage([{ id: TEXT_ID, sourceType: 'pdf', status: 'pending', language: 'eu', ownerId: 'u1' }]);
+    stage([{ id: 'chap-0' }]);
+    ocrMock.mockRejectedValueOnce(new Error('vision boom'));
+
+    await expect(
+      processPdfPage({
+        textId: TEXT_ID,
+        idx: 0,
+        imageBytes: new Uint8Array([1]),
+        mime: 'image/webp',
+        width: 10,
+        height: 10,
+      }),
+    ).rejects.toThrow('vision boom');
+    expect(markFailed).toHaveBeenCalledWith(TEXT_ID, 'vision boom');
+  });
+});

--- a/apps/web/src/lib/server/texts/pdf-page.ts
+++ b/apps/web/src/lib/server/texts/pdf-page.ts
@@ -1,0 +1,259 @@
+/**
+ * PDF per-page processing.
+ *
+ * A PDF text is one `texts` row (sourceType 'pdf') with one
+ * `text_chapters` row per page, created empty by `createPdfText`. The
+ * browser rasterizes each page client-side and uploads the image; the
+ * per-page ingest endpoint (`/api/v1/texts/[id]/pages/[idx]`) calls
+ * `processPdfPage`, which:
+ *
+ *   1. stores the page image (the only persisted artifact),
+ *   2. OCRs it via the NLP `/ocr` endpoint (Vision, or the client's
+ *      born-digital text layer) → tokens + per-token bbox,
+ *   3. fills the page chapter's body + image metadata,
+ *   4. resolves + persists tokens through the shared `persistTokens`
+ *      (same lemma resolution the text pipeline uses), and
+ *   5. flips the text to `ready` once every page has been processed.
+ *
+ * Pages arrive as independent HTTP requests, so unlike the text
+ * dispatcher there's no single "process the whole text" pass — each page
+ * loads its own lemma index. For the lemma table sizes we have that's an
+ * acceptable per-page cost; a process-wide cache is a later optimization.
+ */
+import { and, count, eq, isNotNull } from 'drizzle-orm';
+
+import type { LanguageCode } from '@ciareader/shared-types';
+
+import { db, schema } from '../db/index.js';
+import type { Text } from '../db/schema.js';
+import { nlpClient, type BornDigitalPayload } from '../nlp-client.js';
+import { estimateTokenCount } from './chunking.js';
+import { loadLemmaIndex, persistTokens } from './in-process-dispatcher.js';
+import { markTextFailed, markTextProcessing, markTextReady } from './jobs.js';
+import { getPdfStorage, pageImageStorageKey } from '../pdf/storage.js';
+
+export class PdfPageError extends Error {
+  constructor(
+    message: string,
+    public readonly status: 400 | 403 | 404 = 400,
+  ) {
+    super(message);
+    this.name = 'PdfPageError';
+  }
+}
+
+export type ProcessPdfPageInput = {
+  textId: string;
+  /** Page index (0-based) — matches the page chapter's `idx`. */
+  idx: number;
+  imageBytes: Uint8Array;
+  /** Image mime (image/webp | image/jpeg | image/png). */
+  mime: string;
+  /** Rendered page-image pixel dimensions, from the client. */
+  width: number;
+  height: number;
+  /** 'vision' (default) or 'vision_llm' (on-demand AI proofread). */
+  engine?: 'vision' | 'vision_llm';
+  /** Client-extracted PDF text layer for born-digital pages — when set,
+   *  OCR is skipped server-side. */
+  bornDigital?: BornDigitalPayload | null;
+};
+
+export type ProcessPdfPageResult = {
+  chapterId: string;
+  /** Number of word/non-word tokens persisted for the page. */
+  tokenCount: number;
+  /** True when this page was the last to be processed and the text
+   *  flipped to `ready`. */
+  complete: boolean;
+};
+
+/**
+ * Process one uploaded PDF page image end-to-end. Throws `PdfPageError`
+ * for caller-fixable problems (unknown text / page) and flips the text to
+ * `failed` (re-raising) if OCR or persistence errors out.
+ */
+export async function processPdfPage(
+  input: ProcessPdfPageInput,
+): Promise<ProcessPdfPageResult> {
+  const [text] = (await db
+    .select()
+    .from(schema.texts)
+    .where(eq(schema.texts.id, input.textId))
+    .limit(1)) as Text[];
+  if (!text) throw new PdfPageError('text not found', 404);
+  if (text.sourceType !== 'pdf') {
+    throw new PdfPageError('text is not a PDF', 400);
+  }
+
+  const [chapter] = (await db
+    .select({ id: schema.textChapters.id })
+    .from(schema.textChapters)
+    .where(
+      and(
+        eq(schema.textChapters.textId, input.textId),
+        eq(schema.textChapters.idx, input.idx),
+      ),
+    )
+    .limit(1)) as Array<{ id: string }>;
+  if (!chapter) throw new PdfPageError('page not found', 404);
+
+  const language = text.language as LanguageCode;
+
+  try {
+    // First page in flips the text from queued → processing.
+    if (text.status === 'pending') {
+      await markTextProcessing(input.textId);
+    }
+
+    const key = pageImageStorageKey(input.textId, input.idx, input.mime);
+    await getPdfStorage().put(key, input.imageBytes, input.mime);
+
+    const ocr = await nlpClient.ocr(language, input.imageBytes, {
+      width: input.width,
+      height: input.height,
+      mime: input.mime,
+      engine: input.engine,
+      bornDigital: input.bornDigital,
+    });
+
+    await db
+      .update(schema.textChapters)
+      .set({
+        body: ocr.body,
+        tokenCount: estimateTokenCount(ocr.body),
+        pageImageKey: key,
+        pageImageMime: input.mime,
+        pageWidth: ocr.width,
+        pageHeight: ocr.height,
+      })
+      .where(eq(schema.textChapters.id, chapter.id));
+
+    const index = await loadLemmaIndex(language);
+    const tokenCount = await persistTokens({
+      chapterId: chapter.id,
+      language,
+      index,
+      tokens: ocr.tokens,
+      proposedPhrases: ocr.proposed_phrases,
+    });
+
+    // A page counts as done once it has an image key. Mark the text
+    // ready when every page chapter has been processed (token-count
+    // would wrongly exclude legitimately blank pages).
+    const [totals] = await db
+      .select({ total: count() })
+      .from(schema.textChapters)
+      .where(eq(schema.textChapters.textId, input.textId));
+    const [done] = await db
+      .select({ done: count() })
+      .from(schema.textChapters)
+      .where(
+        and(
+          eq(schema.textChapters.textId, input.textId),
+          isNotNull(schema.textChapters.pageImageKey),
+        ),
+      );
+    const complete = Number(done?.done ?? 0) >= Number(totals?.total ?? 0);
+    if (complete) {
+      await markTextReady(input.textId);
+    }
+
+    return { chapterId: chapter.id, tokenCount, complete };
+  } catch (e) {
+    if (e instanceof PdfPageError) throw e;
+    const message = (e as Error).message ?? String(e);
+    await markTextFailed(input.textId, message);
+    throw e;
+  }
+}
+
+/**
+ * Re-run NLP over an already-imported PDF **without calling Vision**.
+ *
+ * The expensive OCR result is already persisted: each page's text lives in
+ * the stored tokens (their surfaces concatenate to the page text) and each
+ * word token carries its bounding box. We replay that geometry as an OCR
+ * "layout" so the NLP service re-tokenizes + re-resolves lemmas with the
+ * current model/dictionary and recomputes boxes — but pays nothing for
+ * OCR and needs no re-upload. Use after a model/dictionary change (e.g.
+ * switching the Basque pipeline on) instead of re-importing.
+ */
+export async function reprocessPdfText(textId: string): Promise<number> {
+  const [text] = (await db
+    .select()
+    .from(schema.texts)
+    .where(eq(schema.texts.id, textId))
+    .limit(1)) as Text[];
+  if (!text) throw new PdfPageError('text not found', 404);
+  if (text.sourceType !== 'pdf') {
+    throw new PdfPageError('text is not a PDF', 400);
+  }
+  const language = text.language as LanguageCode;
+
+  await markTextProcessing(textId);
+  try {
+    const chapters = (await db
+      .select({
+        id: schema.textChapters.id,
+        pageWidth: schema.textChapters.pageWidth,
+        pageHeight: schema.textChapters.pageHeight,
+      })
+      .from(schema.textChapters)
+      .where(eq(schema.textChapters.textId, textId))
+      .orderBy(schema.textChapters.idx)) as Array<{
+      id: string;
+      pageWidth: number | null;
+      pageHeight: number | null;
+    }>;
+
+    const index = await loadLemmaIndex(language);
+    let total = 0;
+    for (const ch of chapters) {
+      const toks = (await db
+        .select({
+          surface: schema.textTokens.surface,
+          bbox: schema.textTokens.bbox,
+        })
+        .from(schema.textTokens)
+        .where(eq(schema.textTokens.chapterId, ch.id))
+        .orderBy(schema.textTokens.idx)) as Array<{
+        surface: string;
+        bbox: { x: number; y: number; w: number; h: number } | null;
+      }>;
+      // No stored tokens → page was never OCR'd; nothing to replay.
+      if (toks.length === 0) continue;
+
+      // Rebuild the page text + one box per character from the tokens.
+      let pageText = '';
+      const charBoxes: Array<[number, number, number, number] | null> = [];
+      for (const t of toks) {
+        const box: [number, number, number, number] | null = t.bbox
+          ? [t.bbox.x, t.bbox.y, t.bbox.w, t.bbox.h]
+          : null;
+        // One entry per code point (matches Python's len(text)).
+        charBoxes.push(...Array.from(t.surface, () => box));
+        pageText += t.surface;
+      }
+
+      const ocr = await nlpClient.ocr(language, new Uint8Array(0), {
+        width: ch.pageWidth ?? 1,
+        height: ch.pageHeight ?? 1,
+        layout: { text: pageText, charBoxes },
+      });
+      total += await persistTokens({
+        chapterId: ch.id,
+        language,
+        index,
+        tokens: ocr.tokens,
+        proposedPhrases: ocr.proposed_phrases,
+      });
+    }
+    await markTextReady(textId);
+    return total;
+  } catch (e) {
+    const message = (e as Error).message ?? String(e);
+    await markTextFailed(textId, message);
+    throw e;
+  }
+}

--- a/apps/web/src/lib/server/texts/tokens.ts
+++ b/apps/web/src/lib/server/texts/tokens.ts
@@ -109,6 +109,10 @@ export type RenderedToken = {
    *  form + romanization. Null on every other token. */
   numberForms: RenderedNumberForms | null;
   status: 'known' | 'learning' | 'ignored' | 'unknown';
+  /** PDF source only: the word's normalized (0..1) bounding box on the
+   *  page image; drives the image reader's clickable word hotspots.
+   *  Null for text tokens and whitespace/punctuation. */
+  bbox: { x: number; y: number; w: number; h: number } | null;
   /** #435: true when this word's lemma (or a same-headword sibling)
    *  carries a canonical short gloss — i.e. the dictionary has a
    *  definition for it. False for OOV words and for lemmas with no
@@ -461,6 +465,7 @@ export async function loadChapterTokens(
       features: t.features,
       numberForms: renderedNumberForms,
       status,
+      bbox: t.bbox ?? null,
       hasDefinition: effectiveGloss != null,
     };
   });

--- a/apps/web/src/lib/server/texts/upload.test.ts
+++ b/apps/web/src/lib/server/texts/upload.test.ts
@@ -142,6 +142,8 @@ const {
   MAX_EPUB_BYTES,
   MAX_ZIP_BYTES,
   MAX_TITLE_LEN,
+  createPdfText,
+  MAX_PDF_PAGES,
 } = await import('./upload.js');
 
 const JSZip = (await import('jszip')).default;
@@ -376,6 +378,73 @@ describe('createPastedText', () => {
         title: 'X',
         body: oversized,
       }),
+    ).rejects.toBeInstanceOf(TextValidationError);
+  });
+});
+
+// -----------------------------------------------------------------------
+// createPdfText (PDF image reader)
+// -----------------------------------------------------------------------
+
+describe('createPdfText', () => {
+  it('inserts a pdf text + N empty page chapters + nlp_jobs, no enqueue', async () => {
+    stage([textRow({ sourceType: 'pdf' })]);
+    stage([
+      chapterRow({ id: 'chap-0', idx: 0, body: '', tokenCount: 0 }),
+      chapterRow({ id: 'chap-1', idx: 1, body: '', tokenCount: 0 }),
+    ]);
+
+    const result = await createPdfText(OWNER, {
+      language: 'eu',
+      title: '  Scanned book  ',
+      pageCount: 2,
+    });
+    expect(result.text.id).toBe('text-1');
+    expect(result.chapters).toHaveLength(2);
+
+    const insertCalls = calls.filter(
+      (c): c is Extract<Call, { kind: 'insert' }> => c.kind === 'insert',
+    );
+    // texts + chapters + nlp_jobs (NOT enqueued via the dispatcher).
+    expect(insertCalls).toHaveLength(3);
+    expect(insertCalls[0]!.values).toMatchObject({
+      ownerId: OWNER.id,
+      language: 'eu',
+      title: 'Scanned book',
+      sourceType: 'pdf',
+      status: 'pending',
+      visibility: 'private',
+    });
+    const chapterValues = insertCalls[1]!.values as Array<Record<string, unknown>>;
+    expect(chapterValues).toHaveLength(2);
+    expect(chapterValues[0]).toMatchObject({ textId: 'text-1', idx: 0, body: '', tokenCount: 0 });
+    expect(chapterValues[1]).toMatchObject({ idx: 1, body: '' });
+    expect(insertCalls[2]!.values).toMatchObject({ textId: 'text-1', status: 'pending' });
+  });
+
+  it('rejects a non-positive page count', async () => {
+    await expect(
+      createPdfText(OWNER, { language: 'eu', title: 'X', pageCount: 0 }),
+    ).rejects.toBeInstanceOf(TextValidationError);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('rejects a page count over the cap', async () => {
+    await expect(
+      createPdfText(OWNER, { language: 'eu', title: 'X', pageCount: MAX_PDF_PAGES + 1 }),
+    ).rejects.toBeInstanceOf(TextValidationError);
+  });
+
+  it('rejects an unsupported language', async () => {
+    await expect(
+      createPdfText(OWNER, { language: 'xx', title: 'X', pageCount: 1 }),
+    ).rejects.toBeInstanceOf(TextValidationError);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('rejects an empty title', async () => {
+    await expect(
+      createPdfText(OWNER, { language: 'eu', title: '   ', pageCount: 1 }),
     ).rejects.toBeInstanceOf(TextValidationError);
   });
 });

--- a/apps/web/src/lib/server/texts/upload.ts
+++ b/apps/web/src/lib/server/texts/upload.ts
@@ -291,6 +291,100 @@ export async function createTxtText(
   });
 }
 
+/** Hard cap on the number of pages in one PDF upload. A page is one
+ *  `text_chapters` row + one image; 2000 covers any realistic book while
+ *  bounding the up-front row insert and the per-page upload loop. */
+export const MAX_PDF_PAGES = 2000;
+
+export type CreatePdfTextInput = {
+  language: string;
+  title: string;
+  /** Number of pages — the browser reads this from the PDF (pdf.js) and
+   *  uploads page images one by one afterward. */
+  pageCount: number;
+};
+
+/**
+ * Create the shell of a PDF text: a `texts` row (sourceType 'pdf') plus
+ * one empty `text_chapters` row per page. Unlike the paste/txt/epub
+ * paths this does NOT enqueue an NLP job — PDF pages are rasterized in
+ * the browser and processed one at a time by the per-page ingest
+ * endpoint (`processPdfPage`), which fills each chapter's body + image
+ * and flips the text to `ready` when the last page lands. We still
+ * insert an `nlp_jobs` row (status pending) so the status helpers have a
+ * job to update and the admin/monitoring views see the run.
+ */
+export async function createPdfText(
+  owner: Pick<User, 'id'>,
+  input: CreatePdfTextInput,
+  now: Date = new Date(),
+): Promise<CreatedText> {
+  if (!isSupportedLanguage(input.language)) {
+    throw new TextValidationError(
+      `Unsupported language '${input.language}' (expected one of: ${SUPPORTED_LANGUAGE_CODES.join(', ')})`,
+    );
+  }
+  const language = input.language as LanguageCode;
+  const title = normalizeTitle(input.title ?? '');
+  if (title.length < MIN_TITLE_LEN) {
+    throw new TextValidationError('title is required');
+  }
+  if (title.length > MAX_TITLE_LEN) {
+    throw new TextValidationError(`title exceeds ${MAX_TITLE_LEN} characters`);
+  }
+  const pageCount = input.pageCount;
+  if (!Number.isInteger(pageCount) || pageCount < 1) {
+    throw new TextValidationError('pageCount must be a positive integer');
+  }
+  if (pageCount > MAX_PDF_PAGES) {
+    throw new TextValidationError(`PDF exceeds ${MAX_PDF_PAGES} pages`);
+  }
+
+  const [text] = await db
+    .insert(schema.texts)
+    .values({
+      ownerId: owner.id,
+      language,
+      title,
+      sourceType: 'pdf',
+      status: 'pending',
+      visibility: 'private',
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning();
+  if (!text) throw new Error('Failed to insert text row');
+
+  const chapterRows = (await db
+    .insert(schema.textChapters)
+    .values(
+      Array.from({ length: pageCount }, (_unused, i) => ({
+        textId: (text as Text).id,
+        idx: i,
+        title: null,
+        // Body + image fill in as each page is OCR'd; placeholder for now.
+        body: '',
+        tokenCount: 0,
+        createdAt: now,
+      })),
+    )
+    .returning()) as TextChapter[];
+  if (chapterRows.length === 0) throw new Error('Failed to insert chapter rows');
+  chapterRows.sort((a, b) => a.idx - b.idx);
+
+  // Audit-trail job row, inserted directly (NOT via enqueueNlpJob, which
+  // would dispatch the in-process text worker against empty page bodies).
+  await db
+    .insert(schema.nlpJobs)
+    .values({ textId: (text as Text).id, status: 'pending', createdAt: now });
+
+  return {
+    text: text as Text,
+    chapter: chapterRows[0]!,
+    chapters: chapterRows,
+  };
+}
+
 export type CreateChapterBookFromEpubInput = {
   language: string;
   title: string;

--- a/apps/web/src/routes/api/v1/admin/texts/[id]/reprocess/+server.ts
+++ b/apps/web/src/routes/api/v1/admin/texts/[id]/reprocess/+server.ts
@@ -24,6 +24,7 @@ import { requireUser } from '$lib/server/auth/require-user.js';
 import { db, schema } from '$lib/server/db/index.js';
 import { isAdmin } from '$lib/server/dictionary/permissions.js';
 import { processTextNow } from '$lib/server/texts/in-process-dispatcher.js';
+import { reprocessPdfText } from '$lib/server/texts/pdf-page.js';
 import type { Text } from '$lib/server/db/schema.js';
 import type { RequestHandler } from './$types';
 
@@ -34,19 +35,24 @@ export const POST: RequestHandler = async (event) => {
   const id = event.params.id;
   if (!id || !UUID_RE.test(id)) throw error(400, 'Invalid text id');
 
-  if (!isAdmin({ role: user.role })) {
-    // Non-admin path: must own the text. Flat 404 if missing or
-    // owned by someone else, matching the rest of the texts API.
-    const [row] = (await db
-      .select()
-      .from(schema.texts)
-      .where(eq(schema.texts.id, id))
-      .limit(1)) as [Text | undefined];
-    if (!row || row.ownerId !== user.id) {
-      throw error(404, 'Text not found');
-    }
+  // Always load the row: needed for the non-admin ownership check and to
+  // pick the right reprocess path (PDF vs text).
+  const [row] = (await db
+    .select()
+    .from(schema.texts)
+    .where(eq(schema.texts.id, id))
+    .limit(1)) as [Text | undefined];
+  if (!row) throw error(404, 'Text not found');
+  if (!isAdmin({ role: user.role }) && row.ownerId !== user.id) {
+    // Flat 404 if owned by someone else, matching the rest of the texts API.
+    throw error(404, 'Text not found');
   }
 
-  const total = await processTextNow(id);
+  // PDFs re-tokenize from the stored OCR layout (no Vision spend, boxes
+  // preserved); text sources re-run the normal /process pipeline.
+  const total =
+    row.sourceType === 'pdf'
+      ? await reprocessPdfText(id)
+      : await processTextNow(id);
   return json({ ok: true, tokensWritten: total });
 };

--- a/apps/web/src/routes/api/v1/admin/texts/[id]/reprocess/reprocess-server.test.ts
+++ b/apps/web/src/routes/api/v1/admin/texts/[id]/reprocess/reprocess-server.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const processTextNow = vi.fn();
+const reprocessPdfText = vi.fn();
 const requireUser = vi.fn();
 
 // Stage rows for the ownership-check db lookup in the non-admin path.
@@ -40,6 +41,10 @@ vi.mock('$lib/server/texts/in-process-dispatcher.js', async () => {
   };
 });
 
+vi.mock('$lib/server/texts/pdf-page.js', () => ({
+  reprocessPdfText: (...a: unknown[]) => reprocessPdfText(...a),
+}));
+
 vi.mock('$lib/server/auth/require-user.js', () => ({
   requireUser: (...a: unknown[]) => requireUser(...a),
 }));
@@ -69,6 +74,7 @@ async function callPost(id = VALID_ID, user: typeof ADMIN | typeof USER | null =
 
 beforeEach(() => {
   processTextNow.mockReset();
+  reprocessPdfText.mockReset();
   requireUser.mockReset();
   staged.length = 0;
 });
@@ -79,19 +85,32 @@ afterEach(() => {
 
 describe('POST /api/v1/admin/texts/:id/reprocess', () => {
   it('runs the dispatcher and returns the token count for an admin', async () => {
+    stage([{ id: VALID_ID, ownerId: ADMIN.id, sourceType: 'txt' }]);
     processTextNow.mockResolvedValueOnce(1234);
     const res = (await callPost()) as Response;
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.tokensWritten).toBe(1234);
     expect(processTextNow).toHaveBeenCalledWith(VALID_ID);
+    expect(reprocessPdfText).not.toHaveBeenCalled();
+  });
+
+  it('re-tokenizes a PDF from its stored layout (no Vision)', async () => {
+    stage([{ id: VALID_ID, ownerId: ADMIN.id, sourceType: 'pdf' }]);
+    reprocessPdfText.mockResolvedValueOnce(42);
+    const res = (await callPost()) as Response;
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.tokensWritten).toBe(42);
+    expect(reprocessPdfText).toHaveBeenCalledWith(VALID_ID);
+    expect(processTextNow).not.toHaveBeenCalled();
   });
 
   // T-11.3: owners can retry their own failed text. Non-owners
   // (even authenticated readers) get a flat 404, matching the rest
   // of the texts API — we don't leak text existence.
   it('lets the text owner trigger a reprocess (T-11.3)', async () => {
-    stage([{ id: VALID_ID, ownerId: USER.id }]);
+    stage([{ id: VALID_ID, ownerId: USER.id, sourceType: 'txt' }]);
     processTextNow.mockResolvedValueOnce(99);
     const res = (await callPost(VALID_ID, USER)) as Response;
     expect(res.status).toBe(200);

--- a/apps/web/src/routes/api/v1/texts/[id]/pages/[idx]/+server.ts
+++ b/apps/web/src/routes/api/v1/texts/[id]/pages/[idx]/+server.ts
@@ -1,0 +1,106 @@
+/**
+ * POST /api/v1/texts/:id/pages/:idx
+ *
+ * Ingest one rasterized PDF page. Multipart body:
+ *   - image:        the rendered page (WebP/JPEG/PNG)
+ *   - width/height: the rendered image's pixel dimensions
+ *   - bornDigital:  (optional) JSON {items:[…]} extracted from the PDF's
+ *                   text layer; when present, OCR is skipped server-side
+ *   - engine:       (optional) 'vision' | 'vision_llm'
+ *
+ * Owner-or-admin only. Stores the image, OCRs the page, persists tokens,
+ * and flips the text to `ready` once the last page lands.
+ */
+import { error, json } from '@sveltejs/kit';
+import { eq } from 'drizzle-orm';
+
+import { requireVerifiedUser } from '$lib/server/auth/require-user.js';
+import { db, schema } from '$lib/server/db/index.js';
+import {
+  isAllowedPageImageMime,
+  MAX_PAGE_IMAGE_BYTES,
+} from '$lib/server/pdf/storage.js';
+import { PdfPageError, processPdfPage } from '$lib/server/texts/pdf-page.js';
+import type { BornDigitalPayload } from '$lib/server/nlp-client.js';
+import type { RequestHandler } from './$types';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const POST: RequestHandler = async (event) => {
+  const user = await requireVerifiedUser(event);
+  const id = event.params.id;
+  if (!id || !UUID_RE.test(id)) throw error(400, 'Invalid text id');
+  const idx = Number.parseInt(event.params.idx ?? '', 10);
+  if (!Number.isInteger(idx) || idx < 0) throw error(400, 'Invalid page index');
+
+  // Owner-or-admin gate (don't leak existence to others).
+  const [text] = (await db
+    .select({ ownerId: schema.texts.ownerId })
+    .from(schema.texts)
+    .where(eq(schema.texts.id, id))
+    .limit(1)) as Array<{ ownerId: string | null }>;
+  if (!text) throw error(404, 'Text not found');
+  if (user.role !== 'admin' && text.ownerId !== user.id) {
+    throw error(404, 'Text not found');
+  }
+
+  const form = await event.request.formData();
+  const file = form.get('image');
+  if (!(file instanceof File)) throw error(400, 'image field required');
+  const mime = file.type || 'image/webp';
+  if (!isAllowedPageImageMime(mime)) {
+    throw error(415, `Unsupported image type ${mime}`);
+  }
+  const buf = new Uint8Array(await file.arrayBuffer());
+  if (buf.byteLength > MAX_PAGE_IMAGE_BYTES) {
+    throw error(413, 'Page image too large');
+  }
+
+  const width = Number.parseInt(String(form.get('width') ?? ''), 10);
+  const height = Number.parseInt(String(form.get('height') ?? ''), 10);
+  if (
+    !Number.isInteger(width) ||
+    !Number.isInteger(height) ||
+    width <= 0 ||
+    height <= 0
+  ) {
+    throw error(400, 'width and height are required');
+  }
+
+  const engine =
+    form.get('engine') === 'vision_llm' ? 'vision_llm' : 'vision';
+
+  let bornDigital: BornDigitalPayload | null = null;
+  const bd = form.get('bornDigital');
+  if (typeof bd === 'string' && bd) {
+    try {
+      bornDigital = JSON.parse(bd) as BornDigitalPayload;
+    } catch {
+      throw error(400, 'invalid bornDigital JSON');
+    }
+  }
+
+  try {
+    const result = await processPdfPage({
+      textId: id,
+      idx,
+      imageBytes: buf,
+      mime,
+      width,
+      height,
+      engine,
+      bornDigital,
+    });
+    return json(
+      {
+        chapterId: result.chapterId,
+        tokenCount: result.tokenCount,
+        complete: result.complete,
+      },
+      { status: 201 },
+    );
+  } catch (e) {
+    if (e instanceof PdfPageError) throw error(e.status, e.message);
+    throw e;
+  }
+};

--- a/apps/web/src/routes/api/v1/texts/pdf/begin/+server.ts
+++ b/apps/web/src/routes/api/v1/texts/pdf/begin/+server.ts
@@ -1,0 +1,72 @@
+/**
+ * POST /api/v1/texts/pdf/begin
+ *
+ * Opens a PDF import: the browser has read the page count via pdf.js and
+ * calls this to create the `texts` row + N empty page chapters, then
+ * streams page images to `/api/v1/texts/:id/pages/:idx`. Returns the new
+ * text id.
+ */
+import { error, json } from '@sveltejs/kit';
+
+import { requireVerifiedUser } from '$lib/server/auth/require-user.js';
+import {
+  consumeRateLimit,
+  rateLimitHeaders,
+  RequestRateLimitError,
+} from '$lib/server/auth/rate-limits.js';
+import { createPdfText, TextValidationError } from '$lib/server/texts/upload.js';
+import type { RequestHandler } from './$types';
+
+// Per-day cap on PDF imports (the per-page size cap lives in the ingest
+// endpoint). Matches the audio upload envelope.
+const PDF_UPLOADS_PER_DAY = 20;
+const PDF_WINDOW_MS = 24 * 60 * 60 * 1_000;
+
+export const POST: RequestHandler = async (event) => {
+  const user = await requireVerifiedUser(event);
+
+  let payload: unknown;
+  try {
+    payload = await event.request.json();
+  } catch {
+    throw error(400, 'invalid JSON body');
+  }
+  const { language, title, pageCount } = (payload ?? {}) as {
+    language?: unknown;
+    title?: unknown;
+    pageCount?: unknown;
+  };
+  if (typeof language !== 'string') throw error(400, 'language required');
+  if (typeof title !== 'string') throw error(400, 'title required');
+  if (typeof pageCount !== 'number') throw error(400, 'pageCount required');
+
+  try {
+    const requestLimit = await consumeRateLimit(event, user.id, {
+      scope: 'pdf:upload',
+      limit: PDF_UPLOADS_PER_DAY,
+      windowMs: PDF_WINDOW_MS,
+    });
+    const created = await createPdfText(
+      { id: user.id },
+      { language, title, pageCount },
+    );
+    return json(
+      { id: created.text.id, pageCount: created.chapters.length },
+      { status: 201, headers: rateLimitHeaders(requestLimit) },
+    );
+  } catch (e) {
+    if (e instanceof RequestRateLimitError) {
+      return json(
+        {
+          error: 'rate_limited',
+          message: 'Daily PDF upload limit reached. Try again tomorrow.',
+          limit: e.limit,
+          retryAfterSeconds: e.retryAfterSeconds,
+        },
+        { status: 429, headers: rateLimitHeaders(e) },
+      );
+    }
+    if (e instanceof TextValidationError) throw error(e.status, e.message);
+    throw e;
+  }
+};

--- a/apps/web/src/routes/pdf-assets/[...key]/+server.ts
+++ b/apps/web/src/routes/pdf-assets/[...key]/+server.ts
@@ -1,0 +1,59 @@
+/**
+ * GET /pdf-assets/<storage-key> (dev backend only).
+ *
+ * Serves PDF page images from the local volume in dev. The S3 backend
+ * presigns URLs and bypasses this route entirely.
+ *
+ * Unlike audio (which is effectively public once the URL is known),
+ * page images can reproduce a private/copyrighted book, so each request
+ * runs a `canReadText` gate keyed off the text id embedded in the
+ * storage key (`texts/<id>/pages/...`).
+ */
+import { error } from '@sveltejs/kit';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import { getReadableText } from '$lib/server/texts/upload.js';
+import { MIME_BY_EXT, textIdFromPageKey } from '$lib/server/pdf/storage.js';
+import type { RequestHandler } from './$types';
+
+const LOCAL_ROOT = process.env.PDF_LOCAL_ROOT ?? '/tmp/ciareader-pdf';
+
+export const GET: RequestHandler = async ({ params, locals }) => {
+  const key = params.key;
+  if (!key) throw error(400, 'missing key');
+
+  // Only serve page images, and only to viewers allowed to read the
+  // parent text. A malformed / non-page key is a 404 (don't leak which
+  // keys exist).
+  const textId = textIdFromPageKey(key);
+  if (!textId) throw error(404, 'not found');
+  const viewer = locals.user ? { id: locals.user.id } : null;
+  const readable = await getReadableText(viewer, textId);
+  if (!readable) throw error(404, 'not found');
+
+  // Defense-in-depth against path traversal: refuse keys that resolve
+  // outside LOCAL_ROOT.
+  const resolved = path.resolve(LOCAL_ROOT, key);
+  const root = path.resolve(LOCAL_ROOT);
+  if (!resolved.startsWith(root + path.sep) && resolved !== root) {
+    throw error(400, 'invalid key');
+  }
+
+  let body: Buffer;
+  try {
+    body = await fs.readFile(resolved);
+  } catch {
+    throw error(404, 'not found');
+  }
+  const ext = path.extname(resolved).toLowerCase();
+  const mime = MIME_BY_EXT[ext] ?? 'application/octet-stream';
+  return new Response(new Uint8Array(body), {
+    headers: {
+      'content-type': mime,
+      // Private: a logged-in reader's page images shouldn't be cached by
+      // shared proxies. The browser may still cache per-session.
+      'cache-control': 'private, max-age=86400',
+    },
+  });
+};

--- a/apps/web/src/routes/reader/[textId]/+page.server.ts
+++ b/apps/web/src/routes/reader/[textId]/+page.server.ts
@@ -22,6 +22,7 @@ import { error } from '@sveltejs/kit';
 import { and, eq } from 'drizzle-orm';
 
 import { getReadableText } from '$lib/server/texts/upload.js';
+import { getPdfStorage } from '$lib/server/pdf/storage.js';
 import { loadChapterTokens } from '$lib/server/texts/tokens.js';
 import { loadChapterPhraseSpans } from '$lib/server/texts/phrase-spans.js';
 import { getTextProgress } from '$lib/server/texts/progress.js';
@@ -188,6 +189,11 @@ export const load: PageServerLoad = async ({ params, locals, url }) => {
   const audioForText = allAudio.find((a) => a.chapterId === null) ?? null;
   const activeAudio = audioForChapter ?? audioForText;
 
+  // PDF page images: cheap to resolve a URL per chapter (just a key →
+  // path), so include it for every page so the image reader can show a
+  // page indicator + navigate. Tokens/body still ship active-only.
+  const pdfStorage = getPdfStorage();
+
   // T-8.6: course-kind collections gate "next" until the active
   // text is finished (pctRead >= 100). The reader UI grays out the
   // next link unless ?skipLock=1 is set on the URL — a deliberate
@@ -228,6 +234,11 @@ export const load: PageServerLoad = async ({ params, locals, url }) => {
       // active-only / lazy-fill posture. Sibling chapters get null
       // until the lazy fetch lands.
       phraseSpans: c.idx === chapterIdx ? activeChapterSpans : null,
+      // PDF page image (all pages — cheap URL). Null for non-PDF / pages
+      // not yet processed.
+      pageImageUrl: c.pageImageKey ? pdfStorage.urlFor(c.pageImageKey) : null,
+      pageWidth: c.pageWidth,
+      pageHeight: c.pageHeight,
     })),
     anchor: {
       chapterIdx,

--- a/apps/web/src/routes/reader/[textId]/+page.svelte
+++ b/apps/web/src/routes/reader/[textId]/+page.svelte
@@ -6,6 +6,7 @@
   import AudioPlayer from '$lib/components/reader/AudioPlayer.svelte';
   import ChapterNav from '$lib/components/reader/ChapterNav.svelte';
   import ReaderContinuous from '$lib/components/reader/ReaderContinuous.svelte';
+  import ReaderImage from '$lib/components/reader/ReaderImage.svelte';
   import ReaderPage from '$lib/components/reader/ReaderPage.svelte';
   import ReaderScroll from '$lib/components/reader/ReaderScroll.svelte';
   import ReaderSettings from '$lib/components/reader/ReaderSettings.svelte';
@@ -31,6 +32,10 @@
   import type { PageData } from './$types';
 
   let { data }: { data: PageData } = $props();
+
+  // PDF texts render as a page-image reader (clickable word overlays)
+  // regardless of the saved layout mode.
+  const isPdf = $derived(data.text.sourceType === 'pdf');
 
   // T-5.16: Immersive mode hides the AppShell rail / bottom-nav so
   // the reader takes the full viewport. T-5.26 moved the actual
@@ -407,7 +412,7 @@
   <title>{data.text.title} — CIA Reader</title>
 </svelte:head>
 
-<div class="reader" data-mode={data.mode} style={readerStyle}>
+<div class="reader" data-mode={isPdf ? 'pdf' : data.mode} style={readerStyle}>
   <header class="reader-top" bind:this={readerTopEl}>
     <div class="reader-top-left">
       <a class="reader-close" href="/library" aria-label="Close reader" title="Close reader">
@@ -544,7 +549,18 @@
     </p>
   {/if}
 
-  {#if data.mode === 'page'}
+  {#if isPdf}
+    <ReaderImage
+      chapters={data.chapters}
+      chapterIdx={data.anchor.chapterIdx}
+      textId={data.text.id}
+      language={data.text.language as LanguageCode}
+      {showRomanization}
+      isOwner={data.isOwner}
+      isAdmin={data.isAdmin}
+      onProgress={onReaderProgress}
+    />
+  {:else if data.mode === 'page'}
     <ReaderPage
       chapters={data.chapters}
       chapterIdx={data.anchor.chapterIdx}

--- a/apps/web/src/routes/upload/+page.svelte
+++ b/apps/web/src/routes/upload/+page.svelte
@@ -119,9 +119,10 @@
       try {
         const loaded = await loadPdf(file);
         pdfLoaded = loaded;
-        // Default to the embedded text layer when present (fast, free,
-        // exact); fall back to OCR for scans.
-        pdfUseTextLayer = loaded.hasTextLayer;
+        // Default to the embedded text layer ONLY for true born-digital
+        // PDFs. A scan with a (usually poor) built-in OCR layer also
+        // "has text", so gate on !isScanned and default scans to OCR.
+        pdfUseTextLayer = loaded.hasTextLayer && !loaded.isScanned;
       } catch (e) {
         pdfError = `Couldn't read the PDF: ${(e as Error).message}`;
       } finally {
@@ -423,8 +424,11 @@
           <p class="pdf-info">
             {pdfLoaded.numPages}
             {pdfLoaded.numPages === 1 ? 'page' : 'pages'}.
-            {#if pdfLoaded.hasTextLayer}
-              This PDF has a built-in text layer.
+            {#if pdfLoaded.isScanned}
+              Looks like a scanned PDF — defaulting to OCR.{#if pdfLoaded.hasTextLayer}
+                Its built-in text layer is usually poor on scans.{/if}
+            {:else if pdfLoaded.hasTextLayer}
+              This PDF has a real text layer — using it (fast, exact).
             {:else}
               No text layer detected — pages will be OCR'd.
             {/if}

--- a/apps/web/src/routes/upload/+page.svelte
+++ b/apps/web/src/routes/upload/+page.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
   import { enhance } from '$app/forms';
+  import { goto } from '$app/navigation';
   import { untrack } from 'svelte';
+  import {
+    importLoadedPdf,
+    loadPdf,
+    type LoadedPdf,
+  } from '$lib/pdf/render-client';
   import type { ActionData, PageData } from './$types';
 
   let {
@@ -21,9 +27,20 @@
   // 'paste' + 'txt' both submit to ?/paste — the difference is the
   // byte cap (10MB vs 1MB) and the hidden sourceType marker.
   // 'epub' submits to ?/epub. 'zip' submits to ?/zip.
-  let mode = $state<'paste' | 'txt' | 'epub' | 'zip'>(
+  let mode = $state<'paste' | 'txt' | 'epub' | 'zip' | 'pdf'>(
     untrack(() => (form?.values?.sourceType === 'txt' ? 'txt' : 'paste')),
   );
+
+  // PDF flow (client-side render + streaming upload — does NOT use a form
+  // action). Picking a .pdf loads it with pdf.js to read the page count +
+  // detect a text layer; "Import PDF" renders each page to an image and
+  // streams them to the per-page ingest endpoint.
+  let pdfLoaded = $state<LoadedPdf | null>(null);
+  let pdfLoading = $state(false);
+  let pdfUseTextLayer = $state(true);
+  let pdfProgress = $state<{ done: number; total: number } | null>(null);
+  let pdfBusy = $state(false);
+  let pdfError = $state<string | null>(null);
   let pickedFileName = $state<string | null>(null);
   let pickedFileSize = $state(0);
   let dropMessage = $state<string | null>(null);
@@ -86,6 +103,30 @@
       pickedFileSize = file.size;
       if (!title) title = file.name.replace(/\.zip$/i, '');
       dropMessage = null;
+      return;
+    }
+    if (lower.endsWith('.pdf')) {
+      mode = 'pdf';
+      pickedFile = file;
+      pickedFileName = file.name;
+      pickedFileSize = file.size;
+      if (!title) title = file.name.replace(/\.pdf$/i, '');
+      dropMessage = null;
+      pdfError = null;
+      pdfLoaded = null;
+      pdfProgress = null;
+      pdfLoading = true;
+      try {
+        const loaded = await loadPdf(file);
+        pdfLoaded = loaded;
+        // Default to the embedded text layer when present (fast, free,
+        // exact); fall back to OCR for scans.
+        pdfUseTextLayer = loaded.hasTextLayer;
+      } catch (e) {
+        pdfError = `Couldn't read the PDF: ${(e as Error).message}`;
+      } finally {
+        pdfLoading = false;
+      }
       return;
     }
     if (lower.endsWith('.txt')) {
@@ -179,8 +220,39 @@
     pickedFileName = null;
     pickedFileSize = 0;
     dropMessage = null;
+    pdfLoaded = null;
+    pdfProgress = null;
+    pdfError = null;
     // Remount the file input to drop any FileList it was carrying.
     filePickerKey += 1;
+  }
+
+  async function runPdfImport() {
+    if (!pdfLoaded || pdfBusy) return;
+    if (!title.trim()) {
+      pdfError = 'Title is required.';
+      return;
+    }
+    pdfBusy = true;
+    pdfError = null;
+    pdfProgress = { done: 0, total: pdfLoaded.numPages };
+    try {
+      const { id } = await importLoadedPdf(pdfLoaded, {
+        title: title.trim(),
+        language: data.selectedLanguage,
+        useTextLayer: pdfUseTextLayer,
+        onProgress: (p) => {
+          pdfProgress = p;
+        },
+      });
+      // Navigate to the reader; the page processes/streams as it goes, so
+      // it may still be finishing the last page when we land — the reader's
+      // status badge polls to "ready".
+      await goto(`/reader/${id}`);
+    } catch (e) {
+      pdfError = `Import failed: ${(e as Error).message}`;
+      pdfBusy = false;
+    }
   }
 
   const errorMessage = $derived(form && !form.ok ? form.message : null);
@@ -208,10 +280,11 @@
   <header>
     <h1>Upload a text</h1>
     <p class="sub">
-      Paste a passage, drop a <code>.txt</code> file, or upload an
+      Paste a passage, drop a <code>.txt</code> file, upload an
       <code>.epub</code> or a <code>.zip</code> of
-      <code>.txt</code> files to import as a chapter-book collection.
-      Texts are private to your account by default.
+      <code>.txt</code> files to import as a chapter-book collection, or
+      upload a <code>.pdf</code> to read as page images with clickable
+      words. Texts are private to your account by default.
     </p>
   </header>
 
@@ -271,14 +344,14 @@
       aria-label="File drop zone"
     >
       <p>
-        Drag &amp; drop a <code>.txt</code>, <code>.epub</code>, or
-        <code>.zip</code> file, or
+        Drag &amp; drop a <code>.txt</code>, <code>.epub</code>,
+        <code>.zip</code>, or <code>.pdf</code> file, or
         <label class="file-pick">
           {#key filePickerKey}
             <input
               type="file"
               name="file"
-              accept=".txt,.epub,.zip"
+              accept=".txt,.epub,.zip,.pdf"
               onchange={onFilePick}
             />
           {/key}
@@ -294,6 +367,16 @@
           Selected: <code>{pickedFileName}</code>
           ({(pickedFileSize / 1000).toFixed(1)} KB) — will be imported
           as {mode === 'epub' ? 'an EPUB chapter book' : 'a ZIP chapter book'}.
+          <button type="button" class="reset" onclick={resetToPaste}>
+            Switch to paste
+          </button>
+        </p>
+      {/if}
+      {#if mode === 'pdf' && pickedFileName}
+        <p class="muted">
+          Selected: <code>{pickedFileName}</code>
+          ({(pickedFileSize / 1000).toFixed(1)} KB) — will be imported as a PDF
+          page reader.
           <button type="button" class="reset" onclick={resetToPaste}>
             Switch to paste
           </button>
@@ -332,11 +415,71 @@
       </label>
     {/if}
 
-    <button
-      type="submit"
-      disabled={submitDisabled}
-      aria-busy={uploading}
-    >{submitLabel}</button>
+    {#if mode === 'pdf'}
+      <div class="pdf-panel">
+        {#if pdfLoading}
+          <p class="muted">Reading PDF…</p>
+        {:else if pdfLoaded}
+          <p class="pdf-info">
+            {pdfLoaded.numPages}
+            {pdfLoaded.numPages === 1 ? 'page' : 'pages'}.
+            {#if pdfLoaded.hasTextLayer}
+              This PDF has a built-in text layer.
+            {:else}
+              No text layer detected — pages will be OCR'd.
+            {/if}
+          </p>
+          {#if pdfLoaded.hasTextLayer}
+            <fieldset class="pdf-source">
+              <legend>Text source</legend>
+              <label class="radio">
+                <input
+                  type="radio"
+                  name="pdfSource"
+                  checked={pdfUseTextLayer}
+                  disabled={pdfBusy}
+                  onchange={() => (pdfUseTextLayer = true)}
+                />
+                Use the PDF's built-in text (fast, exact)
+              </label>
+              <label class="radio">
+                <input
+                  type="radio"
+                  name="pdfSource"
+                  checked={!pdfUseTextLayer}
+                  disabled={pdfBusy}
+                  onchange={() => (pdfUseTextLayer = false)}
+                />
+                OCR the page images (best for scans / poor built-in text)
+              </label>
+            </fieldset>
+          {/if}
+          {#if pdfProgress}
+            <p class="pdf-progress" aria-live="polite">
+              Uploading page {pdfProgress.done} of {pdfProgress.total}…
+            </p>
+            <progress max={pdfProgress.total} value={pdfProgress.done}></progress>
+          {/if}
+          <button
+            type="button"
+            disabled={pdfBusy || !title.trim()}
+            aria-busy={pdfBusy}
+            onclick={runPdfImport}
+          >
+            {pdfBusy ? 'Importing PDF…' : `Import PDF (${pdfLoaded.numPages} ${pdfLoaded.numPages === 1 ? 'page' : 'pages'})`}
+          </button>
+        {/if}
+        {#if pdfError}
+          <p class="err" role="alert">{pdfError}</p>
+        {/if}
+      </div>
+    {:else}
+      <button
+        type="submit"
+        disabled={submitDisabled}
+        aria-busy={uploading}
+      >{submitLabel}</button>
+    {/if}
   </form>
 </div>
 
@@ -520,5 +663,51 @@
     color: var(--color-fg-muted);
     font-weight: normal;
     font-size: 0.85em;
+  }
+  .pdf-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+  }
+  .pdf-info {
+    margin: 0;
+    font-size: 0.9rem;
+    color: var(--color-fg);
+  }
+  .pdf-source {
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    padding: 0.6rem 0.75rem;
+    margin: 0;
+  }
+  .pdf-source legend {
+    font-size: 0.62rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-fg-muted);
+    padding: 0 0.25rem;
+  }
+  .pdf-source .radio {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 0.25rem 0;
+    font-size: 0.9rem;
+    color: var(--color-fg);
+  }
+  .pdf-source .radio input {
+    display: inline;
+    width: auto;
+    min-height: 0;
+    margin: 0;
+  }
+  .pdf-progress {
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--color-fg-muted);
+  }
+  .pdf-panel progress {
+    width: 100%;
+    height: 0.5rem;
   }
 </style>

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -48,10 +48,20 @@ services:
       - ../services/nlp/app:/srv/nlp/app
       - ../services/nlp/tests:/srv/nlp/tests
       - ../packages/shared-types/python:/opt/shared-types
+      # Uncomment to mount a GCP service-account key for Vision OCR
+      # (scanned-page path) and point GOOGLE_APPLICATION_CREDENTIALS at it:
+      # - ./secrets:/secrets:ro
     ports:
       - "${NLP_HOST_PORT:-8000}:8000"
     environment:
       PYTHONPATH: /opt/shared-types:/srv/nlp
+      # Google Cloud Vision creds for the PDF OCR scanned-page path. Empty
+      # by default — the born-digital path needs no creds, so dev works
+      # without GCP. To OCR scans, drop a service-account JSON under
+      # infra/secrets/ and set GOOGLE_APPLICATION_CREDENTIALS to e.g.
+      # /secrets/gcp-vision.json (matching the volume mount above).
+      GOOGLE_APPLICATION_CREDENTIALS: ${GOOGLE_APPLICATION_CREDENTIALS:-}
+      GOOGLE_CLOUD_PROJECT: ${GOOGLE_CLOUD_PROJECT:-}
     healthcheck:
       test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8000/health').read()\""]
       interval: 5s

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       nodemailer:
         specifier: ^6.9.15
         version: 6.10.1
+      pdfjs-dist:
+        specifier: ^6.0.227
+        version: 6.0.227
       postgres:
         specifier: ^3.4.4
         version: 3.4.9
@@ -856,6 +859,76 @@ packages:
 
   '@libsql/core@0.17.3':
     resolution: {integrity: sha512-2UjK1i7JBkMduJo4WdvvBxMMvVJ31pArBZNONyz/GCJJAH+1UHat2X6vn10S/WpY5fKzIT98WqYFl2vzWRLOfg==}
+
+  '@napi-rs/canvas-android-arm64@1.0.0':
+    resolution: {integrity: sha512-3hNKJObUK7JsCF9aJlVCs1J0/KE/gGfZNeK8MO1ge6bB3aicr5walGme9t9No1f/oyk9GgvdAT/rjSdsx3gbIw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/canvas-darwin-arm64@1.0.0':
+    resolution: {integrity: sha512-ZIja19/BiGz2puhki+WUYSRriwFeFJ8Mi9eK3hZdSS85w4Y60cuEAJVhMCfKwswQkKkUtrnzdKMBuO7TupvexA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-x64@1.0.0':
+    resolution: {integrity: sha512-hImggWc82jqZVpEsFR9S7PE9OQYjq/H/D7vwCGB6X1jRH+UVBP1+1niJTPBOat1B154T6GKK7/kcFtoWgjgFzQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@1.0.0':
+    resolution: {integrity: sha512-hlJRy6d+kWLKVOG/+1rEvNQVURZ0DxxRPJsLmEWwhwiXZUJc0BF5o9esALHSEP4CoJK4wChRtj3hnyBgVx2oWA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-gnu@1.0.0':
+    resolution: {integrity: sha512-5Hru4T3RXkosRQafcjelv7AUzw9mXqmGYsxnzeDDOWveFCJyEPMSJltvGCM+jfH98seOCbfwm9KyFg6Jm5FhAA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-musl@1.0.0':
+    resolution: {integrity: sha512-LTUl9jS8WsLSUGaxQZKQkxfluOJRpgvBuxxdM4pYcjib+di8AU4OzQc6+L6SzGMLcKc9H0RAjojRatBhTMqYdg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-riscv64-gnu@1.0.0':
+    resolution: {integrity: sha512-Iz931SAZf+WVDzpjk52Q3ffW3zw0YflFwEZMgs036Wfu1kX/LrwT9wGjsuSqyduqefUkl91/vTdAjn8hQu5ezA==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-x64-gnu@1.0.0':
+    resolution: {integrity: sha512-pFEQ5eFK4JusgN1K6KkO9DKP/Hi1WMJOkF8Ch03/khTc4bFbCKkCCsJG4YcOMOW9bI4XbT2/eMAWxhO0xaWgPA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-x64-musl@1.0.0':
+    resolution: {integrity: sha512-jnvr8NrLHiZ3NCiOKWqDbkI4Ah+QDrqtZ+sddPZBltEb1mQ2coSvCSJYfict+oAwcm0c970oTmVySpjKP/lnaA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/canvas-win32-arm64-msvc@1.0.0':
+    resolution: {integrity: sha512-y2j9/Gfd5joqiqxdP/L1smqjQ+uAx3C4N0EC7bDHrnZEEH8ToM/OC5p3uHvtj4Lq591aHj+ArL01UDLNwT5HgQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/canvas-win32-x64-msvc@1.0.0':
+    resolution: {integrity: sha512-qwdhh9N6Gge/hC4pL9S1tQp0iKwhSl/dYjg7+RGp9k26iRGRi5MqqUyKGOXIWli0zOcuy5Y2wIH/jk2ry6i/jA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/canvas@1.0.0':
+    resolution: {integrity: sha512-Jqxcy1XOIqj+lH9sl1GT+il6GR3uQv13vI2mrwubP3uT8Olak2ClDrK2RnxlQKjwv8BRr4b3ug0YR7c6hBX8wg==}
+    engines: {node: '>= 10'}
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -2145,6 +2218,10 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
+  pdfjs-dist@6.0.227:
+    resolution: {integrity: sha512-/P6M4SXw+70waMVLUM7rdRtvo+dEzqE1t6W/zQNvBETo2MaRa5rrvCcAYdfWGiUzadTgM0lJmRApUrW0d9zgKg==}
+    engines: {node: '>=22.13.0 || >=24'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -3080,6 +3157,54 @@ snapshots:
   '@libsql/core@0.17.3':
     dependencies:
       js-base64: 3.7.8
+
+  '@napi-rs/canvas-android-arm64@1.0.0':
+    optional: true
+
+  '@napi-rs/canvas-darwin-arm64@1.0.0':
+    optional: true
+
+  '@napi-rs/canvas-darwin-x64@1.0.0':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@1.0.0':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-gnu@1.0.0':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-musl@1.0.0':
+    optional: true
+
+  '@napi-rs/canvas-linux-riscv64-gnu@1.0.0':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@1.0.0':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-musl@1.0.0':
+    optional: true
+
+  '@napi-rs/canvas-win32-arm64-msvc@1.0.0':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@1.0.0':
+    optional: true
+
+  '@napi-rs/canvas@1.0.0':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 1.0.0
+      '@napi-rs/canvas-darwin-arm64': 1.0.0
+      '@napi-rs/canvas-darwin-x64': 1.0.0
+      '@napi-rs/canvas-linux-arm-gnueabihf': 1.0.0
+      '@napi-rs/canvas-linux-arm64-gnu': 1.0.0
+      '@napi-rs/canvas-linux-arm64-musl': 1.0.0
+      '@napi-rs/canvas-linux-riscv64-gnu': 1.0.0
+      '@napi-rs/canvas-linux-x64-gnu': 1.0.0
+      '@napi-rs/canvas-linux-x64-musl': 1.0.0
+      '@napi-rs/canvas-win32-arm64-msvc': 1.0.0
+      '@napi-rs/canvas-win32-x64-msvc': 1.0.0
+    optional: true
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
@@ -4338,6 +4463,10 @@ snapshots:
   pathe@1.1.2: {}
 
   pathval@2.0.1: {}
+
+  pdfjs-dist@6.0.227:
+    optionalDependencies:
+      '@napi-rs/canvas': 1.0.0
 
   picocolors@1.1.1: {}
 

--- a/services/nlp/.env.example
+++ b/services/nlp/.env.example
@@ -1,3 +1,7 @@
-# No runtime env for M0 — the service is stateless and reads zero env vars.
-# This file is a placeholder so future tickets (M2.6 arq queue, M13 deployment)
-# have a conventional spot to land config.
+# PDF OCR (scanned-page path) — Google Cloud Vision credentials.
+# Optional: the born-digital path (PDFs with a real text layer) needs no
+# OCR and no creds. Set these only to OCR scanned PDFs. Requires a GCP
+# project with the Vision API enabled and a service-account key.
+#
+# GOOGLE_APPLICATION_CREDENTIALS=/secrets/gcp-vision.json
+# GOOGLE_CLOUD_PROJECT=your-gcp-project-id

--- a/services/nlp/Dockerfile
+++ b/services/nlp/Dockerfile
@@ -15,7 +15,7 @@ COPY services/nlp/pyproject.toml /srv/nlp/pyproject.toml
 RUN apt-get update \
  && apt-get install -y --no-install-recommends gcc libc6-dev \
  && pip install -U pip \
- && pip install -e '.[dev,models]' \
+ && pip install -e '.[dev,models,ocr]' \
  && apt-get purge -y --auto-remove gcc libc6-dev \
  && rm -rf /var/lib/apt/lists/*
 

--- a/services/nlp/app/main.py
+++ b/services/nlp/app/main.py
@@ -9,16 +9,23 @@ modules so each language can evolve independently.
 
 from __future__ import annotations
 
+import json
 import unicodedata
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile
 
 from app.languages import LANGUAGES, SUPPORTED_LANGUAGE_CODES, is_supported_language
+from app.ocr.align import OcrPage, assign_token_boxes
+from app.ocr.borndigital import build_born_digital_page
+from app.ocr.vision import run_vision_ocr
 from app.phrases import get_detector
 from app.pipelines import get_pipeline
 from app.romanize import UnsupportedScriptError, to_roman
 from app.schemas import (
+    BBox,
     HealthResponse,
+    OcrResponse,
+    OcrToken,
     ProcessRequest,
     ProcessResponse,
     RomanizeRequest,
@@ -78,6 +85,98 @@ async def process(req: ProcessRequest) -> ProcessResponse:
         language=req.language,
         pipeline_id=canonical_pipeline_id,
         tokens=result.tokens,
+        proposed_phrases=proposed_phrases,
+    )
+
+
+def _page_from_layout(payload: dict) -> OcrPage:
+    """Rebuild an OcrPage from a stored layout (page text + one box per
+    character). Lets the web side re-tokenize a previously-OCR'd page with
+    the current model WITHOUT paying for Vision again — the box geometry is
+    replayed from what the first OCR already captured."""
+    text = payload.get("text", "")
+    raw = payload.get("char_boxes") or []
+    boxes: list[BBox | None] = []
+    for b in raw:
+        if b is None:
+            boxes.append(None)
+        else:
+            boxes.append(BBox(x=b[0], y=b[1], w=b[2], h=b[3]))
+    # Keep char_boxes the same length as text (defensive against drift).
+    if len(boxes) < len(text):
+        boxes.extend([None] * (len(text) - len(boxes)))
+    return OcrPage(text=text, char_boxes=boxes[: len(text)])
+
+
+@app.post("/ocr", response_model=OcrResponse)
+async def ocr(
+    language: str = Form(...),
+    width: int = Form(...),
+    height: int = Form(...),
+    image: UploadFile = File(...),
+    engine: str = Form("vision"),
+    born_digital: str | None = Form(None),
+    layout: str | None = Form(None),
+) -> OcrResponse:
+    """OCR one PDF page image into tokens + per-token bounding boxes.
+
+    The browser rasterized the page and (for born-digital PDFs) extracted
+    the embedded text layer; ``width``/``height`` are the rendered image's
+    pixel dimensions. The response mirrors ``/process`` so the web side
+    reuses its lemma-resolution + persist path, with a ``bbox`` per token
+    and the reconstructed page ``body``.
+    """
+    if not is_supported_language(language):
+        supported = list(SUPPORTED_LANGUAGE_CODES)
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported language '{language}'. Supported: {supported}",
+        )
+
+    # Read the image so a future engine can use it; the bytes feed Vision
+    # on the scanned path and are ignored on the born-digital / layout
+    # paths (which carry their own geometry).
+    image_bytes = await image.read()
+
+    if layout:
+        # Free re-tokenize: replay a stored OCR layout, no Vision call.
+        try:
+            page = _page_from_layout(json.loads(layout))
+        except (json.JSONDecodeError, KeyError, IndexError, TypeError) as exc:
+            raise HTTPException(
+                status_code=400, detail=f"Invalid layout JSON: {exc}"
+            ) from exc
+    elif born_digital:
+        try:
+            payload = json.loads(born_digital)
+        except json.JSONDecodeError as exc:
+            raise HTTPException(
+                status_code=400, detail=f"Invalid born_digital JSON: {exc}"
+            ) from exc
+        page = build_born_digital_page(payload.get("items", []))
+    else:
+        # engine 'vision_llm' (the on-demand AI proofread) lands in a
+        # follow-up; for now every scanned page goes through Vision.
+        page = run_vision_ocr(image_bytes)
+
+    pipeline = get_pipeline(language)
+    result = pipeline.process(page.text)
+    detector = get_detector(language)
+    proposed_phrases = detector.detect(result.tokens)
+
+    boxes = assign_token_boxes(result.tokens, page)
+    tokens = [
+        OcrToken(**t.model_dump(), bbox=b)
+        for t, b in zip(result.tokens, boxes, strict=True)
+    ]
+
+    return OcrResponse(
+        language=language,
+        pipeline_id=LANGUAGES[language].pipeline_id,
+        width=width,
+        height=height,
+        body=page.text,
+        tokens=tokens,
         proposed_phrases=proposed_phrases,
     )
 

--- a/services/nlp/app/ocr/__init__.py
+++ b/services/nlp/app/ocr/__init__.py
@@ -1,0 +1,19 @@
+"""OCR support for the PDF image reader.
+
+The browser rasterizes each PDF page client-side and uploads the image;
+this package turns one page image into the same token shape the rest of
+the pipeline already speaks, plus a per-token bounding box so clicks on
+the image map to words.
+
+Two sources of "where is each character on the page":
+
+  - :mod:`app.ocr.vision` — Google Cloud Vision OCR for scanned pages.
+  - :mod:`app.ocr.borndigital` — boxes the client extracted from a PDF's
+    embedded text layer (no Vision call, ≈free/100%).
+
+Both produce an :class:`~app.ocr.align.OcrPage` (page text + per-char
+boxes); :func:`app.ocr.align.assign_token_boxes` then maps the language
+pipeline's tokens onto those boxes.
+"""
+
+from __future__ import annotations

--- a/services/nlp/app/ocr/align.py
+++ b/services/nlp/app/ocr/align.py
@@ -1,0 +1,84 @@
+"""Token ↔ bounding-box alignment.
+
+An :class:`OcrPage` carries the reconstructed page text plus one box per
+character (``None`` for whitespace / line breaks that have no glyph). The
+language pipeline tokenizes ``page.text``; :func:`assign_token_boxes`
+walks the token list and, for each word token, unions the boxes of the
+characters it spans.
+
+Sourcing the boxes per-character (rather than per-Vision-word or
+per-PDF-run) means the alignment is identical regardless of where the
+boxes came from — Vision symbols or the client's born-digital layer — and
+it survives our tokenizer segmenting words differently from the OCR
+engine.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.schemas import BBox, Token
+
+
+@dataclass(slots=True)
+class OcrPage:
+    """Page text + a box for every character in it (``char_boxes`` has the
+    same length as ``text``; entries are ``None`` for separators)."""
+
+    text: str
+    char_boxes: list[BBox | None]
+
+
+def union_boxes(boxes: list[BBox | None]) -> BBox | None:
+    """Smallest box covering every non-``None`` box in ``boxes``.
+
+    Returns ``None`` when there's nothing to cover (e.g. a token made
+    entirely of separator characters). Components are rounded to 6
+    decimals — sub-pixel on a normalized 0..1 page — so the JSON stays
+    clean (no ``0.30000000000000004``) and the float subtraction below
+    is deterministic."""
+    present = [b for b in boxes if b is not None]
+    if not present:
+        return None
+    x0 = min(b.x for b in present)
+    y0 = min(b.y for b in present)
+    x1 = max(b.x + b.w for b in present)
+    y1 = max(b.y + b.h for b in present)
+    return BBox(
+        x=round(x0, 6),
+        y=round(y0, 6),
+        w=round(max(0.0, x1 - x0), 6),
+        h=round(max(0.0, y1 - y0), 6),
+    )
+
+
+def assign_token_boxes(tokens: list[Token], page: OcrPage) -> list[BBox | None]:
+    """Return one box per token, aligned to ``tokens`` by index.
+
+    Word tokens are located by a forward scan through ``page.text`` (each
+    surface picked up where the previous one left off, so repeated words
+    map to their own occurrence). Non-word tokens, empty surfaces, and
+    surfaces that can't be found get ``None``."""
+    out: list[BBox | None] = []
+    cursor = 0
+    text = page.text
+    for t in tokens:
+        if not t.is_word or not t.surface:
+            out.append(None)
+            continue
+        pos = text.find(t.surface, cursor)
+        if pos < 0:
+            # Normalization drift between the OCR text and the tokenizer's
+            # surface (rare). Retry from the start before giving up so a
+            # single mismatch doesn't desync the rest of the page.
+            pos = text.find(t.surface)
+        if pos < 0:
+            out.append(None)
+            continue
+        end = pos + len(t.surface)
+        out.append(union_boxes(page.char_boxes[pos:end]))
+        cursor = end
+    return out
+
+
+__all__ = ["OcrPage", "assign_token_boxes", "union_boxes"]

--- a/services/nlp/app/ocr/borndigital.py
+++ b/services/nlp/app/ocr/borndigital.py
@@ -1,0 +1,55 @@
+"""Born-digital page builder.
+
+For PDFs with a real embedded text layer (generated from a digital
+source, not a scan), the client extracts the text runs + their positions
+via pdf.js and uploads them instead of paying for OCR. Each run is one
+``{str, x, y, w, h, eol}`` item with box coords already normalized to
+0..1 of the rendered page and top-left origin.
+
+We turn the run list into the same per-character :class:`OcrPage` the
+Vision path produces: a run's box is split proportionally across its
+characters (pdf.js gives run-level boxes, coarser than Vision's
+per-symbol boxes), and runs are joined with a newline (``eol``) or a
+space so the language tokenizer sees sensible word boundaries.
+"""
+
+from __future__ import annotations
+
+import unicodedata
+from collections.abc import Sequence
+from typing import Any
+
+from app.schemas import BBox
+
+from .align import OcrPage
+
+
+def build_born_digital_page(items: Sequence[dict[str, Any]]) -> OcrPage:
+    chars: list[str] = []
+    boxes: list[BBox | None] = []
+    n_items = len(items)
+    for i, item in enumerate(items):
+        # NFC per-run (not over the whole page) so normalization can't
+        # reorder/merge across the box boundary and desync char_boxes.
+        s = unicodedata.normalize("NFC", str(item.get("str", "")))
+        n = len(s)
+        if n:
+            x = float(item.get("x", 0.0))
+            y = float(item.get("y", 0.0))
+            w = float(item.get("w", 0.0))
+            h = float(item.get("h", 0.0))
+            per = w / n if n else w
+            for j, ch in enumerate(s):
+                chars.append(ch)
+                boxes.append(BBox(x=x + per * j, y=y, w=per, h=h))
+        # Separator between runs (not after the last). pdf.js flags the
+        # end of a visual line with `eol`.
+        if i < n_items - 1:
+            sep = "\n" if item.get("eol") else " "
+            for ch in sep:
+                chars.append(ch)
+                boxes.append(None)
+    return OcrPage(text="".join(chars), char_boxes=boxes)
+
+
+__all__ = ["build_born_digital_page"]

--- a/services/nlp/app/ocr/vision.py
+++ b/services/nlp/app/ocr/vision.py
@@ -1,0 +1,135 @@
+"""Google Cloud Vision OCR for scanned PDF pages.
+
+`google-cloud-vision` is an ``[ocr]``-extra dependency (not installed in
+the default test/CI lane), so it is imported lazily inside
+:func:`detect_document_text` — exactly like the Stanza pipelines. Tests
+either build an :class:`~app.ocr.align.OcrPage` from a fake annotation via
+:func:`build_ocr_page` or monkeypatch :func:`run_vision_ocr`, so they
+never trigger the import.
+
+Vision returns a character hierarchy (page → block → paragraph → word →
+symbol) with per-symbol bounding polygons and per-symbol "detected break"
+hints. :func:`build_ocr_page` flattens that into page text + one box per
+character, normalizing pixel coords by the page dimensions Vision reports.
+"""
+
+from __future__ import annotations
+
+import unicodedata
+from typing import Any
+
+from app.schemas import BBox
+
+from .align import OcrPage
+
+
+class VisionError(RuntimeError):
+    """Vision returned an API-level error for the page."""
+
+
+# Vision's DetectedBreak.BreakType integer values → the character(s) to
+# splice into the reconstructed text AFTER a word's final symbol. See
+# google.cloud.vision.TextAnnotation.DetectedBreak.BreakType.
+#   0 UNKNOWN, 1 SPACE, 2 SURE_SPACE, 3 EOL_SURE_SPACE, 4 LINE_BREAK,
+#   5 HYPHEN.
+#
+# HYPHEN nominally means a word was split across a line with a hyphen, so
+# joining (drop the hyphen, no separator) would be ideal. But in practice
+# Vision emits HYPHEN at ordinary line/block ends too (observed across a
+# scanned book: every line-final word — "Erraza", "trinkoak", "etzan" —
+# came back HYPHEN). Mapping it to "" then glues unrelated words across
+# lines ("Erraza" + "4.3.1." → "Erraza4.3.1.") and their bounding boxes
+# merge into one tall box covering neighbours. Gluing is far more damaging
+# than the rare cost of splitting a genuinely hyphenated word, so we treat
+# HYPHEN as a line break too. UNKNOWN stays "" — it marks intra-word
+# symbol boundaries (no separator) as well as the odd "4.3.1."+"." case.
+_BREAK_TEXT: dict[int, str] = {
+    1: " ",
+    2: " ",
+    3: "\n",
+    4: "\n",
+    5: "\n",
+}
+
+
+_CLIENT: Any = None
+
+
+def _client(vision_mod: Any) -> Any:
+    global _CLIENT
+    if _CLIENT is None:
+        _CLIENT = vision_mod.ImageAnnotatorClient()
+    return _CLIENT
+
+
+def detect_document_text(image_bytes: bytes) -> Any:
+    """Run Vision document text detection; return its
+    ``full_text_annotation``. Raises :class:`VisionError` on API error."""
+    from google.cloud import vision  # lazy: [ocr] extra
+
+    client = _client(vision)
+    image = vision.Image(content=image_bytes)
+    resp = client.document_text_detection(image=image)
+    if getattr(resp, "error", None) and resp.error.message:
+        raise VisionError(resp.error.message)
+    return resp.full_text_annotation
+
+
+def _break_type(symbol: Any) -> int:
+    prop = getattr(symbol, "property", None)
+    brk = getattr(prop, "detected_break", None) if prop is not None else None
+    if brk is None:
+        return 0
+    # proto-plus exposes the enum as ``type_``; older clients as ``type``.
+    raw = getattr(brk, "type_", getattr(brk, "type", 0))
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _norm_box(bounding_box: Any, page_w: int, page_h: int) -> BBox:
+    xs = [float(v.x) for v in bounding_box.vertices]
+    ys = [float(v.y) for v in bounding_box.vertices]
+    pw = float(page_w) or 1.0
+    ph = float(page_h) or 1.0
+    x0, x1 = min(xs), max(xs)
+    y0, y1 = min(ys), max(ys)
+    return BBox(x=x0 / pw, y=y0 / ph, w=(x1 - x0) / pw, h=(y1 - y0) / ph)
+
+
+def build_ocr_page(annotation: Any) -> OcrPage:
+    """Flatten a Vision ``full_text_annotation`` into an OcrPage."""
+    chars: list[str] = []
+    boxes: list[BBox | None] = []
+    for page in getattr(annotation, "pages", []) or []:
+        pw = getattr(page, "width", 0)
+        ph = getattr(page, "height", 0)
+        for block in getattr(page, "blocks", []) or []:
+            for para in getattr(block, "paragraphs", []) or []:
+                for word in getattr(para, "words", []) or []:
+                    for symbol in getattr(word, "symbols", []) or []:
+                        box = _norm_box(symbol.bounding_box, pw, ph)
+                        # NFC per-symbol so normalization can't desync the
+                        # per-char box list (see borndigital builder).
+                        text = unicodedata.normalize("NFC", symbol.text)
+                        for ch in text:
+                            chars.append(ch)
+                            boxes.append(box)
+                        sep = _BREAK_TEXT.get(_break_type(symbol), "")
+                        for ch in sep:
+                            chars.append(ch)
+                            boxes.append(None)
+    return OcrPage(text="".join(chars), char_boxes=boxes)
+
+
+def run_vision_ocr(image_bytes: bytes) -> OcrPage:
+    return build_ocr_page(detect_document_text(image_bytes))
+
+
+__all__ = [
+    "VisionError",
+    "build_ocr_page",
+    "detect_document_text",
+    "run_vision_ocr",
+]

--- a/services/nlp/app/schemas.py
+++ b/services/nlp/app/schemas.py
@@ -127,3 +127,40 @@ class ProcessResponse(BaseModel):
         default_factory=list,
         description="T-14.5: rule-based phrase proposals over the token list.",
     )
+
+
+class BBox(BaseModel):
+    """A word's bounding box on a PDF page image, normalized to 0..1 of
+    the page width/height. Resolution-independent so the reader overlay
+    scales to whatever size the image renders at."""
+
+    x: float
+    y: float
+    w: float
+    h: float
+
+
+class OcrToken(Token):
+    """A :class:`Token` plus the page-image bounding box the word
+    occupies. ``bbox`` is ``None`` for whitespace/punctuation tokens and
+    for any word the aligner couldn't locate on the page."""
+
+    bbox: BBox | None = None
+
+
+class OcrResponse(BaseModel):
+    """Result of OCR-ing one PDF page image.
+
+    Mirrors :class:`ProcessResponse` (same tokens + phrase proposals so
+    the web side reuses its lemma-resolution/persist path unchanged) and
+    adds the reconstructed page ``body`` text, the page image pixel
+    dimensions, and a per-token ``bbox``.
+    """
+
+    language: str
+    pipeline_id: str
+    width: int
+    height: int
+    body: str
+    tokens: list[OcrToken]
+    proposed_phrases: list[ProposedPhrase] = Field(default_factory=list)

--- a/services/nlp/pyproject.toml
+++ b/services/nlp/pyproject.toml
@@ -22,6 +22,10 @@ dependencies = [
   # worker process imports RedisSettings at module load; keep it in
   # base deps so tests that import app.worker don't need [models].
   "arq>=0.26.0",
+  # Multipart form parsing for the /ocr endpoint (page-image upload).
+  # Pure-Python, tiny; FastAPI requires it for Form/File params and the
+  # tests post multipart bodies, so it stays in base deps.
+  "python-multipart>=0.0.9",
 ]
 
 [project.optional-dependencies]
@@ -45,6 +49,13 @@ models = [
   # underpin the Odia tokenizer (T-2.3a). Small, pure-Python dep.
   "indic-nlp-library>=0.92",
 ]
+# OCR for the PDF image reader. Vision is imported lazily in
+# app.ocr.vision, so the default test/CI lane (which exercises the
+# born-digital path + a fake Vision annotation) doesn't need it; the
+# Docker image installs [ocr] for the real scanned-page path.
+ocr = [
+  "google-cloud-vision>=3.7.0",
+]
 
 [build-system]
 requires = ["setuptools>=68"]
@@ -59,6 +70,12 @@ target-version = "py311"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "B", "UP", "N", "W"]
+
+[tool.ruff.lint.flake8-bugbear]
+# FastAPI's dependency-injection markers are designed to be called in
+# argument defaults (Form/File/Depends). Whitelist them so B008 doesn't
+# fire on the /ocr multipart handler.
+extend-immutable-calls = ["fastapi.Form", "fastapi.File", "fastapi.Depends"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/services/nlp/tests/test_ocr.py
+++ b/services/nlp/tests/test_ocr.py
@@ -1,0 +1,247 @@
+"""Tests for the /ocr endpoint and its OCR helpers.
+
+The default lane never touches Google Vision: the born-digital path needs
+no OCR at all, the Vision endpoint path is exercised by monkeypatching
+``run_vision_ocr``, and the Vision parser is unit-tested against a fake
+annotation. So nothing here requires the ``[ocr]`` extra.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.ocr.align import OcrPage, assign_token_boxes, union_boxes
+from app.ocr.borndigital import build_born_digital_page
+from app.ocr.vision import build_ocr_page
+from app.schemas import BBox, Token
+
+client = TestClient(app)
+
+# A tiny stand-in for the uploaded page image. The born-digital path
+# ignores the bytes; the monkeypatched Vision path never decodes them.
+DUMMY_IMAGE = ("page.webp", b"\x00\x01\x02\x03", "image/webp")
+
+
+def _born_digital_items() -> list[dict]:
+    # Two runs on line one (joined by a space), then a line break, then a
+    # run on line two. Coords are normalized 0..1, top-left origin.
+    return [
+        {"str": "Egun", "x": 0.10, "y": 0.10, "w": 0.20, "h": 0.05},
+        {"str": "on", "x": 0.35, "y": 0.10, "w": 0.10, "h": 0.05, "eol": True},
+        {"str": "mundua", "x": 0.10, "y": 0.20, "w": 0.30, "h": 0.05},
+    ]
+
+
+def test_ocr_born_digital_assigns_boxes():
+    resp = client.post(
+        "/ocr",
+        data={
+            "language": "eu",
+            "width": "1000",
+            "height": "1400",
+            "born_digital": json.dumps({"items": _born_digital_items()}),
+        },
+        files={"image": DUMMY_IMAGE},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["language"] == "eu"
+    assert body["pipeline_id"] == "stanza-eu"
+    assert body["width"] == 1000
+    assert body["height"] == 1400
+    # Runs joined with a space (line 1) and a newline (after the eol run).
+    assert body["body"] == "Egun on\nmundua"
+
+    words = [t for t in body["tokens"] if t["is_word"]]
+    assert [w["surface"] for w in words] == ["Egun", "on", "mundua"]
+    # Every word got a box; the first matches its source run.
+    assert all(w["bbox"] is not None for w in words)
+    assert words[0]["bbox"]["x"] == 0.10
+    assert words[0]["bbox"]["w"] == 0.20
+
+
+def test_ocr_vision_path_uses_char_boxes(monkeypatch):
+    # "Egun on": one box for the first word, another for the second; the
+    # space carries no box.
+    box_a = BBox(x=0.1, y=0.1, w=0.2, h=0.05)
+    box_b = BBox(x=0.4, y=0.1, w=0.1, h=0.05)
+    page = OcrPage(
+        text="Egun on",
+        char_boxes=[box_a, box_a, box_a, box_a, None, box_b, box_b],
+    )
+    monkeypatch.setattr("app.main.run_vision_ocr", lambda _bytes: page)
+
+    resp = client.post(
+        "/ocr",
+        data={"language": "eu", "width": "800", "height": "1200"},
+        files={"image": DUMMY_IMAGE},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    words = [t for t in body["tokens"] if t["is_word"]]
+    assert [w["surface"] for w in words] == ["Egun", "on"]
+    assert words[0]["bbox"] == {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.05}
+    assert words[1]["bbox"] == {"x": 0.4, "y": 0.1, "w": 0.1, "h": 0.05}
+
+
+def test_ocr_layout_replays_stored_boxes_without_vision(monkeypatch):
+    # The free-reprocess path: a stored layout (page text + per-char boxes)
+    # re-tokenizes with the current model and must NOT call Vision.
+    def _boom(_bytes):
+        raise AssertionError("Vision must not be called on the layout path")
+
+    monkeypatch.setattr("app.main.run_vision_ocr", _boom)
+    a = [0.1, 0.1, 0.05, 0.05]
+    b = [0.4, 0.1, 0.05, 0.05]
+    layout = {"text": "Egun on", "char_boxes": [a, a, a, a, None, b, b]}
+    resp = client.post(
+        "/ocr",
+        data={
+            "language": "eu",
+            "width": "800",
+            "height": "1200",
+            "layout": json.dumps(layout),
+        },
+        files={"image": DUMMY_IMAGE},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    words = [t for t in body["tokens"] if t["is_word"]]
+    assert [w["surface"] for w in words] == ["Egun", "on"]
+    assert words[0]["bbox"] == {"x": 0.1, "y": 0.1, "w": 0.05, "h": 0.05}
+    assert words[1]["bbox"] == {"x": 0.4, "y": 0.1, "w": 0.05, "h": 0.05}
+
+
+def test_ocr_rejects_unsupported_language():
+    resp = client.post(
+        "/ocr",
+        data={"language": "ja", "width": "100", "height": "100"},
+        files={"image": DUMMY_IMAGE},
+    )
+    assert resp.status_code == 400
+
+
+def test_ocr_rejects_invalid_born_digital_json():
+    resp = client.post(
+        "/ocr",
+        data={
+            "language": "eu",
+            "width": "100",
+            "height": "100",
+            "born_digital": "{not json",
+        },
+        files={"image": DUMMY_IMAGE},
+    )
+    assert resp.status_code == 400
+
+
+def test_union_boxes_ignores_none_and_covers_all():
+    assert union_boxes([None, None]) is None
+    u = union_boxes(
+        [
+            BBox(x=0.1, y=0.1, w=0.1, h=0.1),
+            None,
+            BBox(x=0.3, y=0.2, w=0.1, h=0.2),
+        ]
+    )
+    assert u == BBox(x=0.1, y=0.1, w=0.3, h=0.3)
+
+
+def test_assign_token_boxes_handles_repeated_words():
+    # "ba ba" — the forward scan must give each occurrence its own box.
+    a = BBox(x=0.0, y=0.0, w=0.1, h=0.1)
+    b = BBox(x=0.5, y=0.0, w=0.1, h=0.1)
+    page = OcrPage(text="ba ba", char_boxes=[a, a, None, b, b])
+    tokens = [
+        Token(idx=0, surface="ba", is_word=True),
+        Token(idx=1, surface=" ", is_word=False),
+        Token(idx=2, surface="ba", is_word=True),
+    ]
+    boxes = assign_token_boxes(tokens, page)
+    assert boxes[0] == a
+    assert boxes[1] is None
+    assert boxes[2] == b
+
+
+def test_build_ocr_page_from_vision_annotation():
+    # Fake Vision hierarchy: page(100x200) → block → paragraph → word → symbols.
+    def sym(text, x0, y0, x1, y1, brk=0):
+        vertices = [
+            SimpleNamespace(x=x0, y=y0),
+            SimpleNamespace(x=x1, y=y0),
+            SimpleNamespace(x=x1, y=y1),
+            SimpleNamespace(x=x0, y=y1),
+        ]
+        prop = SimpleNamespace(
+            detected_break=SimpleNamespace(type_=brk)
+        )
+        return SimpleNamespace(
+            text=text,
+            bounding_box=SimpleNamespace(vertices=vertices),
+            property=prop,
+        )
+
+    word1 = SimpleNamespace(
+        symbols=[sym("H", 10, 10, 20, 30), sym("i", 22, 10, 28, 30, brk=1)]
+    )
+    word2 = SimpleNamespace(
+        symbols=[sym("y", 40, 10, 48, 30), sym("o", 50, 10, 58, 30, brk=4)]
+    )
+    para = SimpleNamespace(words=[word1, word2])
+    block = SimpleNamespace(paragraphs=[para])
+    page = SimpleNamespace(width=100, height=200, blocks=[block])
+    annotation = SimpleNamespace(pages=[page])
+
+    ocr_page = build_ocr_page(annotation)
+    # SPACE break after "i", LINE_BREAK after "o".
+    assert ocr_page.text == "Hi yo\n"
+    assert len(ocr_page.char_boxes) == len(ocr_page.text)
+    # First glyph normalized by the page dims (10/100, 10/200, ...).
+    assert ocr_page.char_boxes[0] == BBox(x=0.1, y=0.05, w=0.1, h=0.1)
+    # The space carries no box.
+    assert ocr_page.char_boxes[2] is None
+
+
+def test_build_ocr_page_hyphen_break_separates_words():
+    # Regression: Vision emits HYPHEN (break type 5) at ordinary line/block
+    # ends in some scanned docs, not just for split words. It must insert a
+    # separator, otherwise the line-final word glues to the next line's
+    # first word ("Erraza" + "4.3.1." → "Erraza4.3.1.") and their boxes
+    # merge into one tall box over neighbouring words.
+    def sym(text, x0, brk=0):
+        vertices = [
+            SimpleNamespace(x=x0, y=0),
+            SimpleNamespace(x=x0 + 10, y=0),
+            SimpleNamespace(x=x0 + 10, y=10),
+            SimpleNamespace(x=x0, y=10),
+        ]
+        return SimpleNamespace(
+            text=text,
+            bounding_box=SimpleNamespace(vertices=vertices),
+            property=SimpleNamespace(detected_break=SimpleNamespace(type_=brk)),
+        )
+
+    # "Erraza" ends a line with a HYPHEN break; "4" begins the next line.
+    w1 = SimpleNamespace(symbols=[sym("Erraza", 0, brk=5)])
+    w2 = SimpleNamespace(symbols=[sym("4", 0, brk=0)])
+    para = SimpleNamespace(words=[w1, w2])
+    block = SimpleNamespace(paragraphs=[para])
+    page = SimpleNamespace(width=100, height=100, blocks=[block])
+    ocr_page = build_ocr_page(SimpleNamespace(pages=[page]))
+
+    assert "Erraza4" not in ocr_page.text
+    assert ocr_page.text == "Erraza\n4"
+
+
+def test_build_born_digital_page_splits_run_box_across_chars():
+    page = build_born_digital_page(
+        [{"str": "ab", "x": 0.0, "y": 0.0, "w": 0.2, "h": 0.1}]
+    )
+    assert page.text == "ab"
+    # The 0.2-wide run is split evenly across its two characters.
+    assert page.char_boxes[0] == BBox(x=0.0, y=0.0, w=0.1, h=0.1)
+    assert page.char_boxes[1] == BBox(x=0.1, y=0.0, w=0.1, h=0.1)


### PR DESCRIPTION
## What

Upload a PDF and read it as **page images with clickable word overlays** — click a word for the same WordPopup (definition, sentence translation, known/unknown) you get in the text reader. Scoped to **Basque** first; the design is language-agnostic.

## How it works

- The **browser** rasterizes each page with pdf.js and uploads the rendered images — **the source PDF never reaches the server** (no server-side rasterization, only page images are persisted).
- The NLP service turns each page into **tokens + a per-word bounding box**: Google Vision for scans, or the PDF's **embedded text layer** for born-digital pages (free, no OCR).
- Once OCR yields `text + per-token bbox`, the existing **lemma-resolution / known-words / WordPopup / sentence-translation** stack is reused unchanged.

## Changes

- **Schema** (migration `0049`): `pdf` source type; `page_image_*` columns on `text_chapters`; `bbox` on `text_tokens`.
- **NLP** (`services/nlp/app/ocr/`): Vision wrapper, char→bbox alignment, born-digital + stored-layout page builders; `POST /ocr`. `google-cloud-vision` is an `[ocr]` extra, lazy-imported (default test lane needs no GCP).
- **Web**: client pdf.js render + streaming upload (`lib/pdf/render-client.ts`); page-image storage + read-gated `/pdf-assets` route; `createPdfText` + `pdf/begin` + per-page ingest endpoints; `ReaderImage` overlay + Image/Text toggle; WordPopup word-crop for verifying OCR.
- **Free reprocess**: the admin "Reprocess" button re-runs the NLP over a PDF's **stored OCR layout** (no Vision spend, boxes preserved) — for use after a model/dictionary change.

## Tests

Web (vitest) + NLP (pytest) cover OCR alignment, the HYPHEN line-break fix, born-digital + stored-layout replay, per-page processing, `createPdfText`, the NLP client, and overlay positioning. `svelte-check`, `eslint`, `ruff` clean; production build succeeds.

## Notes

- No tracking issue existed for this; happy to link one if you'd like.
- **Deferred** (follow-ups): on-demand LLM re-OCR, S3/prod page-image storage, extending to hi/mr/or.
- Out of scope but observed: the Basque dictionary has duplicate lemmas (many same-headword rows, one with a translation), so resolution can link to a gloss-less duplicate — affects the whole app, not just PDFs; tracked as a separate fix.