### PR TITLE
feat(android): reader word translations + status (Phase 3b) + tokens Bearer-auth fix

### DIFF
--- a/apps/android/app/src/main/java/com/ciareader/reader/data/dictionary/DictionaryApi.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/data/dictionary/DictionaryApi.kt
@@ -1,0 +1,17 @@
+package com.ciareader.reader.data.dictionary
+
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.PATCH
+import retrofit2.http.Path
+
+interface DictionaryApi {
+    @GET("api/v1/lemmas/{id}/translations")
+    suspend fun translations(@Path("id") lemmaId: String): LemmaTranslationsDto
+
+    @PATCH("api/v1/me/known-lemmas/{lemmaId}")
+    suspend fun setKnownStatus(
+        @Path("lemmaId") lemmaId: String,
+        @Body body: KnownLemmaRequest,
+    ): KnownLemmaResponseDto
+}

--- a/apps/android/app/src/main/java/com/ciareader/reader/data/dictionary/DictionaryDtos.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/data/dictionary/DictionaryDtos.kt
@@ -1,0 +1,44 @@
+package com.ciareader.reader.data.dictionary
+
+import kotlinx.serialization.Serializable
+
+/** Mirrors GET /api/v1/lemmas/:id/translations. */
+@Serializable
+data class LemmaTranslationsDto(
+    val lemma: LemmaDto,
+    val translations: TranslationGroupsDto = TranslationGroupsDto(),
+    val definitionLanguages: List<String> = emptyList(),
+)
+
+@Serializable
+data class LemmaDto(
+    val id: String,
+    val headword: String,
+    val pos: String? = null,
+    val glossDefault: String? = null,
+)
+
+@Serializable
+data class TranslationGroupsDto(
+    val personal: List<TranslationDto> = emptyList(),
+    val official: List<TranslationDto> = emptyList(),
+    val community: List<TranslationDto> = emptyList(),
+)
+
+@Serializable
+data class TranslationDto(
+    val id: String,
+    val body: String,
+    val targetLanguage: String? = null,
+    val sourceAttribution: String? = null,
+)
+
+/** PATCH /api/v1/me/known-lemmas/:lemmaId */
+@Serializable
+data class KnownLemmaRequest(val status: String)
+
+@Serializable
+data class KnownLemmaResponseDto(val knownLemma: KnownLemmaDto)
+
+@Serializable
+data class KnownLemmaDto(val lemmaId: String, val status: String)

--- a/apps/android/app/src/main/java/com/ciareader/reader/data/dictionary/DictionaryRepository.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/data/dictionary/DictionaryRepository.kt
@@ -1,0 +1,60 @@
+package com.ciareader.reader.data.dictionary
+
+import com.ciareader.reader.core.network.Outcome
+import com.ciareader.reader.core.network.apiCall
+import com.ciareader.reader.data.reader.KnownStatus
+import javax.inject.Inject
+import javax.inject.Singleton
+
+data class WordTranslation(val body: String, val attribution: String?)
+
+/** A lemma's definitions, grouped by source (for the reader's word sheet). */
+data class LemmaTranslations(
+    val headword: String,
+    val pos: String?,
+    val gloss: String?,
+    val personal: List<WordTranslation>,
+    val official: List<WordTranslation>,
+    val community: List<WordTranslation>,
+) {
+    val isEmpty: Boolean
+        get() = personal.isEmpty() && official.isEmpty() && community.isEmpty()
+}
+
+interface DictionaryRepository {
+    suspend fun translations(lemmaId: String): Outcome<LemmaTranslations>
+
+    /** Persists the viewer's status for a lemma; returns the confirmed status. */
+    suspend fun setStatus(lemmaId: String, status: KnownStatus): Outcome<KnownStatus>
+}
+
+@Singleton
+class DictionaryRepositoryImpl @Inject constructor(
+    private val api: DictionaryApi,
+) : DictionaryRepository {
+
+    override suspend fun translations(lemmaId: String): Outcome<LemmaTranslations> =
+        apiCall { api.translations(lemmaId).toDomain() }
+
+    override suspend fun setStatus(lemmaId: String, status: KnownStatus): Outcome<KnownStatus> =
+        apiCall {
+            val response = api.setKnownStatus(lemmaId, KnownLemmaRequest(status.wire()))
+            KnownStatus.fromWire(response.knownLemma.status)
+        }
+}
+
+private fun KnownStatus.wire(): String = when (this) {
+    KnownStatus.UNKNOWN -> "unknown"
+    KnownStatus.LEARNING -> "learning"
+    KnownStatus.KNOWN -> "known"
+    KnownStatus.IGNORED -> "ignored"
+}
+
+private fun LemmaTranslationsDto.toDomain() = LemmaTranslations(
+    headword = lemma.headword,
+    pos = lemma.pos,
+    gloss = lemma.glossDefault,
+    personal = translations.personal.map { WordTranslation(it.body, it.sourceAttribution) },
+    official = translations.official.map { WordTranslation(it.body, it.sourceAttribution) },
+    community = translations.community.map { WordTranslation(it.body, it.sourceAttribution) },
+)

