### PR TITLE
fix(api): reader tokens endpoint honors Bearer auth

### DIFF
--- a/apps/web/src/routes/api/v1/texts/[id]/chapters/[idx]/tokens/+server.ts
+++ b/apps/web/src/routes/api/v1/texts/[id]/chapters/[idx]/tokens/+server.ts
@@ -14,6 +14,7 @@
  */
 import { error, json } from '@sveltejs/kit';
 
+import { resolveUser } from '$lib/server/auth/require-user.js';
 import { getReadableText } from '$lib/server/texts/upload.js';
 import { loadChapterTokens } from '$lib/server/texts/tokens.js';
 import { loadChapterPhraseSpans } from '$lib/server/texts/phrase-spans.js';
@@ -21,16 +22,19 @@ import type { RequestHandler } from './$types';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-export const GET: RequestHandler = async ({ params, locals }) => {
-  const textId = params.id;
+export const GET: RequestHandler = async (event) => {
+  const textId = event.params.id;
   if (!textId || !UUID_RE.test(textId)) throw error(400, 'Invalid text id');
-  const idxRaw = params.idx;
+  const idxRaw = event.params.idx;
   if (!idxRaw) throw error(400, 'Invalid chapter index');
   const idx = Number.parseInt(idxRaw, 10);
   if (!Number.isFinite(idx) || idx < 0) throw error(400, 'Invalid chapter index');
 
-  const viewer = locals.user ? { id: locals.user.id } : null;
-  const result = await getReadableText(viewer, textId);
+  // resolveUser (not locals.user) so Bearer-authenticated API clients — the
+  // Android reader — are recognized, not just cookie sessions. Without it an
+  // app client reads as anonymous and 404s on its own private texts.
+  const viewer = await resolveUser(event);
+  const result = await getReadableText(viewer ? { id: viewer.id } : null, textId);
   if (!result) throw error(404, 'Text not found');
   const chapter = result.chapters.find((c) => c.idx === idx);
   if (!chapter) throw error(404, 'Chapter not found');

--- a/apps/web/src/routes/api/v1/texts/[id]/chapters/[idx]/tokens/tokens-server.test.ts
+++ b/apps/web/src/routes/api/v1/texts/[id]/chapters/[idx]/tokens/tokens-server.test.ts
@@ -9,6 +9,7 @@ import { jsonContract } from '$lib/test/json-contract.js';
 const getReadableText = vi.fn();
 const loadChapterTokens = vi.fn();
 const loadChapterPhraseSpans = vi.fn();
+const resolveUser = vi.fn();
 
 vi.mock('$lib/server/texts/upload.js', async () => {
   const actual = await vi.importActual<typeof import('$lib/server/texts/upload.js')>(
@@ -20,6 +21,11 @@ vi.mock('$lib/server/texts/upload.js', async () => {
     getOwnedText: (...a: unknown[]) => getReadableText(...a),
   };
 });
+
+vi.mock('$lib/server/auth/require-user.js', () => ({
+  resolveUser: (...a: unknown[]) => resolveUser(...a),
+  requireUser: (...a: unknown[]) => resolveUser(...a),
+}));
 
 vi.mock('$lib/server/texts/tokens.js', async () => {
   const actual = await vi.importActual<typeof import('$lib/server/texts/tokens.js')>(
@@ -55,9 +61,9 @@ async function callGet(
   user: { id: string } | null = { id: 'user-1' },
 ) {
   const { GET } = await import('./+server.js');
+  resolveUser.mockResolvedValue(user);
   const event = {
     params: { id: textId, idx },
-    locals: { user },
   } as unknown as Parameters<Get>[0];
   try {
     return (await GET(event)) as Response;
@@ -81,6 +87,7 @@ function fixtureWithChapters(n: number) {
 
 beforeEach(() => {
   getReadableText.mockReset();
+  resolveUser.mockReset();
   loadChapterTokens.mockReset();
   loadChapterTokens.mockResolvedValue(null);
   loadChapterPhraseSpans.mockReset();
@@ -182,5 +189,19 @@ describe('GET /api/v1/texts/:id/chapters/:idx/tokens', () => {
     await callGet(VALID_ID, '0', null);
     expect(getReadableText).toHaveBeenCalledWith(null, VALID_ID);
     expect(loadChapterTokens).toHaveBeenCalledWith('c0', null);
+  });
+
+  // Regression: the endpoint must authenticate via resolveUser (Bearer-aware),
+  // not locals.user (cookie-only). Without it the Android reader — which sends
+  // a Bearer token and no cookie — reads as anonymous and 404s on its own
+  // private texts.
+  it('authenticates the viewer via resolveUser so Bearer clients read private texts', async () => {
+    getReadableText.mockResolvedValueOnce(fixtureWithChapters(1));
+    loadChapterTokens.mockResolvedValueOnce([]);
+    const res = (await callGet(VALID_ID, '0', { id: 'user-1' })) as Response;
+    expect(res.status).toBe(200);
+    expect(resolveUser).toHaveBeenCalled();
+    expect(getReadableText).toHaveBeenCalledWith({ id: 'user-1' }, VALID_ID);
+    expect(loadChapterTokens).toHaveBeenCalledWith('c0', 'user-1');
   });
 });


### PR DESCRIPTION
## Bug
Tapping a book chapter in the Android app shows **"Not found."**

## Cause
`GET /api/v1/texts/:id/chapters/:idx/tokens` resolved the viewer from `locals.user`, which is populated **only by the session-cookie hook**. The Android client authenticates with a **Bearer token and no cookie**, so it read as anonymous → `getReadableText(null, …)` → **404** on the user's own *private* texts.

The metadata endpoint `GET /texts/:id` (#449) uses `resolveUser` (Bearer-aware), so the title loaded but the tokens 404'd — hence the reader's "Not found." Public/official texts were unaffected (readable anonymously), which is why it only bit your own books.

## Fix
Use `resolveUser(event)` — same as the metadata and lemma-translation endpoints — so both Bearer and cookie sessions are recognized. Anonymous reads of official texts still work.

## Tests
Updated `tokens-server.test.ts` to drive auth through `resolveUser` and added a regression test asserting a Bearer viewer reads a private text. 8/8 pass.

## Note
`texts/:id/audio` has the same `locals.user` pattern (latent, app doesn't use audio yet) — tracked separately.
