### PR TITLE
feat(android): reader romanization toggle + RTL

### DIFF
--- a/apps/android/app/src/main/java/com/ciareader/reader/core/settings/SettingsStore.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/core/settings/SettingsStore.kt
@@ -1,6 +1,7 @@
 package com.ciareader.reader.core.settings
 
 import android.content.Context
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
@@ -22,6 +23,10 @@ interface SettingsStore {
     val currentLanguage: Flow<String?>
     suspend fun currentLanguage(): String?
     suspend fun setCurrentLanguage(code: String)
+
+    /** Whether the reader shows romanization in place of the native script. */
+    suspend fun showRomanization(): Boolean
+    suspend fun setShowRomanization(value: Boolean)
 }
 
 private val Context.settingsDataStore by preferencesDataStore(name = "settings")
@@ -40,7 +45,15 @@ class DataStoreSettingsStore @Inject constructor(
         context.settingsDataStore.edit { it[CURRENT_LANGUAGE] = code }
     }
 
+    override suspend fun showRomanization(): Boolean =
+        context.settingsDataStore.data.map { it[SHOW_ROMANIZATION] ?: false }.first()
+
+    override suspend fun setShowRomanization(value: Boolean) {
+        context.settingsDataStore.edit { it[SHOW_ROMANIZATION] = value }
+    }
+
     private companion object {
         val CURRENT_LANGUAGE = stringPreferencesKey("current_language")
+        val SHOW_ROMANIZATION = booleanPreferencesKey("show_romanization")
     }
 }

--- a/apps/android/app/src/main/java/com/ciareader/reader/ui/reader/ReaderScreen.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/ui/reader/ReaderScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
@@ -67,6 +68,7 @@ fun ReaderScreen(onBack: () -> Unit, viewModel: ReaderViewModel = hiltViewModel(
         onSetStatus = viewModel::setStatus,
         onRecordPosition = viewModel::recordPosition,
         onRestoreConsumed = viewModel::onRestoreConsumed,
+        onToggleRomanize = viewModel::toggleRomanization,
     )
 }
 