--- a/apps/android/app/src/main/java/com/ciareader/reader/di/BindingsModule.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/di/BindingsModule.kt
@@ -10,6 +10,8 @@ import com.ciareader.reader.data.library.LibraryRepository
 import com.ciareader.reader.data.library.LibraryRepositoryImpl
 import com.ciareader.reader.data.collection.CollectionRepository
 import com.ciareader.reader.data.collection.CollectionRepositoryImpl
+import com.ciareader.reader.data.dictionary.DictionaryRepository
+import com.ciareader.reader.data.dictionary.DictionaryRepositoryImpl
 import com.ciareader.reader.data.reader.ReaderRepository
 import com.ciareader.reader.data.reader.ReaderRepositoryImpl
 import dagger.Binds
@@ -45,4 +47,8 @@ abstract class BindingsModule {
     @Binds
     @Singleton
     abstract fun bindCollectionRepository(impl: CollectionRepositoryImpl): CollectionRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindDictionaryRepository(impl: DictionaryRepositoryImpl): DictionaryRepository
 }

--- a/apps/android/app/src/main/java/com/ciareader/reader/di/NetworkModule.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/di/NetworkModule.kt
@@ -8,6 +8,7 @@ import com.ciareader.reader.data.auth.TokenRefreshApi
 import com.ciareader.reader.data.language.LanguagesApi
 import com.ciareader.reader.data.library.LibraryApi
 import com.ciareader.reader.data.collection.CollectionsApi
+import com.ciareader.reader.data.dictionary.DictionaryApi
 import com.ciareader.reader.data.reader.ReaderApi
 import dagger.Module
 import dagger.Provides
