### PR TITLE
feat(android): reader navigation — open book directly, working chapter nav, resume

### DIFF
--- a/apps/android/app/src/main/java/com/ciareader/reader/data/collection/CollectionDtos.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/data/collection/CollectionDtos.kt
@@ -11,6 +11,7 @@ data class MyCollectionsDto(val collections: List<CollectionListItemDto> = empty
 data class CollectionListItemDto(
     val collection: CollectionDto,
     val textCount: Int = 0,
+    val openTextId: String? = null,
 )
 
 @Serializable

--- a/apps/android/app/src/main/java/com/ciareader/reader/data/collection/CollectionRepository.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/data/collection/CollectionRepository.kt
@@ -12,6 +12,8 @@ data class CollectionSummary(
     val language: String,
     val kind: String,
     val textCount: Int,
+    /** Chapter-text to open when tapped: last-read, else the first chapter. */
+    val openTextId: String? = null,
 )
 
 data class CollectionChapter(
@@ -49,6 +51,7 @@ class CollectionRepositoryImpl @Inject constructor(
                     language = it.collection.language,
                     kind = it.collection.kind,
                     textCount = it.textCount,
+                    openTextId = it.openTextId,
                 )
             }
         }

--- a/apps/android/app/src/main/java/com/ciareader/reader/ui/library/LibraryScreen.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/ui/library/LibraryScreen.kt
@@ -38,7 +38,7 @@ import com.ciareader.reader.data.library.TextCard
 @Composable
 fun LibraryScreen(
     onOpenText: (String) -> Unit,
-    onOpenCollection: (String) -> Unit,
+    onOpenCollection: (CollectionSummary) -> Unit,
     onLogout: () -> Unit,
     viewModel: LibraryViewModel = hiltViewModel(),
 ) {
@@ -59,7 +59,7 @@ internal fun LibraryScreenContent(
     state: LibraryUiState,
     onSelectLanguage: (String) -> Unit,
     onOpenText: (String) -> Unit,
-    onOpenCollection: (String) -> Unit,
+    onOpenCollection: (CollectionSummary) -> Unit,
     onRetry: () -> Unit,
     onLogout: () -> Unit,
 ) {
@@ -109,7 +109,7 @@ internal fun LibraryScreenContent(
 private fun ContentList(
     collections: List<CollectionSummary>,
     texts: List<TextCard>,
-    onOpenCollection: (String) -> Unit,
+    onOpenCollection: (CollectionSummary) -> Unit,
     onOpenText: (String) -> Unit,
 ) {
     LazyColumn(modifier = Modifier.fillMaxSize()) {
@@ -121,7 +121,7 @@ private fun ContentList(
                     supportingContent = {
                         Text("${c.textCount} chapters", color = MaterialTheme.colorScheme.onSurfaceVariant)
                     },
-                    modifier = Modifier.clickable { onOpenCollection(c.id) },
+                    modifier = Modifier.clickable { onOpenCollection(c) },
                 )
                 HorizontalDivider()
             }

--- a/apps/android/app/src/main/java/com/ciareader/reader/ui/navigation/CiaReaderNavHost.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/ui/navigation/CiaReaderNavHost.kt
@@ -12,13 +12,19 @@ import com.ciareader.reader.ui.reader.ReaderScreen
 
 object Routes {
     const val LIBRARY = "library"
-    const val READER = "reader/{textId}?collectionId={collectionId}"
+    const val READER = "reader/{textId}?collectionId={collectionId}&atEnd={atEnd}"
     const val COLLECTION = "collection/{collectionId}"
 
-    /** Reader for [textId]; [collectionId] (optional) gives the reader the
-     *  book context so Previous/Next move between the book's chapters. */
-    fun reader(textId: String, collectionId: String? = null) =
-        "reader/$textId" + (collectionId?.let { "?collectionId=$it" }.orEmpty())
+    /** Reader for [textId]; [collectionId] (optional) gives the book context so
+     *  Previous/Next move between chapters; [atEnd] opens the chapter at its last
+     *  page (for going back to a prior chapter). */
+    fun reader(textId: String, collectionId: String? = null, atEnd: Boolean = false): String {
+        val params = buildList {
+            collectionId?.let { add("collectionId=$it") }
+            if (atEnd) add("atEnd=true")
+        }
+        return "reader/$textId" + if (params.isEmpty()) "" else "?" + params.joinToString("&")
+    }
 
     fun collection(collectionId: String) = "collection/$collectionId"
 }
@@ -55,6 +61,10 @@ fun CiaReaderNavHost(onLogout: () -> Unit) {
                     nullable = true
                     defaultValue = null
                 },
+                navArgument("atEnd") {
+                    type = NavType.BoolType
+                    defaultValue = false
+                },
             ),
         ) { entry ->
             val collectionId = entry.arguments?.getString("collectionId")
@@ -63,12 +73,12 @@ fun CiaReaderNavHost(onLogout: () -> Unit) {
                 // Replace the current reader rather than stacking chapters, so Back
                 // exits the reader (to the book / library) instead of walking back
                 // through every chapter you opened.
-                onOpenChapterText = { textId ->
+                onOpenChapterText = { textId, atEnd ->
                     // Each chapter is a distinct text and needs its own back-stack
                     // entry + ViewModel. launchSingleTop reused the entry, so the
                     // reader stayed stuck on the first chapter. popUpTo still keeps
                     // only one reader, so Back exits to the book/library.
-                    navController.navigate(Routes.reader(textId, collectionId)) {
+                    navController.navigate(Routes.reader(textId, collectionId, atEnd)) {
                         popUpTo(Routes.READER) { inclusive = true }
                     }
                 },

--- a/apps/android/app/src/main/java/com/ciareader/reader/ui/navigation/CiaReaderNavHost.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/ui/navigation/CiaReaderNavHost.kt
@@ -37,7 +37,16 @@ fun CiaReaderNavHost(onLogout: () -> Unit) {
         composable(Routes.LIBRARY) {
             LibraryScreen(
                 onOpenText = { textId -> navController.navigate(Routes.reader(textId)) },
-                onOpenCollection = { id -> navController.navigate(Routes.collection(id)) },
+                // Open a book straight to where you left off (or its first chapter);
+                // fall back to the chapter list only for an empty book.
+                onOpenCollection = { c ->
+                    val open = c.openTextId
+                    if (open != null) {
+                        navController.navigate(Routes.reader(open, c.id))
+                    } else {
+                        navController.navigate(Routes.collection(c.id))
+                    }
+                },
                 onLogout = onLogout,
             )
         }

--- a/apps/android/app/src/main/java/com/ciareader/reader/ui/navigation/CiaReaderNavHost.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/ui/navigation/CiaReaderNavHost.kt
@@ -37,15 +37,11 @@ fun CiaReaderNavHost(onLogout: () -> Unit) {
         composable(Routes.LIBRARY) {
             LibraryScreen(
                 onOpenText = { textId -> navController.navigate(Routes.reader(textId)) },
-                // Open a book straight to where you left off (or its first chapter);
-                // fall back to the chapter list only for an empty book.
+                // Tapping a book opens the reader directly — the last-read chapter,
+                // else the first. No chapter-select screen; chapters are switched
+                // from the in-reader chapter dropdown (tap the title).
                 onOpenCollection = { c ->
-                    val open = c.openTextId
-                    if (open != null) {
-                        navController.navigate(Routes.reader(open, c.id))
-                    } else {
-                        navController.navigate(Routes.collection(c.id))
-                    }
+                    c.openTextId?.let { navController.navigate(Routes.reader(it, c.id)) }
                 },
                 onLogout = onLogout,
             )

--- a/apps/android/app/src/main/java/com/ciareader/reader/ui/navigation/CiaReaderNavHost.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/ui/navigation/CiaReaderNavHost.kt
@@ -64,9 +64,12 @@ fun CiaReaderNavHost(onLogout: () -> Unit) {
                 // exits the reader (to the book / library) instead of walking back
                 // through every chapter you opened.
                 onOpenChapterText = { textId ->
+                    // Each chapter is a distinct text and needs its own back-stack
+                    // entry + ViewModel. launchSingleTop reused the entry, so the
+                    // reader stayed stuck on the first chapter. popUpTo still keeps
+                    // only one reader, so Back exits to the book/library.
                     navController.navigate(Routes.reader(textId, collectionId)) {
                         popUpTo(Routes.READER) { inclusive = true }
-                        launchSingleTop = true
                     }
                 },
             )

--- a/apps/android/app/src/main/java/com/ciareader/reader/ui/reader/ReaderScreen.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/ui/reader/ReaderScreen.kt
@@ -78,7 +78,7 @@ import kotlin.math.roundToInt
 @Composable
 fun ReaderScreen(
     onBack: () -> Unit,
-    onOpenChapterText: (String) -> Unit,
+    onOpenChapterText: (textId: String, atEnd: Boolean) -> Unit,
     viewModel: ReaderViewModel = hiltViewModel(),
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -88,12 +88,13 @@ fun ReaderScreen(
         onWordTap = viewModel::onWordTap,
         onDismissWord = viewModel::dismissWord,
         // Within a multi-chapter text, move between its chapters; otherwise (e.g.
-        // a book whose chapters are separate texts) jump to the sibling chapter.
+        // a book whose chapters are separate texts) jump to the sibling chapter —
+        // going back opens that chapter at its last page.
         onPrevChapter = {
-            if (state.hasPrev) viewModel.prevChapter() else state.prevTextId?.let(onOpenChapterText)
+            if (state.hasPrev) viewModel.prevChapter() else state.prevTextId?.let { onOpenChapterText(it, true) }
         },
         onNextChapter = {
-            if (state.hasNext) viewModel.nextChapter() else state.nextTextId?.let(onOpenChapterText)
+            if (state.hasNext) viewModel.nextChapter() else state.nextTextId?.let { onOpenChapterText(it, false) }
         },
         onRetry = viewModel::retry,
         onSetStatus = viewModel::setStatus,
@@ -105,7 +106,7 @@ fun ReaderScreen(
         onSetLineSpacing = viewModel::setLineSpacing,
         onSelectChapter = { ref ->
             val tid = ref.textId
-            if (tid != null) onOpenChapterText(tid) else ref.chapterIdx?.let { viewModel.loadChapter(it) }
+            if (tid != null) onOpenChapterText(tid, false) else ref.chapterIdx?.let { viewModel.loadChapter(it) }
         },
         onProgress = viewModel::setProgress,
     )
@@ -203,6 +204,8 @@ internal fun ReaderScreenContent(
                         onNext = onNextChapter,
                         onWordTap = onWordTap,
                         onProgress = onProgress,
+                        restoreTokenIdx = state.restoreTokenIdx,
+                        onRestoreConsumed = onRestoreConsumed,
                         modifier = Modifier.fillMaxSize(),
                     )
 
@@ -391,6 +394,8 @@ private fun PagedChapter(
     onNext: () -> Unit,
     onWordTap: (ReaderToken) -> Unit,
     onProgress: (Float) -> Unit,
+    restoreTokenIdx: Int?,
+    onRestoreConsumed: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val scheme = MaterialTheme.colorScheme
@@ -450,9 +455,13 @@ private fun PagedChapter(
         val leading = if (canGoPrev) 1 else 0
         val trailing = if (canGoNext) 1 else 0
         val total = leading + pages.size + trailing
-        val pagerState = rememberPagerState(initialPage = leading, pageCount = { total })
-        // Reset to the first real page when the rendering changes (font/romanize).
-        LaunchedEffect(annotated) { pagerState.scrollToPage(leading) }
+        // Start on the saved anchor's page — the last page when coming back to a
+        // chapter — otherwise the first real page.
+        val restorePage = restoreTokenIdx?.let { t ->
+            ranges.getOrNull(t)?.first?.let { c -> pages.indexOfFirst { c in it }.takeIf { it >= 0 } }
+        }
+        val pagerState = rememberPagerState(initialPage = leading + (restorePage ?: 0), pageCount = { total })
+        LaunchedEffect(restoreTokenIdx) { if (restoreTokenIdx != null) onRestoreConsumed() }
         // Settling on an edge splash flips to that chapter.
         LaunchedEffect(pagerState, total) {
             snapshotFlow { pagerState.settledPage }.collect { settled ->

--- a/apps/android/app/src/main/java/com/ciareader/reader/ui/reader/ReaderScreen.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/ui/reader/ReaderScreen.kt
@@ -87,14 +87,20 @@ fun ReaderScreen(
         onBack = onBack,
         onWordTap = viewModel::onWordTap,
         onDismissWord = viewModel::dismissWord,
-        // Within a multi-chapter text, move between its chapters; otherwise (e.g.
-        // a book whose chapters are separate texts) jump to the sibling chapter —
-        // going back opens that chapter at its last page.
+        // Top arrows jump to the START of the adjacent chapter.
         onPrevChapter = {
-            if (state.hasPrev) viewModel.prevChapter() else state.prevTextId?.let { onOpenChapterText(it, true) }
+            if (state.hasPrev) viewModel.prevChapter() else state.prevTextId?.let { onOpenChapterText(it, false) }
         },
         onNextChapter = {
             if (state.hasNext) viewModel.nextChapter() else state.nextTextId?.let { onOpenChapterText(it, false) }
+        },
+        // Edge-swiping back opens the previous chapter at its LAST page.
+        onSwipeToPrevChapter = {
+            if (state.hasPrev) {
+                viewModel.loadChapter(state.chapterIdx - 1, atEnd = true)
+            } else {
+                state.prevTextId?.let { onOpenChapterText(it, true) }
+            }
         },
         onRetry = viewModel::retry,
         onSetStatus = viewModel::setStatus,
@@ -120,6 +126,7 @@ internal fun ReaderScreenContent(
     onDismissWord: () -> Unit,
     onPrevChapter: () -> Unit,
     onNextChapter: () -> Unit,
+    onSwipeToPrevChapter: () -> Unit = onPrevChapter,
     onRetry: () -> Unit,
     onSetStatus: (KnownStatus) -> Unit,
     onRecordPosition: (Int, Double) -> Unit,
@@ -145,7 +152,7 @@ internal fun ReaderScreenContent(
                             )
                         }
                         Text(
-                            state.title.ifEmpty { "Reader" },
+                            state.title,
                             modifier = Modifier
                                 .weight(1f)
                                 .clickable(enabled = state.chapters.isNotEmpty()) { showChapters = true },
@@ -200,10 +207,11 @@ internal fun ReaderScreenContent(
                         canGoNext = state.canGoNext,
                         prevTitle = state.prevTitle,
                         nextTitle = state.nextTitle,
-                        onPrev = onPrevChapter,
+                        onPrev = onSwipeToPrevChapter,
                         onNext = onNextChapter,
                         onWordTap = onWordTap,
                         onProgress = onProgress,
+                        onRecordPosition = onRecordPosition,
                         restoreTokenIdx = state.restoreTokenIdx,
                         onRestoreConsumed = onRestoreConsumed,
                         modifier = Modifier.fillMaxSize(),
@@ -394,6 +402,7 @@ private fun PagedChapter(
     onNext: () -> Unit,
     onWordTap: (ReaderToken) -> Unit,
     onProgress: (Float) -> Unit,
+    onRecordPosition: (Int, Double) -> Unit,
     restoreTokenIdx: Int?,
     onRestoreConsumed: () -> Unit,
     modifier: Modifier = Modifier,
@@ -471,9 +480,15 @@ private fun PagedChapter(
                 }
             }
         }
-        LaunchedEffect(pagerState, total) {
+        LaunchedEffect(pagerState, total, pages) {
             snapshotFlow { pagerState.currentPage }.collect { p ->
-                onProgress(if (total > 1) p.toFloat() / (total - 1) else 0f)
+                val fraction = if (total > 1) p.toFloat() / (total - 1) else 0f
+                onProgress(fraction)
+                // Save the spot: the first token of the current (real) page.
+                val realPage = (p - leading).coerceIn(0, (pages.size - 1).coerceAtLeast(0))
+                val charOffset = pages.getOrNull(realPage)?.first ?: 0
+                val tokenIdx = ranges.indexOfFirst { charOffset in it }.coerceAtLeast(0)
+                onRecordPosition(tokenIdx, (fraction * 100).toDouble())
             }
         }
 

--- a/apps/android/app/src/main/java/com/ciareader/reader/ui/reader/ReaderViewModel.kt
+++ b/apps/android/app/src/main/java/com/ciareader/reader/ui/reader/ReaderViewModel.kt
@@ -92,6 +92,7 @@ class ReaderViewModel @Inject constructor(
     private val textId: String =
         checkNotNull(savedStateHandle.get<String>("textId")) { "reader requires a textId arg" }
     private val collectionId: String? = savedStateHandle.get<String>("collectionId")
+    private val openAtEnd: Boolean = savedStateHandle.get<Boolean>("atEnd") ?: false
 
     private val _state = MutableStateFlow(ReaderUiState())
     val state: StateFlow<ReaderUiState> = _state.asStateFlow()
@@ -131,7 +132,9 @@ class ReaderViewModel @Inject constructor(
                         is Outcome.Failure -> null
                     }
                     val startChapter = (saved?.chapterIdx ?: 0).coerceIn(0, chapterCount - 1)
-                    val restoreToken = saved?.takeIf { it.chapterIdx == startChapter }?.tokenIdx
+                    // Going back to a chapter opens it at the end; otherwise resume.
+                    val restoreToken =
+                        if (openAtEnd) null else saved?.takeIf { it.chapterIdx == startChapter }?.tokenIdx
                     // For a multi-chapter single text, the TOC lists its own chapters.
                     if (collectionId == null && chapterCount > 1) {
                         _state.update { s ->
@@ -148,23 +151,25 @@ class ReaderViewModel @Inject constructor(
                             )
                         }
                     }
-                    loadChapter(startChapter, restoreToken)
+                    loadChapter(startChapter, restoreToken, atEnd = openAtEnd)
                 }
             }
         }
     }
 
-    fun loadChapter(chapterIdx: Int, restoreTokenIdx: Int? = null) {
+    fun loadChapter(chapterIdx: Int, restoreTokenIdx: Int? = null, atEnd: Boolean = false) {
         _state.update { it.copy(isLoading = true, errorMessage = null, selectedWord = null, wordTranslations = null) }
         viewModelScope.launch {
             when (val chapter = repository.chapter(textId, chapterIdx)) {
                 is Outcome.Success ->
                     _state.update {
+                        val anchor =
+                            if (atEnd) chapter.data.tokens.lastIndex.coerceAtLeast(0) else restoreTokenIdx
                         it.copy(
                             isLoading = false,
                             chapterIdx = chapterIdx,
                             tokens = chapter.data.tokens,
-                            restoreTokenIdx = restoreTokenIdx,
+                            restoreTokenIdx = anchor,
                             chapters = it.chapters.map { ref ->
                                 if (ref.chapterIdx != null) ref.copy(isCurrent = ref.chapterIdx == chapterIdx) else ref
                             },

--- a/apps/android/app/src/test/java/com/ciareader/reader/ui/library/LibraryScreenTest.kt
+++ b/apps/android/app/src/test/java/com/ciareader/reader/ui/library/LibraryScreenTest.kt
@@ -26,7 +26,7 @@ class LibraryScreenTest {
     private fun setContent(
         state: LibraryUiState,
         onOpenText: (String) -> Unit = {},
-        onOpenCollection: (String) -> Unit = {},
+        onOpenCollection: (CollectionSummary) -> Unit = {},
         onSelectLanguage: (String) -> Unit = {},
         onRetry: () -> Unit = {},
         onLogout: () -> Unit = {},
@@ -74,7 +74,7 @@ class LibraryScreenTest {
                     CollectionSummary("c1", "Afrika express", "eu", "chapter_book", 12),
                 ),
             ),
-            onOpenCollection = { opened = it },
+            onOpenCollection = { opened = it.id },
         )
         compose.onNodeWithText("Afrika express").assertIsDisplayed()
         compose.onNodeWithText("Afrika express").performClick()

--- a/apps/android/app/src/test/java/com/ciareader/reader/ui/reader/ReaderScreenTest.kt
+++ b/apps/android/app/src/test/java/com/ciareader/reader/ui/reader/ReaderScreenTest.kt
@@ -264,6 +264,47 @@ class ReaderScreenTest {
         compose.onNodeWithText("hello").assertIsDisplayed()
     }
 
+    /**
+     * Saving the spot, at the UI layer: rendering the reader in page mode must
+     * report the current reading position (the top token of the visible page)
+     * so it can be persisted. This is the wiring that was missing — page mode
+     * never called onRecordPosition, so reopening a book never resumed.
+     */
+    @Test
+    fun pageModeSavesReadingPosition() {
+        var recordedToken: Int? = null
+        compose.setContent {
+            CiaReaderTheme {
+                ReaderScreenContent(
+                    state = ReaderUiState(
+                        isLoading = false,
+                        title = "Book",
+                        pageMode = true,
+                        tokens = listOf(
+                            token("alpha", isWord = true),
+                            token(" ", isWord = false),
+                            token("beta", isWord = true),
+                        ),
+                    ),
+                    onBack = {},
+                    onWordTap = {},
+                    onDismissWord = {},
+                    onPrevChapter = {},
+                    onNextChapter = {},
+                    onRetry = {},
+                    onSetStatus = {},
+                    onRecordPosition = { tokenIdx, _ -> recordedToken = tokenIdx },
+                    onRestoreConsumed = {},
+                    onToggleRomanize = {},
+                    onTogglePageMode = {},
+                )
+            }
+        }
+        compose.waitForIdle()
+        // The first page starts at the first token, so that's the saved spot.
+        assertEquals(0, recordedToken)
+    }
+
     private fun token(surface: String, isWord: Boolean, status: KnownStatus = KnownStatus.UNKNOWN) =
         ReaderToken(0, surface, isWord, status, null, null, null, false, false, false)
 }

--- a/apps/android/app/src/test/java/com/ciareader/reader/ui/reader/ReaderViewModelTest.kt
+++ b/apps/android/app/src/test/java/com/ciareader/reader/ui/reader/ReaderViewModelTest.kt
@@ -43,12 +43,19 @@ class ReaderViewModelTest {
         settings: SettingsStore = FakeSettingsStore(),
         collections: CollectionRepository = FakeCollectionRepository(),
         collectionId: String? = null,
+        atEnd: Boolean = false,
     ) = ReaderViewModel(
         repo,
         dict,
         settings,
         collections,
-        SavedStateHandle(buildMap { put("textId", "t1"); collectionId?.let { put("collectionId", it) } }),
+        SavedStateHandle(
+            buildMap {
+                put("textId", "t1")
+                collectionId?.let { put("collectionId", it) }
+                if (atEnd) put("atEnd", true)
+            },
+        ),
     )
 
     @Test
@@ -354,6 +361,18 @@ class ReaderViewModelTest {
             progress = 0.5f,
         )
         assertEquals(0.625f, s.bookProgress, 0.0001f) // (100 + 0.5*300) / 400
+    }
+
+    @Test
+    fun goingBackOpensChapterAtItsLastToken() = runTest(mainRule.dispatcher) {
+        val repo = FakeReaderRepository(
+            meta = meta(1),
+            chapters = mapOf(0 to Chapter(0, listOf(word("a"), word("b"), word("c")))),
+        )
+        val v = vm(repo, atEnd = true)
+        advanceUntilIdle()
+
+        assertEquals(2, v.state.value.restoreTokenIdx) // last of 3 tokens
     }
 
     private fun word(surface: String) =

--- a/apps/android/app/src/test/java/com/ciareader/reader/ui/reader/ReaderViewModelTest.kt
+++ b/apps/android/app/src/test/java/com/ciareader/reader/ui/reader/ReaderViewModelTest.kt
@@ -375,6 +375,26 @@ class ReaderViewModelTest {
         assertEquals(2, v.state.value.restoreTokenIdx) // last of 3 tokens
     }
 
+    @Test
+    fun savesAndRestoresReadingSpot() = runTest(mainRule.dispatcher) {
+        // A repo that actually persists progress, like the server round-trip.
+        val repo = SavingReaderRepository(
+            meta = meta(1),
+            chapterTokens = listOf(word("a"), word("b"), word("c")),
+        )
+
+        // Read to token 2 and let the debounced save fire.
+        val first = vm(repo)
+        advanceUntilIdle()
+        first.recordPosition(tokenIdx = 2, pctRead = 66.0)
+        advanceUntilIdle()
+
+        // Reopen the same text → it resumes at the saved token.
+        val reopened = vm(repo)
+        advanceUntilIdle()
+        assertEquals(2, reopened.state.value.restoreTokenIdx)
+    }
+
     private fun word(surface: String) =
         ReaderToken(0, surface, true, KnownStatus.UNKNOWN, null, null, null, false, false, false)
 
@@ -386,6 +406,27 @@ class ReaderViewModelTest {
         chapterCount = chapterCount,
         chapters = (0 until chapterCount).map { ChapterRef(it, "c$it", 1) },
     )
+}
+
+/** Persists progress in-memory so a reopened reader resumes — a round-trip. */
+private class SavingReaderRepository(
+    private val meta: TextMeta,
+    private val chapterTokens: List<ReaderToken>,
+) : ReaderRepository {
+    private var saved: ReadingProgress? = null
+    override suspend fun textMeta(textId: String): Outcome<TextMeta> = Outcome.Success(meta)
+    override suspend fun chapter(textId: String, chapterIdx: Int): Outcome<Chapter> =
+        Outcome.Success(Chapter(chapterIdx, chapterTokens))
+    override suspend fun progress(textId: String): Outcome<ReadingProgress?> = Outcome.Success(saved)
+    override suspend fun saveProgress(
+        textId: String,
+        chapterIdx: Int,
+        tokenIdx: Int,
+        pctRead: Double,
+    ): Outcome<Unit> {
+        saved = ReadingProgress(chapterIdx, tokenIdx, pctRead)
+        return Outcome.Success(Unit)
+    }
 }
 
 private class FakeReaderRepository(

--- a/apps/web/src/lib/server/collections.test.ts
+++ b/apps/web/src/lib/server/collections.test.ts
@@ -69,6 +69,11 @@ vi.mock('./db/index.js', () => ({
     },
     texts: { id: 't.id', language: 't.language', title: 't.title' },
     textChapters: { textId: 'tc.text_id', tokenCount: 'tc.token_count' },
+    userTextProgress: {
+      userId: 'utp.user_id',
+      textId: 'utp.text_id',
+      updatedAt: 'utp.updated_at',
+    },
     users: { id: 'u.id' },
   },
 }));
@@ -681,6 +686,25 @@ describe('listCollectionsForUser', () => {
     const out = await listCollectionsForUser(OWNER.id);
     expect(out).toHaveLength(2);
     expect(out[0]?.textCount).toBe(3);
+  });
+
+  it('openTextId resumes the most-recently-read chapter', async () => {
+    queue.push([{ collection: baseCollection, textCount: 2 }]); // collections + count
+    queue.push([
+      { collectionId: baseCollection.id, textId: 'text-b', updatedAt: new Date('2026-05-02') },
+      { collectionId: baseCollection.id, textId: 'text-a', updatedAt: new Date('2026-05-01') },
+    ]); // progress
+    queue.push([{ collectionId: baseCollection.id, textId: 'text-a' }]); // first chapter
+    const out = await listCollectionsForUser(OWNER.id);
+    expect(out[0]?.openTextId).toBe('text-b');
+  });
+
+  it('openTextId falls back to the first chapter when not started', async () => {
+    queue.push([{ collection: baseCollection, textCount: 2 }]);
+    queue.push([]); // no progress
+    queue.push([{ collectionId: baseCollection.id, textId: 'text-a' }]); // first chapter
+    const out = await listCollectionsForUser(OWNER.id);
+    expect(out[0]?.openTextId).toBe('text-a');
   });
 });
 

--- a/apps/web/src/lib/server/collections.ts
+++ b/apps/web/src/lib/server/collections.ts
@@ -502,6 +502,9 @@ export async function reorderCollection(
 export type CollectionListItem = {
   collection: Collection;
   textCount: number;
+  /** The chapter-text to open when the book is tapped: the one read most
+   *  recently, else the first chapter. Null only for an empty book. */
+  openTextId?: string | null;
 };
 
 export async function listCollectionsForUser(
@@ -523,7 +526,57 @@ export async function listCollectionsForUser(
     collection: Collection;
     textCount: number;
   }>;
-  return rows;
+
+  // Most-recently-read chapter-text per collection, so opening a book resumes.
+  const progress = (await db
+    .select({
+      collectionId: schema.collectionItems.collectionId,
+      textId: schema.collectionItems.textId,
+      updatedAt: schema.userTextProgress.updatedAt,
+    })
+    .from(schema.userTextProgress)
+    .innerJoin(
+      schema.collectionItems,
+      eq(schema.collectionItems.textId, schema.userTextProgress.textId),
+    )
+    .where(eq(schema.userTextProgress.userId, userId))) as Array<{
+    collectionId: string;
+    textId: string;
+    updatedAt: Date;
+  }>;
+  const lastRead = new Map<string, { textId: string; updatedAt: Date }>();
+  for (const p of progress) {
+    const cur = lastRead.get(p.collectionId);
+    if (!cur || p.updatedAt > cur.updatedAt) {
+      lastRead.set(p.collectionId, { textId: p.textId, updatedAt: p.updatedAt });
+    }
+  }
+
+  // First chapter per collection — the fallback for a book not yet started.
+  const items = (await db
+    .select({
+      collectionId: schema.collectionItems.collectionId,
+      textId: schema.collectionItems.textId,
+    })
+    .from(schema.collectionItems)
+    .innerJoin(
+      schema.collections,
+      eq(schema.collections.id, schema.collectionItems.collectionId),
+    )
+    .where(eq(schema.collections.ownerId, userId))
+    .orderBy(asc(schema.collectionItems.position))) as Array<{
+    collectionId: string;
+    textId: string;
+  }>;
+  const firstText = new Map<string, string>();
+  for (const it of items) {
+    if (!firstText.has(it.collectionId)) firstText.set(it.collectionId, it.textId);
+  }
+
+  return rows.map((r) => ({
+    ...r,
+    openTextId: lastRead.get(r.collection.id)?.textId ?? firstText.get(r.collection.id) ?? null,
+  }));
 }
 
 export async function listOfficialCollections(


### PR DESCRIPTION
Reader navigation, consolidated into one branch (off `main`). apps/android (+ small server bit for resume).

- **Tapping a book opens the reader directly** — last-read chapter, else the first. **No chapter-select screen**; switch chapters via the in-reader chapter dropdown (tap the title).
- **Chapter navigation works** — dropped `launchSingleTop`, which reused the nav entry/ViewModel and kept the reader on the first chapter.
- **Going back opens the previous chapter's last page** (page mode) / bottom (scroll); forward + dropdown selection open at the start.
- **Resume** — the book remembers the chapter you were on (server `openTextId` = last-read, else first).

Supersedes #461 (cherry-picked here).

## Tests
Android 86 unit/UI; web collections (`openTextId` resume + first-chapter fallback). Lint clean.
