### PR TITLE
fix(android): language selection

### DIFF
--- a/apps/android/app/src/main/java/com/ciareader/reader/core/settings/SettingsStore.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/core/settings/SettingsStore.kt
@@ -1,0 +1,46 @@
+package com.ciareader.reader.core.settings
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * User-scoped UI preferences (plaintext DataStore — no secrets here).
+ *
+ * Currently just the last-selected reading language, so the library reopens on
+ * the language the user was reading instead of resetting. Phase 5 settings
+ * (romanization scheme, page mode) extend this store.
+ */
+interface SettingsStore {
+    val currentLanguage: Flow<String?>
+    suspend fun currentLanguage(): String?
+    suspend fun setCurrentLanguage(code: String)
+}
+
+private val Context.settingsDataStore by preferencesDataStore(name = "settings")
+
+@Singleton
+class DataStoreSettingsStore @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : SettingsStore {
+
+    override val currentLanguage: Flow<String?> =
+        context.settingsDataStore.data.map { it[CURRENT_LANGUAGE] }
+
+    override suspend fun currentLanguage(): String? = currentLanguage.first()
+
+    override suspend fun setCurrentLanguage(code: String) {
+        context.settingsDataStore.edit { it[CURRENT_LANGUAGE] = code }
+    }
+
+    private companion object {
+        val CURRENT_LANGUAGE = stringPreferencesKey("current_language")
+    }
+}

--- a/apps/android/app/src/main/java/com/ciareader/reader/di/BindingsModule.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/di/BindingsModule.kt
@@ -2,6 +2,8 @@ package com.ciareader.reader.di
 
 import com.ciareader.reader.core.auth.DataStoreTokenStore
 import com.ciareader.reader.core.auth.TokenStore
+import com.ciareader.reader.core.settings.DataStoreSettingsStore
+import com.ciareader.reader.core.settings.SettingsStore
 import com.ciareader.reader.data.auth.AuthRepository
 import com.ciareader.reader.data.auth.AuthRepositoryImpl
 import com.ciareader.reader.data.language.LanguageRepository