@@ -125,6 +126,11 @@ object NetworkModule {
     @Singleton
     fun provideCollectionsApi(@Authenticated retrofit: Retrofit): CollectionsApi =
         retrofit.create(CollectionsApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideDictionaryApi(@Authenticated retrofit: Retrofit): DictionaryApi =
+        retrofit.create(DictionaryApi::class.java)
 
     private val JSON_MEDIA_TYPE = "application/json".toMediaType()
 }

--- a/apps/android/app/src/main/java/com/ciareader/reader/ui/reader/ReaderScreen.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/ui/reader/ReaderScreen.kt
@@ -1,10 +1,12 @@
-@file:OptIn(ExperimentalMaterial3Api::class)
+@file:OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 
 package com.ciareader.reader.ui.reader
 
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -18,6 +20,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
@@ -42,6 +45,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.ciareader.reader.data.dictionary.LemmaTranslations
+import com.ciareader.reader.data.dictionary.WordTranslation
 import com.ciareader.reader.data.reader.KnownStatus
 import com.ciareader.reader.data.reader.ReaderToken
 
@@ -56,6 +61,7 @@ fun ReaderScreen(onBack: () -> Unit, viewModel: ReaderViewModel = hiltViewModel(
         onPrevChapter = viewModel::prevChapter,
         onNextChapter = viewModel::nextChapter,
         onRetry = viewModel::retry,
+        onSetStatus = viewModel::setStatus,
     )
 }
 
@@ -68,6 +74,7 @@ internal fun ReaderScreenContent(
     onPrevChapter: () -> Unit,
     onNextChapter: () -> Unit,
     onRetry: () -> Unit,
+    onSetStatus: (KnownStatus) -> Unit,
 ) {
     Scaffold(
         topBar = {
@@ -123,7 +130,12 @@ internal fun ReaderScreenContent(
     val selected = state.selectedWord
     if (selected != null) {
         ModalBottomSheet(onDismissRequest = onDismissWord) {
-            WordDetails(selected)
+            WordDetails(
+                token = selected,
+                translations = state.wordTranslations,
+                isLoading = state.isWordLoading,
+                onSetStatus = onSetStatus,
+            )
         }
     }
 }
@@ -188,28 +200,69 @@ private fun ChapterNavBar(
 }
 
 @Composable
-internal fun WordDetails(token: ReaderToken, modifier: Modifier = Modifier) {
+internal fun WordDetails(
+    token: ReaderToken,
+    translations: LemmaTranslations?,
+    isLoading: Boolean,
+    onSetStatus: (KnownStatus) -> Unit,
+    modifier: Modifier = Modifier,
+) {
     Column(
         modifier = modifier
             .fillMaxWidth()
             .padding(24.dp),
     ) {
-        Text(token.surface, style = MaterialTheme.typography.headlineSmall)
-        token.romanization?.let {
-            Text(it, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Text(translations?.headword ?: token.surface, style = MaterialTheme.typography.headlineSmall)
+        val subtitle = listOfNotNull(token.romanization, translations?.pos).joinToString("  ·  ")
+        if (subtitle.isNotEmpty()) {
+            Text(subtitle, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
         }
         Spacer(Modifier.height(12.dp))
-        Text(
-            token.glossDefault ?: "No definition yet.",
-            style = MaterialTheme.typography.bodyLarge,
-        )
-        Spacer(Modifier.height(12.dp))
-        Text(
-            "Status: ${statusLabel(token.status)}",
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.primary,
-        )
+
+        when {
+            isLoading ->
+                Text("Loading…", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+
+            translations != null && !translations.isEmpty ->
+                TranslationGroups(translations)
+
+            else ->
+                Text(token.glossDefault ?: "No definition yet.", style = MaterialTheme.typography.bodyLarge)
+        }
+
+        Spacer(Modifier.height(16.dp))
+        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            StatusChip("New", token.status == KnownStatus.UNKNOWN) { onSetStatus(KnownStatus.UNKNOWN) }
+            StatusChip("Learning", token.status == KnownStatus.LEARNING) { onSetStatus(KnownStatus.LEARNING) }
+            StatusChip("Known", token.status == KnownStatus.KNOWN) { onSetStatus(KnownStatus.KNOWN) }
+            StatusChip("Ignored", token.status == KnownStatus.IGNORED) { onSetStatus(KnownStatus.IGNORED) }
+        }
     }
+}
+
+@Composable
+private fun StatusChip(label: String, selected: Boolean, onClick: () -> Unit) {
+    FilterChip(selected = selected, onClick = onClick, label = { Text(label) })
+}
+
+@Composable
+private fun TranslationGroups(translations: LemmaTranslations) {
+    TranslationGroup("Your notes", translations.personal)
+    TranslationGroup("Dictionary", translations.official)
+    TranslationGroup("Community", translations.community)
+}
+
+@Composable
+private fun TranslationGroup(title: String, items: List<WordTranslation>) {
+    if (items.isEmpty()) return
+    Text(title, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
+    items.forEach { item ->
+        Text(item.body, style = MaterialTheme.typography.bodyLarge)
+        item.attribution?.let {
+            Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+    }
+    Spacer(Modifier.height(8.dp))
 }
 
 @Composable

--- a/apps/android/app/src/main/java/com/ciareader/reader/ui/reader/ReaderViewModel.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/ui/reader/ReaderViewModel.kt
@@ -4,6 +4,9 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ciareader.reader.core.network.Outcome
+import com.ciareader.reader.data.dictionary.DictionaryRepository
+import com.ciareader.reader.data.dictionary.LemmaTranslations
+import com.ciareader.reader.data.reader.KnownStatus
 import com.ciareader.reader.data.reader.ReaderRepository
 import com.ciareader.reader.data.reader.ReaderToken
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -21,6 +24,8 @@ data class ReaderUiState(
     val chapterIdx: Int = 0,
     val tokens: List<ReaderToken> = emptyList(),
     val selectedWord: ReaderToken? = null,
+    val wordTranslations: LemmaTranslations? = null,
+    val isWordLoading: Boolean = false,
     val errorMessage: String? = null,
 ) {
     val hasPrev: Boolean get() = chapterIdx > 0
@@ -30,6 +35,7 @@ data class ReaderUiState(
 @HiltViewModel
 class ReaderViewModel @Inject constructor(
     private val repository: ReaderRepository,
+    private val dictionary: DictionaryRepository,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
@@ -64,7 +70,7 @@ class ReaderViewModel @Inject constructor(
     }
 
     fun loadChapter(chapterIdx: Int) {
-        _state.update { it.copy(isLoading = true, errorMessage = null, selectedWord = null) }
+        _state.update { it.copy(isLoading = true, errorMessage = null, selectedWord = null, wordTranslations = null) }
         viewModelScope.launch {
             when (val chapter = repository.chapter(textId, chapterIdx)) {
                 is Outcome.Success ->
@@ -79,10 +85,47 @@ class ReaderViewModel @Inject constructor(
     }
 
     fun onWordTap(token: ReaderToken) {
-        if (token.isWord) _state.update { it.copy(selectedWord = token) }
+        if (!token.isWord) return
+        val lemmaId = token.lemmaId
+        _state.update {
+            it.copy(selectedWord = token, wordTranslations = null, isWordLoading = lemmaId != null)
+        }
+        if (lemmaId == null) return
+        viewModelScope.launch {
+            val outcome = dictionary.translations(lemmaId)
+            _state.update { s ->
+                // Ignore if the user has since tapped a different word.
+                if (s.selectedWord?.lemmaId != lemmaId) return@update s
+                when (outcome) {
+                    is Outcome.Success -> s.copy(isWordLoading = false, wordTranslations = outcome.data)
+                    is Outcome.Failure -> s.copy(isWordLoading = false)
+                }
+            }
+        }
     }
 
-    fun dismissWord() = _state.update { it.copy(selectedWord = null) }
+    /** Persist a status for the selected word's lemma and recolor every
+     *  occurrence of that lemma in the current chapter. */
+    fun setStatus(status: KnownStatus) {
+        val lemmaId = _state.value.selectedWord?.lemmaId ?: return
+        viewModelScope.launch {
+            when (val res = dictionary.setStatus(lemmaId, status)) {
+                is Outcome.Success -> _state.update { s ->
+                    val confirmed = res.data
+                    s.copy(
+                        tokens = s.tokens.map {
+                            if (it.lemmaId == lemmaId) it.copy(status = confirmed) else it
+                        },
+                        selectedWord = s.selectedWord?.copy(status = confirmed),
+                    )
+                }
+
+                is Outcome.Failure -> Unit // leave status unchanged; user can retry
+            }
+        }
+    }
+
+    fun dismissWord() = _state.update { it.copy(selectedWord = null, wordTranslations = null, isWordLoading = false) }
 
     fun nextChapter() {
         if (_state.value.hasNext) loadChapter(_state.value.chapterIdx + 1)

--- a/apps/android/app/src/test/java/com/ciareader/reader/data/dictionary/DictionaryRepositoryTest.kt
+++ b/apps/android/app/src/test/java/com/ciareader/reader/data/dictionary/DictionaryRepositoryTest.kt
@@ -1,0 +1,101 @@
+package com.ciareader.reader.data.dictionary
+
+import com.ciareader.reader.core.network.Outcome
+import com.ciareader.reader.data.reader.KnownStatus
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import retrofit2.HttpException
+import retrofit2.Response
+
+class DictionaryRepositoryTest {
+
+    private val json = Json { ignoreUnknownKeys = true; explicitNulls = false }
+
+    @Test
+    fun mapsTranslationsGroupedBySource() = runTest {
+        val api = FakeDictionaryApi(
+            translations = LemmaTranslationsDto(
+                lemma = LemmaDto("l1", "नमस्ते", "INTJ", "hello"),
+                translations = TranslationGroupsDto(
+                    personal = listOf(TranslationDto("p1", "my note")),
+                    official = listOf(TranslationDto("o1", "greeting", "en", "Platts")),
+                ),
+            ),
+        )
+        val repo = DictionaryRepositoryImpl(api)
+
+        val result = repo.translations("l1")
+
+        assertTrue(result is Outcome.Success)
+        val t = (result as Outcome.Success).data
+        assertEquals("नमस्ते", t.headword)
+        assertEquals("hello", t.gloss)
+        assertEquals(listOf("my note"), t.personal.map { it.body })
+        assertEquals(listOf("greeting"), t.official.map { it.body })
+        assertEquals("Platts", t.official[0].attribution)
+        assertTrue(t.community.isEmpty())
+    }
+
+    @Test
+    fun setStatusSendsWireValueAndReturnsConfirmedStatus() = runTest {
+        val api = FakeDictionaryApi(known = KnownLemmaResponseDto(KnownLemmaDto("l1", "known")))
+        val repo = DictionaryRepositoryImpl(api)
+
+        val result = repo.setStatus("l1", KnownStatus.KNOWN)
+
+        assertTrue(result is Outcome.Success)
+        assertEquals(KnownStatus.KNOWN, (result as Outcome.Success).data)
+        assertEquals("l1" to "known", api.lastSet)
+    }
+
+    @Test
+    fun httpErrorMapsToFailure() = runTest {
+        val repo = DictionaryRepositoryImpl(FakeDictionaryApi(error = http(404)))
+        assertTrue(repo.translations("missing") is Outcome.Failure)
+    }
+
+    @Test
+    fun decodesTranslationsIgnoringUnmodeledFields() {
+        val payload = """
+            {
+              "lemma": { "id": "l1", "language": "hi", "headword": "नमस्ते", "pos": "INTJ",
+                         "script": "Deva", "glossDefault": "hello", "frequencyRank": 42 },
+              "translations": {
+                "personal": [],
+                "official": [ { "id": "o1", "source": "official_dictionary", "body": "greeting",
+                  "targetLanguage": "en", "sourceAttribution": "Platts", "voteScore": 3,
+                  "viewerVote": null, "createdAt": "2026-01-01T00:00:00Z" } ],
+                "community": []
+              },
+              "definitionLanguages": ["en"]
+            }
+        """.trimIndent()
+        val dto = json.decodeFromString<LemmaTranslationsDto>(payload)
+        assertEquals("नमस्ते", dto.lemma.headword)
+        assertEquals("greeting", dto.translations.official[0].body)
+    }
+
+    private fun http(code: Int) =
+        HttpException(Response.error<Any>(code, "e".toResponseBody("text/plain".toMediaType())))
+}
+
+private class FakeDictionaryApi(
+    private val translations: LemmaTranslationsDto? = null,
+    private val known: KnownLemmaResponseDto? = null,
+    private val error: Throwable? = null,
+) : DictionaryApi {
+    var lastSet: Pair<String, String>? = null
+    override suspend fun translations(lemmaId: String): LemmaTranslationsDto =
+        error?.let { throw it } ?: translations!!
+
+    override suspend fun setKnownStatus(lemmaId: String, body: KnownLemmaRequest): KnownLemmaResponseDto {
+        lastSet = lemmaId to body.status
+        return error?.let { throw it } ?: known!!
+    }
+}

--- a/apps/android/app/src/test/java/com/ciareader/reader/ui/reader/ReaderScreenTest.kt
+++ b/apps/android/app/src/test/java/com/ciareader/reader/ui/reader/ReaderScreenTest.kt
@@ -5,9 +5,12 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import com.ciareader.reader.data.dictionary.LemmaTranslations
+import com.ciareader.reader.data.dictionary.WordTranslation
 import com.ciareader.reader.data.reader.KnownStatus
 import com.ciareader.reader.data.reader.ReaderToken
 import com.ciareader.reader.ui.theme.CiaReaderTheme
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -42,6 +45,7 @@ class ReaderScreenTest {
                     onPrevChapter = {},
                     onNextChapter = {},
                     onRetry = {},
+                    onSetStatus = {},
                 )
             }
         }
@@ -62,6 +66,7 @@ class ReaderScreenTest {
                     onPrevChapter = {},
                     onNextChapter = {},
                     onRetry = { retried = true },
+                    onSetStatus = {},
                 )
             }
         }
@@ -71,11 +76,12 @@ class ReaderScreenTest {
     }
 
     @Test
-    fun wordDetailsShowsSurfaceRomanizationGloss() {
+    fun wordDetailsShowsTranslationsAndStatusButtons() {
+        var chosen: KnownStatus? = null
         compose.setContent {
             CiaReaderTheme {
                 WordDetails(
-                    ReaderToken(
+                    token = ReaderToken(
                         idx = 0,
                         surface = "नमस्ते",
                         isWord = true,
@@ -87,13 +93,40 @@ class ReaderScreenTest {
                         isAmbiguous = false,
                         hasDefinition = true,
                     ),
+                    translations = LemmaTranslations(
+                        headword = "नमस्ते",
+                        pos = "INTJ",
+                        gloss = "hello",
+                        personal = emptyList(),
+                        official = listOf(WordTranslation("greeting", "Platts")),
+                        community = emptyList(),
+                    ),
+                    isLoading = false,
+                    onSetStatus = { chosen = it },
                 )
             }
         }
         compose.onNodeWithText("नमस्ते").assertIsDisplayed()
+        compose.onNodeWithText("greeting").assertIsDisplayed()
+        compose.onNodeWithText("Known").assertIsDisplayed()
+        compose.onNodeWithText("Known").performClick()
+        assertEquals(KnownStatus.KNOWN, chosen)
+    }
+
+    @Test
+    fun wordDetailsFallsBackToInlineGloss() {
+        compose.setContent {
+            CiaReaderTheme {
+                WordDetails(
+                    token = ReaderToken(0, "नमस्ते", true, KnownStatus.UNKNOWN, "l1", "namaste", "hello", false, false, true),
+                    translations = null,
+                    isLoading = false,
+                    onSetStatus = {},
+                )
+            }
+        }
         compose.onNodeWithText("namaste").assertIsDisplayed()
         compose.onNodeWithText("hello").assertIsDisplayed()
-        compose.onNodeWithText("Status: Learning").assertIsDisplayed()
     }
 
     private fun token(surface: String, isWord: Boolean, status: KnownStatus = KnownStatus.UNKNOWN) =

--- a/apps/android/app/src/test/java/com/ciareader/reader/ui/reader/ReaderViewModelTest.kt
+++ b/apps/android/app/src/test/java/com/ciareader/reader/ui/reader/ReaderViewModelTest.kt
@@ -2,6 +2,9 @@ package com.ciareader.reader.ui.reader
 
 import androidx.lifecycle.SavedStateHandle
 import com.ciareader.reader.core.network.Outcome
+import com.ciareader.reader.data.dictionary.DictionaryRepository
+import com.ciareader.reader.data.dictionary.LemmaTranslations
+import com.ciareader.reader.data.dictionary.WordTranslation
 import com.ciareader.reader.data.reader.Chapter
 import com.ciareader.reader.data.reader.ChapterRef
 import com.ciareader.reader.data.reader.KnownStatus
@@ -14,6 +17,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Rule
 import org.junit.Test
@@ -24,8 +28,8 @@ class ReaderViewModelTest {
     @get:Rule
     val mainRule = MainDispatcherRule()
 
-    private fun vm(repo: ReaderRepository) =
-        ReaderViewModel(repo, SavedStateHandle(mapOf("textId" to "t1")))
+    private fun vm(repo: ReaderRepository, dict: DictionaryRepository = FakeDictionaryRepository()) =
+        ReaderViewModel(repo, dict, SavedStateHandle(mapOf("textId" to "t1")))
 
     @Test
     fun loadsTitleAndFirstChapter() = runTest(mainRule.dispatcher) {
@@ -76,6 +80,47 @@ class ReaderViewModelTest {
     }
 
     @Test
+    fun wordTapFetchesTranslations() = runTest(mainRule.dispatcher) {
+        val w = ReaderToken(0, "नमस्ते", true, KnownStatus.UNKNOWN, "l1", null, null, false, false, true)
+        val repo = FakeReaderRepository(meta = meta(1), chapters = mapOf(0 to Chapter(0, listOf(w))))
+        val dict = FakeDictionaryRepository(
+            translations = LemmaTranslations(
+                headword = "नमस्ते",
+                pos = "INTJ",
+                gloss = "hello",
+                personal = emptyList(),
+                official = listOf(WordTranslation("greeting", null)),
+                community = emptyList(),
+            ),
+        )
+        val v = vm(repo, dict)
+        advanceUntilIdle()
+
+        v.onWordTap(w)
+        advanceUntilIdle()
+
+        assertNotNull(v.state.value.wordTranslations)
+        assertEquals("नमस्ते", v.state.value.wordTranslations?.headword)
+        assertFalse(v.state.value.isWordLoading)
+    }
+
+    @Test
+    fun setStatusRecolorsTokensAndSelectedWord() = runTest(mainRule.dispatcher) {
+        val w = ReaderToken(0, "नमस्ते", true, KnownStatus.UNKNOWN, "l1", null, null, false, false, true)
+        val repo = FakeReaderRepository(meta = meta(1), chapters = mapOf(0 to Chapter(0, listOf(w))))
+        val v = vm(repo)
+        advanceUntilIdle()
+
+        v.onWordTap(w)
+        advanceUntilIdle()
+        v.setStatus(KnownStatus.KNOWN)
+        advanceUntilIdle()
+
+        assertEquals(KnownStatus.KNOWN, v.state.value.tokens[0].status)
+        assertEquals(KnownStatus.KNOWN, v.state.value.selectedWord?.status)
+    }
+
+    @Test
     fun nextChapterLoadsThatChapter() = runTest(mainRule.dispatcher) {
         val repo = FakeReaderRepository(
             meta = meta(2),
@@ -119,4 +164,14 @@ private class FakeReaderRepository(
     override suspend fun chapter(textId: String, chapterIdx: Int): Outcome<Chapter> =
         chapterError?.let { Outcome.Failure(it) }
             ?: Outcome.Success(chapters[chapterIdx] ?: Chapter(chapterIdx, emptyList()))
+}
+
+private class FakeDictionaryRepository(
+    private val translations: LemmaTranslations? = null,
+) : DictionaryRepository {
+    override suspend fun translations(lemmaId: String): Outcome<LemmaTranslations> =
+        translations?.let { Outcome.Success(it) } ?: Outcome.Failure("no translations")
+
+    override suspend fun setStatus(lemmaId: String, status: KnownStatus): Outcome<KnownStatus> =
+        Outcome.Success(status)
 }

--- a/apps/web/src/routes/api/v1/texts/[id]/chapters/[idx]/tokens/+server.ts
+++ b/apps/web/src/routes/api/v1/texts/[id]/chapters/[idx]/tokens/+server.ts
@@ -14,6 +14,7 @@
  */
 import { error, json } from '@sveltejs/kit';
 
+import { resolveUser } from '$lib/server/auth/require-user.js';
 import { getReadableText } from '$lib/server/texts/upload.js';
 import { loadChapterTokens } from '$lib/server/texts/tokens.js';
 import { loadChapterPhraseSpans } from '$lib/server/texts/phrase-spans.js';
@@ -21,16 +22,19 @@ import type { RequestHandler } from './$types';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-export const GET: RequestHandler = async ({ params, locals }) => {
-  const textId = params.id;
+export const GET: RequestHandler = async (event) => {
+  const textId = event.params.id;
   if (!textId || !UUID_RE.test(textId)) throw error(400, 'Invalid text id');
-  const idxRaw = params.idx;
+  const idxRaw = event.params.idx;
   if (!idxRaw) throw error(400, 'Invalid chapter index');
   const idx = Number.parseInt(idxRaw, 10);
   if (!Number.isFinite(idx) || idx < 0) throw error(400, 'Invalid chapter index');
 
-  const viewer = locals.user ? { id: locals.user.id } : null;
-  const result = await getReadableText(viewer, textId);
+  // resolveUser (not locals.user) so Bearer-authenticated API clients — the
+  // Android reader — are recognized, not just cookie sessions. Without it an
+  // app client reads as anonymous and 404s on its own private texts.
+  const viewer = await resolveUser(event);
+  const result = await getReadableText(viewer ? { id: viewer.id } : null, textId);
   if (!result) throw error(404, 'Text not found');
   const chapter = result.chapters.find((c) => c.idx === idx);
   if (!chapter) throw error(404, 'Chapter not found');

--- a/apps/web/src/routes/api/v1/texts/[id]/chapters/[idx]/tokens/tokens-server.test.ts
+++ b/apps/web/src/routes/api/v1/texts/[id]/chapters/[idx]/tokens/tokens-server.test.ts
@@ -9,6 +9,7 @@ import { jsonContract } from '$lib/test/json-contract.js';
 const getReadableText = vi.fn();
 const loadChapterTokens = vi.fn();
 const loadChapterPhraseSpans = vi.fn();
+const resolveUser = vi.fn();
 
 vi.mock('$lib/server/texts/upload.js', async () => {
   const actual = await vi.importActual<typeof import('$lib/server/texts/upload.js')>(
@@ -20,6 +21,11 @@ vi.mock('$lib/server/texts/upload.js', async () => {
     getOwnedText: (...a: unknown[]) => getReadableText(...a),
   };
 });
+
+vi.mock('$lib/server/auth/require-user.js', () => ({
+  resolveUser: (...a: unknown[]) => resolveUser(...a),
+  requireUser: (...a: unknown[]) => resolveUser(...a),
+}));
 
 vi.mock('$lib/server/texts/tokens.js', async () => {
   const actual = await vi.importActual<typeof import('$lib/server/texts/tokens.js')>(
@@ -55,9 +61,9 @@ async function callGet(
   user: { id: string } | null = { id: 'user-1' },
 ) {
   const { GET } = await import('./+server.js');
+  resolveUser.mockResolvedValue(user);
   const event = {
     params: { id: textId, idx },
-    locals: { user },
   } as unknown as Parameters<Get>[0];
   try {
     return (await GET(event)) as Response;
@@ -81,6 +87,7 @@ function fixtureWithChapters(n: number) {
 
 beforeEach(() => {
   getReadableText.mockReset();
+  resolveUser.mockReset();
   loadChapterTokens.mockReset();
   loadChapterTokens.mockResolvedValue(null);
   loadChapterPhraseSpans.mockReset();
@@ -182,5 +189,19 @@ describe('GET /api/v1/texts/:id/chapters/:idx/tokens', () => {
     await callGet(VALID_ID, '0', null);
     expect(getReadableText).toHaveBeenCalledWith(null, VALID_ID);
     expect(loadChapterTokens).toHaveBeenCalledWith('c0', null);
+  });
+
+  // Regression: the endpoint must authenticate via resolveUser (Bearer-aware),
+  // not locals.user (cookie-only). Without it the Android reader — which sends
+  // a Bearer token and no cookie — reads as anonymous and 404s on its own
+  // private texts.
+  it('authenticates the viewer via resolveUser so Bearer clients read private texts', async () => {
+    getReadableText.mockResolvedValueOnce(fixtureWithChapters(1));
+    loadChapterTokens.mockResolvedValueOnce([]);
+    const res = (await callGet(VALID_ID, '0', { id: 'user-1' })) as Response;
+    expect(res.status).toBe(200);
+    expect(resolveUser).toHaveBeenCalled();
+    expect(getReadableText).toHaveBeenCalledWith({ id: 'user-1' }, VALID_ID);
+    expect(loadChapterTokens).toHaveBeenCalledWith('c0', 'user-1');
   });
 });


### PR DESCRIPTION
Two changes that have to ship together — the Android reader (Phase 3b) is only testable end-to-end with the server fix. Branches off `main`.

## 1. Phase 3b — word translations + persistent status (Android)
- **Translations on tap** — `data/dictionary` wraps `GET /api/v1/lemmas/:id/translations`; the word sheet shows definitions grouped by source (your notes / dictionary / community), falling back to the token's inline gloss while loading or when there are none.
- **Persistent status** — `FilterChip`s (New / Learning / Known / Ignored) `PATCH /api/v1/me/known-lemmas/:id` and recolor every occurrence of that lemma in the chapter immediately.
- Tests: `DictionaryRepository` (+ serialization), `ReaderViewModel` (translation fetch + status recolor), `ReaderScreen` word-details. 52 unit/UI tests, lint clean.

## 2. Reader tokens endpoint honors Bearer auth (server)
`GET /api/v1/texts/:id/chapters/:idx/tokens` resolved the viewer from `locals.user` (cookie-only), so the Bearer-token Android client read as anonymous and **404'd on its own private texts** — tapping a book chapter showed "Not found." The metadata endpoint already uses `resolveUser`, so the title loaded but the body 404'd. Now uses `resolveUser(event)`, matching the metadata + translation endpoints. Public/official texts still read anonymously. Regression test added (Bearer viewer reads a private text). Supersedes #453.

> Note: `texts/:id/audio` has the same latent `locals.user` pattern (app doesn't use audio yet) — tracked separately.
