### PR TITLE
feat(api): GET /api/v1/texts/:id (text metadata + chapter list)

### DIFF
--- a/apps/web/src/routes/api/v1/texts/[id]/+server.ts
+++ b/apps/web/src/routes/api/v1/texts/[id]/+server.ts
@@ -8,11 +8,47 @@
  */
 import { error, json } from '@sveltejs/kit';
 
-import { requireUser } from '$lib/server/auth/require-user.js';
-import { deleteText, TextValidationError } from '$lib/server/texts/upload.js';
+import { requireUser, resolveUser } from '$lib/server/auth/require-user.js';
+import { deleteText, getReadableText, TextValidationError } from '$lib/server/texts/upload.js';
 import type { RequestHandler } from './$types';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * GET /api/v1/texts/:id — text metadata + a lightweight chapter list (idx,
+ * title, tokenCount; no chapter bodies). The web reads this from its page
+ * loader; an API client (the Android reader) needs it to show the title and
+ * page through chapters. resolveUser so an official/public text is readable
+ * anonymously; getReadableText returns null (→ 404) when the viewer can't
+ * read it, so a private text never leaks its existence.
+ */
+export const GET: RequestHandler = async (event) => {
+  const id = event.params.id;
+  if (!id || !UUID_RE.test(id)) throw error(400, 'Invalid text id');
+  const viewer = await resolveUser(event);
+  const result = await getReadableText(viewer ? { id: viewer.id } : null, id);
+  if (!result) throw error(404, 'Text not found');
+  const { text, chapters } = result;
+  return json({
+    text: {
+      id: text.id,
+      ownerId: text.ownerId,
+      language: text.language,
+      title: text.title,
+      sourceType: text.sourceType,
+      status: text.status,
+      visibility: text.visibility,
+      createdAt: text.createdAt,
+      updatedAt: text.updatedAt,
+    },
+    chapterCount: chapters.length,
+    chapters: chapters.map((c) => ({
+      idx: c.idx,
+      title: c.title,
+      tokenCount: c.tokenCount,
+    })),
+  });
+};
 
 export const DELETE: RequestHandler = async (event) => {
   const user = await requireUser(event);

--- a/apps/web/src/routes/api/v1/texts/[id]/text-detail-server.test.ts
+++ b/apps/web/src/routes/api/v1/texts/[id]/text-detail-server.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment node
+/**
+ * Route tests for GET /api/v1/texts/:id (text metadata + chapter list).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getReadableText = vi.fn();
+const resolveUser = vi.fn();
+
+vi.mock('$lib/server/texts/upload.js', async () => {
+  const actual = await vi.importActual<typeof import('$lib/server/texts/upload.js')>(
+    '$lib/server/texts/upload.js',
+  );
+  return {
+    ...actual,
+    getReadableText: (...a: unknown[]) => getReadableText(...a),
+  };
+});
+
+vi.mock('$lib/server/auth/require-user.js', () => ({
+  resolveUser: (...a: unknown[]) => resolveUser(...a),
+  requireUser: (...a: unknown[]) => resolveUser(...a),
+}));
+
+type GetFn = (typeof import('./+server.js'))['GET'];
+
+const ID = '11111111-1111-1111-1111-111111111111';
+
+async function callGet(id = ID, viewer: { id: string } | null = { id: 'u1' }) {
+  resolveUser.mockResolvedValueOnce(viewer);
+  const { GET } = await import('./+server.js');
+  const event = {
+    params: { id },
+    request: new Request('http://x'),
+    url: new URL('http://x'),
+  } as unknown as Parameters<GetFn>[0];
+  try {
+    return await GET(event);
+  } catch (e) {
+    return e as { status: number };
+  }
+}
+
+beforeEach(() => {
+  getReadableText.mockReset();
+  resolveUser.mockReset();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('GET /api/v1/texts/:id', () => {
+  it('rejects a non-UUID id with 400 before any lookup', async () => {
+    const res = (await callGet('not-a-uuid')) as { status: number };
+    expect(res.status).toBe(400);
+    expect(getReadableText).not.toHaveBeenCalled();
+  });
+
+  it('404s when the text is not readable (or absent)', async () => {
+    getReadableText.mockResolvedValueOnce(null);
+    const res = (await callGet()) as { status: number };
+    expect(res.status).toBe(404);
+  });
+
+  it('returns metadata + a lightweight chapter list (no bodies)', async () => {
+    const ts = new Date('2026-06-21T00:00:00Z');
+    getReadableText.mockResolvedValueOnce({
+      text: {
+        id: ID,
+        ownerId: 'u1',
+        language: 'hi',
+        title: 'A Book',
+        sourceType: 'epub',
+        status: 'ready',
+        visibility: 'private',
+        createdAt: ts,
+        updatedAt: ts,
+      },
+      chapters: [
+        { id: 'c0', textId: ID, idx: 0, title: 'Ch 1', body: 'x', tokenCount: 100, createdAt: ts },
+        { id: 'c1', textId: ID, idx: 1, title: null, body: 'y', tokenCount: 50, createdAt: ts },
+      ],
+    });
+
+    const res = (await callGet()) as Response;
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.text.title).toBe('A Book');
+    expect(json.chapterCount).toBe(2);
+    expect(json.chapters).toEqual([
+      { idx: 0, title: 'Ch 1', tokenCount: 100 },
+      { idx: 1, title: null, tokenCount: 50 },
+    ]);
+    // Chapter bodies are intentionally not included.
+    expect(json.chapters[0].body).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Adds the text-metadata endpoint the Android reader needs (Phase 3). The web app reads a text's title + chapter count from its page loader; a cookieless API client has no equivalent — the tokens endpoint returns one chapter but not the title or how many chapters exist.

## What
`GET /api/v1/texts/:id` (added to the existing `texts/[id]` route alongside `DELETE`):
- **text** metadata — id, ownerId, language, title, sourceType, status, visibility, createdAt, updatedAt
- **chapterCount**
- **chapters** — lightweight list of `{ idx, title, tokenCount }` (no chapter bodies)

Auth mirrors the reader: `resolveUser` + `getReadableText`, so an official/public text is readable anonymously, and a non-readable text returns **404** (deny-by-default, no existence leak).

## Tests
3 route specs: 400 (non-UUID), 404 (not readable), and the metadata + chapter projection (asserts bodies are excluded). Part of the M12 mobile-readiness direction (#102); unblocks the Android reader.
