### PR TITLE
feat(android): reader progress bar + position polish

### DIFF
--- a/apps/android/app/src/main/java/com/ciareader/reader/ui/reader/ReaderScreen.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/ui/reader/ReaderScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
@@ -104,6 +105,7 @@ fun ReaderScreen(
             val tid = ref.textId
             if (tid != null) onOpenChapterText(tid) else ref.chapterIdx?.let { viewModel.loadChapter(it) }
         },
+        onProgress = viewModel::setProgress,
     )
 }
 
@@ -124,6 +126,7 @@ internal fun ReaderScreenContent(
     onSetFontSize: (Int) -> Unit = {},
     onSetLineSpacing: (Float) -> Unit = {},
     onSelectChapter: (ReaderChapterRef) -> Unit = {},
+    onProgress: (Float) -> Unit = {},
 ) {
     var showSettings by remember { mutableStateOf(false) }
     var showChapters by remember { mutableStateOf(false) }
@@ -193,6 +196,7 @@ internal fun ReaderScreenContent(
                         onPrev = onPrevChapter,
                         onNext = onNextChapter,
                         onWordTap = onWordTap,
+                        onProgress = onProgress,
                         modifier = Modifier.fillMaxSize(),
                     )
 
@@ -207,8 +211,17 @@ internal fun ReaderScreenContent(
                         restoreTokenIdx = state.restoreTokenIdx,
                         onRecordPosition = onRecordPosition,
                         onRestoreConsumed = onRestoreConsumed,
+                        onProgress = onProgress,
                         modifier = Modifier.fillMaxSize(),
                     )
+            }
+            if (!state.isLoading && state.errorMessage == null) {
+                LinearProgressIndicator(
+                    progress = { state.progress },
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .fillMaxWidth(),
+                )
             }
         }
     }
@@ -268,6 +281,7 @@ private fun ChapterText(
     restoreTokenIdx: Int?,
     onRecordPosition: (Int, Double) -> Unit,
     onRestoreConsumed: () -> Unit,
+    onProgress: (Float) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val scheme = MaterialTheme.colorScheme
@@ -317,6 +331,7 @@ private fun ChapterText(
                 0.0
             }
             onRecordPosition(tokenIdx, pct)
+            onProgress((pct / 100.0).toFloat())
         }
     }
 
@@ -357,6 +372,7 @@ private fun PagedChapter(
     onPrev: () -> Unit,
     onNext: () -> Unit,
     onWordTap: (ReaderToken) -> Unit,
+    onProgress: (Float) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val scheme = MaterialTheme.colorScheme
@@ -426,6 +442,11 @@ private fun PagedChapter(
                     leading == 1 && settled == 0 -> onPrev()
                     trailing == 1 && settled == total - 1 -> onNext()
                 }
+            }
+        }
+        LaunchedEffect(pagerState, total) {
+            snapshotFlow { pagerState.currentPage }.collect { p ->
+                onProgress(if (total > 1) p.toFloat() / (total - 1) else 0f)
             }
         }
 

--- a/apps/android/app/src/main/java/com/ciareader/reader/ui/reader/ReaderScreen.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/ui/reader/ReaderScreen.kt
@@ -2,6 +2,7 @@
 
 package com.ciareader.reader.ui.reader
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
@@ -15,6 +16,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.lazy.LazyColumn
@@ -216,12 +218,24 @@ internal fun ReaderScreenContent(
                     )
             }
             if (!state.isLoading && state.errorMessage == null) {
-                LinearProgressIndicator(
-                    progress = { state.progress },
+                Row(
                     modifier = Modifier
                         .align(Alignment.BottomCenter)
-                        .fillMaxWidth(),
-                )
+                        .fillMaxWidth()
+                        .background(MaterialTheme.colorScheme.surface)
+                        .padding(horizontal = 12.dp, vertical = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    LinearProgressIndicator(
+                        progress = { state.bookProgress },
+                        modifier = Modifier.weight(1f),
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text(
+                        "${(state.bookProgress * 100).roundToInt()}%",
+                        style = MaterialTheme.typography.labelMedium,
+                    )
+                }
             }
         }
     }