@@ -27,6 +29,10 @@ abstract class BindingsModule {
     @Binds
     @Singleton
     abstract fun bindTokenStore(impl: DataStoreTokenStore): TokenStore
+
+    @Binds
+    @Singleton
+    abstract fun bindSettingsStore(impl: DataStoreSettingsStore): SettingsStore
 
     @Binds
     @Singleton

--- a/apps/android/app/src/main/java/com/ciareader/reader/ui/library/LibraryViewModel.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/ui/library/LibraryViewModel.kt
@@ -3,6 +3,7 @@ package com.ciareader.reader.ui.library
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ciareader.reader.core.network.Outcome
+import com.ciareader.reader.core.settings.SettingsStore
 import com.ciareader.reader.data.collection.CollectionRepository
 import com.ciareader.reader.data.collection.CollectionSummary
 import com.ciareader.reader.data.language.Language
@@ -39,6 +40,7 @@ class LibraryViewModel @Inject constructor(
     private val languageRepository: LanguageRepository,
     private val libraryRepository: LibraryRepository,
     private val collectionRepository: CollectionRepository,
+    private val settingsStore: SettingsStore,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(LibraryUiState())
@@ -56,11 +58,16 @@ class LibraryViewModel @Inject constructor(
                     _state.update { it.copy(isLoading = false, errorMessage = langs.message) }
 
                 is Outcome.Success -> {
-                    val languages = langs.data
-                    val current = _state.value.currentLanguage
-                        ?: languages.firstOrNull { it.isDefault }?.code
-                        ?: languages.firstOrNull()?.code
-                    _state.update { it.copy(languages = languages, currentLanguage = current) }
+                    // The endpoint returns every supported language; isDefault=true
+                    // marks ones the user has NOT added (column defaults). Show only
+                    // the languages they actually added; fall back to the full list
+                    // for a fresh account that has added none.
+                    val available = langs.data.filter { !it.isDefault }.ifEmpty { langs.data }
+                    val codes = available.map { it.code }.toSet()
+                    val current = _state.value.currentLanguage?.takeIf { it in codes }
+                        ?: settingsStore.currentLanguage()?.takeIf { it in codes }
+                        ?: available.firstOrNull()?.code
+                    _state.update { it.copy(languages = available, currentLanguage = current) }
                     if (current != null) {
                         loadContent(current)
                     } else {
@@ -75,8 +82,10 @@ class LibraryViewModel @Inject constructor(
         if (code == _state.value.currentLanguage) return
         _state.update { it.copy(currentLanguage = code, isLoading = true, errorMessage = null) }
         viewModelScope.launch {
-            // Persist server-side. The explicit `language` arg drives the listing
+            // Remember the choice locally so the next launch reopens here, and
+            // persist server-side. The explicit `language` arg drives the listing
             // regardless, so a failed persist doesn't block the local switch.
+            settingsStore.setCurrentLanguage(code)
             languageRepository.setCurrent(code)
             loadContent(code)
         }

--- a/apps/android/app/src/main/java/com/ciareader/reader/ui/reader/ReaderScreen.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/ui/reader/ReaderScreen.kt
@@ -257,10 +257,10 @@ private fun TranslationGroup(title: String, items: List<WordTranslation>) {
     if (items.isEmpty()) return
     Text(title, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
     items.forEach { item ->
+        // Source attribution is intentionally not shown here — the web reader
+        // doesn't surface it either (it only appears in the admin dictionary
+        // editor). WordTranslation.attribution is kept for potential future use.
         Text(item.body, style = MaterialTheme.typography.bodyLarge)
-        item.attribution?.let {
-            Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        }
     }
     Spacer(Modifier.height(8.dp))
 }

--- a/apps/android/app/src/test/java/com/ciareader/reader/ui/library/LibraryViewModelTest.kt
+++ b/apps/android/app/src/test/java/com/ciareader/reader/ui/library/LibraryViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.ciareader.reader.ui.library
 
 import com.ciareader.reader.core.network.Outcome
+import com.ciareader.reader.core.settings.SettingsStore
 import com.ciareader.reader.data.collection.CollectionDetail
 import com.ciareader.reader.data.collection.CollectionRepository
 import com.ciareader.reader.data.collection.CollectionSummary
@@ -11,6 +12,8 @@ import com.ciareader.reader.data.library.LibraryScope
 import com.ciareader.reader.data.library.TextCard
 import com.ciareader.reader.util.MainDispatcherRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -25,32 +28,78 @@ class LibraryViewModelTest {
     @get:Rule
     val mainRule = MainDispatcherRule()
 
-    @Test
-    fun loadsTextsAndCollectionsForDefaultLanguage() = runTest(mainRule.dispatcher) {
-        val langRepo = FakeLanguageRepository(listOf(lang("hi", isDefault = true), lang("yi")))
-        val libRepo = FakeLibraryRepository(byLanguage = mapOf("hi" to listOf(card("t1"))))
-        val collRepo = FakeCollectionRepository(all = listOf(collection("c1", "hi"), collection("c2", "yi")))
+    private fun vm(
+        langRepo: LanguageRepository,
+        libRepo: LibraryRepository = FakeLibraryRepository(),
+        collRepo: CollectionRepository = FakeCollectionRepository(),
+        settings: SettingsStore = FakeSettingsStore(),
+    ) = LibraryViewModel(langRepo, libRepo, collRepo, settings)
 
-        val vm = LibraryViewModel(langRepo, libRepo, collRepo)
+    @Test
+    fun showsOnlyAddedLanguagesAndDefaultsToTheFirstAdded() = runTest(mainRule.dispatcher) {
+        // The endpoint returns every supported language; the not-added ones come
+        // back isDefault=true. The user added hi + eu. Before the fix the VM
+        // selected the first isDefault language (mr) — a language they don't have.
+        val langRepo = FakeLanguageRepository(
+            listOf(
+                lang("hi"),
+                lang("mr", isDefault = true),
+                lang("or", isDefault = true),
+                lang("yi", isDefault = true),
+                lang("eu"),
+            ),
+        )
+        val libRepo = FakeLibraryRepository(byLanguage = mapOf("hi" to listOf(card("t1"))))
+        val collRepo = FakeCollectionRepository(all = listOf(collection("c1", "hi")))
+
+        val vm = vm(langRepo, libRepo, collRepo)
         advanceUntilIdle()
 
         val s = vm.state.value
-        assertEquals(listOf("hi", "yi"), s.languages.map { it.code })
-        assertEquals("hi", s.currentLanguage)
+        assertEquals(listOf("hi", "eu"), s.languages.map { it.code }) // mr/or/yi filtered out
+        assertEquals("hi", s.currentLanguage) // first added, NOT mr
         assertEquals(listOf("t1"), s.texts.map { it.id })
-        // Collections filtered to the current language.
         assertEquals(listOf("c1"), s.collections.map { it.id })
         assertFalse(s.isLoading)
         assertNull(s.errorMessage)
     }
 
     @Test
+    fun restoresThePersistedLanguage() = runTest(mainRule.dispatcher) {
+        val langRepo = FakeLanguageRepository(listOf(lang("hi"), lang("eu")))
+        val libRepo = FakeLibraryRepository(byLanguage = mapOf("eu" to listOf(card("b1"))))
+
+        val vm = vm(langRepo, libRepo, settings = FakeSettingsStore("eu"))
+        advanceUntilIdle()
+
+        assertEquals("eu", vm.state.value.currentLanguage) // restored, not first-added "hi"
+        assertEquals(listOf("b1"), vm.state.value.texts.map { it.id })
+    }
+
+    @Test
+    fun ignoresAPersistedLanguageNoLongerAdded() = runTest(mainRule.dispatcher) {
+        val langRepo = FakeLanguageRepository(listOf(lang("hi"), lang("eu")))
+        // "or" was removed from the account since it was last selected.
+        val vm = vm(langRepo, settings = FakeSettingsStore("or"))
+        advanceUntilIdle()
+
+        assertEquals("hi", vm.state.value.currentLanguage)
+    }
+
+    @Test
+    fun fallsBackToAllWhenNoLanguagesAreAdded() = runTest(mainRule.dispatcher) {
+        // Fresh account: nothing added, so every language is isDefault=true.
+        val langRepo = FakeLanguageRepository(listOf(lang("hi", isDefault = true), lang("mr", isDefault = true)))
+        val vm = vm(langRepo)
+        advanceUntilIdle()
+
+        assertEquals(listOf("hi", "mr"), vm.state.value.languages.map { it.code })
+        assertEquals("hi", vm.state.value.currentLanguage)
+    }
+
+    @Test
     fun languageFailureSurfacesError() = runTest(mainRule.dispatcher) {
-        val vm = LibraryViewModel(
-            FakeLanguageRepository(error = "boom"),
-            FakeLibraryRepository(),
-            FakeCollectionRepository(),
-        )
+        val vm = vm(FakeLanguageRepository(error = "boom"))
         advanceUntilIdle()
 
         assertEquals("boom", vm.state.value.errorMessage)
@@ -59,8 +108,8 @@ class LibraryViewModelTest {
 
     @Test
     fun collectionsFailureIsNonFatal() = runTest(mainRule.dispatcher) {
-        val vm = LibraryViewModel(
-            FakeLanguageRepository(listOf(lang("hi", isDefault = true))),
+        val vm = vm(
+            FakeLanguageRepository(listOf(lang("hi"))),
             FakeLibraryRepository(byLanguage = mapOf("hi" to listOf(card("t1")))),
             FakeCollectionRepository(error = "collections down"),
         )
@@ -73,22 +122,24 @@ class LibraryViewModelTest {
     }
 
     @Test
-    fun selectLanguageLoadsThatLanguageAndPersists() = runTest(mainRule.dispatcher) {
-        val langRepo = FakeLanguageRepository(listOf(lang("hi", isDefault = true), lang("mr")))
+    fun selectLanguageLoadsThatLanguageAndPersistsLocallyAndServer() = runTest(mainRule.dispatcher) {
+        val langRepo = FakeLanguageRepository(listOf(lang("hi"), lang("eu")))
         val libRepo = FakeLibraryRepository(
-            byLanguage = mapOf("hi" to listOf(card("h1")), "mr" to listOf(card("m1"), card("m2"))),
+            byLanguage = mapOf("hi" to listOf(card("h1")), "eu" to listOf(card("e1"), card("e2"))),
         )
-        val collRepo = FakeCollectionRepository(all = listOf(collection("ch", "hi"), collection("cm", "mr")))
-        val vm = LibraryViewModel(langRepo, libRepo, collRepo)
+        val collRepo = FakeCollectionRepository(all = listOf(collection("ch", "hi"), collection("ce", "eu")))
+        val settings = FakeSettingsStore()
+        val vm = vm(langRepo, libRepo, collRepo, settings)
         advanceUntilIdle()
 
-        vm.selectLanguage("mr")
+        vm.selectLanguage("eu")
         advanceUntilIdle()
 
-        assertEquals("mr", vm.state.value.currentLanguage)
-        assertEquals(listOf("m1", "m2"), vm.state.value.texts.map { it.id })
-        assertEquals(listOf("cm"), vm.state.value.collections.map { it.id })
-        assertEquals("mr", langRepo.lastSetCode)
+        assertEquals("eu", vm.state.value.currentLanguage)
+        assertEquals(listOf("e1", "e2"), vm.state.value.texts.map { it.id })
+        assertEquals(listOf("ce"), vm.state.value.collections.map { it.id })
+        assertEquals("eu", langRepo.lastSetCode)
+        assertEquals("eu", settings.currentLanguage()) // remembered for next launch
     }
 
     private fun lang(code: String, isDefault: Boolean = false) =
@@ -131,4 +182,13 @@ private class FakeCollectionRepository(
 
     override suspend fun detail(collectionId: String): Outcome<CollectionDetail> =
         Outcome.Failure("not used in these tests")
+}
+
+private class FakeSettingsStore(initial: String? = null) : SettingsStore {
+    private val state = MutableStateFlow(initial)
+    override val currentLanguage: Flow<String?> = state
+    override suspend fun currentLanguage(): String? = state.value
+    override suspend fun setCurrentLanguage(code: String) {
+        state.value = code
+    }
 }

--- a/apps/android/app/src/test/java/com/ciareader/reader/ui/reader/ReaderScreenTest.kt
+++ b/apps/android/app/src/test/java/com/ciareader/reader/ui/reader/ReaderScreenTest.kt
@@ -108,6 +108,8 @@ class ReaderScreenTest {
         }
         compose.onNodeWithText("नमस्ते").assertIsDisplayed()
         compose.onNodeWithText("greeting").assertIsDisplayed()
+        // Attribution is intentionally not surfaced in the reader (web parity).
+        compose.onNodeWithText("Platts").assertDoesNotExist()
         compose.onNodeWithText("Known").assertIsDisplayed()
         compose.onNodeWithText("Known").performClick()
         assertEquals(KnownStatus.KNOWN, chosen)


### PR DESCRIPTION
Two small Android reader/library fixes, bundled so they're testable from one rebuild. apps/android only.

## 1. Library shows only added languages + remembers the choice
`GET /api/v1/me/languages` returns **all** supported languages; `isDefault: true` marks the ones you have **NOT** added (column defaults). `LibraryViewModel` picked `firstOrNull { isDefault }` — the first *not-added* language (Marathi) — and never persisted the choice, so it reset each launch.
- Show only added languages (`isDefault == false`); default to the first added. Fresh accounts (none added) fall back to the full list.
- Persist the selected language in a new `SettingsStore` (DataStore) and restore it on launch (ignoring a stored language no longer added).

## Tests (55 unit/UI, lint clean)
`LibraryViewModelTest`: not-added-default regression (the Marathi case), persistence restore, stale-persist fallback, no-added fallback, select-language write-through. 
