### PR TITLE
feat(android): resume reading position + dark-mode window theme

### DIFF
--- a/apps/android/app/src/main/java/com/ciareader/reader/data/reader/ReaderApi.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/data/reader/ReaderApi.kt
@@ -1,9 +1,11 @@
 package com.ciareader.reader.data.reader
 
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.PATCH
 import retrofit2.http.Path
 
-/** Reader endpoints: text metadata and per-chapter tokens. */
+/** Reader endpoints: text metadata, per-chapter tokens, and reading progress. */
 interface ReaderApi {
     @GET("api/v1/texts/{id}")
     suspend fun textMeta(@Path("id") textId: String): TextMetaDto
@@ -13,4 +15,13 @@ interface ReaderApi {
         @Path("id") textId: String,
         @Path("idx") chapterIdx: Int,
     ): ChapterTokensDto
+
+    @GET("api/v1/me/text-progress/{textId}")
+    suspend fun progress(@Path("textId") textId: String): TextProgressEnvelopeDto
+
+    @PATCH("api/v1/me/text-progress/{textId}")
+    suspend fun saveProgress(
+        @Path("textId") textId: String,
+        @Body body: SaveProgressRequest,
+    ): TextProgressEnvelopeDto
 }

--- a/apps/android/app/src/main/java/com/ciareader/reader/data/reader/ReaderDtos.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/data/reader/ReaderDtos.kt
@@ -59,3 +59,22 @@ data class PhraseSpanDto(
     val glossDefault: String? = null,
     val status: String = "unknown",
 )
+
+// --- GET / PATCH /api/v1/me/text-progress/:textId ---
+
+@Serializable
+data class TextProgressEnvelopeDto(val progress: TextProgressDto? = null)
+
+@Serializable
+data class TextProgressDto(
+    val lastChapterIdx: Int = 0,
+    val lastTokenIdx: Int = 0,
+    val pctRead: Double = 0.0,
+)
+
+@Serializable
+data class SaveProgressRequest(
+    val chapterIdx: Int,
+    val tokenIdx: Int,
+    val pctRead: Double,
+)

--- a/apps/android/app/src/main/java/com/ciareader/reader/data/reader/ReaderRepository.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/data/reader/ReaderRepository.kt
@@ -57,9 +57,23 @@ data class TextMeta(
     val chapters: List<ChapterRef>,
 )
 
+/** The reader's saved anchor: which chapter/token and how far through. */
+data class ReadingProgress(
+    val chapterIdx: Int,
+    val tokenIdx: Int,
+    val pctRead: Double,
+)
+
 interface ReaderRepository {
     suspend fun textMeta(textId: String): Outcome<TextMeta>
     suspend fun chapter(textId: String, chapterIdx: Int): Outcome<Chapter>
+    suspend fun progress(textId: String): Outcome<ReadingProgress?>
+    suspend fun saveProgress(
+        textId: String,
+        chapterIdx: Int,
+        tokenIdx: Int,
+        pctRead: Double,
+    ): Outcome<Unit>
 }
 
 @Singleton
