### PR TITLE
feat(android): X back button + chapter word counts

### DIFF
--- a/apps/android/app/src/main/java/com/ciareader/reader/data/collection/CollectionDtos.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/data/collection/CollectionDtos.kt
@@ -41,4 +41,5 @@ data class CollectionItemTextDto(
     val id: String,
     val title: String,
     val status: String,
+    val wordCount: Int = 0,
 )

--- a/apps/android/app/src/main/java/com/ciareader/reader/data/collection/CollectionRepository.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/data/collection/CollectionRepository.kt
@@ -19,6 +19,7 @@ data class CollectionChapter(
     val title: String,
     val position: Int,
     val status: String,
+    val wordCount: Int = 0,
 ) {
     val isReady: Boolean get() = status == "ready"
 }
@@ -64,6 +65,7 @@ class CollectionRepositoryImpl @Inject constructor(
                         title = it.text.title,
                         position = it.position,
                         status = it.text.status,
+                        wordCount = it.text.wordCount,
                     )
                 },
             )

--- a/apps/android/app/src/main/java/com/ciareader/reader/ui/reader/ReaderScreen.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/ui/reader/ReaderScreen.kt
@@ -160,7 +160,11 @@ internal fun ReaderScreenContent(
                         }
                     }
                 },
-                navigationIcon = { TextButton(onClick = onBack) { Text("Back") } },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(painter = painterResource(R.drawable.ic_close), contentDescription = "Close")
+                    }
+                },
                 actions = {
                     IconButton(onClick = { showSettings = true }) {
                         Icon(
@@ -558,16 +562,24 @@ internal fun ChapterListSheet(
                     .padding(horizontal = 24.dp, vertical = 12.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Text(
-                    ch.title,
-                    modifier = Modifier.weight(1f),
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = if (ch.isCurrent) {
-                        MaterialTheme.colorScheme.primary
-                    } else {
-                        MaterialTheme.colorScheme.onSurface
-                    },
-                )
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        ch.title,
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = if (ch.isCurrent) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.onSurface
+                        },
+                    )
+                    if (ch.wordCount > 0) {
+                        Text(
+                            "${ch.wordCount} words",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
                 if (ch.isCurrent) {
                     Text(
                         "Current",

--- a/apps/android/app/src/main/java/com/ciareader/reader/ui/reader/ReaderViewModel.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/ui/reader/ReaderViewModel.kt
@@ -281,7 +281,13 @@ class ReaderViewModel @Inject constructor(
                 val chapters = detail.data.chapters
                 val idx = chapters.indexOfFirst { it.textId == textId }
                 val refs = chapters.map {
-                    ReaderChapterRef(it.title, textId = it.textId, chapterIdx = null, isCurrent = it.textId == textId)
+                    ReaderChapterRef(
+                        it.title,
+                        textId = it.textId,
+                        chapterIdx = null,
+                        isCurrent = it.textId == textId,
+                        wordCount = it.wordCount,
+                    )
                 }
                 val prev = if (idx >= 0) chapters.getOrNull(idx - 1) else null
                 val next = if (idx >= 0) chapters.getOrNull(idx + 1) else null

--- a/apps/android/app/src/main/res/drawable/ic_close.xml
+++ b/apps/android/app/src/main/res/drawable/ic_close.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z" />
+</vector>

--- a/apps/android/app/src/test/java/com/ciareader/reader/ui/reader/ReaderScreenTest.kt
+++ b/apps/android/app/src/test/java/com/ciareader/reader/ui/reader/ReaderScreenTest.kt
@@ -120,7 +120,7 @@ class ReaderScreenTest {
             CiaReaderTheme {
                 ChapterListSheet(
                     chapters = listOf(
-                        ReaderChapterRef("Intro", textId = "t0", chapterIdx = null, isCurrent = false),
+                        ReaderChapterRef("Intro", textId = "t0", chapterIdx = null, isCurrent = false, wordCount = 1200),
                         ReaderChapterRef("Two", textId = "t1", chapterIdx = null, isCurrent = true),
                     ),
                     onSelect = { picked = it.textId },
@@ -128,6 +128,7 @@ class ReaderScreenTest {
             }
         }
         compose.onNodeWithText("Intro").assertIsDisplayed()
+        compose.onNodeWithText("1200 words").assertIsDisplayed()
         compose.onNodeWithText("Current").assertIsDisplayed()
         compose.onNodeWithText("Intro").performClick()
         assertEquals("t0", picked)

--- a/apps/android/app/src/test/java/com/ciareader/reader/ui/reader/ReaderViewModelTest.kt
+++ b/apps/android/app/src/test/java/com/ciareader/reader/ui/reader/ReaderViewModelTest.kt
@@ -259,9 +259,9 @@ class ReaderViewModelTest {
                 id = "c1",
                 title = "Book",
                 chapters = listOf(
-                    CollectionChapter("t0", "One", 0, "ready"),
-                    CollectionChapter("t1", "Two", 1, "ready"),
-                    CollectionChapter("t2", "Three", 2, "ready"),
+                    CollectionChapter("t0", "One", 0, "ready", wordCount = 100),
+                    CollectionChapter("t1", "Two", 1, "ready", wordCount = 200),
+                    CollectionChapter("t2", "Three", 2, "ready", wordCount = 300),
                 ),
             ),
         )
@@ -275,6 +275,7 @@ class ReaderViewModelTest {
         // Full chapter list for the TOC, with the current chapter flagged.
         assertEquals(listOf("t0", "t1", "t2"), v.state.value.chapters.map { it.textId })
         assertTrue(v.state.value.chapters[1].isCurrent)
+        assertEquals(200, v.state.value.chapters[1].wordCount)
     }
 
     @Test

--- a/apps/web/src/lib/server/collections.ts
+++ b/apps/web/src/lib/server/collections.ts
@@ -558,6 +558,9 @@ export type CollectionDetail = {
      *  `null` for flat collections + manually-curated ones. */
     sectionTitle: string | null;
     text: Text;
+    /** Total tokens across the chapter-text's chapters (for word counts /
+     *  book-progress weighting). */
+    wordCount: number;
   }>;
 };
 
@@ -571,6 +574,7 @@ export async function loadCollectionDetail(
       position: schema.collectionItems.position,
       sectionTitle: schema.collectionItems.sectionTitle,
       text: schema.texts,
+      wordCount: sql<number>`COALESCE((SELECT SUM(${schema.textChapters.tokenCount}) FROM ${schema.textChapters} WHERE ${schema.textChapters.textId} = ${schema.texts.id}), 0)::int`,
     })
     .from(schema.collectionItems)
     .innerJoin(
@@ -582,6 +586,7 @@ export async function loadCollectionDetail(
     position: number;
     sectionTitle: string | null;
     text: Text;
+    wordCount: number;
   }>;
   return { collection: c, items: rows };
 }

--- a/apps/web/src/routes/api/v1/collections/[id]/+server.ts
+++ b/apps/web/src/routes/api/v1/collections/[id]/+server.ts
@@ -116,6 +116,7 @@ export const GET: RequestHandler = async (event) => {
         status: item.text.status,
         visibility: item.text.visibility,
         createdAt: item.text.createdAt,
+        wordCount: item.wordCount,
       },
     })),
   });

--- a/apps/web/src/routes/api/v1/collections/[id]/collection-detail-server.test.ts
+++ b/apps/web/src/routes/api/v1/collections/[id]/collection-detail-server.test.ts
@@ -49,6 +49,7 @@ function detail(collectionOverrides: Record<string, unknown> = {}) {
       {
         position: 0,
         sectionTitle: null,
+        wordCount: 1234,
         text: {
           id: 'text-1',
           ownerId: OWNER.id,
@@ -111,7 +112,7 @@ describe('GET /api/v1/collections/:id', () => {
     expect(json.collection.id).toBe(ID);
     expect(json.items).toHaveLength(1);
     expect(json.items[0]).toMatchObject({ position: 0, sectionTitle: null });
-    expect(json.items[0].text).toMatchObject({ id: 'text-1', title: 'Ch 1' });
+    expect(json.items[0].text).toMatchObject({ id: 'text-1', title: 'Ch 1', wordCount: 1234 });
   });
 
   it('404s a private collection for a non-owner without a share', async () => {


### PR DESCRIPTION
Off `main`. Closes the ask-1/ask-2 follow-ups plus a small UI tweak.

## X back button
The reader's "Back" text button is now an **X (close) icon**.

## Chapter word counts (ask 2)
- **Server:** `GET /api/v1/collections/:id` now returns a `wordCount` per item (sum of the chapter-text's `text_chapters.token_count`).
- **App:** the chapter-list (TOC) sheet shows **"N words"** per chapter (like web), and book-wide progress is now **word-weighted for books** too (it already was for multi-chapter texts).

## Tests
Endpoint `wordCount`; TOC renders word counts; ViewModel exposes per-chapter `wordCount` + word-weighted `bookProgress`. Android 85 + web collection suites green, lint clean.
