### PR TITLE
feat(android): book resume — open to last-read or first chapter

### DIFF
--- a/apps/android/app/src/main/java/com/ciareader/reader/data/collection/CollectionDtos.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/data/collection/CollectionDtos.kt
@@ -11,6 +11,7 @@ data class MyCollectionsDto(val collections: List<CollectionListItemDto> = empty
 data class CollectionListItemDto(
     val collection: CollectionDto,
     val textCount: Int = 0,
+    val openTextId: String? = null,
 )
 
 @Serializable

--- a/apps/android/app/src/main/java/com/ciareader/reader/data/collection/CollectionRepository.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/data/collection/CollectionRepository.kt
@@ -12,6 +12,8 @@ data class CollectionSummary(
     val language: String,
     val kind: String,
     val textCount: Int,
+    /** Chapter-text to open when tapped: last-read, else the first chapter. */
+    val openTextId: String? = null,
 )
 
 data class CollectionChapter(
@@ -49,6 +51,7 @@ class CollectionRepositoryImpl @Inject constructor(
                     language = it.collection.language,
                     kind = it.collection.kind,
                     textCount = it.textCount,
+                    openTextId = it.openTextId,
                 )
             }
         }

--- a/apps/android/app/src/main/java/com/ciareader/reader/ui/library/LibraryScreen.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/ui/library/LibraryScreen.kt
@@ -38,7 +38,7 @@ import com.ciareader.reader.data.library.TextCard
 @Composable
 fun LibraryScreen(
     onOpenText: (String) -> Unit,
-    onOpenCollection: (String) -> Unit,
+    onOpenCollection: (CollectionSummary) -> Unit,
     onLogout: () -> Unit,
     viewModel: LibraryViewModel = hiltViewModel(),
 ) {
@@ -59,7 +59,7 @@ internal fun LibraryScreenContent(
     state: LibraryUiState,
     onSelectLanguage: (String) -> Unit,
     onOpenText: (String) -> Unit,
-    onOpenCollection: (String) -> Unit,
+    onOpenCollection: (CollectionSummary) -> Unit,
     onRetry: () -> Unit,
     onLogout: () -> Unit,
 ) {
@@ -109,7 +109,7 @@ internal fun LibraryScreenContent(
 private fun ContentList(
     collections: List<CollectionSummary>,
     texts: List<TextCard>,
-    onOpenCollection: (String) -> Unit,
+    onOpenCollection: (CollectionSummary) -> Unit,
     onOpenText: (String) -> Unit,
 ) {
     LazyColumn(modifier = Modifier.fillMaxSize()) {
@@ -121,7 +121,7 @@ private fun ContentList(
                     supportingContent = {
                         Text("${c.textCount} chapters", color = MaterialTheme.colorScheme.onSurfaceVariant)
                     },
-                    modifier = Modifier.clickable { onOpenCollection(c.id) },
+                    modifier = Modifier.clickable { onOpenCollection(c) },
                 )
                 HorizontalDivider()
             }

--- a/apps/android/app/src/main/java/com/ciareader/reader/ui/navigation/CiaReaderNavHost.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/ui/navigation/CiaReaderNavHost.kt
@@ -31,7 +31,16 @@ fun CiaReaderNavHost(onLogout: () -> Unit) {
         composable(Routes.LIBRARY) {
             LibraryScreen(
                 onOpenText = { textId -> navController.navigate(Routes.reader(textId)) },
-                onOpenCollection = { id -> navController.navigate(Routes.collection(id)) },
+                // Open a book straight to where you left off (or its first chapter);
+                // fall back to the chapter list only for an empty book.
+                onOpenCollection = { c ->
+                    val open = c.openTextId
+                    if (open != null) {
+                        navController.navigate(Routes.reader(open, c.id))
+                    } else {
+                        navController.navigate(Routes.collection(c.id))
+                    }
+                },
                 onLogout = onLogout,
             )
         }

--- a/apps/android/app/src/test/java/com/ciareader/reader/ui/library/LibraryScreenTest.kt
+++ b/apps/android/app/src/test/java/com/ciareader/reader/ui/library/LibraryScreenTest.kt
@@ -26,7 +26,7 @@ class LibraryScreenTest {
     private fun setContent(
         state: LibraryUiState,
         onOpenText: (String) -> Unit = {},
-        onOpenCollection: (String) -> Unit = {},
+        onOpenCollection: (CollectionSummary) -> Unit = {},
         onSelectLanguage: (String) -> Unit = {},
         onRetry: () -> Unit = {},
         onLogout: () -> Unit = {},
@@ -74,7 +74,7 @@ class LibraryScreenTest {
                     CollectionSummary("c1", "Afrika express", "eu", "chapter_book", 12),
                 ),
             ),
-            onOpenCollection = { opened = it },
+            onOpenCollection = { opened = it.id },
         )
         compose.onNodeWithText("Afrika express").assertIsDisplayed()
         compose.onNodeWithText("Afrika express").performClick()

--- a/apps/web/src/lib/server/collections.test.ts
+++ b/apps/web/src/lib/server/collections.test.ts
@@ -69,6 +69,11 @@ vi.mock('./db/index.js', () => ({
     },
     texts: { id: 't.id', language: 't.language', title: 't.title' },
     textChapters: { textId: 'tc.text_id', tokenCount: 'tc.token_count' },
+    userTextProgress: {
+      userId: 'utp.user_id',
+      textId: 'utp.text_id',
+      updatedAt: 'utp.updated_at',
+    },
     users: { id: 'u.id' },
   },
 }));
@@ -681,6 +686,25 @@ describe('listCollectionsForUser', () => {
     const out = await listCollectionsForUser(OWNER.id);
     expect(out).toHaveLength(2);
     expect(out[0]?.textCount).toBe(3);
+  });
+
+  it('openTextId resumes the most-recently-read chapter', async () => {
+    queue.push([{ collection: baseCollection, textCount: 2 }]); // collections + count
+    queue.push([
+      { collectionId: baseCollection.id, textId: 'text-b', updatedAt: new Date('2026-05-02') },
+      { collectionId: baseCollection.id, textId: 'text-a', updatedAt: new Date('2026-05-01') },
+    ]); // progress
+    queue.push([{ collectionId: baseCollection.id, textId: 'text-a' }]); // first chapter
+    const out = await listCollectionsForUser(OWNER.id);
+    expect(out[0]?.openTextId).toBe('text-b');
+  });
+
+  it('openTextId falls back to the first chapter when not started', async () => {
+    queue.push([{ collection: baseCollection, textCount: 2 }]);
+    queue.push([]); // no progress
+    queue.push([{ collectionId: baseCollection.id, textId: 'text-a' }]); // first chapter
+    const out = await listCollectionsForUser(OWNER.id);
+    expect(out[0]?.openTextId).toBe('text-a');
   });
 });
 

--- a/apps/web/src/lib/server/collections.ts
+++ b/apps/web/src/lib/server/collections.ts
@@ -502,6 +502,9 @@ export async function reorderCollection(
 export type CollectionListItem = {
   collection: Collection;
   textCount: number;
+  /** The chapter-text to open when the book is tapped: the one read most
+   *  recently, else the first chapter. Null only for an empty book. */
+  openTextId?: string | null;
 };
 
 export async function listCollectionsForUser(
@@ -523,7 +526,57 @@ export async function listCollectionsForUser(
     collection: Collection;
     textCount: number;
   }>;
-  return rows;
+
+  // Most-recently-read chapter-text per collection, so opening a book resumes.
+  const progress = (await db
+    .select({
+      collectionId: schema.collectionItems.collectionId,
+      textId: schema.collectionItems.textId,
+      updatedAt: schema.userTextProgress.updatedAt,
+    })
+    .from(schema.userTextProgress)
+    .innerJoin(
+      schema.collectionItems,
+      eq(schema.collectionItems.textId, schema.userTextProgress.textId),
+    )
+    .where(eq(schema.userTextProgress.userId, userId))) as Array<{
+    collectionId: string;
+    textId: string;
+    updatedAt: Date;
+  }>;
+  const lastRead = new Map<string, { textId: string; updatedAt: Date }>();
+  for (const p of progress) {
+    const cur = lastRead.get(p.collectionId);
+    if (!cur || p.updatedAt > cur.updatedAt) {
+      lastRead.set(p.collectionId, { textId: p.textId, updatedAt: p.updatedAt });
+    }
+  }
+
+  // First chapter per collection — the fallback for a book not yet started.
+  const items = (await db
+    .select({
+      collectionId: schema.collectionItems.collectionId,
+      textId: schema.collectionItems.textId,
+    })
+    .from(schema.collectionItems)
+    .innerJoin(
+      schema.collections,
+      eq(schema.collections.id, schema.collectionItems.collectionId),
+    )
+    .where(eq(schema.collections.ownerId, userId))
+    .orderBy(asc(schema.collectionItems.position))) as Array<{
+    collectionId: string;
+    textId: string;
+  }>;
+  const firstText = new Map<string, string>();
+  for (const it of items) {
+    if (!firstText.has(it.collectionId)) firstText.set(it.collectionId, it.textId);
+  }
+
+  return rows.map((r) => ({
+    ...r,
+    openTextId: lastRead.get(r.collection.id)?.textId ?? firstText.get(r.collection.id) ?? null,
+  }));
 }
 
 export async function listOfficialCollections(


### PR DESCRIPTION
**Item 3** — opening a book resumes (off `main`).

- **Server:** `GET /api/v1/me/collections` returns `openTextId` per book = the chapter-text with the most recent progress, else the first chapter (null only for an empty book).
- **App:** tapping a book opens the reader directly to `openTextId` (with the collection id, so Prev/Next + the TOC work); an empty book still opens the chapter list.

So a book you've started resumes where you left off, and a fresh book opens to its first chapter — no stop at the chapter list.

## Tests
`listCollectionsForUser` openTextId (resume + first-chapter fallback); library tap passes the collection summary through. Android 85 unit/UI + web collection suites green, lint clean.