@@ -72,6 +86,21 @@ class ReaderRepositoryImpl @Inject constructor(
 
     override suspend fun chapter(textId: String, chapterIdx: Int): Outcome<Chapter> =
         apiCall { api.chapterTokens(textId, chapterIdx).toDomain() }
+
+    override suspend fun progress(textId: String): Outcome<ReadingProgress?> =
+        apiCall {
+            api.progress(textId).progress?.let {
+                ReadingProgress(it.lastChapterIdx, it.lastTokenIdx, it.pctRead)
+            }
+        }
+
+    override suspend fun saveProgress(
+        textId: String,
+        chapterIdx: Int,
+        tokenIdx: Int,
+        pctRead: Double,
+    ): Outcome<Unit> =
+        apiCall { api.saveProgress(textId, SaveProgressRequest(chapterIdx, tokenIdx, pctRead)); Unit }
 }
 
 private fun TextMetaDto.toDomain() = TextMeta(

--- a/apps/android/app/src/main/java/com/ciareader/reader/ui/reader/ReaderScreen.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/ui/reader/ReaderScreen.kt
@@ -13,7 +13,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.Button
@@ -28,10 +28,12 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
@@ -49,6 +51,7 @@ import com.ciareader.reader.data.dictionary.LemmaTranslations
 import com.ciareader.reader.data.dictionary.WordTranslation
 import com.ciareader.reader.data.reader.KnownStatus
 import com.ciareader.reader.data.reader.ReaderToken
+import kotlin.math.roundToInt
 
 @Composable
 fun ReaderScreen(onBack: () -> Unit, viewModel: ReaderViewModel = hiltViewModel()) {
@@ -62,6 +65,8 @@ fun ReaderScreen(onBack: () -> Unit, viewModel: ReaderViewModel = hiltViewModel(
         onNextChapter = viewModel::nextChapter,
         onRetry = viewModel::retry,
         onSetStatus = viewModel::setStatus,
+        onRecordPosition = viewModel::recordPosition,
+        onRestoreConsumed = viewModel::onRestoreConsumed,
     )
 }
 
@@ -75,6 +80,8 @@ internal fun ReaderScreenContent(
     onNextChapter: () -> Unit,
     onRetry: () -> Unit,
     onSetStatus: (KnownStatus) -> Unit,
+    onRecordPosition: (Int, Double) -> Unit,
+    onRestoreConsumed: () -> Unit,
 ) {
     Scaffold(
         topBar = {
@@ -118,10 +125,10 @@ internal fun ReaderScreenContent(
                     ChapterText(
                         tokens = state.tokens,
                         onWordTap = onWordTap,
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .verticalScroll(rememberScrollState())
-                            .padding(16.dp),
+                        restoreTokenIdx = state.restoreTokenIdx,
+                        onRecordPosition = onRecordPosition,
+                        onRestoreConsumed = onRestoreConsumed,
+                        modifier = Modifier.fillMaxSize(),
                     )
             }
         }
@@ -144,6 +151,9 @@ internal fun ReaderScreenContent(
 private fun ChapterText(
     tokens: List<ReaderToken>,
     onWordTap: (ReaderToken) -> Unit,
+    restoreTokenIdx: Int?,
+    onRecordPosition: (Int, Double) -> Unit,
+    onRestoreConsumed: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val scheme = MaterialTheme.colorScheme
@@ -165,19 +175,51 @@ private fun ChapterText(
         }
     }
     var layout by remember { mutableStateOf<TextLayoutResult?>(null) }
+    // Fresh scroll position per chapter, so navigating starts at the top.
+    val scrollState = remember(tokens) { ScrollState(0) }
+
+    // Restore the saved reading anchor once the chapter has laid out.
+    LaunchedEffect(layout, restoreTokenIdx) {
+        val result = layout ?: return@LaunchedEffect
+        val target = restoreTokenIdx ?: return@LaunchedEffect
+        ranges.getOrNull(target)?.let { range ->
+            scrollState.scrollTo(result.getLineTop(result.getLineForOffset(range.first)).roundToInt())
+        }
+        onRestoreConsumed()
+    }
+
+    // Report the top-visible token + percentage as the user scrolls; the
+    // ViewModel debounces the actual write-back.
+    LaunchedEffect(layout, scrollState) {
+        val result = layout ?: return@LaunchedEffect
+        snapshotFlow { scrollState.value }.collect { y ->
+            val line = result.getLineForVerticalPosition(y.toFloat())
+            val charOffset = result.getLineStart(line)
+            val tokenIdx = ranges.indexOfFirst { charOffset in it }.coerceAtLeast(0)
+            val pct = if (scrollState.maxValue > 0) {
+                (y.toFloat() / scrollState.maxValue * 100).toDouble()
+            } else {
+                0.0
+            }
+            onRecordPosition(tokenIdx, pct)
+        }
+    }
 
     Text(
         text = annotated,
         onTextLayout = { layout = it },
         style = MaterialTheme.typography.bodyLarge,
-        modifier = modifier.pointerInput(tokens) {
-            detectTapGestures { pos ->
-                val result = layout ?: return@detectTapGestures
-                val charOffset = result.getOffsetForPosition(pos)
-                val tokenIndex = ranges.indexOfFirst { charOffset in it }
-                tokens.getOrNull(tokenIndex)?.let { if (it.isWord) onWordTap(it) }
-            }
-        },
+        modifier = modifier
+            .verticalScroll(scrollState)
+            .padding(16.dp)
+            .pointerInput(tokens) {
+                detectTapGestures { pos ->
+                    val result = layout ?: return@detectTapGestures
+                    val charOffset = result.getOffsetForPosition(pos)
+                    val tokenIndex = ranges.indexOfFirst { charOffset in it }
+                    tokens.getOrNull(tokenIndex)?.let { if (it.isWord) onWordTap(it) }
+                }
+            },
     )
 }
 

--- a/apps/android/app/src/main/java/com/ciareader/reader/ui/reader/ReaderViewModel.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/ui/reader/ReaderViewModel.kt
@@ -10,6 +10,8 @@ import com.ciareader.reader.data.reader.KnownStatus
 import com.ciareader.reader.data.reader.ReaderRepository
 import com.ciareader.reader.data.reader.ReaderToken
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -26,6 +28,7 @@ data class ReaderUiState(
     val selectedWord: ReaderToken? = null,
     val wordTranslations: LemmaTranslations? = null,
     val isWordLoading: Boolean = false,
+    val restoreTokenIdx: Int? = null,
     val errorMessage: String? = null,
 ) {
     val hasPrev: Boolean get() = chapterIdx > 0
@@ -45,6 +48,8 @@ class ReaderViewModel @Inject constructor(
     private val _state = MutableStateFlow(ReaderUiState())
     val state: StateFlow<ReaderUiState> = _state.asStateFlow()
 
+    private var progressJob: Job? = null
+
     init {
         loadInitial()
     }
@@ -57,25 +62,34 @@ class ReaderViewModel @Inject constructor(
                     _state.update { it.copy(isLoading = false, errorMessage = meta.message) }
 
                 is Outcome.Success -> {
-                    _state.update {
-                        it.copy(
-                            title = meta.data.title,
-                            chapterCount = meta.data.chapterCount.coerceAtLeast(1),
-                        )
+                    val chapterCount = meta.data.chapterCount.coerceAtLeast(1)
+                    _state.update { it.copy(title = meta.data.title, chapterCount = chapterCount) }
+                    // Resume where the reader left off (chapter clamped to range);
+                    // restore the token only within that saved chapter.
+                    val saved = when (val p = repository.progress(textId)) {
+                        is Outcome.Success -> p.data
+                        is Outcome.Failure -> null
                     }
-                    loadChapter(0)
+                    val startChapter = (saved?.chapterIdx ?: 0).coerceIn(0, chapterCount - 1)
+                    val restoreToken = saved?.takeIf { it.chapterIdx == startChapter }?.tokenIdx
+                    loadChapter(startChapter, restoreToken)
                 }
             }
         }
     }
 
-    fun loadChapter(chapterIdx: Int) {
+    fun loadChapter(chapterIdx: Int, restoreTokenIdx: Int? = null) {
         _state.update { it.copy(isLoading = true, errorMessage = null, selectedWord = null, wordTranslations = null) }
         viewModelScope.launch {
             when (val chapter = repository.chapter(textId, chapterIdx)) {
                 is Outcome.Success ->
                     _state.update {
-                        it.copy(isLoading = false, chapterIdx = chapterIdx, tokens = chapter.data.tokens)
+                        it.copy(
+                            isLoading = false,
+                            chapterIdx = chapterIdx,
+                            tokens = chapter.data.tokens,
+                            restoreTokenIdx = restoreTokenIdx,
+                        )
                     }
 
                 is Outcome.Failure ->
@@ -135,7 +149,23 @@ class ReaderViewModel @Inject constructor(
         if (_state.value.hasPrev) loadChapter(_state.value.chapterIdx - 1)
     }
 
+    /** Debounced reading-progress write-back as the user scrolls. */
+    fun recordPosition(tokenIdx: Int, pctRead: Double) {
+        progressJob?.cancel()
+        progressJob = viewModelScope.launch {
+            delay(PROGRESS_DEBOUNCE_MS)
+            repository.saveProgress(textId, _state.value.chapterIdx, tokenIdx, pctRead)
+        }
+    }
+
+    /** The UI has scrolled to the restored anchor; don't scroll there again. */
+    fun onRestoreConsumed() = _state.update { it.copy(restoreTokenIdx = null) }
+
     fun retry() {
         if (_state.value.title.isEmpty()) loadInitial() else loadChapter(_state.value.chapterIdx)
+    }
+
+    private companion object {
+        const val PROGRESS_DEBOUNCE_MS = 800L
     }
 }

--- a/apps/android/app/src/main/res/values-night/themes.xml
+++ b/apps/android/app/src/main/res/values-night/themes.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!--
+      Dark-mode window theme (night variant of values/themes.xml). Uses the
+      framework dark Material parent so the window background / splash is dark
+      in system dark mode — otherwise a light window shows before Compose
+      draws. In-app colors still come from MaterialTheme (Compose).
+    -->
+    <style name="Theme.CiaReader" parent="android:Theme.Material.NoActionBar">
+        <item name="android:windowBackground">?android:colorBackground</item>
+    </style>
+</resources>

--- a/apps/android/app/src/test/java/com/ciareader/reader/data/reader/ReaderRepositoryTest.kt
+++ b/apps/android/app/src/test/java/com/ciareader/reader/data/reader/ReaderRepositoryTest.kt
@@ -72,6 +72,33 @@ class ReaderRepositoryTest {
         assertEquals("Not found.", (result as Outcome.Failure).message)
     }
 
+    @Test
+    fun mapsProgressToDomain() = runTest {
+        val api = FakeReaderApi(
+            progress = TextProgressEnvelopeDto(TextProgressDto(lastChapterIdx = 2, lastTokenIdx = 40, pctRead = 15.0)),
+        )
+        val result = ReaderRepositoryImpl(api).progress("t1")
+        assertTrue(result is Outcome.Success)
+        val p = (result as Outcome.Success).data
+        assertEquals(2, p?.chapterIdx)
+        assertEquals(40, p?.tokenIdx)
+    }
+
+    @Test
+    fun mapsNullProgressToNull() = runTest {
+        val result = ReaderRepositoryImpl(FakeReaderApi()).progress("t1")
+        assertTrue(result is Outcome.Success)
+        assertEquals(null, (result as Outcome.Success).data)
+    }
+
+    @Test
+    fun saveProgressSendsValues() = runTest {
+        val api = FakeReaderApi()
+        val result = ReaderRepositoryImpl(api).saveProgress("t1", chapterIdx = 1, tokenIdx = 9, pctRead = 33.0)
+        assertTrue(result is Outcome.Success)
+        assertEquals(SaveProgressRequest(1, 9, 33.0), api.lastSaved)
+    }
+
     private fun http(code: Int) =
         HttpException(Response.error<Any>(code, "e".toResponseBody("text/plain".toMediaType())))
 }
@@ -79,9 +106,19 @@ class ReaderRepositoryTest {
 private class FakeReaderApi(
     private val meta: TextMetaDto? = null,
     private val chapter: ChapterTokensDto? = null,
+    private val progress: TextProgressEnvelopeDto = TextProgressEnvelopeDto(progress = null),
     private val error: Throwable? = null,
 ) : ReaderApi {
+    var lastSaved: SaveProgressRequest? = null
+
     override suspend fun textMeta(textId: String): TextMetaDto = error?.let { throw it } ?: meta!!
     override suspend fun chapterTokens(textId: String, chapterIdx: Int): ChapterTokensDto =
         error?.let { throw it } ?: chapter!!
+
+    override suspend fun progress(textId: String): TextProgressEnvelopeDto = error?.let { throw it } ?: progress
+
+    override suspend fun saveProgress(textId: String, body: SaveProgressRequest): TextProgressEnvelopeDto {
+        lastSaved = body
+        return TextProgressEnvelopeDto(progress = TextProgressDto(body.chapterIdx, body.tokenIdx, body.pctRead))
+    }
 }

--- a/apps/android/app/src/test/java/com/ciareader/reader/data/reader/ReaderSerializationTest.kt
+++ b/apps/android/app/src/test/java/com/ciareader/reader/data/reader/ReaderSerializationTest.kt
@@ -69,4 +69,24 @@ class ReaderSerializationTest {
         assertEquals(2, dto.chapters.size)
         assertEquals(50, dto.chapters[1].tokenCount)
     }
+
+    @Test
+    fun decodesTextProgress() {
+        val withRow = """
+            {
+              "progress": {
+                "userId": "u1", "textId": "t1",
+                "lastChapterIdx": 3, "lastTokenIdx": 120, "pctRead": 42.5,
+                "updatedAt": "2026-06-21T00:00:00Z"
+              }
+            }
+        """.trimIndent()
+        val dto = json.decodeFromString<TextProgressEnvelopeDto>(withRow)
+        assertEquals(3, dto.progress?.lastChapterIdx)
+        assertEquals(120, dto.progress?.lastTokenIdx)
+        assertEquals(42.5, dto.progress?.pctRead)
+
+        val none = json.decodeFromString<TextProgressEnvelopeDto>("""{ "progress": null }""")
+        assertEquals(null, none.progress)
+    }
 }

--- a/apps/android/app/src/test/java/com/ciareader/reader/ui/reader/ReaderScreenTest.kt
+++ b/apps/android/app/src/test/java/com/ciareader/reader/ui/reader/ReaderScreenTest.kt
@@ -46,6 +46,8 @@ class ReaderScreenTest {
                     onNextChapter = {},
                     onRetry = {},
                     onSetStatus = {},
+                    onRecordPosition = { _, _ -> },
+                    onRestoreConsumed = {},
                 )
             }
         }
@@ -67,6 +69,8 @@ class ReaderScreenTest {
                     onNextChapter = {},
                     onRetry = { retried = true },
                     onSetStatus = {},
+                    onRecordPosition = { _, _ -> },
+                    onRestoreConsumed = {},
                 )
             }
         }

--- a/apps/android/app/src/test/java/com/ciareader/reader/ui/reader/ReaderViewModelTest.kt
+++ b/apps/android/app/src/test/java/com/ciareader/reader/ui/reader/ReaderViewModelTest.kt
@@ -10,6 +10,7 @@ import com.ciareader.reader.data.reader.ChapterRef
 import com.ciareader.reader.data.reader.KnownStatus
 import com.ciareader.reader.data.reader.ReaderRepository
 import com.ciareader.reader.data.reader.ReaderToken
+import com.ciareader.reader.data.reader.ReadingProgress
 import com.ciareader.reader.data.reader.TextMeta
 import com.ciareader.reader.util.MainDispatcherRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -139,6 +140,32 @@ class ReaderViewModelTest {
         assertEquals(2, v.state.value.tokens.size)
     }
 
+    @Test
+    fun restoresSavedChapterAndToken() = runTest(mainRule.dispatcher) {
+        val repo = FakeReaderRepository(
+            meta = meta(2),
+            chapters = mapOf(0 to Chapter(0, listOf(word("a"))), 1 to Chapter(1, listOf(word("b")))),
+            savedProgress = ReadingProgress(chapterIdx = 1, tokenIdx = 7, pctRead = 42.0),
+        )
+        val v = vm(repo)
+        advanceUntilIdle()
+
+        assertEquals(1, v.state.value.chapterIdx)
+        assertEquals(7, v.state.value.restoreTokenIdx)
+    }
+
+    @Test
+    fun recordPositionWritesDebouncedProgress() = runTest(mainRule.dispatcher) {
+        val repo = FakeReaderRepository(meta = meta(1), chapters = mapOf(0 to Chapter(0, listOf(word("a")))))
+        val v = vm(repo)
+        advanceUntilIdle()
+
+        v.recordPosition(tokenIdx = 12, pctRead = 30.0)
+        advanceUntilIdle()
+
+        assertEquals(ReadingProgress(0, 12, 30.0), repo.lastSaved)
+    }
+
     private fun word(surface: String) =
         ReaderToken(0, surface, true, KnownStatus.UNKNOWN, null, null, null, false, false, false)
 
@@ -157,13 +184,29 @@ private class FakeReaderRepository(
     private val chapters: Map<Int, Chapter> = emptyMap(),
     private val metaError: String? = null,
     private val chapterError: String? = null,
+    private val savedProgress: ReadingProgress? = null,
 ) : ReaderRepository {
+    var lastSaved: ReadingProgress? = null
+
     override suspend fun textMeta(textId: String): Outcome<TextMeta> =
         metaError?.let { Outcome.Failure(it) } ?: Outcome.Success(meta!!)
 
     override suspend fun chapter(textId: String, chapterIdx: Int): Outcome<Chapter> =
         chapterError?.let { Outcome.Failure(it) }
             ?: Outcome.Success(chapters[chapterIdx] ?: Chapter(chapterIdx, emptyList()))
+
+    override suspend fun progress(textId: String): Outcome<ReadingProgress?> =
+        Outcome.Success(savedProgress)
+
+    override suspend fun saveProgress(
+        textId: String,
+        chapterIdx: Int,
+        tokenIdx: Int,
+        pctRead: Double,
+    ): Outcome<Unit> {
+        lastSaved = ReadingProgress(chapterIdx, tokenIdx, pctRead)
+        return Outcome.Success(Unit)
+    }
 }
 
 private class FakeDictionaryRepository(

--- a/apps/web/src/routes/api/v1/me/text-progress/[textId]/+server.ts
+++ b/apps/web/src/routes/api/v1/me/text-progress/[textId]/+server.ts
@@ -1,16 +1,21 @@
 /**
- * PATCH /api/v1/me/text-progress/:textId (T-5.6).
+ * GET/PATCH /api/v1/me/text-progress/:textId (T-5.6).
  *
- * Reader writes its debounced anchor here as the user scrolls /
+ * PATCH: reader writes its debounced anchor here as the user scrolls /
  * paginates. The values are persisted to user_text_progress. A 404
  * is returned if the viewer can't read the text — either it
  * doesn't exist or the canReadText helper says no.
+ *
+ * GET: the viewer's saved anchor for this text, or null if none. The
+ * Android reader reads this on open to resume; the web reader reads the
+ * same progress server-side in its page loader.
  */
 import { error, json } from '@sveltejs/kit';
 import { z } from 'zod';
 
 import { requireUser } from '$lib/server/auth/require-user.js';
 import {
+  getTextProgress,
   ProgressNotAccessibleError,
   setTextProgress,
 } from '$lib/server/texts/progress.js';
@@ -23,6 +28,25 @@ const body = z.object({
   tokenIdx: z.number().int().min(0).optional().default(0),
   pctRead: z.number().min(0).max(100).optional().default(0),
 });
+
+export const GET: RequestHandler = async (event) => {
+  const user = await requireUser(event);
+  const textId = event.params.textId;
+  if (!textId || !UUID_RE.test(textId)) throw error(400, 'Invalid text id');
+  const row = await getTextProgress(user.id, textId);
+  return json({
+    progress: row
+      ? {
+          userId: row.userId,
+          textId: row.textId,
+          lastChapterIdx: row.lastChapterIdx,
+          lastTokenIdx: row.lastTokenIdx,
+          pctRead: row.pctRead,
+          updatedAt: row.updatedAt,
+        }
+      : null,
+  });
+};
 
 export const PATCH: RequestHandler = async (event) => {
   const user = await requireUser(event);

--- a/apps/web/src/routes/api/v1/me/text-progress/[textId]/text-progress-server.test.ts
+++ b/apps/web/src/routes/api/v1/me/text-progress/[textId]/text-progress-server.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const setTextProgress = vi.fn();
+const getTextProgress = vi.fn();
 const requireUser = vi.fn();
 
 vi.mock('$lib/server/texts/progress.js', async () => {
@@ -11,6 +12,7 @@ vi.mock('$lib/server/texts/progress.js', async () => {
   return {
     ...actual,
     setTextProgress: (...a: unknown[]) => setTextProgress(...a),
+    getTextProgress: (...a: unknown[]) => getTextProgress(...a),
   };
 });
 
@@ -51,8 +53,31 @@ async function callPatch(
   }
 }
 
+type GetFn = (typeof import('./+server.js'))['GET'];
+
+async function callGet(textId = VALID_ID, user: typeof USER | null = USER) {
+  if (user) {
+    requireUser.mockResolvedValueOnce(user);
+  } else {
+    requireUser.mockImplementationOnce(() => {
+      throw { status: 401 };
+    });
+  }
+  const { GET } = await import('./+server.js');
+  const event = {
+    params: { textId },
+    request: new Request(`http://x/api/v1/me/text-progress/${textId}`),
+  } as unknown as Parameters<GetFn>[0];
+  try {
+    return await GET(event);
+  } catch (e) {
+    return e as { status: number };
+  }
+}
+
 beforeEach(() => {
   setTextProgress.mockReset();
+  getTextProgress.mockReset();
   requireUser.mockReset();
 });
 
@@ -119,6 +144,44 @@ describe('PATCH /api/v1/me/text-progress/:textId', () => {
     const res = (await callPatch({ chapterIdx: 0 }, VALID_ID, null)) as {
       status: number;
     };
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('GET /api/v1/me/text-progress/:textId', () => {
+  it('returns the saved progress row', async () => {
+    getTextProgress.mockResolvedValueOnce({
+      userId: USER.id,
+      textId: VALID_ID,
+      lastChapterIdx: 2,
+      lastTokenIdx: 40,
+      pctRead: 15,
+      updatedAt: new Date('2026-04-27T00:00:00Z'),
+    });
+    const res = (await callGet()) as Response;
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.progress.lastChapterIdx).toBe(2);
+    expect(json.progress.lastTokenIdx).toBe(40);
+    expect(getTextProgress).toHaveBeenCalledWith(USER.id, VALID_ID);
+  });
+
+  it('returns null when there is no saved progress', async () => {
+    getTextProgress.mockResolvedValueOnce(null);
+    const res = (await callGet()) as Response;
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.progress).toBeNull();
+  });
+
+  it('rejects an invalid uuid with 400', async () => {
+    const res = (await callGet('not-a-uuid')) as { status: number };
+    expect(res.status).toBe(400);
+    expect(getTextProgress).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const res = (await callGet(VALID_ID, null)) as { status: number };
     expect(res.status).toBe(401);
   });
 });


### PR DESCRIPTION
**Stacked on #455** (base = `fix/android-language-selection`); merge that first. Once it lands I'll retarget this to `main`.

## 1. Resume reading position
The reader restores where you left off and writes progress back as you read.
- **Server:** new `GET /api/v1/me/text-progress/:textId` — companion to the existing PATCH — so API clients can read the saved anchor (the web reader already reads it server-side). `requireUser`; returns `null` when there's none.
- **Android:** `ReaderRepository.progress()/saveProgress()`; `ReaderViewModel` restores the saved chapter (clamped to range) + token on open and **debounces** write-back (800ms) of `{chapterIdx, tokenIdx, pctRead}` as you scroll; `ReaderScreen` maps scroll↔token via the text layout, with a fresh scroll position per chapter.

## 2. Respect dark mode
The window theme was `android:Theme.Material.Light.NoActionBar` with no `values-night` variant, so the window background/splash stayed light in system dark mode (the Compose `MaterialTheme` was already dark-aware). Added a `values-night` theme with the framework dark Material parent.

## Tests (61 Android unit/UI + web suite, lint clean)
Server GET cases; repository progress mapping; ViewModel restore + debounced write; DTO serialization. Dark-mode change is resource-only (build + lint verified).