--- a/apps/android/app/src/main/java/com/ciareader/reader/ui/reader/ReaderViewModel.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/ui/reader/ReaderViewModel.kt
@@ -27,6 +27,7 @@ data class ReaderChapterRef(
     val textId: String?,   // a separate chapter-text within a book (collection)
     val chapterIdx: Int?,  // a chapter within this text
     val isCurrent: Boolean,
+    val wordCount: Int = 0,
 )
 
 data class ReaderUiState(
@@ -59,6 +60,24 @@ data class ReaderUiState(
      *  chapter-text when reading a book (collection). */
     val canGoPrev: Boolean get() = hasPrev || prevTextId != null
     val canGoNext: Boolean get() = hasNext || nextTextId != null
+
+    /** Progress through the whole book — chapters before the current one count
+     *  fully, plus the within-chapter fraction — weighted by chapter word counts
+     *  when known, else evenly. Falls back to the chapter fraction for a
+     *  standalone text with no chapter list. */
+    val bookProgress: Float
+        get() {
+            if (chapters.isEmpty()) return progress
+            val idx = chapters.indexOfFirst { it.isCurrent }.coerceAtLeast(0)
+            val weights = chapters.map { it.wordCount.coerceAtLeast(0) }
+            val total = weights.sum()
+            return if (total > 0) {
+                val before = weights.take(idx).sum()
+                ((before + progress * weights[idx]) / total).coerceIn(0f, 1f)
+            } else {
+                ((idx + progress) / chapters.size).coerceIn(0f, 1f)
+            }
+        }
 }
 
 @HiltViewModel
@@ -118,7 +137,13 @@ class ReaderViewModel @Inject constructor(
                         _state.update { s ->
                             s.copy(
                                 chapters = meta.data.chapters.map { c ->
-                                    ReaderChapterRef(c.title, textId = null, chapterIdx = c.idx, isCurrent = c.idx == startChapter)
+                                    ReaderChapterRef(
+                                        c.title,
+                                        textId = null,
+                                        chapterIdx = c.idx,
+                                        isCurrent = c.idx == startChapter,
+                                        wordCount = c.tokenCount,
+                                    )
                                 },
                             )
                         }

--- a/apps/android/app/src/main/java/com/ciareader/reader/ui/reader/ReaderViewModel.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/ui/reader/ReaderViewModel.kt
@@ -78,6 +78,7 @@ class ReaderViewModel @Inject constructor(
     val state: StateFlow<ReaderUiState> = _state.asStateFlow()
 
     private var progressJob: Job? = null
+    private var currentTopToken = 0
 
     init {
         loadInitial()
@@ -204,6 +205,7 @@ class ReaderViewModel @Inject constructor(
 
     /** Debounced reading-progress write-back as the user scrolls. */
     fun recordPosition(tokenIdx: Int, pctRead: Double) {
+        currentTopToken = tokenIdx
         progressJob?.cancel()
         progressJob = viewModelScope.launch {
             delay(PROGRESS_DEBOUNCE_MS)
@@ -234,14 +236,15 @@ class ReaderViewModel @Inject constructor(
     /** Reader body font size in sp, clamped + remembered. */
     fun setFontSize(sp: Int) {
         val v = sp.coerceIn(FONT_SIZE_MIN, FONT_SIZE_MAX)
-        _state.update { it.copy(fontSize = v) }
+        // Re-anchor to the current top word so resizing doesn't lose your place.
+        _state.update { it.copy(fontSize = v, restoreTokenIdx = currentTopToken) }
         viewModelScope.launch { settings.setFontSizeSp(v) }
     }
 
     /** Reader line-height multiple, clamped + remembered. */
     fun setLineSpacing(value: Float) {
         val v = value.coerceIn(LINE_SPACING_MIN, LINE_SPACING_MAX)
-        _state.update { it.copy(lineSpacing = v) }
+        _state.update { it.copy(lineSpacing = v, restoreTokenIdx = currentTopToken) }
         viewModelScope.launch { settings.setLineSpacing(v) }
     }
 

--- a/apps/android/app/src/main/java/com/ciareader/reader/ui/reader/ReaderViewModel.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/ui/reader/ReaderViewModel.kt
@@ -49,6 +49,7 @@ data class ReaderUiState(
     val chapters: List<ReaderChapterRef> = emptyList(),
     val fontSize: Int = SettingsStore.DEFAULT_FONT_SIZE_SP,
     val lineSpacing: Float = SettingsStore.DEFAULT_LINE_SPACING,
+    val progress: Float = 0f,
     val errorMessage: String? = null,
 ) {
     val hasPrev: Boolean get() = chapterIdx > 0
@@ -212,6 +213,9 @@ class ReaderViewModel @Inject constructor(
 
     /** The UI has scrolled to the restored anchor; don't scroll there again. */
     fun onRestoreConsumed() = _state.update { it.copy(restoreTokenIdx = null) }
+
+    /** Live reading-progress fraction (0..1) for the bottom bar. UI-only. */
+    fun setProgress(fraction: Float) = _state.update { it.copy(progress = fraction.coerceIn(0f, 1f)) }
 
     /** Toggle native ⇄ romanized rendering and remember the choice. */
     fun toggleRomanization() {

--- a/apps/android/app/src/test/java/com/ciareader/reader/ui/reader/ReaderViewModelTest.kt
+++ b/apps/android/app/src/test/java/com/ciareader/reader/ui/reader/ReaderViewModelTest.kt
@@ -329,6 +329,32 @@ class ReaderViewModelTest {
         assertEquals(5, v.state.value.restoreTokenIdx)
     }
 
+    @Test
+    fun bookProgressIsEvenAcrossChaptersWithoutWordCounts() {
+        val s = ReaderUiState(
+            chapters = listOf(
+                ReaderChapterRef("a", "t0", null, isCurrent = false),
+                ReaderChapterRef("b", "t1", null, isCurrent = true),
+                ReaderChapterRef("c", "t2", null, isCurrent = false),
+                ReaderChapterRef("d", "t3", null, isCurrent = false),
+            ),
+            progress = 0.5f,
+        )
+        assertEquals(0.375f, s.bookProgress, 0.0001f) // (1 + 0.5) / 4
+    }
+
+    @Test
+    fun bookProgressIsWeightedByWordCounts() {
+        val s = ReaderUiState(
+            chapters = listOf(
+                ReaderChapterRef("a", "t0", null, isCurrent = false, wordCount = 100),
+                ReaderChapterRef("b", "t1", null, isCurrent = true, wordCount = 300),
+            ),
+            progress = 0.5f,
+        )
+        assertEquals(0.625f, s.bookProgress, 0.0001f) // (100 + 0.5*300) / 400
+    }
+
     private fun word(surface: String) =
         ReaderToken(0, surface, true, KnownStatus.UNKNOWN, null, null, null, false, false, false)
 

--- a/apps/android/app/src/test/java/com/ciareader/reader/ui/reader/ReaderViewModelTest.kt
+++ b/apps/android/app/src/test/java/com/ciareader/reader/ui/reader/ReaderViewModelTest.kt
@@ -316,6 +316,19 @@ class ReaderViewModelTest {
         assertEquals(2.0f, v.state.value.lineSpacing, 0.0001f)
     }
 
+    @Test
+    fun fontChangeReanchorsToCurrentTopWord() = runTest(mainRule.dispatcher) {
+        val repo = FakeReaderRepository(meta = meta(1), chapters = mapOf(0 to Chapter(0, listOf(word("a")))))
+        val v = vm(repo)
+        advanceUntilIdle()
+
+        v.recordPosition(tokenIdx = 5, pctRead = 20.0) // user scrolled; top word = token 5
+        advanceUntilIdle()
+        v.setFontSize(22)
+
+        assertEquals(5, v.state.value.restoreTokenIdx)
+    }
+
     private fun word(surface: String) =
         ReaderToken(0, surface, true, KnownStatus.UNKNOWN, null, null, null, false, false, false)
 


### PR DESCRIPTION
Reader progress + position polish. Off `main`. apps/android (+ a small server addition coming for word counts).

- [x] **Progress bar + counter — book-wide.** Bottom bar reflects progress through the whole book (chapters before the current count fully + within-chapter fraction), weighted by chapter word counts when known, with a % counter beside it.
- [x] **Keep your place on font/line change** (continuous mode re-anchors to the top word).
- [ ] **Chapter word counts in the TOC** — needs the collection-detail endpoint to sum `text_chapters.token_count` per chapter-text; then the TOC shows "N words" and book progress becomes word-weighted for books too.
- [ ] Page-mode re-anchor + brief highlight of the anchor word on settings close.

Tests green (85 unit/UI, lint clean).