@@ -82,6 +84,7 @@ internal fun ReaderScreenContent(
     onSetStatus: (KnownStatus) -> Unit,
     onRecordPosition: (Int, Double) -> Unit,
     onRestoreConsumed: () -> Unit,
+    onToggleRomanize: () -> Unit,
 ) {
     Scaffold(
         topBar = {
@@ -94,6 +97,11 @@ internal fun ReaderScreenContent(
                     )
                 },
                 navigationIcon = { TextButton(onClick = onBack) { Text("Back") } },
+                actions = {
+                    TextButton(onClick = onToggleRomanize) {
+                        Text(if (state.romanize) "Native" else "Romanize")
+                    }
+                },
             )
         },
         bottomBar = {
@@ -124,6 +132,8 @@ internal fun ReaderScreenContent(
                 else ->
                     ChapterText(
                         tokens = state.tokens,
+                        romanize = state.romanize,
+                        rtl = state.isRtl,
                         onWordTap = onWordTap,
                         restoreTokenIdx = state.restoreTokenIdx,
                         onRecordPosition = onRecordPosition,
@@ -147,9 +157,15 @@ internal fun ReaderScreenContent(
     }
 }
 
+/** The text to render for a token — romanization for words when enabled. */
+private fun displayText(token: ReaderToken, romanize: Boolean): String =
+    if (romanize && token.isWord) token.romanization ?: token.surface else token.surface
+
 @Composable
 private fun ChapterText(
     tokens: List<ReaderToken>,
+    romanize: Boolean,
+    rtl: Boolean,
     onWordTap: (ReaderToken) -> Unit,
     restoreTokenIdx: Int?,
     onRecordPosition: (Int, Double) -> Unit,
@@ -159,18 +175,19 @@ private fun ChapterText(
     val scheme = MaterialTheme.colorScheme
     // One AnnotatedString for proper text flow, plus per-token char ranges so a
     // tap maps back to the token under the finger.
-    val annotated = remember(tokens, scheme) {
+    val annotated = remember(tokens, scheme, romanize) {
         buildAnnotatedString {
             tokens.forEach { token ->
-                withStyle(spanStyleFor(token, scheme)) { append(token.surface) }
+                withStyle(spanStyleFor(token, scheme)) { append(displayText(token, romanize)) }
             }
         }
     }
-    val ranges = remember(tokens) {
+    val ranges = remember(tokens, romanize) {
         var offset = 0
         tokens.map { token ->
+            val text = displayText(token, romanize)
             val start = offset
-            offset += token.surface.length
+            offset += text.length
             start until offset
         }
     }
@@ -208,7 +225,10 @@ private fun ChapterText(
     Text(
         text = annotated,
         onTextLayout = { layout = it },
-        style = MaterialTheme.typography.bodyLarge,
+        style = MaterialTheme.typography.bodyLarge.copy(
+            textDirection = if (rtl) TextDirection.Rtl else TextDirection.Content,
+            textAlign = if (rtl) TextAlign.Right else TextAlign.Start,
+        ),
         modifier = modifier
             .verticalScroll(scrollState)
             .padding(16.dp)

--- a/apps/android/app/src/main/java/com/ciareader/reader/ui/reader/ReaderScreen.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/ui/reader/ReaderScreen.kt
@@ -21,6 +21,8 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconToggleButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
@@ -37,6 +39,7 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.buildAnnotatedString
@@ -48,6 +51,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.ciareader.reader.R
 import com.ciareader.reader.data.dictionary.LemmaTranslations
 import com.ciareader.reader.data.dictionary.WordTranslation
 import com.ciareader.reader.data.reader.KnownStatus
@@ -98,8 +102,18 @@ internal fun ReaderScreenContent(
                 },
                 navigationIcon = { TextButton(onClick = onBack) { Text("Back") } },
                 actions = {
-                    TextButton(onClick = onToggleRomanize) {
-                        Text(if (state.romanize) "Native" else "Romanize")
+                    IconToggleButton(
+                        checked = state.romanize,
+                        onCheckedChange = { onToggleRomanize() },
+                    ) {
+                        Icon(
+                            painter = painterResource(R.drawable.ic_translate),
+                            contentDescription = if (state.romanize) {
+                                "Show native script"
+                            } else {
+                                "Show romanization"
+                            },
+                        )
                     }
                 },
             )

--- a/apps/android/app/src/main/java/com/ciareader/reader/ui/reader/ReaderViewModel.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/ui/reader/ReaderViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ciareader.reader.core.network.Outcome
+import com.ciareader.reader.core.settings.SettingsStore
 import com.ciareader.reader.data.dictionary.DictionaryRepository
 import com.ciareader.reader.data.dictionary.LemmaTranslations
 import com.ciareader.reader.data.reader.KnownStatus
@@ -29,6 +30,8 @@ data class ReaderUiState(
     val wordTranslations: LemmaTranslations? = null,
     val isWordLoading: Boolean = false,
     val restoreTokenIdx: Int? = null,
+    val romanize: Boolean = false,
+    val isRtl: Boolean = false,
     val errorMessage: String? = null,
 ) {
     val hasPrev: Boolean get() = chapterIdx > 0
@@ -39,6 +42,7 @@ data class ReaderUiState(
 class ReaderViewModel @Inject constructor(
     private val repository: ReaderRepository,
     private val dictionary: DictionaryRepository,
+    private val settings: SettingsStore,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
@@ -63,7 +67,14 @@ class ReaderViewModel @Inject constructor(
 
                 is Outcome.Success -> {
                     val chapterCount = meta.data.chapterCount.coerceAtLeast(1)
-                    _state.update { it.copy(title = meta.data.title, chapterCount = chapterCount) }
+                    _state.update {
+                        it.copy(
+                            title = meta.data.title,
+                            chapterCount = chapterCount,
+                            romanize = settings.showRomanization(),
+                            isRtl = isRtlLanguage(meta.data.language),
+                        )
+                    }
                     // Resume where the reader left off (chapter clamped to range);
                     // restore the token only within that saved chapter.
                     val saved = when (val p = repository.progress(textId)) {
@@ -161,11 +172,20 @@ class ReaderViewModel @Inject constructor(
     /** The UI has scrolled to the restored anchor; don't scroll there again. */
     fun onRestoreConsumed() = _state.update { it.copy(restoreTokenIdx = null) }
 
+    /** Toggle native ⇄ romanized rendering and remember the choice. */
+    fun toggleRomanization() {
+        val next = !_state.value.romanize
+        _state.update { it.copy(romanize = next) }
+        viewModelScope.launch { settings.setShowRomanization(next) }
+    }
+
     fun retry() {
         if (_state.value.title.isEmpty()) loadInitial() else loadChapter(_state.value.chapterIdx)
     }
 
     private companion object {
         const val PROGRESS_DEBOUNCE_MS = 800L
+        private val RTL_LANGUAGES = setOf("yi", "ur", "fa", "ar", "he", "sd")
+        fun isRtlLanguage(code: String) = code.lowercase() in RTL_LANGUAGES
     }
 }

--- a/apps/android/app/src/main/res/drawable/ic_translate.xml
+++ b/apps/android/app/src/main/res/drawable/ic_translate.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12.87,15.07l-2.54,-2.51 0.03,-0.03c1.74,-1.94 2.98,-4.17 3.71,-6.53L17,6L17,4h-7L10,2L8,2v2L1,4v1.99h11.17C11.5,7.92 10.44,9.75 9,11.35 8.07,10.32 7.3,9.19 6.69,8h-2c0.73,1.63 1.73,3.17 2.98,4.56l-5.09,5.02L4,19l5,-5 3.11,3.11 0.76,-2.04zM18.5,10h-2L12,22h2l1.12,-3h4.75L21,22h2l-4.5,-12zM15.88,17l1.62,-4.33L19.12,17h-3.24z" />
+</vector>

--- a/apps/android/app/src/test/java/com/ciareader/reader/ui/library/LibraryViewModelTest.kt
+++ b/apps/android/app/src/test/java/com/ciareader/reader/ui/library/LibraryViewModelTest.kt
@@ -191,4 +191,10 @@ private class FakeSettingsStore(initial: String? = null) : SettingsStore {
     override suspend fun setCurrentLanguage(code: String) {
         state.value = code
     }
+
+    private var romanize = false
+    override suspend fun showRomanization(): Boolean = romanize
+    override suspend fun setShowRomanization(value: Boolean) {
+        romanize = value
+    }
 }

--- a/apps/android/app/src/test/java/com/ciareader/reader/ui/reader/ReaderScreenTest.kt
+++ b/apps/android/app/src/test/java/com/ciareader/reader/ui/reader/ReaderScreenTest.kt
@@ -48,11 +48,41 @@ class ReaderScreenTest {
                     onSetStatus = {},
                     onRecordPosition = { _, _ -> },
                     onRestoreConsumed = {},
+                    onToggleRomanize = {},
                 )
             }
         }
         compose.onNodeWithText("My Book").assertIsDisplayed()
         compose.onNodeWithText("Hello world").assertIsDisplayed()
+    }
+
+    @Test
+    fun rendersRomanizationWhenEnabled() {
+        compose.setContent {
+            CiaReaderTheme {
+                ReaderScreenContent(
+                    state = ReaderUiState(
+                        isLoading = false,
+                        title = "Book",
+                        romanize = true,
+                        tokens = listOf(
+                            ReaderToken(0, "नमस्ते", true, KnownStatus.UNKNOWN, "l1", "namaste", null, false, false, true),
+                        ),
+                    ),
+                    onBack = {},
+                    onWordTap = {},
+                    onDismissWord = {},
+                    onPrevChapter = {},
+                    onNextChapter = {},
+                    onRetry = {},
+                    onSetStatus = {},
+                    onRecordPosition = { _, _ -> },
+                    onRestoreConsumed = {},
+                    onToggleRomanize = {},
+                )
+            }
+        }
+        compose.onNodeWithText("namaste").assertIsDisplayed()
     }
 
     @Test
@@ -71,6 +101,7 @@ class ReaderScreenTest {
                     onSetStatus = {},
                     onRecordPosition = { _, _ -> },
                     onRestoreConsumed = {},
+                    onToggleRomanize = {},
                 )
             }
         }

--- a/apps/android/app/src/test/java/com/ciareader/reader/ui/reader/ReaderScreenTest.kt
+++ b/apps/android/app/src/test/java/com/ciareader/reader/ui/reader/ReaderScreenTest.kt
@@ -3,6 +3,7 @@ package com.ciareader.reader.ui.reader
 import android.app.Application
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.ciareader.reader.data.dictionary.LemmaTranslations
@@ -83,6 +84,30 @@ class ReaderScreenTest {
             }
         }
         compose.onNodeWithText("namaste").assertIsDisplayed()
+    }
+
+    @Test
+    fun romanizeToggleInvokesCallback() {
+        var toggled = false
+        compose.setContent {
+            CiaReaderTheme {
+                ReaderScreenContent(
+                    state = ReaderUiState(isLoading = false, title = "Book"),
+                    onBack = {},
+                    onWordTap = {},
+                    onDismissWord = {},
+                    onPrevChapter = {},
+                    onNextChapter = {},
+                    onRetry = {},
+                    onSetStatus = {},
+                    onRecordPosition = { _, _ -> },
+                    onRestoreConsumed = {},
+                    onToggleRomanize = { toggled = true },
+                )
+            }
+        }
+        compose.onNodeWithContentDescription("Show romanization").performClick()
+        assertTrue(toggled)
     }
 
     @Test

--- a/apps/android/app/src/test/java/com/ciareader/reader/ui/reader/ReaderViewModelTest.kt
+++ b/apps/android/app/src/test/java/com/ciareader/reader/ui/reader/ReaderViewModelTest.kt
@@ -2,6 +2,7 @@ package com.ciareader.reader.ui.reader
 
 import androidx.lifecycle.SavedStateHandle
 import com.ciareader.reader.core.network.Outcome
+import com.ciareader.reader.core.settings.SettingsStore
 import com.ciareader.reader.data.dictionary.DictionaryRepository
 import com.ciareader.reader.data.dictionary.LemmaTranslations
 import com.ciareader.reader.data.dictionary.WordTranslation
@@ -14,12 +15,15 @@ import com.ciareader.reader.data.reader.ReadingProgress
 import com.ciareader.reader.data.reader.TextMeta
 import com.ciareader.reader.util.MainDispatcherRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 
@@ -29,8 +33,11 @@ class ReaderViewModelTest {
     @get:Rule
     val mainRule = MainDispatcherRule()
 
-    private fun vm(repo: ReaderRepository, dict: DictionaryRepository = FakeDictionaryRepository()) =
-        ReaderViewModel(repo, dict, SavedStateHandle(mapOf("textId" to "t1")))
+    private fun vm(
+        repo: ReaderRepository,
+        dict: DictionaryRepository = FakeDictionaryRepository(),
+        settings: SettingsStore = FakeSettingsStore(),
+    ) = ReaderViewModel(repo, dict, settings, SavedStateHandle(mapOf("textId" to "t1")))
 
     @Test
     fun loadsTitleAndFirstChapter() = runTest(mainRule.dispatcher) {
@@ -166,13 +173,55 @@ class ReaderViewModelTest {
         assertEquals(ReadingProgress(0, 12, 30.0), repo.lastSaved)
     }
 
+    @Test
+    fun togglesRomanizationAndPersists() = runTest(mainRule.dispatcher) {
+        val repo = FakeReaderRepository(meta = meta(1), chapters = mapOf(0 to Chapter(0, listOf(word("a")))))
+        val settings = FakeSettingsStore(romanization = false)
+        val v = vm(repo, settings = settings)
+        advanceUntilIdle()
+
+        assertFalse(v.state.value.romanize)
+        v.toggleRomanization()
+        advanceUntilIdle()
+
+        assertTrue(v.state.value.romanize)
+        assertEquals(true, settings.lastSetRomanization)
+    }
+
+    @Test
+    fun restoresRomanizationPreference() = runTest(mainRule.dispatcher) {
+        val repo = FakeReaderRepository(meta = meta(1), chapters = mapOf(0 to Chapter(0, listOf(word("a")))))
+        val v = vm(repo, settings = FakeSettingsStore(romanization = true))
+        advanceUntilIdle()
+
+        assertTrue(v.state.value.romanize)
+    }
+
+    @Test
+    fun marksRtlForHebrewScriptLanguage() = runTest(mainRule.dispatcher) {
+        val repo = FakeReaderRepository(meta = meta(1, language = "yi"), chapters = mapOf(0 to Chapter(0, emptyList())))
+        val v = vm(repo)
+        advanceUntilIdle()
+
+        assertTrue(v.state.value.isRtl)
+    }
+
+    @Test
+    fun leftToRightForOtherLanguages() = runTest(mainRule.dispatcher) {
+        val repo = FakeReaderRepository(meta = meta(1, language = "hi"), chapters = mapOf(0 to Chapter(0, emptyList())))
+        val v = vm(repo)
+        advanceUntilIdle()
+
+        assertFalse(v.state.value.isRtl)
+    }
+
     private fun word(surface: String) =
         ReaderToken(0, surface, true, KnownStatus.UNKNOWN, null, null, null, false, false, false)
 
-    private fun meta(chapterCount: Int) = TextMeta(
+    private fun meta(chapterCount: Int, language: String = "hi") = TextMeta(
         id = "t1",
         title = "Book",
-        language = "hi",
+        language = language,
         status = "ready",
         chapterCount = chapterCount,
         chapters = (0 until chapterCount).map { ChapterRef(it, "c$it", 1) },
@@ -217,4 +266,17 @@ private class FakeDictionaryRepository(
 
     override suspend fun setStatus(lemmaId: String, status: KnownStatus): Outcome<KnownStatus> =
         Outcome.Success(status)
+}
+
+private class FakeSettingsStore(
+    private val romanization: Boolean = false,
+) : SettingsStore {
+    var lastSetRomanization: Boolean? = null
+    override val currentLanguage: Flow<String?> = MutableStateFlow(null)
+    override suspend fun currentLanguage(): String? = null
+    override suspend fun setCurrentLanguage(code: String) {}
+    override suspend fun showRomanization(): Boolean = romanization
+    override suspend fun setShowRomanization(value: Boolean) {
+        lastSetRomanization = value
+    }
 }


### PR DESCRIPTION
Reader display options. Branches off `main` (resume + dark mode from #456 are merged). apps/android only.

## Romanization toggle
A top-bar toggle switches word rendering between **native script** and **romanization** (`token.romanization`, falling back to the surface form). Persisted in `SettingsStore` like the language choice, so it sticks across launches. Latin-script languages (Basque — no romanization) are unaffected.

> Note: true interlinear "ruby" (romanization *above* each word, like the web) isn't feasible in the reader's single flowing `Text`; this is the native⇄romanized swap.

## RTL
The reader lays out **right-to-left** for Hebrew/Arabic-script languages (`yi`, `ur`, …), derived from the text's language — `textDirection` + right alignment. (Not end-to-end testable until a Yiddish text exists, but the detection + layout are unit-tested.)

## Tests (66 unit/UI, lint clean)
`ReaderViewModel`: toggle persistence, romanization-preference restore on open, RTL/LTR detection. `ReaderScreen`: renders romanization when enabled.
