### PR TITLE
fix(reader,nlp): readable reader-setting selection + Basque dialogue-dash/title-case lemmas

### DIFF
--- a/apps/web/src/lib/components/reader/ReaderSettings.svelte
+++ b/apps/web/src/lib/components/reader/ReaderSettings.svelte
@@ -415,10 +415,15 @@
     color: var(--ink-2, var(--color-fg));
     cursor: pointer;
   }
+  /* Selected segment: the soft accent tint is a *translucent* fill, so
+     it pairs with the strong page ink — NOT `--accent-ink`, which is
+     tuned dark to sit on a SOLID accent surface and reads as dark-on-dark
+     over this tint in dark mode (#438). Same pairing as ScriptAwareInput's
+     pressed toggle. */
   .rs-seg button[data-active='1'] {
     background: var(--accent-soft, color-mix(in oklch, var(--accent, var(--color-accent)) 18%, transparent));
-    color: var(--accent-ink, var(--color-fg));
-    font-weight: 500;
+    color: var(--ink, var(--color-fg));
+    font-weight: 600;
   }
   input[type='range'] {
     width: 100%;

--- a/services/nlp/app/pipelines/stanza_ud.py
+++ b/services/nlp/app/pipelines/stanza_ud.py
@@ -56,6 +56,16 @@ NON_WORD_UPOS: frozenset[str] = frozenset({"PUNCT", "SYM"})
 # at decimals or comma-joined phrases.
 _TRAILING_SPLIT_MARKS: tuple[str, ...] = ("।", "॥", "?", "!")
 
+# Leading dialogue dashes that Latin-script prose (Basque especially)
+# glues to the first word of a quotation — "–Ondo" / "—Ondo" — when no
+# space follows the dash. Left attached, the dash blocks dictionary
+# lookup and, worse, drags the word through Stanza's character seq2seq
+# lemma fallback, which mangled "–Ondo" into the lemma "hondo" (#437).
+# Restricted to the en/em dash: the ASCII hyphen-minus is deliberately
+# excluded so compounds ("kale-garbitzaile") and negative numbers
+# ("-15") keep their shape.
+_LEADING_SPLIT_MARKS: tuple[str, ...] = ("–", "—")
+
 _SCRIPT_RANGES: dict[str, tuple[tuple[int, int], ...]] = {
     "Deva": ((0x0900, 0x097F),),
     "Orya": ((0x0B00, 0x0B7F),),
@@ -117,24 +127,26 @@ def should_treat_as_word(surface: str, upos: str, *, script: str | None) -> bool
     return True
 
 
-def _is_allcaps_word(surface: str) -> bool:
-    """Return True for a multi-letter, fully-uppercase surface.
+def _needs_lowercase_relemma(surface: str) -> bool:
+    """Return True for a multi-letter word whose casing can miss Stanza's
+    lowercase-keyed lemma cache.
 
-    Headings and emphasised words ("HITZAURREA") confuse Stanza's
-    lemmatizer: its dictionary cache is keyed on normal case, so an
-    all-caps form that misses the cache falls through to the character
-    seq2seq model, which can drop or duplicate letters
-    ("HITZAURREA" → "hitzaure" instead of "hitzaurre"). Title-case
-    ("Hitzaurrea") and lowercase forms hit the cache and lemmatize
-    correctly, so they return False here.
+    Stanza caches dictionary lemmas keyed on the *lowercased* surface, so
+    any form that isn't already all-lowercase can miss the cache and fall
+    through to the character seq2seq model. That fallback drops or
+    duplicates letters in all-caps headings ("HITZAURREA" → "hitzaure"
+    instead of "hitzaurre") and *inserts* an etymological h in sentence-
+    or dialogue-initial title-case words ("Ondo" → "hondo", #437).
+    Re-lemmatizing a lowercased copy recovers the cached lemma in both
+    cases.
 
-    ``str.isupper()`` is only True when there is at least one cased
-    character and every cased character is uppercase, so non-cased
-    scripts (Devanagari, Odia, Hebrew) always return False — the
-    re-lemmatization path never fires for them. The ≥2-letter floor
-    skips single initials ("A") where a re-run buys nothing.
+    Already-lowercase words return False (cache hit). Non-cased scripts
+    (Devanagari, Odia, Hebrew) also return False because
+    ``surface.lower() == surface`` for them, so the re-lemmatization path
+    never fires there. The ≥2-letter floor skips single initials ("A")
+    where a re-run buys nothing.
     """
-    if not surface.isupper():
+    if surface == surface.lower():
         return False
     return sum(1 for ch in surface if ch.isalpha()) >= 2
 
@@ -153,6 +165,22 @@ def _trailing_split_mark(surface: str) -> str | None:
     last = surface[-1]
     if last in _TRAILING_SPLIT_MARKS:
         return last
+    return None
+
+
+def _leading_split_mark(surface: str) -> str | None:
+    """Return the leading dialogue dash to peel off, or None.
+
+    Mirrors :func:`_trailing_split_mark`. A surface that is *only* the
+    mark (Stanza already split it correctly) is left alone; we only
+    intervene when the dash is glued to a following word. See
+    ``_LEADING_SPLIT_MARKS``.
+    """
+    if len(surface) < 2:
+        return None
+    first = surface[0]
+    if first in _LEADING_SPLIT_MARKS:
+        return first
     return None
 
 
@@ -232,8 +260,9 @@ class StanzaUDPipeline(Pipeline):
         tokens: list[Token] = []
         idx = 0
         cursor = 0
-        # Memoizes the lowercased re-lemmatization of all-caps words so a
-        # heading repeated across a chapter only runs the extra pass once.
+        # Memoizes the lowercased re-lemmatization of upper/title-case
+        # words so a heading or a repeated dialogue-initial word only
+        # runs the extra pass once per chapter.
         relemma_cache: dict[str, str | None] = {}
         for sentence in doc.sentences:
             for word in sentence.words:
@@ -245,6 +274,16 @@ class StanzaUDPipeline(Pipeline):
                         tokens.append(self._make_gap_token(idx, gap))
                         idx += 1
                 surface = word.text
+                lemma = word.lemma or surface
+                # Peel a glued leading dialogue dash off the surface
+                # before the per-word Token shaping (see
+                # `_LEADING_SPLIT_MARKS`). It is emitted as its own
+                # boundary token below, ahead of the word.
+                leading_mark = _leading_split_mark(surface)
+                if leading_mark:
+                    surface = surface[len(leading_mark):]
+                    if lemma.startswith(leading_mark):
+                        lemma = lemma[len(leading_mark):]
                 # Split a trailing sentence-end mark off the surface
                 # before the per-word Token shaping. Stanza's Hindi
                 # tokenizer occasionally glues the danda to its
@@ -252,7 +291,6 @@ class StanzaUDPipeline(Pipeline):
                 # them, leaving the dictionary lookup with no chance
                 # of matching. See `_TRAILING_SPLIT_MARKS`.
                 trailing_mark = _trailing_split_mark(surface)
-                lemma = word.lemma or surface
                 if trailing_mark:
                     # Recompute lemma + surface for the word part. If
                     # Stanza's lemma was the glued form (the OOV
@@ -268,17 +306,26 @@ class StanzaUDPipeline(Pipeline):
                     upos,
                     script=self._script,
                 )
-                # Repair the lemma of an all-caps lexical word by
-                # re-lemmatizing a lowercased copy (see
-                # ``_is_allcaps_word``). PROPN / NUM / SYM / X are skipped:
-                # a proper noun's capitalized lemma and the
+                # Repair the lemma of an upper/title/mixed-case lexical
+                # word by re-lemmatizing a lowercased copy (see
+                # ``_needs_lowercase_relemma``). PROPN / NUM / SYM / X are
+                # skipped: a proper noun's capitalized lemma and the
                 # ``lemma == surface`` contract for the rest would only
                 # regress under lowercasing.
-                if is_word and upos not in NON_OOV_UPOS and _is_allcaps_word(surface):
+                if (
+                    is_word
+                    and upos not in NON_OOV_UPOS
+                    and _needs_lowercase_relemma(surface)
+                ):
                     repaired = self._relemmatize_lower(surface, relemma_cache)
                     if repaired:
                         lemma = repaired
                 is_oov = is_word and lemma == surface and upos not in NON_OOV_UPOS
+                if leading_mark:
+                    # Emit the dialogue dash as its own non-word boundary
+                    # token, ahead of the word it was glued to.
+                    tokens.append(self._make_punct_token(idx, leading_mark))
+                    idx += 1
                 tokens.append(
                     Token(
                         idx=idx,
@@ -304,25 +351,7 @@ class StanzaUDPipeline(Pipeline):
                     # reader paints it as a non-word boundary marker
                     # and the phrase-create logic refuses to span
                     # across sentence ends.
-                    tokens.append(
-                        Token(
-                            idx=idx,
-                            surface=trailing_mark,
-                            is_word=False,
-                            candidates=[
-                                LemmaCandidate(
-                                    lemma=trailing_mark,
-                                    pos="PUNCT",
-                                    score=1.0,
-                                    features={},
-                                ),
-                            ],
-                            is_ambiguous=False,
-                            is_oov=False,
-                            romanization=None,
-                            number_forms=None,
-                        )
-                    )
+                    tokens.append(self._make_punct_token(idx, trailing_mark))
                     idx += 1
                 if has_offsets and end is not None:
                     cursor = end
@@ -380,6 +409,24 @@ class StanzaUDPipeline(Pipeline):
             romanization=None,
         )
 
+    def _make_punct_token(self, idx: int, mark: str) -> Token:
+        """A punctuation mark peeled off a Stanza word — a leading
+        dialogue dash or a trailing sentence-end mark — emitted as its
+        own boundary token so the reader paints it as a non-word and
+        phrase-create refuses to span across it."""
+        return Token(
+            idx=idx,
+            surface=mark,
+            is_word=False,
+            candidates=[
+                LemmaCandidate(lemma=mark, pos="PUNCT", score=1.0, features={}),
+            ],
+            is_ambiguous=False,
+            is_oov=False,
+            romanization=None,
+            number_forms=None,
+        )
+
     def _romanize(self, surface: str) -> str | None:
         if not self._script or not self._roman_scheme:
             return None
@@ -399,7 +446,8 @@ __all__ = [
     "NON_WORD_UPOS",
     "StanzaLike",
     "StanzaUDPipeline",
-    "_is_allcaps_word",
+    "_leading_split_mark",
+    "_needs_lowercase_relemma",
     "_trailing_split_mark",
     "parse_feats",
     "should_treat_as_word",

--- a/services/nlp/tests/test_basque_pipeline.py
+++ b/services/nlp/tests/test_basque_pipeline.py
@@ -2,11 +2,14 @@
 
 Like the Hindi/Marathi pipeline tests, these inject a minimal fake
 Stanza-like object so we exercise the pipeline's output-shaping logic
-without the ~600MB UD_Basque-BDT model. The focus here is the all-caps
-lemma-repair pass (see ``_is_allcaps_word`` / ``_relemmatize_lower`` in
-``app.pipelines.stanza_ud``): Stanza's character seq2seq fallback mangles
-all-caps words ("HITZAURREA" → "hitzaure"), so the pipeline re-lemmatizes
-a lowercased copy and adopts that lemma for genuine lexical words.
+without the ~600MB UD_Basque-BDT model. The focus here is the case
+lemma-repair pass (see ``_needs_lowercase_relemma`` / ``_relemmatize_lower``
+in ``app.pipelines.stanza_ud``): Stanza's character seq2seq fallback
+mangles non-lowercase words — dropping letters in all-caps headings
+("HITZAURREA" → "hitzaure") and inserting an h in dialogue-initial
+title-case words ("Ondo" → "hondo", #437) — so the pipeline re-lemmatizes
+a lowercased copy and adopts that lemma for genuine lexical words. It also
+covers the leading dialogue-dash split (#437).
 """
 
 from __future__ import annotations
@@ -14,7 +17,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from app.pipelines.basque import BasquePipeline
-from app.pipelines.stanza_ud import _is_allcaps_word
+from app.pipelines.stanza_ud import _leading_split_mark, _needs_lowercase_relemma
 
 
 @dataclass
@@ -66,26 +69,46 @@ def _word_tokens(result):
     return [t for t in result.tokens if t.is_word]
 
 
-# --- _is_allcaps_word ---------------------------------------------------
+# --- _needs_lowercase_relemma ------------------------------------------
 
 
-def test_is_allcaps_word_true_for_multiletter_uppercase():
-    assert _is_allcaps_word("HITZAURREA") is True
-    assert _is_allcaps_word("EZ") is True
+def test_needs_lowercase_relemma_true_for_uppercase_forms():
+    # All-caps headings and title/dialogue-initial words both risk a
+    # lowercase-cache miss, so both opt into the re-lemmatization pass.
+    assert _needs_lowercase_relemma("HITZAURREA") is True
+    assert _needs_lowercase_relemma("EZ") is True
+    assert _needs_lowercase_relemma("Hitzaurrea") is True
+    assert _needs_lowercase_relemma("Ondo") is True
 
 
-def test_is_allcaps_word_false_for_title_and_lower_case():
-    assert _is_allcaps_word("Hitzaurrea") is False
-    assert _is_allcaps_word("hitzaurrea") is False
+def test_needs_lowercase_relemma_false_for_lowercase():
+    assert _needs_lowercase_relemma("hitzaurrea") is False
+    assert _needs_lowercase_relemma("ondo") is False
 
 
-def test_is_allcaps_word_false_for_single_letter_and_non_letters():
-    assert _is_allcaps_word("A") is False
-    assert _is_allcaps_word("123") is False
-    assert _is_allcaps_word("") is False
+def test_needs_lowercase_relemma_false_for_single_letter_and_non_letters():
+    assert _needs_lowercase_relemma("A") is False
+    assert _needs_lowercase_relemma("123") is False
+    assert _needs_lowercase_relemma("") is False
 
 
-# --- all-caps lemma repair ---------------------------------------------
+# --- _leading_split_mark -----------------------------------------------
+
+
+def test_leading_split_mark_detects_glued_dialogue_dash():
+    assert _leading_split_mark("–Ondo") == "–"  # en dash
+    assert _leading_split_mark("—Ondo") == "—"  # em dash
+
+
+def test_leading_split_mark_ignores_bare_dash_and_hyphen():
+    # A standalone dash (Stanza already split it) and the ASCII
+    # hyphen-minus (compounds, negative numbers) are left alone.
+    assert _leading_split_mark("–") is None
+    assert _leading_split_mark("-15") is None
+    assert _leading_split_mark("kale-garbitzaile") is None
+
+
+# --- case lemma repair -------------------------------------------------
 
 
 def test_allcaps_lemma_is_repaired_from_lowercased_form():
@@ -104,12 +127,52 @@ def test_allcaps_lemma_is_repaired_from_lowercased_form():
     assert "hitzaurrea" in fake.calls
 
 
-def test_title_case_word_is_not_re_lemmatized():
-    pipe, fake = _pipe({"Hitzaurrea": [("Hitzaurrea", "hitzaurre", "NOUN")]})
-    [tok] = _word_tokens(pipe.process("Hitzaurrea"))
-    assert tok.candidates[0].lemma == "hitzaurre"
-    # No lowercased re-run — title case already lemmatizes correctly.
-    assert fake.calls == ["Hitzaurrea"]
+def test_title_case_lemma_is_repaired_from_lowercased_form():
+    # #437: a dialogue/sentence-initial title-case word misses Stanza's
+    # lowercase lemma cache and the seq2seq fallback inserts an h
+    # ("Ondo" → "hondo"). The lowercased form hits the cache and
+    # lemmatizes correctly, so the pipeline adopts it.
+    pipe, fake = _pipe(
+        {
+            "Ondo": [("Ondo", "hondo", "ADV")],
+            "ondo": [("ondo", "ondo", "ADV")],
+        }
+    )
+    [tok] = _word_tokens(pipe.process("Ondo"))
+    assert tok.surface == "Ondo"
+    assert tok.candidates[0].lemma == "ondo"
+    assert "ondo" in fake.calls
+
+
+def test_leading_dialogue_dash_is_split_and_word_relemmatized():
+    # #437: "–Ondo" arrives as one glued token whose seq2seq lemma is
+    # "hondo". The pipeline peels the en dash into its own non-word
+    # token and re-lemmatizes the title-case word part from lowercase.
+    pipe, fake = _pipe(
+        {
+            "–Ondo": [("–Ondo", "hondo", "ADV")],
+            "ondo": [("ondo", "ondo", "ADV")],
+        }
+    )
+    result = pipe.process("–Ondo")
+    assert [t.surface for t in result.tokens] == ["–", "Ondo"]
+    dash, word = result.tokens
+    assert dash.is_word is False
+    assert dash.candidates[0].pos == "PUNCT"
+    assert word.is_word is True
+    assert word.candidates[0].lemma == "ondo"
+    assert "ondo" in fake.calls
+
+
+def test_leading_dash_is_stripped_from_a_glued_lemma():
+    # When Stanza returns the dash glued onto the lemma too ("–bai"), the
+    # peel strips it from both surface and lemma. A PROPN skips the
+    # case-repair pass, so the stripped lemma is what surfaces.
+    pipe, _ = _pipe({"–Bai": [("–Bai", "–Bai", "PROPN")]})
+    result = pipe.process("–Bai")
+    assert [t.surface for t in result.tokens] == ["–", "Bai"]
+    _, word = result.tokens
+    assert word.candidates[0].lemma == "Bai"
 
 
 def test_allcaps_proper_noun_lemma_is_left_alone():


### PR DESCRIPTION
Fixes two reader bugs.

## #438 — selected reader-setting option hard to read
The active segmented-control button paired the translucent `--accent-soft`
tint with `--accent-ink`, which is tuned dark to sit on a *solid* accent
fill — so the selected Mode/Width/Highlight labels rendered dark-on-dark in
dark mode. Keep the soft tint but use the strong page ink (the same pairing
`ScriptAwareInput`'s pressed toggle uses), clearing WCAG AA in both themes.

## #437 — "–Ondo" gets parsed as "hondo"
`–Ondo` reached Stanza as one glued token and the character seq2seq lemma
fallback mangled it (e.g. `hondo`/`uondo`). Two fixes in the shared UD
pipeline (`stanza_ud.py`):

- Peel a leading en/em **dialogue dash** into its own punctuation token
  before lemmatization (mirrors the existing trailing sentence-mark split).
  Restricted to en/em dash so compounds (`kale-garbitzaile`) and negative
  numbers (`-15`) are untouched.
- Generalize the all-caps lemma repair to **title/mixed case**
  (`_is_allcaps_word` → `_needs_lowercase_relemma`) so sentence- or
  dialogue-initial words like `Ondo` re-lemmatize from their lowercase form.

Verified against the real `UD_Basque-BDT` model: `–Ondo etorri zara.` →
`–` + `ondo` `etorri` `izan` `.`.

> Note: existing texts keep their stored lemmas until **reprocessed** — the
> reader renders saved tokens, not a live re-parse.

## Tests
- NLP: updated/added `test_basque_pipeline.py` cases (leading-dash split,
  title-case repair, glued-lemma strip). Full suite green (`707 passed`,
  ~92% coverage).
- Web: CSS-only change; no test asserts the active-button color
  (tests assert `data-active`), so none required.

Closes #437
Closes #438